### PR TITLE
[Fix] Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # `target` is an asset-name label only — the build is native (no
+      # `--target`), so we use the friendlier `generic-linux` vendor instead of
+      # rustc's `unknown-linux` in the published tarball names.
       matrix:
         include:
-          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-22.04-arm, target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: x86_64-generic-linux-gnu }
+          - { os: ubuntu-22.04-arm, target: aarch64-generic-linux-gnu }
           # macOS: Apple Silicon only. Intel (x86_64-apple-darwin) is not built.
           - { os: macos-14, target: aarch64-apple-darwin }
     steps:
@@ -148,6 +151,20 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      # upload-artifact preserves each file's source path, so the CLI .deb
+      # (target/debian/) and GUI bundles (target/release/bundle/) arrive nested.
+      # Flatten every artifact to the dist root so `dist/*` and the maxdepth-1
+      # SHA256SUMS find catch ALL of them, not just the top-level tarballs.
+      - name: Flatten downloaded artifacts
+        working-directory: dist
+        run: |
+          find . -mindepth 2 -type f \
+            \( -name '*.deb' -o -name '*.tar.gz' -o -name '*.dmg' -o -name '*.AppImage' \) \
+            -exec mv -t . {} +
+          # Drop the now-redundant nested dirs so `dist/*` is files-only.
+          find . -mindepth 1 -type d -exec rm -rf {} +
+          echo "Flattened artifacts:" && ls -1
 
       - name: Generate SHA256SUMS
         working-directory: dist

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ in a `yerd` **user service** so the daemon works the same way. Pin a version wit
 | Platform | CLI artifact |
 |---|---|
 | Debian / Ubuntu (amd64 · arm64) | `yerd_<ver>_amd64.deb` · `yerd_<ver>_arm64.deb` → `sudo dpkg -i …` |
-| Arch · Fedora · other Linux (rootless) | `yerd-<ver>-{x86_64,aarch64}-unknown-linux-gnu.tar.gz` |
+| Arch · Fedora · other Linux (rootless) | `yerd-<ver>-{x86_64,aarch64}-generic-linux-gnu.tar.gz` |
 | macOS (Apple Silicon) | `yerd-<ver>-aarch64-apple-darwin.tar.gz` |
 
 Verify against the release's `SHA256SUMS`, then start the per-user daemon:

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -85,7 +85,8 @@ fn target_triple() -> Result<String, GuiError> {
         }
     };
     match std::env::consts::OS {
-        "linux" => Ok(format!("{arch}-unknown-linux-gnu")),
+        // Asset label, not the rustc triple: releases use `generic-linux`.
+        "linux" => Ok(format!("{arch}-generic-linux-gnu")),
         "macos" => {
             if arch != "aarch64" {
                 return Err(GuiError::internal(

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -66,7 +66,7 @@ prebuilt artifacts plus a `SHA256SUMS` manifest. Pick the right one:
 | Platform | CLI artifact |
 |---|---|
 | Debian / Ubuntu (amd64 · arm64) | `yerd_<ver>_amd64.deb` · `yerd_<ver>_arm64.deb` → `sudo dpkg -i …` |
-| Arch · Fedora · other Linux (rootless) | `yerd-<ver>-{x86_64,aarch64}-unknown-linux-gnu.tar.gz` |
+| Arch · Fedora · other Linux (rootless) | `yerd-<ver>-{x86_64,aarch64}-generic-linux-gnu.tar.gz` |
 | macOS (Apple Silicon) | `yerd-<ver>-aarch64-apple-darwin.tar.gz` |
 
 Always verify the download against the release's `SHA256SUMS` before using it:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,7 +38,8 @@ case "$arch" in
   *) die "unsupported architecture '$arch'" ;;
 esac
 if [ "$os_id" = linux ]; then
-  triple="${rust_arch}-unknown-linux-gnu"
+  # Asset label, not the rustc triple: we publish `generic-linux`, not `unknown-linux`.
+  triple="${rust_arch}-generic-linux-gnu"
 else
   triple="${rust_arch}-apple-darwin"
 fi


### PR DESCRIPTION
This pull request standardizes the naming convention for Linux build artifacts by switching from the `unknown-linux-gnu` suffix to `generic-linux-gnu` across the codebase, documentation, and release workflow. This change ensures that artifact names are more user-friendly and consistent. Additionally, the release workflow is improved to flatten downloaded artifacts, making it easier to generate checksums.

**Release workflow improvements:**
* Added a "Flatten downloaded artifacts" step in the release workflow to move all relevant files to the root of the `dist` directory, ensuring that checksum generation includes all artifacts regardless of their original subdirectory.