### PR TITLE
[Fix] Release Names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,15 @@ jobs:
             -exec mv -t . {} +
           # Drop the now-redundant nested dirs so `dist/*` is files-only.
           find . -mindepth 1 -type d -exec rm -rf {} +
+          # Tauri names its bundles after productName ("Yerd_<ver>_<arch>.*"). The
+          # GUI .deb would then differ from the CLI `yerd_<ver>_<arch>.deb` only by
+          # case — and GitHub release asset names are case-insensitive-unique, so
+          # the two collide and one upload fails. Rename the GUI bundles to the
+          # distinct `yerd-gui` package so CLI and GUI never clash.
+          for f in Yerd_*; do
+            [ -e "$f" ] || continue
+            mv "$f" "yerd-gui_${f#Yerd_}"
+          done
           echo "Flattened artifacts:" && ls -1
 
       - name: Generate SHA256SUMS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5892,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "yerd"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "clap",
  "interprocess",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-config"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "serde",
  "tempfile",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-core"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "serde",
  "serde_json",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-dns"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "async-trait",
  "hickory-client",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-doctor"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "yerd-core",
  "yerd-ipc",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-gui"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "core-foundation 0.9.4",
  "core-foundation-sys",
@@ -6008,7 +6008,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-helper"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "clap",
  "hex",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-ipc"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-php"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "async-trait",
  "nix",
@@ -6049,7 +6049,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-platform"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "directories",
  "hex",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-proxy"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-services"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "async-trait",
  "serde",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-supervise"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "async-trait",
  "nix",
@@ -6113,7 +6113,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-tls"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "pem",
  "rcgen",
@@ -6127,7 +6127,7 @@ dependencies = [
 
 [[package]]
 name = "yerdd"
-version = "2.0.1-alpha1"
+version = "2.0.1-alpha2"
 dependencies = [
  "async-trait",
  "clap",

--- a/README.md
+++ b/README.md
@@ -22,24 +22,13 @@ PHP version per site, and manage it all from one tiny daemon — no Docker, no
 
 ## Why Yerd?
 
-Type a URL like `https://my-app.test` and your site just works, with the right
-PHP version and a trusted certificate. Yerd makes local PHP development
-frictionless — **cross-platform, fully open-source, and rootless by design.**
-
-- 🚀 **Zero-config sites.** Drop a project in a parked directory and it's instantly
-  live at `<name>.test`.
-- 🔒 **HTTPS that just works.** A local certificate authority issues per-site
-  certificates automatically — no `mkcert` dance, no browser warnings once trusted.
-- 🐘 **Any PHP, per site.** Install multiple PHP versions and pin each site to the
-  one it needs.
-- 🗄️ **Databases & caches, no Docker.** Install and supervise MySQL, MariaDB,
-  PostgreSQL, and Redis as native, per-user processes — create, drop, back up, and
-  restore databases straight from the CLI.
-- 🪶 **Lightweight & native.** A single ~8 MB daemon binary. No containers, no VM,
-  no Electron.
-- 🛡️ **Rootless.** Setup elevates **once**; everything after runs as your user.
-- 🔍 **Self-diagnosing.** `yerd status` and `yerd doctor` tell you exactly what's
-  running and how to fix what isn't.
+- 🚀 **Zero-config sites** — drop a project in a parked folder, it's live at `<name>.test`.
+- 🔒 **Trusted HTTPS** per site from a local CA — no `mkcert`, no browser warnings.
+- 🐘 **Multiple PHP versions**, pinned per site.
+- 🗄️ **Native MySQL · MariaDB · PostgreSQL · Redis** — no Docker.
+- 🪶 **One ~8 MB daemon** — no containers, no VM, no Electron.
+- 🛡️ **Rootless** — setup elevates once; daily use never does.
+- 🔍 **Self-diagnosing** with `yerd status` and `yerd doctor`.
 
 ---
 
@@ -65,7 +54,7 @@ frictionless — **cross-platform, fully open-source, and rootless by design.**
 | Built-in health checks (`doctor`) | ❌ | ❌ | ✅ |
 | Under the hood | Native app (nginx + dnsmasq) | Containers (rootless Podman) | Native Rust (`rustls` proxy + embedded DNS) |
 
-<sub>✅\* = on the Yerd [roadmap](#roadmap). Everything without an asterisk works today on macOS and Linux.</sub>
+<sub>✅\* = Windows is planned. Everything without an asterisk works today on macOS and Linux.</sub>
 <br><sub>**Lerd** runs your stack in containers via **rootless Podman** (Linux +
 macOS; no Docker) — so it trivially adds database/cache services, but it pulls and
 runs container images rather than native processes. † Rootless by design on
@@ -80,106 +69,37 @@ its own Rust proxy + DNS. No Valet, no Homebrew.</sub>
 
 ## Installation
 
-> **Yerd runs entirely as your user — never as root.** `sudo` appears in exactly
-> two non-ongoing places: installing the system `.deb` (standard for *any*
-> package), and a single **one-time** setup step. Day-to-day use needs no
-> elevation. Prefer no `sudo` at all? Use the tarball or [build from source](#from-source).
+The easiest way to run Yerd is the **desktop app** — it installs the daemon and
+CLI for you. Grab the latest build from the
+[releases page](https://github.com/forjedio/yerd/releases):
 
-Pre-built artifacts for **macOS and Linux** (x86-64 and arm64) are attached to
-each [GitHub Release](https://github.com/forjedio/yerd/releases), each verified
-by a `SHA256SUMS` manifest.
+| Platform | Download | Install |
+|---|---|---|
+| macOS (Apple Silicon) | `yerd-gui_<ver>_aarch64.dmg` | open, drag to Applications |
+| Linux | `yerd-gui_<ver>_amd64.AppImage` | `chmod +x` and run |
+| Linux | `yerd-gui_<ver>_amd64.deb` | `sudo dpkg -i …` |
 
-### Quick install (CLI + daemon)
+On first launch the app downloads and installs the `yerd` CLI, the `yerdd`
+daemon, and `yerd-helper` into `~/.local/bin` (verified against `SHA256SUMS`) —
+so on macOS, setup is essentially drag-and-drop. It then walks you through a
+**one-time** `sudo yerd elevate` to trust the local CA, route `*.test`, and bind
+ports 80/443. Everything after runs as your user — never as root.
+
+### Advanced: CLI + daemon only
+
+Prefer the terminal? Install just the daemon and CLI (no GUI):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/forjedio/yerd/main/scripts/install.sh | sh
 ```
 
-This fetches the latest release, **verifies it against `SHA256SUMS`**, and
-installs `yerd` + `yerdd` + `yerd-helper` — the `.deb` on Debian/Ubuntu
-(system-wide), or a tarball to `~/.local/bin` everywhere else (no sudo). On
-non-Debian systemd distros (**Arch/Omarchy, Fedora, openSUSE, …**) it also drops
-in a `yerd` **user service** so the daemon works the same way. Pin a version with
-`YERD_VERSION=2.0.2`.
-
-### Manual download
-
-| Platform | CLI artifact |
-|---|---|
-| Debian / Ubuntu (amd64 · arm64) | `yerd_<ver>_amd64.deb` · `yerd_<ver>_arm64.deb` → `sudo dpkg -i …` |
-| Arch · Fedora · other Linux (rootless) | `yerd-<ver>-{x86_64,aarch64}-generic-linux-gnu.tar.gz` |
-| macOS (Apple Silicon) | `yerd-<ver>-aarch64-apple-darwin.tar.gz` |
-
-Verify against the release's `SHA256SUMS`, then start the per-user daemon:
+This fetches the latest release (SHA-verified) and installs `yerd` + `yerdd` +
+`yerd-helper` — a `.deb` on Debian/Ubuntu, or a tarball to `~/.local/bin`
+elsewhere. Then run the one-time setup:
 
 ```bash
-sha256sum -c SHA256SUMS --ignore-missing       # macOS: shasum -a 256 -c SHA256SUMS --ignore-missing
-systemctl --user enable --now yerd             # .deb install (runs as you, not root)
-# …or from the tarball:  yerdd serve &          # rootless; 8080/8443 out of the box
+sudo yerd elevate    # trust the CA · route *.test · allow 80/443
 ```
-
-The `.deb`'s post-install grants `yerdd` `cap_net_bind_service` (so the
-**unprivileged** daemon binds 80/443) and re-applies it on every upgrade; if
-unavailable, Yerd falls back to `8080`/`8443` (and `yerd doctor` tells you).
-
-### Desktop GUI (optional)
-
-The tray app ships as separate bundles on the same release:
-
-| Platform | GUI artifact | Install |
-|---|---|---|
-| macOS (Apple Silicon) | `Yerd_<ver>_aarch64.dmg` | open, drag to Applications |
-| Linux | `Yerd_<ver>_amd64.AppImage` | `chmod +x` and run |
-| Linux | `Yerd_<ver>_amd64.deb` | `sudo dpkg -i …` |
-
-> **The GUI installs the backend for you.** It's a client of the daemon, but you
-> don't need to install the CLI first — on launch, if `yerdd` isn't already
-> present the app downloads the matching release, **verifies it against
-> `SHA256SUMS`**, and installs `yerd` + `yerdd` + `yerd-helper` into `~/.local/bin`
-> (ad-hoc-signing them on macOS). **On macOS that means setup is essentially
-> drag-and-drop:** open the `.dmg`, drag Yerd to Applications, launch it, and let
-> it pull down the backend. (Already installed the CLI, or on a Linux `.deb`? The
-> app just finds and uses the existing binaries.)
->
-> Auto-install covers Linux (x86-64 · arm64) and **Apple Silicon** macOS; on Intel
-> Macs, [install the CLI](#installation) manually first.
-
-> **Unsigned for now:** macOS warns on first launch — right-click → **Open**, or
-> `xattr -dr com.apple.quarantine /Applications/Yerd.app`.
-
-### One-time setup
-
-Run this **once** for the full experience — the only command that uses root, and
-each part is independent:
-
-```bash
-sudo yerd elevate            # trust the local CA · route *.test · allow 80/443
-# …or pick pieces:  sudo yerd elevate trust | resolver | ports
-```
-
-This mirrors the one-time admin step Herd and Valet also need (reconfiguring the
-system resolver and trusting a local certificate can't be done rootlessly).
-After it, `yerd` never touches root again.
-
-### From source
-
-No system package (or any `sudo` to install)? Build and drop the binaries on
-your `PATH` — no root required:
-
-```bash
-git clone https://github.com/forjedio/yerd
-cd yerd
-cargo build --release -p yerd -p yerdd -p yerd-helper
-install -Dm755 target/release/{yerd,yerdd,yerd-helper} -t ~/.local/bin
-yerdd serve &                # rootless; runs on 8080/8443 out of the box
-```
-
-`cargo xtask deb` packages a `.deb` instead. (Browser `*.test` resolution and
-trusted HTTPS still need the one-time `sudo yerd elevate`, or drive sites
-directly on `127.0.0.1:8080`.)
-
-> PHP itself is **not** bundled — Yerd downloads prebuilt, static PHP builds on
-> demand when you run `yerd install php`. Installing Yerd is tiny and fast.
 
 ---
 
@@ -301,95 +221,6 @@ a newer patch exists, but never installs anything behind your back.
 
 ---
 
-## How it works
-
-```
-            ┌──────────────┐         .test domain
- browser ──▶│  yerdd        │◀── embedded DNS resolver (*.test → 127.0.0.1)
-            │  reverse      │
-            │  proxy        │── HTTPS termination via local CA (rustls + rcgen)
-            └──────┬────────┘
-                   │ FastCGI
-            ┌──────▼────────┐
-            │  PHP-FPM      │  one supervised pool per PHP version
-            │  pools        │  (downloaded static builds)
-            └───────────────┘
-
-  yerd (CLI) ──IPC socket──▶ yerdd          sudo yerd elevate ──▶ yerd-helper
-```
-
-| Concern | Choice |
-|---|---|
-| Core language | Rust (edition 2021; core MSRV 1.77, GUI needs 1.85+) |
-| TLS / local CA | `rustls` + `rcgen` (never OpenSSL) |
-| Reverse proxy | hand-rolled `hyper` + `hyper-util` + `tokio-rustls` |
-| DNS | `hickory-dns` embedded resolver for `*.test` |
-| PHP runtime | `static-php-cli` builds, PHP-FPM per version |
-| Services | native MySQL / MariaDB / PostgreSQL / Redis, supervised per-user (`yerd-services` + `yerd-supervise`) |
-| IPC | Unix socket / Windows named pipe via `interprocess` |
-| GUI | Tauri v2 + Vue 3 + TypeScript + Tailwind (`apps/yerd-gui`) |
-
----
-
-## Roadmap
-
-Shipping today (macOS + Linux): multi-version PHP, parked/linked `.test` sites,
-HTTP + HTTPS with a local CA, the embedded DNS resolver, native database & cache
-services (MySQL · MariaDB · PostgreSQL · Redis), `status`/`doctor`, the **desktop
-GUI** (`apps/yerd-gui` — a Tauri v2 tray app over the same daemon, a thin IPC
-client like the CLI; bundled as `.dmg`/`.AppImage`/`.deb` by the release
-pipeline), and the Debian package.
-
-On the way:
-
-- 🪟 **Windows support** — NRPT-based resolver, named-pipe IPC, system cert store,
-  TCP-loopback PHP-FPM.
-- 📦 **More packaging** — code-signing/notarisation, an Arch AUR package, and
-  Fedora/openSUSE `.rpm`s. (`.dmg`/`.AppImage`/`.deb` + checksummed CLI artifacts
-  are already built per release.)
-
----
-
-## Development
-
-```bash
-# The full CI gate (all must pass):
-cargo fmt --all --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
-
-# Build a .deb locally:
-cargo xtask deb
-```
-
-The desktop GUI lives in `apps/yerd-gui` (Tauri v2 + Vue 3). It builds with a
-newer toolchain than the core MSRV — `rust-toolchain.toml` pins **1.96** because
-current Tauri v2 needs edition2024 (rustc ≥ 1.85) — and needs Node plus the
-GTK/WebKit `-dev` system libraries. Setup, the `apt` one-liner, and
-`npm run tauri dev` are documented in
-[`apps/yerd-gui/README.md`](apps/yerd-gui/README.md).
-
-**CI & releasing.** `.github/workflows/ci.yml` runs the gate above (plus the GUI
-frontend tests) on every PR. To cut a release, bump the version everywhere and
-push a tag — the pipeline builds and publishes **all** artifacts atomically (the
-release stays a hidden draft until every file + `SHA256SUMS` is attached, then
-flips public):
-
-```bash
-cargo xtask bump 2.0.2      # sets Cargo.toml + tauri.conf.json + package.json
-git commit -am "release: v2.0.2" && git tag v2.0.2 && git push --follow-tags
-```
-
-`release.yml` then builds the CLI (`.deb` + tarballs) and GUI
-(`.dmg`/`.AppImage`/`.deb`) for Linux (amd64 + arm64) and macOS (Apple Silicon).
-A mismatched tag fails fast via `cargo xtask version-check`.
-
-Conventions: `thiserror` in libraries / `anyhow` only at binary top level; no
-`unwrap`/`expect`/`panic` outside tests (clippy-enforced); pure crates stay pure;
-the IPC wire format is a versioned, byte-pinned contract.
-
----
-
 ## Lineage
 
 Yerd v2 is a ground-up rewrite of **our own v1 package**
@@ -406,5 +237,4 @@ operations, v2 ships prebuilt PHP and runs unprivileged.
 
 Licensed under the [MIT License](LICENSE.md).
 
-A [Forjed](https://forjed.io) project · <support@forjed.io> ·
-[github.com/forjedio/yerd](https://github.com/forjedio/yerd)
+A [Forjed](https://forjed.io) project · [github.com/forjedio/yerd](https://github.com/forjedio/yerd)

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -10,9 +10,9 @@ The app ships as separate bundles on the same release as the CLI:
 
 | Platform | Artifact | Install |
 |---|---|---|
-| macOS (Apple Silicon) | `Yerd_<ver>_aarch64.dmg` | Open the DMG, drag Yerd to Applications |
-| Linux | `Yerd_<ver>_amd64.AppImage` | `chmod +x Yerd_<ver>_amd64.AppImage` and run it |
-| Linux | `Yerd_<ver>_amd64.deb` | `sudo dpkg -i Yerd_<ver>_amd64.deb` |
+| macOS (Apple Silicon) | `yerd-gui_<ver>_aarch64.dmg` | Open the DMG, drag Yerd to Applications |
+| Linux | `yerd-gui_<ver>_amd64.AppImage` | `chmod +x yerd-gui_<ver>_amd64.AppImage` and run it |
+| Linux | `yerd-gui_<ver>_amd64.deb` | `sudo dpkg -i yerd-gui_<ver>_amd64.deb` |
 
 The macOS DMG targets Apple Silicon (`aarch64`) only; Intel (x86-64) Macs are not supported at this time. There's no Windows bundle yet: the daemon's named-pipe address isn't client-derivable.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -97,9 +97,9 @@ the daemon** - install the CLI/daemon above too, so `yerdd` is present.
 
 | Platform | GUI artifact | Install |
 |---|---|---|
-| macOS (Apple Silicon) | `Yerd_<ver>_aarch64.dmg` | open, drag to Applications |
-| Linux | `Yerd_<ver>_amd64.AppImage` | `chmod +x` and run |
-| Linux | `Yerd_<ver>_amd64.deb` | `sudo dpkg -i …` |
+| macOS (Apple Silicon) | `yerd-gui_<ver>_aarch64.dmg` | open, drag to Applications |
+| Linux | `yerd-gui_<ver>_amd64.AppImage` | `chmod +x` and run |
+| Linux | `yerd-gui_<ver>_amd64.deb` | `sudo dpkg -i …` |
 
 ::: warning Unsigned for now
 macOS warns on first launch - right-click → **Open**, or clear the quarantine


### PR DESCRIPTION
This pull request primarily updates the naming and installation instructions for the Yerd desktop GUI across documentation and the release workflow. The changes ensure that the GUI release artifacts use a consistent, lowercase `yerd-gui` naming scheme, preventing case-insensitive conflicts with CLI artifacts, and update documentation to reflect this. Additionally, the README is reorganized for clarity, with installation instructions emphasizing the desktop app and simplifying advanced/CLI-only setup. Minor clarifications and roadmap updates are also included.