### PR TITLE
[Feat] Email Capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1664,18 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "heck"
@@ -2259,6 +2280,16 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "mail-parser"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2420e9ce11c2b0583ca97ddff7ab2398c8a613154e9b72e3bafdbf767f1d7"
+dependencies = [
+ "encoding_rs",
+ "hashify",
+]
 
 [[package]]
 name = "markup5ever"
@@ -5892,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "anyhow",
  "clap",
@@ -5910,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "yerd"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "clap",
  "interprocess",
@@ -5927,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-config"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "serde",
  "tempfile",
@@ -5938,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-core"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "serde",
  "serde_json",
@@ -5949,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-dns"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "async-trait",
  "hickory-client",
@@ -5963,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-doctor"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "yerd-core",
  "yerd-ipc",
@@ -5971,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-gui"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "core-foundation 0.9.4",
  "core-foundation-sys",
@@ -6008,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-helper"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "clap",
  "hex",
@@ -6022,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-ipc"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6032,8 +6063,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "yerd-mail"
+version = "2.0.1-alpha3"
+dependencies = [
+ "mail-parser",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "yerd-ipc",
+]
+
+[[package]]
 name = "yerd-php"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "async-trait",
  "nix",
@@ -6049,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-platform"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "directories",
  "hex",
@@ -6065,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-proxy"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6089,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-services"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "async-trait",
  "serde",
@@ -6103,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-supervise"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "async-trait",
  "nix",
@@ -6113,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "yerd-tls"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "pem",
  "rcgen",
@@ -6127,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "yerdd"
-version = "2.0.1-alpha2"
+version = "2.0.1-alpha3"
 dependencies = [
  "async-trait",
  "clap",
@@ -6151,6 +6196,7 @@ dependencies = [
  "yerd-dns",
  "yerd-doctor",
  "yerd-ipc",
+ "yerd-mail",
  "yerd-php",
  "yerd-platform",
  "yerd-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members  = ["crates/yerd-core", "crates/yerd-ipc", "crates/yerd-config", "crates/yerd-tls", "crates/yerd-platform", "crates/yerd-dns", "crates/yerd-supervise", "crates/yerd-php", "crates/yerd-services", "crates/yerd-proxy", "crates/yerd-doctor", "bin/yerd-helper", "bin/yerdd", "bin/yerd", "apps/yerd-gui/src-tauri", "xtask"]
+members  = ["crates/yerd-core", "crates/yerd-ipc", "crates/yerd-config", "crates/yerd-tls", "crates/yerd-platform", "crates/yerd-dns", "crates/yerd-supervise", "crates/yerd-php", "crates/yerd-services", "crates/yerd-proxy", "crates/yerd-doctor", "crates/yerd-mail", "bin/yerd-helper", "bin/yerdd", "bin/yerd", "apps/yerd-gui/src-tauri", "xtask"]
 
 [workspace.package]
 version      = "2.0.1-alpha3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["s
 http               = "1"
 interprocess       = { version = "2", features = ["tokio"] }
 fs4                = { version = "0.13", default-features = false, features = ["sync"] }
+# Pure-Rust MIME parser for the mail-capture viewer. `full_encoding` pulls
+# `encoding_rs` for non-UTF-8 charsets; the `serde` feature is deliberately off.
+mail-parser        = { version = "0.11", default-features = false, features = ["full_encoding"] }
 
 [workspace.lints.rust]
 unsafe_code  = "forbid"

--- a/apps/yerd-gui/src-tauri/capabilities/default.json
+++ b/apps/yerd-gui/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Core access plus the opener/dialog plugin commands the host helpers use, and the window-control commands the custom (decorationless) titlebar drives. App commands (our #[tauri::command]s) are permitted by registration.",
-  "windows": ["main"],
+  "windows": ["main", "mails"],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -270,6 +270,33 @@ pub async fn restore_database(
     )
 }
 
+// ── mail capture ───────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn list_mails() -> Result<Response, GuiError> {
+    finish(exchange(&Request::ListMails).await?)
+}
+
+#[tauri::command]
+pub async fn get_mail(id: String) -> Result<Response, GuiError> {
+    finish(exchange(&Request::GetMail { id }).await?)
+}
+
+#[tauri::command]
+pub async fn clear_mails() -> Result<Response, GuiError> {
+    finish(exchange(&Request::ClearMails).await?)
+}
+
+#[tauri::command]
+pub async fn set_mail_port(port: u16) -> Result<Response, GuiError> {
+    finish(exchange(&Request::SetMailPort { port }).await?)
+}
+
+#[tauri::command]
+pub async fn set_mail_enabled(enabled: bool) -> Result<Response, GuiError> {
+    finish(exchange(&Request::SetMailEnabled { enabled }).await?)
+}
+
 // ── status / doctor / info ─────────────────────────────────────────────────
 
 #[tauri::command]

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -288,6 +288,11 @@ pub async fn clear_mails() -> Result<Response, GuiError> {
 }
 
 #[tauri::command]
+pub async fn delete_mails(ids: Vec<String>) -> Result<Response, GuiError> {
+    finish(exchange(&Request::DeleteMails { ids }).await?)
+}
+
+#[tauri::command]
 pub async fn set_mail_port(port: u16) -> Result<Response, GuiError> {
     finish(exchange(&Request::SetMailPort { port }).await?)
 }

--- a/apps/yerd-gui/src-tauri/src/mail_window.rs
+++ b/apps/yerd-gui/src-tauri/src/mail_window.rs
@@ -1,0 +1,21 @@
+//! The separate "Mails" viewer window.
+//!
+//! The window is declared statically in `tauri.conf.json` (label `mails`,
+//! `visible: false`, loading `index.html#/mails-viewer`), so this command just
+//! shows-and-focuses it — mirroring `show_main`. It is hidden (never destroyed)
+//! on close by the window-event handler in `main.rs`, so "show the existing
+//! window" is always correct.
+
+use tauri::Manager;
+
+/// Open (show + focus) the Mails viewer window. Invoked from the Mail settings
+/// page's "Show Mails" button.
+#[tauri::command]
+pub fn show_mails_window(app: tauri::AppHandle) -> Result<(), String> {
+    let win = app
+        .get_webview_window("mails")
+        .ok_or_else(|| "mails window is not configured".to_string())?;
+    win.show().map_err(|e| e.to_string())?;
+    win.set_focus().map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/apps/yerd-gui/src-tauri/src/mail_window.rs
+++ b/apps/yerd-gui/src-tauri/src/mail_window.rs
@@ -8,14 +8,19 @@
 
 use tauri::Manager;
 
+use crate::error::GuiError;
+
 /// Open (show + focus) the Mails viewer window. Invoked from the Mail settings
-/// page's "Show Mails" button.
+/// page's "Show Mails" button. Returns the crate's single `GuiError` type so the
+/// frontend sees the same typed `{ code, message }` failure shape as every other
+/// command.
 #[tauri::command]
-pub fn show_mails_window(app: tauri::AppHandle) -> Result<(), String> {
+pub fn show_mails_window(app: tauri::AppHandle) -> Result<(), GuiError> {
     let win = app
         .get_webview_window("mails")
-        .ok_or_else(|| "mails window is not configured".to_string())?;
-    win.show().map_err(|e| e.to_string())?;
-    win.set_focus().map_err(|e| e.to_string())?;
+        .ok_or_else(|| GuiError::internal("mails window is not configured"))?;
+    win.show().map_err(|e| GuiError::internal(e.to_string()))?;
+    win.set_focus()
+        .map_err(|e| GuiError::internal(e.to_string()))?;
     Ok(())
 }

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -99,6 +99,7 @@ fn main() {
             commands::list_mails,
             commands::get_mail,
             commands::clear_mails,
+            commands::delete_mails,
             commands::set_mail_port,
             commands::set_mail_enabled,
             mail_window::show_mails_window,

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod error;
 mod ipc;
 #[cfg(target_os = "macos")]
 mod mac_trust;
+mod mail_window;
 
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
@@ -95,6 +96,12 @@ fn main() {
             commands::drop_database,
             commands::backup_database,
             commands::restore_database,
+            commands::list_mails,
+            commands::get_mail,
+            commands::clear_mails,
+            commands::set_mail_port,
+            commands::set_mail_enabled,
+            mail_window::show_mails_window,
             commands::status,
             commands::diagnose,
             commands::doctor_fix,
@@ -120,10 +127,15 @@ fn main() {
         // item is the real exit.
         .on_window_event(|window, event| {
             if let WindowEvent::CloseRequested { api, .. } = event {
+                // The handler is global (fires for every window). The Mails
+                // viewer just hides on close — but must NOT touch the Dock
+                // activation policy, or closing it would drop the app's Dock
+                // icon while the main window is still open. Only the main window
+                // drives the close-to-tray + Dock-accessory behaviour.
                 let _ = window.hide();
-                // Drop the Dock icon (macOS) so a closed window leaves no active
-                // app presence; the tray icon reopens it.
-                set_dock_visible(window.app_handle(), false);
+                if window.label() == "main" {
+                    set_dock_visible(window.app_handle(), false);
+                }
                 api.prevent_close();
             }
         })
@@ -219,6 +231,7 @@ const NAV_ITEMS: &[(&str, &str)] = &[
     ("nav:/php", "PHP"),
     ("nav:/sites", "Sites"),
     ("nav:/services", "Services"),
+    ("nav:/mail", "Mail"),
     ("nav:/about", "About"),
 ];
 

--- a/apps/yerd-gui/src-tauri/tauri.conf.json
+++ b/apps/yerd-gui/src-tauri/tauri.conf.json
@@ -35,7 +35,8 @@
         "minWidth": 720,
         "minHeight": 480,
         "resizable": true,
-        "decorations": true,
+        "decorations": false,
+        "transparent": true,
         "visible": false
       }
     ],

--- a/apps/yerd-gui/src-tauri/tauri.conf.json
+++ b/apps/yerd-gui/src-tauri/tauri.conf.json
@@ -25,10 +25,22 @@
         "decorations": false,
         "transparent": true,
         "visible": false
+      },
+      {
+        "label": "mails",
+        "title": "Mails",
+        "url": "index.html#/mails-viewer",
+        "width": 1100,
+        "height": 760,
+        "minWidth": 720,
+        "minHeight": 480,
+        "resizable": true,
+        "decorations": true,
+        "visible": false
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; frame-src 'self'"
     }
   },
   "bundle": {

--- a/apps/yerd-gui/src/App.vue
+++ b/apps/yerd-gui/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { onMounted, onUnmounted, ref } from "vue";
-import { useRouter } from "vue-router";
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
 
 import AppShell from "@/components/AppShell.vue";
 import Spinner from "@/components/ui/Spinner.vue";
@@ -21,8 +21,14 @@ import {
 // Start the single shared daemon poller for the app's lifetime.
 const { start, stop, refresh } = useDaemon();
 const router = useRouter();
+const route = useRoute();
 const toast = useToast();
 let unlistenNav: UnlistenFn | undefined;
+
+// The separate Mails viewer window loads a `standalone` route: it must render
+// bare (no sidebar/titlebar) and must NOT spin up a second daemon poller or the
+// first-run install flow (the main window owns those).
+const standalone = computed(() => route.meta.standalone === true);
 
 // First-load auto-install of yerdd. A module-level guard keeps it to one run.
 let autoInstallDone = false;
@@ -73,6 +79,9 @@ async function maybeAutoInstall(): Promise<void> {
 }
 
 onMounted(async () => {
+  // The viewer window shares this SPA bundle but must not duplicate the poller,
+  // the tray-nav listener, or the install flow — those belong to the main window.
+  if (standalone.value) return;
   start(4000);
   // The tray's "go to <page>" items emit `navigate` with a route path (e.g.
   // "/sites") after showing the window; jump the router there.
@@ -83,13 +92,16 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  if (standalone.value) return;
   stop();
   unlistenNav?.();
 });
 </script>
 
 <template>
-  <AppShell />
+  <!-- Standalone routes (the Mails viewer window) render bare — no shell. -->
+  <RouterView v-if="standalone" />
+  <AppShell v-else />
   <Toaster />
 
   <!-- First-run yerdd install overlay. -->

--- a/apps/yerd-gui/src/components/SideNav.vue
+++ b/apps/yerd-gui/src/components/SideNav.vue
@@ -2,6 +2,7 @@
 import {
   Info,
   LayoutGrid,
+  Mail,
   Server,
   Settings,
   SquareCode,
@@ -24,6 +25,7 @@ const items = [
   { to: "/php", label: "PHP", icon: SquareCode, chip: GREY },
   { to: "/sites", label: "Sites", icon: LayoutGrid, chip: GREY },
   { to: "/services", label: "Services", icon: Server, chip: RED },
+  { to: "/mail", label: "Mail", icon: Mail, chip: RED },
   { to: "/doctor", label: "Doctor", icon: Stethoscope, chip: BLUE },
   { to: "/about", label: "About", icon: Info, chip: BLUE },
 ];

--- a/apps/yerd-gui/src/components/TitleBar.vue
+++ b/apps/yerd-gui/src/components/TitleBar.vue
@@ -6,6 +6,14 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 // titlebar. It's a `data-tauri-drag-region`, giving native click-drag-to-move
 // and double-click-to-zoom for free; the controls below opt out by being their
 // own (non-drag) elements. Identical on macOS and Linux by design.
+//
+// `title` lets a secondary window (the Mails viewer) reuse this bar with its own
+// caption; the optional `actions` slot draws window-scoped buttons on the right
+// (outside the drag region, so they stay clickable).
+withDefaults(defineProps<{ title?: string }>(), { title: "Yerd" });
+
+// Controls always target the window this titlebar is mounted in, so the one
+// component drives both the main window and the Mails window.
 const win = getCurrentWindow();
 
 // Close mirrors the native red button: main.rs intercepts CloseRequested and
@@ -59,7 +67,12 @@ function toggleMaximize() {
     <span
       class="pointer-events-none absolute left-1/2 -translate-x-1/2 text-xs font-medium text-muted-foreground"
     >
-      Yerd
+      {{ title }}
     </span>
+
+    <!-- Window-scoped actions (e.g. the Mails "clear all" button), right-aligned. -->
+    <div class="ml-auto flex items-center gap-1">
+      <slot name="actions" />
+    </div>
   </header>
 </template>

--- a/apps/yerd-gui/src/ipc/client.test.ts
+++ b/apps/yerd-gui/src/ipc/client.test.ts
@@ -7,9 +7,13 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 import {
+  clearMails,
+  getMail,
   IpcError,
+  listMails,
   listPhp,
   listSites,
+  setMailPort,
   status,
   unlink,
   updatePhp,
@@ -55,6 +59,50 @@ describe("client → command mapping", () => {
     invokeMock.mockResolvedValue({ type: "ok" });
     await updatePhp(null);
     expect(invokeMock).toHaveBeenCalledWith("update_php", { version: null });
+  });
+
+  it("listMails unwraps the mails array", async () => {
+    invokeMock.mockResolvedValue({
+      type: "mails",
+      mails: [
+        {
+          id: "000001",
+          from: "a@b.c",
+          to: ["d@e.f"],
+          subject: "Hi",
+          date_epoch: 1700000000,
+        },
+      ],
+    });
+    const r = await listMails();
+    expect(r).toHaveLength(1);
+    expect(r[0].subject).toBe("Hi");
+    expect(invokeMock).toHaveBeenCalledWith("list_mails", undefined);
+  });
+
+  it("getMail returns the inner detail", async () => {
+    const mail = {
+      id: "000001",
+      from: "a@b.c",
+      to: ["d@e.f"],
+      subject: "Hi",
+      date_epoch: 0,
+      headers: [],
+      html_body: "<p>Hi</p>",
+      text_body: null,
+    };
+    invokeMock.mockResolvedValue({ type: "mail", mail });
+    await expect(getMail("000001")).resolves.toEqual(mail);
+    expect(invokeMock).toHaveBeenCalledWith("get_mail", { id: "000001" });
+  });
+
+  it("setMailPort sends the port; clearMails takes no args", async () => {
+    invokeMock.mockResolvedValue({ type: "ok" });
+    await setMailPort(2525);
+    expect(invokeMock).toHaveBeenCalledWith("set_mail_port", { port: 2525 });
+    invokeMock.mockResolvedValue({ type: "ok" });
+    await clearMails();
+    expect(invokeMock).toHaveBeenCalledWith("clear_mails", undefined);
   });
 });
 

--- a/apps/yerd-gui/src/ipc/client.test.ts
+++ b/apps/yerd-gui/src/ipc/client.test.ts
@@ -8,11 +8,13 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 import {
   clearMails,
+  deleteMails,
   getMail,
   IpcError,
   listMails,
   listPhp,
   listSites,
+  setMailEnabled,
   setMailPort,
   status,
   unlink,
@@ -103,6 +105,17 @@ describe("client → command mapping", () => {
     invokeMock.mockResolvedValue({ type: "ok" });
     await clearMails();
     expect(invokeMock).toHaveBeenCalledWith("clear_mails", undefined);
+  });
+
+  it("deleteMails sends the id list; setMailEnabled sends the flag", async () => {
+    invokeMock.mockResolvedValue({ type: "ok" });
+    await deleteMails(["000001", "000002"]);
+    expect(invokeMock).toHaveBeenCalledWith("delete_mails", {
+      ids: ["000001", "000002"],
+    });
+    invokeMock.mockResolvedValue({ type: "ok" });
+    await setMailEnabled(true);
+    expect(invokeMock).toHaveBeenCalledWith("set_mail_enabled", { enabled: true });
   });
 });
 

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -307,6 +307,11 @@ export async function clearMails(): Promise<void> {
   ensureOk(await call<Response>("clear_mails"));
 }
 
+/** Delete a specific set of captured emails by id (e.g. one application's mail). */
+export async function deleteMails(ids: string[]): Promise<void> {
+  ensureOk(await call<Response>("delete_mails", { ids }));
+}
+
 /** Persist the mail-capture SMTP port; takes effect on the next daemon restart. */
 export async function setMailPort(port: number): Promise<void> {
   ensureOk(await call<Response>("set_mail_port", { port }));

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -16,6 +16,8 @@ import type {
   DoctorFixResponse,
   ElevateTarget,
   InfoResponse,
+  MailDetail,
+  MailSummary,
   PhpVersion,
   PhpVersionsResponse,
   Response,
@@ -283,6 +285,41 @@ export async function restoreDatabase(
   path: string,
 ): Promise<void> {
   ensureOk(await call<Response>("restore_database", { service, name, path }));
+}
+
+// ── mail capture ─────────────────────────────────────────────────────────────
+
+/** Captured email metadata, newest first. */
+export async function listMails(): Promise<MailSummary[]> {
+  const r = ensureOk(await call<Response>("list_mails"));
+  return r.type === "mails" ? r.mails : [];
+}
+
+/** One captured email's full decoded content (headers + bodies). */
+export async function getMail(id: string): Promise<MailDetail> {
+  const r = ensureOk(await call<Response>("get_mail", { id }));
+  if (r.type !== "mail") throw new IpcError("unexpected response", "internal");
+  return r.mail;
+}
+
+/** Delete every captured email. */
+export async function clearMails(): Promise<void> {
+  ensureOk(await call<Response>("clear_mails"));
+}
+
+/** Persist the mail-capture SMTP port; takes effect on the next daemon restart. */
+export async function setMailPort(port: number): Promise<void> {
+  ensureOk(await call<Response>("set_mail_port", { port }));
+}
+
+/** Enable/disable mail capture; takes effect on the next daemon restart. */
+export async function setMailEnabled(enabled: boolean): Promise<void> {
+  ensureOk(await call<Response>("set_mail_enabled", { enabled }));
+}
+
+/** Open (or focus) the separate Mails viewer window. Host command, not daemon IPC. */
+export async function showMailsWindow(): Promise<void> {
+  await call<void>("show_mails_window");
 }
 
 // ── status / doctor ────────────────────────────────────────────────────────

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -92,6 +92,44 @@ export interface PhpPoolStatus {
   update_available: string | null;
 }
 
+/** crates/yerd-ipc/src/status.rs — MailStatus. */
+export interface MailStatus {
+  enabled: boolean;
+  port: number;
+  /** Whether the SMTP listener actually bound (enabled && !listening = port busy). */
+  listening: boolean;
+  count: number;
+}
+
+/** crates/yerd-ipc/src/status.rs — MailSummary. */
+export interface MailSummary {
+  id: string;
+  from: string;
+  to: string[];
+  subject: string;
+  /** Unix epoch seconds; 0 when the Date header was absent/unparseable. */
+  date_epoch: number;
+}
+
+/** crates/yerd-ipc/src/status.rs — MailHeader. */
+export interface MailHeader {
+  name: string;
+  value: string;
+}
+
+/** crates/yerd-ipc/src/status.rs — MailDetail. */
+export interface MailDetail {
+  id: string;
+  from: string;
+  to: string[];
+  subject: string;
+  date_epoch: number;
+  headers: MailHeader[];
+  /** Decoded text/html body (cid: images already rewritten to data: URLs). */
+  html_body: string | null;
+  text_body: string | null;
+}
+
 export interface StatusReport {
   daemon_pid: number;
   uptime_secs: number;
@@ -129,6 +167,9 @@ export interface StatusReport {
   /** Per-service status. Omitted (undefined) by a daemon with no services
    *  (the Rust field is `#[serde(default, skip_serializing_if)]`). */
   services?: ServiceStatus[];
+  /** Built-in mail-capture status. Omitted (undefined) by a daemon predating
+   *  the feature (the Rust field is `#[serde(default, skip_serializing_if)]`). */
+  mail?: MailStatus | null;
 }
 
 export type Severity = "ok" | "warn" | "fail";
@@ -222,7 +263,9 @@ export type Response =
   | { type: "services"; services: ServiceStatus[] }
   | { type: "available_services"; services: ServiceAvailability[] }
   | { type: "service_logs"; lines: string[] }
-  | { type: "databases"; databases: DatabaseSummary[] };
+  | { type: "databases"; databases: DatabaseSummary[] }
+  | { type: "mails"; mails: MailSummary[] }
+  | { type: "mail"; mail: MailDetail };
 
 /** One user database in a SQL service (mirrors the daemon's `DatabaseSummary`). */
 export interface DatabaseSummary {
@@ -241,6 +284,8 @@ export type DoctorFixResponse = Extract<Response, { type: "doctor_fix" }>;
 export type ServicesResponse = Extract<Response, { type: "services" }>;
 export type AvailableServicesResponse = Extract<Response, { type: "available_services" }>;
 export type ServiceLogsResponse = Extract<Response, { type: "service_logs" }>;
+export type MailsResponse = Extract<Response, { type: "mails" }>;
+export type MailResponse = Extract<Response, { type: "mail" }>;
 
 /** Privilege targets for the OS-elevated `yerd elevate` host command. */
 export type ElevateTarget = "trust" | "resolver" | "ports";

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -168,8 +168,9 @@ export interface StatusReport {
    *  (the Rust field is `#[serde(default, skip_serializing_if)]`). */
   services?: ServiceStatus[];
   /** Built-in mail-capture status. Omitted (undefined) by a daemon predating
-   *  the feature (the Rust field is `#[serde(default, skip_serializing_if)]`). */
-  mail?: MailStatus | null;
+   *  the feature (the Rust field is `#[serde(default, skip_serializing_if)]`, so
+   *  it is never `null` on the wire — mirrors the `services?` convention). */
+  mail?: MailStatus;
 }
 
 export type Severity = "ok" | "warn" | "fail";

--- a/apps/yerd-gui/src/router.ts
+++ b/apps/yerd-gui/src/router.ts
@@ -27,6 +27,19 @@ export const router = createRouter({
       component: () => import("@/views/ServicesView.vue"),
     },
     {
+      path: "/mail",
+      name: "mail",
+      component: () => import("@/views/MailView.vue"),
+    },
+    {
+      // The separate "Mails" window loads this route. `standalone` tells App.vue
+      // to render it bare (no sidebar/titlebar) and skip the daemon poller.
+      path: "/mails-viewer",
+      name: "mails-viewer",
+      meta: { standalone: true },
+      component: () => import("@/views/MailsViewerView.vue"),
+    },
+    {
       path: "/doctor",
       name: "doctor",
       component: () => import("@/views/DoctorView.vue"),

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -147,10 +147,32 @@ function portRow(
   };
 }
 
+function mailRow(r: StatusReport): Row | null {
+  const m = r.mail;
+  if (!m) return null; // daemon predates the mail subsystem
+  let tone: Tone;
+  let state: string;
+  let info: string;
+  if (!m.enabled) {
+    tone = "muted";
+    state = "disabled";
+    info = "enable it on the Mail page · runs inside the daemon process";
+  } else if (m.listening) {
+    tone = "ok";
+    state = "listening";
+    info = `SMTP on 127.0.0.1:${m.port} · ${m.count} captured · runs inside the daemon process`;
+  } else {
+    tone = "warn";
+    state = "not listening";
+    info = `port :${m.port} unavailable · runs inside the daemon process`;
+  }
+  return { key: "mail", name: "Mail capture", tone, state, memory: "—", info, child: true };
+}
+
 const rows = computed<Row[]>(() => {
   const r = report.value;
   if (!r) return [];
-  return [
+  const base: Row[] = [
     {
       key: "daemon",
       name: "Daemon (yerdd)",
@@ -172,6 +194,9 @@ const rows = computed<Row[]>(() => {
     portRow("proxy-http", "Proxy (HTTP)", r, "http"),
     portRow("proxy-https", "Proxy (HTTPS)", r, "https"),
   ];
+  const mail = mailRow(r);
+  if (mail) base.push(mail);
+  return base;
 });
 
 // ── environment (tri-state OS privileges) ──

--- a/apps/yerd-gui/src/views/MailView.vue
+++ b/apps/yerd-gui/src/views/MailView.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { Mail } from "lucide-vue-next";
+import { computed, ref, watch } from "vue";
+
+import PageHeader from "@/components/PageHeader.vue";
+import StatusPill from "@/components/StatusPill.vue";
+import type { Tone } from "@/components/StatusPill.vue";
+import Button from "@/components/ui/Button.vue";
+import Card from "@/components/ui/Card.vue";
+import CardContent from "@/components/ui/CardContent.vue";
+import CardDescription from "@/components/ui/CardDescription.vue";
+import CardHeader from "@/components/ui/CardHeader.vue";
+import CardTitle from "@/components/ui/CardTitle.vue";
+import Input from "@/components/ui/Input.vue";
+import Spinner from "@/components/ui/Spinner.vue";
+import Switch from "@/components/ui/Switch.vue";
+import { useDaemon } from "@/composables/useDaemon";
+import { useToast } from "@/composables/useToast";
+import {
+  IpcError,
+  openInBrowser,
+  setMailEnabled,
+  setMailPort,
+  showMailsWindow,
+} from "@/ipc/client";
+
+const DOCS_URL = "https://yerd.dev/guide/features";
+
+const toast = useToast();
+const { report, refresh } = useDaemon();
+
+// Live mail status comes from the shared 4s status poll (no extra loop).
+const mail = computed(() => report.value?.mail ?? null);
+
+// Local editable copies of the config values, seeded from the live status and
+// re-seeded whenever it changes (unless the user is mid-edit).
+const portInput = ref("");
+const enabled = ref(false);
+const busy = ref(false);
+let dirtyPort = false;
+
+watch(
+  mail,
+  (m) => {
+    if (!m) return;
+    enabled.value = m.enabled;
+    if (!dirtyPort) portInput.value = String(m.port);
+  },
+  { immediate: true },
+);
+
+const statusTone = computed<Tone>(() => {
+  const m = mail.value;
+  if (!m || !m.enabled) return "muted";
+  return m.listening ? "ok" : "warn";
+});
+
+const statusLabel = computed(() => {
+  const m = mail.value;
+  if (!m) return "Unknown";
+  if (!m.enabled) return "Disabled";
+  return m.listening ? "Running" : "Enabled — port unavailable";
+});
+
+async function onToggleEnabled(next: boolean): Promise<void> {
+  busy.value = true;
+  try {
+    await setMailEnabled(next);
+    enabled.value = next;
+    toast.success(
+      next ? "Mail capture enabled" : "Mail capture disabled",
+      "Takes effect after the daemon restarts.",
+    );
+    await refresh();
+  } catch (e) {
+    toast.error("Couldn't update mail capture", (e as IpcError).message);
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onSavePort(): Promise<void> {
+  const port = Number(portInput.value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    toast.error("Invalid port", "Enter a number between 1 and 65535.");
+    return;
+  }
+  busy.value = true;
+  try {
+    await setMailPort(port);
+    dirtyPort = false;
+    toast.success("Mail port saved", "Takes effect after the daemon restarts.");
+    await refresh();
+  } catch (e) {
+    toast.error("Couldn't save the mail port", (e as IpcError).message);
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onShowMails(): Promise<void> {
+  try {
+    await showMailsWindow();
+  } catch (e) {
+    toast.error("Couldn't open the mail viewer", (e as IpcError).message);
+  }
+}
+</script>
+
+<template>
+  <div class="flex h-full flex-col">
+    <PageHeader
+      title="Mail"
+      subtitle="Capture and inspect emails your apps send during development"
+    />
+
+    <div class="flex-1 overflow-y-auto p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle class="flex items-center gap-2">
+            <Mail class="size-4" /> Mail Server
+          </CardTitle>
+          <CardDescription>
+            Yerd runs a local SMTP server that captures every outgoing email so
+            you can preview it here. Point your app's mailer at
+            <code>127.0.0.1</code> on the port below.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-5">
+          <!-- Status -->
+          <div class="flex items-center justify-between border-b pb-4">
+            <div>
+              <p class="text-sm font-medium">Mail Server Status</p>
+              <p class="text-xs text-muted-foreground">
+                {{ mail?.count ?? 0 }} captured email(s)
+              </p>
+            </div>
+            <StatusPill
+              :tone="statusTone"
+              :label="statusLabel"
+              :pulse="statusTone === 'ok'"
+            />
+          </div>
+
+          <!-- Enable toggle -->
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm font-medium">Enabled</p>
+              <p class="text-xs text-muted-foreground">
+                Start the capture server when the daemon boots.
+              </p>
+            </div>
+            <Switch
+              :model-value="enabled"
+              :disabled="busy"
+              aria-label="Enable mail capture"
+              @update:model-value="onToggleEnabled"
+            />
+          </div>
+
+          <!-- Port -->
+          <div>
+            <label class="text-sm font-medium" for="mail-port">Mail Server Port</label>
+            <p class="mb-2 text-xs text-muted-foreground">
+              The port number the mail server will listen on.
+            </p>
+            <div class="flex items-center gap-2">
+              <Input
+                id="mail-port"
+                v-model="portInput"
+                class="max-w-32"
+                placeholder="2525"
+                @input="dirtyPort = true"
+              />
+              <Button variant="outline" size="sm" :disabled="busy" @click="onSavePort">
+                <Spinner v-if="busy" class="size-4" /> Save
+              </Button>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex items-center justify-between border-t pt-4">
+            <Button variant="ghost" size="sm" @click="openInBrowser(DOCS_URL)">
+              Learn how to use Yerd's mailserver
+            </Button>
+            <Button @click="onShowMails">Show Mails</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  </div>
+</template>

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -2,12 +2,14 @@
 import { Inbox, Trash2 } from "lucide-vue-next";
 import { computed, ref, watch } from "vue";
 
+import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
 import Modal from "@/components/ui/Modal.vue";
+import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { usePoll } from "@/composables/usePoll";
 import { useToast } from "@/composables/useToast";
-import { clearMails, getMail, IpcError, listMails } from "@/ipc/client";
+import { clearMails, deleteMails, getMail, IpcError, listMails } from "@/ipc/client";
 import type { MailDetail, MailSummary } from "@/ipc/types";
 
 // The rendered HTML email is sandboxed: no scripts, no same-origin, and a strict
@@ -24,12 +26,55 @@ const detail = ref<MailDetail | null>(null);
 const loadingDetail = ref(false);
 const clearOpen = ref(false);
 const clearing = ref(false);
+// Filter the list to a single application (or "" = all). Laravel sends the app
+// name as the From display name (MAIL_FROM_NAME = config('app.name')); we group
+// by that, falling back to the From email when there's no display name.
+const selectedApp = ref<string>("");
 
 const list = computed<MailSummary[]>(() => mails.value ?? []);
 
-// Auto-select the first message; keep the selection valid as the list changes.
+/** The "application" an email belongs to: its From display name, or — when the
+ *  From has no name — the bare email address. */
+function applicationOf(from: string): string {
+  const named = from.match(/^\s*(.*?)\s*<([^>]+)>\s*$/);
+  if (named) {
+    const name = named[1].replace(/^"|"$/g, "").trim();
+    return name || named[2].trim();
+  }
+  return from.trim();
+}
+
+// Distinct applications present, for the filter dropdown.
+const applications = computed<string[]>(() => {
+  const set = new Set<string>();
+  for (const m of list.value) set.add(applicationOf(m.from));
+  return [...set].sort((a, b) => a.localeCompare(b));
+});
+
+const appOptions = computed(() => [
+  { value: "", label: `All applications (${list.value.length})` },
+  ...applications.value.map((a) => ({ value: a, label: a })),
+]);
+
+// The list narrowed to the selected application.
+const filteredList = computed<MailSummary[]>(() =>
+  selectedApp.value
+    ? list.value.filter((m) => applicationOf(m.from) === selectedApp.value)
+    : list.value,
+);
+
+// If the selected application disappears (e.g. its mail was cleared), fall back
+// to showing everything.
+watch(applications, (apps) => {
+  if (selectedApp.value && !apps.includes(selectedApp.value)) {
+    selectedApp.value = "";
+  }
+});
+
+// Auto-select the first visible message; keep the selection valid as the
+// (filtered) list changes.
 watch(
-  list,
+  filteredList,
   (items) => {
     if (items.length === 0) {
       selectedId.value = null;
@@ -56,17 +101,28 @@ async function select(id: string): Promise<void> {
   }
 }
 
-async function confirmClear(close: () => void): Promise<void> {
+// The delete button is scoped to the current filter: with no application
+// selected it clears everything; with one selected it deletes only that
+// application's currently-shown emails.
+const deleteScopeLabel = computed(() =>
+  selectedApp.value ? `all ${filteredList.value.length} email(s) from “${selectedApp.value}”` : "every captured email",
+);
+
+async function confirmDelete(close: () => void): Promise<void> {
   clearing.value = true;
   try {
-    await clearMails();
+    if (selectedApp.value) {
+      await deleteMails(filteredList.value.map((m) => m.id));
+    } else {
+      await clearMails();
+    }
     selectedId.value = null;
     detail.value = null;
     close();
     await refresh();
-    toast.success("Mailbox cleared");
+    toast.success(selectedApp.value ? "Emails deleted" : "Mailbox cleared");
   } catch (e) {
-    toast.error("Couldn't clear the mailbox", (e as IpcError).message);
+    toast.error("Couldn't delete emails", (e as IpcError).message);
   } finally {
     clearing.value = false;
   }
@@ -84,47 +140,59 @@ function formatDate(epoch: number): string {
 
 <template>
   <div class="flex h-screen flex-col bg-background">
-    <!-- Toolbar -->
-    <header
-      class="flex shrink-0 items-center justify-between border-b px-4 py-2.5"
-    >
-      <h1 class="text-sm font-semibold">Mails</h1>
-      <Button
-        variant="ghost"
-        size="icon"
-        :disabled="list.length === 0"
-        aria-label="Clear all mails"
-        @click="clearOpen = true"
-      >
-        <Trash2 class="size-4" />
-      </Button>
-    </header>
+    <!-- Custom dark titlebar (matches the main window; the window is
+         decorationless), with the clear-all action on the right. -->
+    <TitleBar title="Mails">
+      <template #actions>
+        <!-- Filter to one application (From display name) / from-email. -->
+        <Select
+          v-model="selectedApp"
+          :options="appOptions"
+          :disabled="list.length === 0"
+          aria-label="Filter by application"
+          class="!h-6 max-w-44 text-xs"
+        />
+        <!-- Plain button (not the icon-variant Button) so it sits cleanly in the
+             32px titlebar without overflowing it. -->
+        <button
+          type="button"
+          class="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+          :disabled="filteredList.length === 0"
+          :aria-label="selectedApp ? 'Delete emails for this application' : 'Delete all emails'"
+          @click="clearOpen = true"
+        >
+          <Trash2 class="size-3.5" />
+        </button>
+      </template>
+    </TitleBar>
 
     <div class="flex min-h-0 flex-1">
       <!-- List pane -->
       <aside class="w-72 shrink-0 overflow-y-auto border-r">
         <div
-          v-if="list.length === 0"
+          v-if="filteredList.length === 0"
           class="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-muted-foreground"
         >
           <Inbox class="size-8" />
-          <p class="text-sm">No captured emails yet</p>
+          <p class="text-sm">
+            {{ list.length === 0 ? "No captured emails yet" : "No emails for this application" }}
+          </p>
         </div>
         <ul v-else class="divide-y">
           <li
-            v-for="m in list"
+            v-for="m in filteredList"
             :key="m.id"
             class="cursor-pointer px-3 py-2.5 transition-colors hover:bg-accent/60"
             :class="m.id === selectedId ? 'bg-accent' : ''"
             @click="select(m.id)"
           >
             <div class="flex items-center justify-between gap-2">
-              <span class="truncate text-xs text-muted-foreground">{{ m.from }}</span>
+              <span class="truncate text-xs font-medium">{{ applicationOf(m.from) }}</span>
               <span class="shrink-0 text-[10px] text-muted-foreground">
                 {{ formatDate(m.date_epoch) }}
               </span>
             </div>
-            <p class="mt-0.5 truncate text-sm font-medium">
+            <p class="mt-0.5 truncate text-sm">
               {{ m.subject || "(no subject)" }}
             </p>
           </li>
@@ -191,18 +259,22 @@ function formatDate(epoch: number): string {
       </aside>
     </div>
 
-    <Modal v-model:open="clearOpen" title="Clear all mails?">
+    <Modal
+      v-model:open="clearOpen"
+      :title="selectedApp ? 'Delete these emails?' : 'Clear all mails?'"
+    >
       <p class="text-sm text-muted-foreground">
-        This permanently deletes every captured email. This cannot be undone.
+        This permanently deletes {{ deleteScopeLabel }}. This cannot be undone.
       </p>
       <template #footer="{ close }">
         <Button variant="ghost" @click="close">Cancel</Button>
         <Button
           variant="destructive"
           :disabled="clearing"
-          @click="confirmClear(close)"
+          @click="confirmDelete(close)"
         >
-          <Spinner v-if="clearing" class="size-4" /> Delete all
+          <Spinner v-if="clearing" class="size-4" />
+          {{ selectedApp ? "Delete" : "Delete all" }}
         </Button>
       </template>
     </Modal>

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -24,6 +24,9 @@ const { data: mails, refresh } = usePoll<MailSummary[]>(listMails, 4000);
 const selectedId = ref<string | null>(null);
 const detail = ref<MailDetail | null>(null);
 const loadingDetail = ref(false);
+// Monotonic guard so an out-of-order getMail() response from a superseded
+// select() can't overwrite the body of a newer selection.
+let selectSeq = 0;
 const clearOpen = ref(false);
 const clearing = ref(false);
 // Filter the list to a single application (or "" = all). Laravel sends the app
@@ -89,15 +92,19 @@ watch(
 );
 
 async function select(id: string): Promise<void> {
+  const seq = ++selectSeq;
   selectedId.value = id;
   loadingDetail.value = true;
   try {
-    detail.value = await getMail(id);
+    const mail = await getMail(id);
+    if (seq !== selectSeq) return; // a newer select() superseded this one
+    detail.value = mail;
   } catch (e) {
+    if (seq !== selectSeq) return;
     toast.error("Couldn't open the email", (e as IpcError).message);
     detail.value = null;
   } finally {
-    loadingDetail.value = false;
+    if (seq === selectSeq) loadingDetail.value = false;
   }
 }
 

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -1,0 +1,210 @@
+<script setup lang="ts">
+import { Inbox, Trash2 } from "lucide-vue-next";
+import { computed, ref, watch } from "vue";
+
+import Button from "@/components/ui/Button.vue";
+import Modal from "@/components/ui/Modal.vue";
+import Spinner from "@/components/ui/Spinner.vue";
+import { usePoll } from "@/composables/usePoll";
+import { useToast } from "@/composables/useToast";
+import { clearMails, getMail, IpcError, listMails } from "@/ipc/client";
+import type { MailDetail, MailSummary } from "@/ipc/types";
+
+// The rendered HTML email is sandboxed: no scripts, no same-origin, and a strict
+// child CSP injected into the srcdoc so only inline styles + data: images load.
+const CHILD_CSP = "default-src 'none'; img-src data:; style-src 'unsafe-inline'";
+
+const toast = useToast();
+
+// Live list of captured mail (newest first).
+const { data: mails, refresh } = usePoll<MailSummary[]>(listMails, 4000);
+
+const selectedId = ref<string | null>(null);
+const detail = ref<MailDetail | null>(null);
+const loadingDetail = ref(false);
+const clearOpen = ref(false);
+const clearing = ref(false);
+
+const list = computed<MailSummary[]>(() => mails.value ?? []);
+
+// Auto-select the first message; keep the selection valid as the list changes.
+watch(
+  list,
+  (items) => {
+    if (items.length === 0) {
+      selectedId.value = null;
+      detail.value = null;
+      return;
+    }
+    if (!selectedId.value || !items.some((m) => m.id === selectedId.value)) {
+      void select(items[0].id);
+    }
+  },
+  { immediate: true },
+);
+
+async function select(id: string): Promise<void> {
+  selectedId.value = id;
+  loadingDetail.value = true;
+  try {
+    detail.value = await getMail(id);
+  } catch (e) {
+    toast.error("Couldn't open the email", (e as IpcError).message);
+    detail.value = null;
+  } finally {
+    loadingDetail.value = false;
+  }
+}
+
+async function confirmClear(close: () => void): Promise<void> {
+  clearing.value = true;
+  try {
+    await clearMails();
+    selectedId.value = null;
+    detail.value = null;
+    close();
+    await refresh();
+    toast.success("Mailbox cleared");
+  } catch (e) {
+    toast.error("Couldn't clear the mailbox", (e as IpcError).message);
+  } finally {
+    clearing.value = false;
+  }
+}
+
+function frameSrcdoc(html: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${CHILD_CSP}"></head><body>${html}</body></html>`;
+}
+
+function formatDate(epoch: number): string {
+  if (!epoch) return "—";
+  return new Date(epoch * 1000).toLocaleString();
+}
+</script>
+
+<template>
+  <div class="flex h-screen flex-col bg-background">
+    <!-- Toolbar -->
+    <header
+      class="flex shrink-0 items-center justify-between border-b px-4 py-2.5"
+    >
+      <h1 class="text-sm font-semibold">Mails</h1>
+      <Button
+        variant="ghost"
+        size="icon"
+        :disabled="list.length === 0"
+        aria-label="Clear all mails"
+        @click="clearOpen = true"
+      >
+        <Trash2 class="size-4" />
+      </Button>
+    </header>
+
+    <div class="flex min-h-0 flex-1">
+      <!-- List pane -->
+      <aside class="w-72 shrink-0 overflow-y-auto border-r">
+        <div
+          v-if="list.length === 0"
+          class="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-muted-foreground"
+        >
+          <Inbox class="size-8" />
+          <p class="text-sm">No captured emails yet</p>
+        </div>
+        <ul v-else class="divide-y">
+          <li
+            v-for="m in list"
+            :key="m.id"
+            class="cursor-pointer px-3 py-2.5 transition-colors hover:bg-accent/60"
+            :class="m.id === selectedId ? 'bg-accent' : ''"
+            @click="select(m.id)"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <span class="truncate text-xs text-muted-foreground">{{ m.from }}</span>
+              <span class="shrink-0 text-[10px] text-muted-foreground">
+                {{ formatDate(m.date_epoch) }}
+              </span>
+            </div>
+            <p class="mt-0.5 truncate text-sm font-medium">
+              {{ m.subject || "(no subject)" }}
+            </p>
+          </li>
+        </ul>
+      </aside>
+
+      <!-- Body pane -->
+      <main class="flex min-w-0 flex-1 flex-col">
+        <div
+          v-if="loadingDetail"
+          class="flex flex-1 items-center justify-center"
+        >
+          <Spinner class="size-6" />
+        </div>
+        <template v-else-if="detail">
+          <div class="shrink-0 border-b px-5 py-3">
+            <h2 class="text-base font-semibold">
+              {{ detail.subject || "(no subject)" }}
+            </h2>
+            <p class="mt-1 text-xs text-muted-foreground">
+              <strong>From:</strong> {{ detail.from }}
+            </p>
+            <p class="text-xs text-muted-foreground">
+              <strong>To:</strong> {{ detail.to.join(", ") }}
+            </p>
+            <p class="text-xs text-muted-foreground">
+              {{ formatDate(detail.date_epoch) }}
+            </p>
+          </div>
+          <iframe
+            v-if="detail.html_body"
+            :srcdoc="frameSrcdoc(detail.html_body)"
+            sandbox=""
+            class="min-h-0 flex-1 bg-white"
+            title="Email body"
+          />
+          <pre
+            v-else
+            class="min-h-0 flex-1 overflow-auto whitespace-pre-wrap p-5 text-sm"
+          >{{ detail.text_body || "(empty message)" }}</pre>
+        </template>
+        <div
+          v-else
+          class="flex flex-1 items-center justify-center text-sm text-muted-foreground"
+        >
+          Select an email to read it
+        </div>
+      </main>
+
+      <!-- Headers pane -->
+      <aside
+        v-if="detail"
+        class="w-80 shrink-0 overflow-y-auto border-l bg-muted/30 p-4"
+      >
+        <h3 class="mb-2 text-xs font-semibold uppercase text-muted-foreground">
+          Header
+        </h3>
+        <dl class="space-y-1.5">
+          <div v-for="(h, i) in detail.headers" :key="i" class="text-xs">
+            <dt class="font-medium">{{ h.name }}</dt>
+            <dd class="break-words text-muted-foreground">{{ h.value }}</dd>
+          </div>
+        </dl>
+      </aside>
+    </div>
+
+    <Modal v-model:open="clearOpen" title="Clear all mails?">
+      <p class="text-sm text-muted-foreground">
+        This permanently deletes every captured email. This cannot be undone.
+      </p>
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close">Cancel</Button>
+        <Button
+          variant="destructive"
+          :disabled="clearing"
+          @click="confirmClear(close)"
+        >
+          <Spinner v-if="clearing" class="size-4" /> Delete all
+        </Button>
+      </template>
+    </Modal>
+  </div>
+</template>

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -109,6 +109,12 @@ pub enum Command {
         #[command(subcommand)]
         action: DbAction,
     },
+    /// Inspect emails captured by the built-in mail server.
+    Mail {
+        /// What to do.
+        #[command(subcommand)]
+        action: MailAction,
+    },
     /// Show a snapshot of daemon, proxy, DNS, ports, CA, and PHP health.
     Status,
     /// Diagnose common problems; `yerd doctor fix` attempts safe repairs.
@@ -257,6 +263,20 @@ pub enum DbAction {
         /// Source file to replay (relative paths resolve against your current directory).
         path: PathBuf,
     },
+}
+
+/// Action of `yerd mail`.
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum MailAction {
+    /// List captured emails (newest first).
+    List,
+    /// Show one captured email's headers and body by id.
+    Show {
+        /// The email id (from `yerd mail list`).
+        id: String,
+    },
+    /// Delete every captured email.
+    Clear,
 }
 
 /// Action of `yerd doctor`.

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -437,6 +437,13 @@ fn format_service_state(s: ServiceRunState) -> &'static str {
     }
 }
 
+/// Flatten tab/CR/LF in a value so a folded or multi-line mail header can't
+/// break the tab-separated `yerd mail list` table (the `--json` path needs no
+/// such treatment — serde already escapes control bytes).
+fn flatten_cell(s: &str) -> String {
+    s.replace(['\t', '\r', '\n'], " ")
+}
+
 /// Render `yerd mail list` — a tab-separated table of captured emails.
 fn format_mails(mails: &[yerd_ipc::MailSummary]) -> String {
     if mails.is_empty() {
@@ -445,11 +452,11 @@ fn format_mails(mails: &[yerd_ipc::MailSummary]) -> String {
     let mut out = String::from("ID\tFROM\tSUBJECT");
     for m in mails {
         let subject = if m.subject.is_empty() {
-            "(no subject)"
+            "(no subject)".to_owned()
         } else {
-            &m.subject
+            flatten_cell(&m.subject)
         };
-        let _ = write!(out, "\n{}\t{}\t{}", m.id, m.from, subject);
+        let _ = write!(out, "\n{}\t{}\t{}", m.id, flatten_cell(&m.from), subject);
     }
     out
 }

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -13,7 +13,7 @@ use yerd_ipc::{
     ServiceAvailability, ServiceRunState, ServiceStatus, Severity, StatusReport,
 };
 
-use crate::cli::{Command, DbAction, ServiceAction};
+use crate::cli::{Command, DbAction, MailAction, ServiceAction};
 use crate::error::ClientError;
 
 /// Map a parsed [`Command`] to the wire [`Request`], validating site names and
@@ -119,6 +119,11 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
         Command::Services => Request::ListServices,
         Command::Service { action } => service_request(action),
         Command::Db { action } => db_request(action),
+        Command::Mail { action } => match action {
+            MailAction::List => Request::ListMails,
+            MailAction::Show { id } => Request::GetMail { id: id.clone() },
+            MailAction::Clear => Request::ClearMails,
+        },
         Command::Status => Request::Status,
         Command::Doctor { action: None } => Request::Diagnose,
         Command::Doctor {
@@ -359,6 +364,8 @@ pub fn render(resp: &Response, json: bool) -> Rendered {
                 .collect::<Vec<_>>()
                 .join("\n")
         }),
+        Response::Mails { mails } => Rendered::ok(format_mails(mails)),
+        Response::Mail { mail } => Rendered::ok(format_mail(mail)),
         // `Response` is `#[non_exhaustive]`; a future variant from a newer
         // daemon is surfaced benignly rather than panicking.
         _ => Rendered::err("unexpected response from daemon".to_owned()),
@@ -428,6 +435,39 @@ fn format_service_state(s: ServiceRunState) -> &'static str {
         // as "unknown" rather than failing the render.
         _ => "unknown",
     }
+}
+
+/// Render `yerd mail list` — a tab-separated table of captured emails.
+fn format_mails(mails: &[yerd_ipc::MailSummary]) -> String {
+    if mails.is_empty() {
+        return "no captured emails".to_owned();
+    }
+    let mut out = String::from("ID\tFROM\tSUBJECT");
+    for m in mails {
+        let subject = if m.subject.is_empty() {
+            "(no subject)"
+        } else {
+            &m.subject
+        };
+        let _ = write!(out, "\n{}\t{}\t{}", m.id, m.from, subject);
+    }
+    out
+}
+
+/// Render `yerd mail show <id>` — headers followed by the text body (falling
+/// back to a note when only an HTML body is present).
+fn format_mail(mail: &yerd_ipc::MailDetail) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "From:    {}", mail.from);
+    let _ = writeln!(out, "To:      {}", mail.to.join(", "));
+    let _ = writeln!(out, "Subject: {}", mail.subject);
+    out.push('\n');
+    match (&mail.text_body, &mail.html_body) {
+        (Some(text), _) => out.push_str(text),
+        (None, Some(_)) => out.push_str("(HTML-only message — open it in the GUI viewer)"),
+        (None, None) => out.push_str("(empty message)"),
+    }
+    out
 }
 
 fn format_services(services: &[ServiceStatus]) -> String {
@@ -1275,6 +1315,7 @@ mod tests {
             load_avg: Some([152, 48, 5]),
             daemon_version: "2.0.1".into(),
             services: vec![],
+            mail: None,
         }
     }
 

--- a/bin/yerdd/Cargo.toml
+++ b/bin/yerdd/Cargo.toml
@@ -27,6 +27,7 @@ yerd-services  = { path = "../../crates/yerd-services" }
 yerd-supervise = { path = "../../crates/yerd-supervise" }
 yerd-proxy     = { path = "../../crates/yerd-proxy" }
 yerd-doctor    = { path = "../../crates/yerd-doctor" }
+yerd-mail      = { path = "../../crates/yerd-mail" }
 thiserror      = { workspace = true }
 async-trait    = { workspace = true }
 clap           = { workspace = true }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -202,6 +202,23 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
             let dl = crate::php_install::ReqwestDownloader::new();
             crate::services::change_service_version(&service, &version, state, &dl).await
         }
+        Request::ListMails => Response::Mails {
+            mails: state.mail_store.list().await,
+        },
+        Request::GetMail { id } => match state.mail_store.get(&id).await {
+            Ok(Some(mail)) => Response::Mail { mail },
+            Ok(None) => Response::Error {
+                code: ErrorCode::NotFound,
+                message: format!("no captured mail with id {id}"),
+            },
+            Err(e) => internal(format!("mail read failed: {e}")),
+        },
+        Request::ClearMails => match state.mail_store.clear().await {
+            Ok(()) => Response::Ok,
+            Err(e) => internal(format!("mail clear failed: {e}")),
+        },
+        Request::SetMailPort { port } => set_mail_port(port, state).await,
+        Request::SetMailEnabled { enabled } => set_mail_enabled(enabled, state).await,
         // `Request` is `#[non_exhaustive]` (external crate): a wildcard is
         // required even though every known variant is handled above.
         _ => Response::Error {
@@ -419,6 +436,12 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
         load_avg,
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
         services: crate::services::service_statuses(state).await,
+        mail: Some(yerd_ipc::MailStatus {
+            enabled: state.mail.enabled,
+            port: state.mail.port,
+            listening: state.mail.listening,
+            count: state.mail_store.count().await,
+        }),
     }
 }
 
@@ -723,6 +746,41 @@ async fn set_default_php(version: yerd_core::PhpVersion, state: &DaemonState) ->
     }
     *cfg_guard = new;
     tracing::info!(version = %version, "set default PHP");
+    Response::Ok
+}
+
+/// Set the mail-capture SMTP port. Persisted to config; takes effect on the next
+/// daemon start/restart (no hot rebind), matching `SetServicePort`. Modelled on
+/// `set_default_php` (clone → set → save → commit under the config mutex).
+async fn set_mail_port(port: u16, state: &DaemonState) -> Response {
+    if port == 0 {
+        return Response::Error {
+            code: ErrorCode::InvalidPath,
+            message: "mail port must be non-zero".into(),
+        };
+    }
+    let mut cfg_guard = state.config.lock().await;
+    let mut new = cfg_guard.clone();
+    new.mail.port = port;
+    if let Err(e) = new.save(&state.config_path) {
+        return internal(format!("config save failed: {e}"));
+    }
+    *cfg_guard = new;
+    tracing::info!(port, "set mail port (effective on next restart)");
+    Response::Ok
+}
+
+/// Enable or disable mail capture. Persisted to config; takes effect on the next
+/// daemon start/restart.
+async fn set_mail_enabled(enabled: bool, state: &DaemonState) -> Response {
+    let mut cfg_guard = state.config.lock().await;
+    let mut new = cfg_guard.clone();
+    new.mail.enabled = enabled;
+    if let Err(e) = new.save(&state.config_path) {
+        return internal(format!("config save failed: {e}"));
+    }
+    *cfg_guard = new;
+    tracing::info!(enabled, "set mail enabled (effective on next restart)");
     Response::Ok
 }
 
@@ -1081,6 +1139,14 @@ mod tests {
             service_manager: std::sync::Arc::new(Mutex::new(crate::services::new_manager(
                 dirs_in(tmp),
             ))),
+            mail_store: std::sync::Arc::new(
+                yerd_mail::Store::open(tmp.join("mail")).unwrap(),
+            ),
+            mail: crate::state::MailRuntime {
+                enabled: false,
+                port: yerd_config::DEFAULT_MAIL_PORT,
+                listening: false,
+            },
             http: yerd_ipc::PortStatus {
                 requested: 80,
                 bound: 8080,
@@ -1107,6 +1173,99 @@ mod tests {
             dispatch(Request::Ping, &state).await,
             Response::Pong
         ));
+    }
+
+    const SAMPLE_EML: &[u8] = b"From: Example <hello@example.com>\r\n\
+To: test@test.com\r\n\
+Subject: Captured\r\n\r\nhi\r\n";
+
+    #[tokio::test]
+    async fn dispatch_list_mails_empty_then_populated_then_cleared() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+
+        // Empty.
+        match dispatch(Request::ListMails, &state).await {
+            Response::Mails { mails } => assert!(mails.is_empty()),
+            other => panic!("expected Mails, got {other:?}"),
+        }
+
+        // Capture one directly through the store (the SMTP path is covered in
+        // yerd-mail) and list it.
+        state.mail_store.append(SAMPLE_EML).await.unwrap();
+        let id = match dispatch(Request::ListMails, &state).await {
+            Response::Mails { mails } => {
+                assert_eq!(mails.len(), 1);
+                assert_eq!(mails[0].subject, "Captured");
+                mails[0].id.clone()
+            }
+            other => panic!("expected Mails, got {other:?}"),
+        };
+
+        // Fetch the detail by id.
+        match dispatch(Request::GetMail { id: id.clone() }, &state).await {
+            Response::Mail { mail } => assert_eq!(mail.subject, "Captured"),
+            other => panic!("expected Mail, got {other:?}"),
+        }
+
+        // Unknown id → NotFound.
+        match dispatch(Request::GetMail { id: "999999".into() }, &state).await {
+            Response::Error { code, .. } => assert!(matches!(code, ErrorCode::NotFound)),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+
+        // Clear empties the store.
+        assert!(matches!(
+            dispatch(Request::ClearMails, &state).await,
+            Response::Ok
+        ));
+        match dispatch(Request::ListMails, &state).await {
+            Response::Mails { mails } => assert!(mails.is_empty()),
+            other => panic!("expected empty Mails, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_status_includes_mail() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        match dispatch(Request::Status, &state).await {
+            Response::Status { report } => {
+                let mail = report.mail.expect("status should carry mail");
+                assert!(!mail.enabled);
+                assert_eq!(mail.port, yerd_config::DEFAULT_MAIL_PORT);
+                assert_eq!(mail.count, 0);
+            }
+            other => panic!("expected Status, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_set_mail_port_persists_and_rejects_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+
+        match dispatch(Request::SetMailPort { port: 0 }, &state).await {
+            Response::Error { code, .. } => assert!(matches!(code, ErrorCode::InvalidPath)),
+            other => panic!("expected InvalidPath, got {other:?}"),
+        }
+
+        assert!(matches!(
+            dispatch(Request::SetMailPort { port: 3030 }, &state).await,
+            Response::Ok
+        ));
+        assert_eq!(state.config.lock().await.mail.port, 3030);
+
+        assert!(matches!(
+            dispatch(Request::SetMailEnabled { enabled: true }, &state).await,
+            Response::Ok
+        ));
+        assert!(state.config.lock().await.mail.enabled);
+
+        // Persisted to disk.
+        let reloaded = yerd_config::Config::load(&state.config_path).unwrap();
+        assert_eq!(reloaded.mail.port, 3030);
+        assert!(reloaded.mail.enabled);
     }
 
     #[tokio::test]

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -217,6 +217,10 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
             Ok(()) => Response::Ok,
             Err(e) => internal(format!("mail clear failed: {e}")),
         },
+        Request::DeleteMails { ids } => match state.mail_store.delete_many(&ids).await {
+            Ok(()) => Response::Ok,
+            Err(e) => internal(format!("mail delete failed: {e}")),
+        },
         Request::SetMailPort { port } => set_mail_port(port, state).await,
         Request::SetMailEnabled { enabled } => set_mail_enabled(enabled, state).await,
         // `Request` is `#[non_exhaustive]` (external crate): a wildcard is

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -206,7 +206,9 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
             mails: state.mail_store.list().await,
         },
         Request::GetMail { id } => match state.mail_store.get(&id).await {
-            Ok(Some(mail)) => Response::Mail { mail },
+            Ok(Some(mail)) => Response::Mail {
+                mail: Box::new(mail),
+            },
             Ok(None) => Response::Error {
                 code: ErrorCode::NotFound,
                 message: format!("no captured mail with id {id}"),
@@ -317,10 +319,20 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
         counts
     };
 
-    // 2. Config lock → tld + default PHP (dropped).
-    let (tld, default_php) = {
+    // 2. Config lock → tld + default PHP + the *configured* mail enabled/port
+    // (dropped). Sourcing mail enabled/port from config (not the startup
+    // snapshot) means `SetMailPort`/`SetMailEnabled` are reflected in `Status`
+    // immediately, so the GUI can confirm a save; `listening` below still comes
+    // from the runtime snapshot, so an enabled-but-not-yet-bound state (a change
+    // pending the next restart) reads as `enabled && !listening`.
+    let (tld, default_php, mail_enabled, mail_port) = {
         let cfg = state.config.lock().await;
-        (cfg.tld.as_str().to_owned(), cfg.php.default)
+        (
+            cfg.tld.as_str().to_owned(),
+            cfg.php.default,
+            cfg.mail.enabled,
+            cfg.mail.port,
+        )
     };
 
     // 3. PHP manager lock → live pool snapshots (dropped).
@@ -441,8 +453,8 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
         services: crate::services::service_statuses(state).await,
         mail: Some(yerd_ipc::MailStatus {
-            enabled: state.mail.enabled,
-            port: state.mail.port,
+            enabled: mail_enabled,
+            port: mail_port,
             listening: state.mail.listening,
             count: state.mail_store.count().await,
         }),
@@ -1142,14 +1154,8 @@ mod tests {
             service_manager: std::sync::Arc::new(Mutex::new(crate::services::new_manager(
                 dirs_in(tmp),
             ))),
-            mail_store: std::sync::Arc::new(
-                yerd_mail::Store::open(tmp.join("mail")).unwrap(),
-            ),
-            mail: crate::state::MailRuntime {
-                enabled: false,
-                port: yerd_config::DEFAULT_MAIL_PORT,
-                listening: false,
-            },
+            mail_store: std::sync::Arc::new(yerd_mail::Store::open(tmp.join("mail")).unwrap()),
+            mail: crate::state::MailRuntime { listening: false },
             http: yerd_ipc::PortStatus {
                 requested: 80,
                 bound: 8080,
@@ -1212,7 +1218,14 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
 
         // Unknown id → NotFound.
-        match dispatch(Request::GetMail { id: "999999".into() }, &state).await {
+        match dispatch(
+            Request::GetMail {
+                id: "999999".into(),
+            },
+            &state,
+        )
+        .await
+        {
             Response::Error { code, .. } => assert!(matches!(code, ErrorCode::NotFound)),
             other => panic!("expected NotFound, got {other:?}"),
         }
@@ -1235,8 +1248,11 @@ Subject: Captured\r\n\r\nhi\r\n";
         match dispatch(Request::Status, &state).await {
             Response::Status { report } => {
                 let mail = report.mail.expect("status should carry mail");
-                assert!(!mail.enabled);
+                // `enabled`/`port` come from the (default) config; `listening` is
+                // the runtime snapshot (false in this test harness).
+                assert!(mail.enabled);
                 assert_eq!(mail.port, yerd_config::DEFAULT_MAIL_PORT);
+                assert!(!mail.listening);
                 assert_eq!(mail.count, 0);
             }
             other => panic!("expected Status, got {other:?}"),

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -755,17 +755,16 @@ async fn set_default_php(version: yerd_core::PhpVersion, state: &DaemonState) ->
 
 /// Set the mail-capture SMTP port. Persisted to config; takes effect on the next
 /// daemon start/restart (no hot rebind), matching `SetServicePort`. Modelled on
-/// `set_default_php` (clone → set → save → commit under the config mutex).
+/// `set_php_settings` (clone → set → validate → save → commit under the config
+/// mutex) so an invalid value (e.g. a zero port) is rejected by the config
+/// validator rather than overloading an unrelated `ErrorCode`.
 async fn set_mail_port(port: u16, state: &DaemonState) -> Response {
-    if port == 0 {
-        return Response::Error {
-            code: ErrorCode::InvalidPath,
-            message: "mail port must be non-zero".into(),
-        };
-    }
     let mut cfg_guard = state.config.lock().await;
     let mut new = cfg_guard.clone();
     new.mail.port = port;
+    if let Err(e) = new.validate() {
+        return internal(format!("config validation failed: {e}"));
+    }
     if let Err(e) = new.save(&state.config_path) {
         return internal(format!("config save failed: {e}"));
     }
@@ -1249,9 +1248,11 @@ Subject: Captured\r\n\r\nhi\r\n";
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
 
+        // A zero port is rejected by the config validator (mapped to Internal),
+        // not by overloading a path/port code.
         match dispatch(Request::SetMailPort { port: 0 }, &state).await {
-            Response::Error { code, .. } => assert!(matches!(code, ErrorCode::InvalidPath)),
-            other => panic!("expected InvalidPath, got {other:?}"),
+            Response::Error { code, .. } => assert!(matches!(code, ErrorCode::Internal)),
+            other => panic!("expected Error, got {other:?}"),
         }
 
         assert!(matches!(

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -155,6 +155,17 @@ async fn run_until_shutdown(
         tokio::spawn(crate::fs_watch::run(state, rx))
     };
 
+    // Mail-capture SMTP task (the 6th subsystem). Present only when capture is
+    // enabled AND the port bound at startup; otherwise nothing is spawned (a
+    // disabled/failed bind is non-fatal — already logged in `bring_up`).
+    let mail_handle = daemon.mail_listener.map(|listener| {
+        let store = daemon.state.mail_store.clone();
+        let mut rx = shutdown_rx.clone();
+        tokio::spawn(yerd_mail::serve(listener, store, async move {
+            let _ = rx.changed().await;
+        }))
+    });
+
     // Auto-start enabled services in the background — deliberately NOT awaited,
     // so a slow/failing DB cold-boot never delays the listeners above. Each
     // engine's outcome is logged inside the task.
@@ -174,6 +185,9 @@ async fn run_until_shutdown(
     let _ = tokio::time::timeout(Duration::from_secs(5), ipc_handle).await;
     let _ = tokio::time::timeout(Duration::from_secs(5), update_check_handle).await;
     let _ = tokio::time::timeout(Duration::from_secs(5), watch_handle).await;
+    if let Some(mail_handle) = mail_handle {
+        let _ = tokio::time::timeout(Duration::from_secs(5), mail_handle).await;
+    }
 
     {
         let mut mgr = daemon.php_manager.lock().await;

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -200,12 +200,13 @@ pub async fn bring_up_with_dirs(
     // not-listening rather than aborting the whole daemon.
     let mail_enabled = config.mail.enabled;
     let mail_port = config.mail.port;
-    let mail_store = Arc::new(
-        yerd_mail::Store::open(dirs.data.join("mail")).map_err(|e| DaemonError::Io {
-            path: dirs.data.join("mail"),
-            source: std::io::Error::other(e.to_string()),
-        })?,
-    );
+    let mail_store =
+        Arc::new(
+            yerd_mail::Store::open(dirs.data.join("mail")).map_err(|e| DaemonError::Io {
+                path: dirs.data.join("mail"),
+                source: std::io::Error::other(e.to_string()),
+            })?,
+        );
     let mail_listener = if mail_enabled {
         match yerd_mail::bind(mail_port).await {
             Ok(listener) => {
@@ -235,8 +236,6 @@ pub async fn bring_up_with_dirs(
         service_manager,
         mail_store,
         mail: crate::state::MailRuntime {
-            enabled: mail_enabled,
-            port: mail_port,
             listening: mail_listening,
         },
         http: yerd_ipc::PortStatus {

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -67,6 +67,10 @@ pub struct Daemon {
     /// Actual DNS bind address, read back from the kernel after the ephemeral
     /// bind. The resolver installer (post-MVP) wires `.test → this port`.
     pub dns_addr: SocketAddr,
+    /// Bound mail-capture SMTP listener, when capture is enabled and the port was
+    /// free. `None` = disabled, or the bind failed (non-fatal). Consumed when the
+    /// mail task is spawned.
+    pub mail_listener: Option<tokio::net::TcpListener>,
 }
 
 /// Top-level startup: resolve platform dirs, then run the shared
@@ -190,6 +194,34 @@ pub async fn bring_up_with_dirs(
     let dns_addr = dns_bound.local_addr();
     tracing::info!(dns = %dns_addr, "DNS responder bound");
 
+    // Mail-capture store + (optional, non-fatal) SMTP listener. The store always
+    // exists so already-captured mail stays listable even when capture is off; a
+    // bind failure (e.g. the port is busy) is logged and degrades to
+    // not-listening rather than aborting the whole daemon.
+    let mail_enabled = config.mail.enabled;
+    let mail_port = config.mail.port;
+    let mail_store = Arc::new(
+        yerd_mail::Store::open(dirs.data.join("mail")).map_err(|e| DaemonError::Io {
+            path: dirs.data.join("mail"),
+            source: std::io::Error::other(e.to_string()),
+        })?,
+    );
+    let mail_listener = if mail_enabled {
+        match yerd_mail::bind(mail_port).await {
+            Ok(listener) => {
+                tracing::info!(port = mail_port, "mail capture SMTP server bound");
+                Some(listener)
+            }
+            Err(e) => {
+                tracing::warn!(port = mail_port, error = %e, "mail capture disabled: could not bind port");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let mail_listening = mail_listener.is_some();
+
     let state = Arc::new(DaemonState {
         config: Mutex::new(config),
         router,
@@ -201,6 +233,12 @@ pub async fn bring_up_with_dirs(
         php_updates: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         php_manager: php_manager.clone(),
         service_manager,
+        mail_store,
+        mail: crate::state::MailRuntime {
+            enabled: mail_enabled,
+            port: mail_port,
+            listening: mail_listening,
+        },
         http: yerd_ipc::PortStatus {
             requested: cfg_http,
             bound: bound_http,
@@ -234,6 +272,7 @@ pub async fn bring_up_with_dirs(
         ipc_listener,
         dns_bound,
         dns_addr,
+        mail_listener,
     })
 }
 

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -25,16 +25,13 @@ use yerd_proxy::SharedRouter;
 use crate::backend_resolver::DaemonPhpManager;
 use crate::detect_cache::DetectCache;
 
-/// Mail-capture runtime facts captured at startup (the config snapshot plus
-/// whether the listener actually bound). Mutated config (`SetMailPort` /
-/// `SetMailEnabled`) only takes effect on the next start, so these values stay
-/// fixed for the daemon's lifetime — matching service-port semantics.
+/// Mail-capture runtime fact captured at startup: whether the SMTP listener
+/// actually bound. `Status` sources `enabled`/`port` from the live config (so a
+/// `SetMailPort`/`SetMailEnabled` save is reflected immediately), but whether the
+/// server is *actually* bound is a startup property — a config change only takes
+/// effect on the next restart — so it lives here.
 #[derive(Debug, Clone, Copy)]
 pub struct MailRuntime {
-    /// Whether capture was enabled in the config at startup.
-    pub enabled: bool,
-    /// The configured SMTP port.
-    pub port: u16,
     /// Whether the SMTP listener actually bound (and is accepting mail).
     pub listening: bool,
 }

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -25,6 +25,20 @@ use yerd_proxy::SharedRouter;
 use crate::backend_resolver::DaemonPhpManager;
 use crate::detect_cache::DetectCache;
 
+/// Mail-capture runtime facts captured at startup (the config snapshot plus
+/// whether the listener actually bound). Mutated config (`SetMailPort` /
+/// `SetMailEnabled`) only takes effect on the next start, so these values stay
+/// fixed for the daemon's lifetime — matching service-port semantics.
+#[derive(Debug, Clone, Copy)]
+pub struct MailRuntime {
+    /// Whether capture was enabled in the config at startup.
+    pub enabled: bool,
+    /// The configured SMTP port.
+    pub port: u16,
+    /// Whether the SMTP listener actually bound (and is accepting mail).
+    pub listening: bool,
+}
+
 /// Everything the IPC dispatch and proxy share at runtime.
 pub struct DaemonState {
     /// Authoritative on-disk config, mirrored in memory. The mutex serializes
@@ -55,6 +69,14 @@ pub struct DaemonState {
     /// The database/cache service supervisor (Redis/Valkey in Phase 1). Holds
     /// one supervised instance per engine; status/doctor read live state from it.
     pub service_manager: Arc<Mutex<crate::services::DaemonServiceManager>>,
+    /// Captured-mail store (the built-in SMTP sink writes here; IPC reads/clears
+    /// it). Always present even when capture is disabled, so stored mail remains
+    /// listable/clearable after the server is turned off.
+    pub mail_store: Arc<yerd_mail::Store>,
+    /// Mail-capture runtime facts, surfaced in `Status`. `listening` reflects
+    /// whether the SMTP port was actually bound (it can be `enabled && !listening`
+    /// when the port was busy at startup — a non-fatal condition).
+    pub mail: MailRuntime,
     /// HTTP listener: requested vs actually-bound port (reported by `Status`).
     pub http: PortStatus,
     /// HTTPS listener: requested vs actually-bound port (reported by `Status`).

--- a/crates/yerd-config/src/error.rs
+++ b/crates/yerd-config/src/error.rs
@@ -96,6 +96,8 @@ pub enum ValidateErrorReason {
     HttpPortZero,
     /// `ports.https == 0`.
     HttpsPortZero,
+    /// `mail.port == 0` (a bindable loopback port must be non-zero).
+    MailPortZero,
     /// `[services]` contained an instance whose id is not in `KNOWN_SERVICES`.
     UnknownService,
     /// `parked.paths` contained an empty string.
@@ -117,6 +119,7 @@ impl fmt::Display for ValidateErrorReason {
             Self::HttpHttpsPortsEqual => "ports.http and ports.https must differ",
             Self::HttpPortZero => "ports.http must be non-zero",
             Self::HttpsPortZero => "ports.https must be non-zero",
+            Self::MailPortZero => "mail.port must be non-zero",
             Self::UnknownService => "services contains an unrecognised service id",
             Self::ParkedPathEmpty => "parked.paths contains an empty string",
             Self::OverridePathEmpty => "overrides contains an empty path key",
@@ -179,6 +182,7 @@ mod tests {
             ValidateErrorReason::HttpHttpsPortsEqual,
             ValidateErrorReason::HttpPortZero,
             ValidateErrorReason::HttpsPortZero,
+            ValidateErrorReason::MailPortZero,
             ValidateErrorReason::UnknownService,
             ValidateErrorReason::ParkedPathEmpty,
             ValidateErrorReason::OverridePathEmpty,

--- a/crates/yerd-config/src/lib.rs
+++ b/crates/yerd-config/src/lib.rs
@@ -23,8 +23,8 @@ mod serialize;
 
 pub use error::{ConfigError, MigrationErrorReason, ValidateErrorReason};
 pub use schema::{
-    Config, ParkedSection, PhpSection, Ports, ServiceInstance, ServicesSection, SiteOverride,
-    DEFAULT_DNS_PORT,
+    Config, MailSection, ParkedSection, PhpSection, Ports, ServiceInstance, ServicesSection,
+    SiteOverride, DEFAULT_DNS_PORT, DEFAULT_MAIL_PORT,
 };
 
 /// The on-disk schema version this crate writes. Bumped together with a new
@@ -44,4 +44,10 @@ pub use schema::{
 /// service `[services.<id>]` tables ([`ServiceInstance`], carrying version /
 /// port / enabled). The v2→v3 migration rewrites the old array — the first
 /// *structural* migration step (v0→v1 and v1→v2 are bare version bumps).
-pub const CURRENT_VERSION: u32 = 3;
+///
+/// v4 added the optional `[mail]` section ([`MailSection`]) for the built-in
+/// mail-capture SMTP server. It defaults when absent, so a v3 file migrates
+/// forward by a bare version bump; the bump exists so an *older* (v3) binary
+/// rejects a `[mail]`-bearing file cleanly as
+/// [`ConfigError::UnsupportedVersion`] rather than failing on the unknown key.
+pub const CURRENT_VERSION: u32 = 4;

--- a/crates/yerd-config/src/migrate.rs
+++ b/crates/yerd-config/src/migrate.rs
@@ -19,11 +19,16 @@ pub(crate) type MigrationStep = fn(&mut Value) -> Result<(), ConfigError>;
 /// Forward-migration steps, indexed so that **`STEPS[N]` walks `vN → v(N+1)`**.
 /// This matches [`up`], which indexes `STEPS[current]` (== the version being
 /// migrated *from*). Example: a v1 file is migrated by `STEPS[1]`. When
-/// `CURRENT_VERSION == 3`, `STEPS = [v0→v1, v1→v2, v2→v3]`, length 3.
+/// `CURRENT_VERSION == 4`, `STEPS = [v0→v1, v1→v2, v2→v3, v3→v4]`, length 4.
 ///
 /// `STEPS[0]` (v0→v1) is only reachable via a hand-crafted `version = 0` file —
 /// v0 was never written to disk — but it must exist so that `STEPS[1]` does.
-pub(crate) const STEPS: &[MigrationStep] = &[migrate_v0_to_v1, migrate_v1_to_v2, migrate_v2_to_v3];
+pub(crate) const STEPS: &[MigrationStep] = &[
+    migrate_v0_to_v1,
+    migrate_v1_to_v2,
+    migrate_v2_to_v3,
+    migrate_v3_to_v4,
+];
 
 /// `v0 → v1`: bump the version. v0 predates any shipped config, so there is no
 /// structural change to apply.
@@ -62,6 +67,12 @@ fn migrate_v2_to_v3(value: &mut Value) -> Result<(), ConfigError> {
         }
     }
     set_version(value, 3)
+}
+
+/// `v3 → v4`: bump the version. v4 added the optional `[mail]` section, which
+/// defaults when absent, so an in-place version bump is the entire migration.
+fn migrate_v3_to_v4(value: &mut Value) -> Result<(), ConfigError> {
+    set_version(value, 4)
 }
 
 /// Set the top-level `version` key, erroring if the root is not a table.
@@ -134,8 +145,16 @@ mod tests {
     }
 
     #[test]
-    fn current_version_pinned_to_three() {
-        assert_eq!(crate::CURRENT_VERSION, 3);
+    fn current_version_pinned_to_four() {
+        assert_eq!(crate::CURRENT_VERSION, 4);
+    }
+
+    #[test]
+    fn v3_to_v4_is_a_bare_version_bump() {
+        // v4 only adds the optional `[mail]` section; the migration is a bump.
+        let mut v: Value = toml::from_str("version = 3\n").unwrap();
+        migrate_v3_to_v4(&mut v).unwrap();
+        assert_eq!(read_version(&v).unwrap(), 4);
     }
 
     #[test]
@@ -210,7 +229,7 @@ mod tests {
 
     #[test]
     fn up_migrates_v1_to_current_via_steps_index_one() {
-        // A real v1 file is migrated by STEPS[1] then STEPS[2] up to current.
+        // A real v1 file is migrated by STEPS[1], [2], [3]… up to current.
         let mut v: Value = toml::from_str("version = 1").unwrap();
         up(&mut v, 1).unwrap();
         assert_eq!(read_version(&v).unwrap(), crate::CURRENT_VERSION);
@@ -218,7 +237,7 @@ mod tests {
 
     #[test]
     fn up_walks_v0_all_the_way_to_current() {
-        // A hand-crafted v0 file walks STEPS[0], [1], [2] up to current.
+        // A hand-crafted v0 file walks STEPS[0], [1], [2], [3]… up to current.
         let mut v: Value = toml::from_str("version = 0").unwrap();
         up(&mut v, 0).unwrap();
         assert_eq!(read_version(&v).unwrap(), crate::CURRENT_VERSION);

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -310,6 +310,11 @@ fn validate_ports(c: &Config) -> Result<(), ConfigError> {
     if c.ports.http == c.ports.https {
         return Err(ve(ValidateErrorReason::HttpHttpsPortsEqual));
     }
+    // The mail-capture port is bound on `127.0.0.1` when enabled; a zero port is
+    // meaningless (it would bind an ephemeral port no sender could find).
+    if c.mail.port == 0 {
+        return Err(ve(ValidateErrorReason::MailPortZero));
+    }
     Ok(())
 }
 
@@ -692,6 +697,18 @@ php = "not-a-version"
                 reason: ValidateErrorReason::HttpsPortZero,
             }) => {}
             other => panic!("expected HttpsPortZero, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_zero_mail_port() {
+        let mut c = Config::default();
+        c.mail.port = 0;
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::MailPortZero,
+            }) => {}
+            other => panic!("expected MailPortZero, got {other:?}"),
         }
     }
 

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -12,7 +12,9 @@ use std::str::FromStr;
 use serde::Deserialize;
 
 use crate::error::ValidateErrorReason;
-use crate::schema::{Config, ParkedSection, PhpSection, Ports, ServiceInstance, ServicesSection};
+use crate::schema::{
+    Config, MailSection, ParkedSection, PhpSection, Ports, ServiceInstance, ServicesSection,
+};
 use crate::ConfigError;
 
 pub(crate) const KNOWN_SERVICES: &[&str] = &["mysql", "mariadb", "postgres", "redis"];
@@ -43,6 +45,10 @@ struct Wire {
     // migration before deserialisation, so this never sees the old array.
     #[serde(default)]
     services: BTreeMap<String, ServiceInstanceWire>,
+    // v4: built-in mail-capture server. `default` is mandatory (Wire is
+    // `deny_unknown_fields`) so a v1/v2/v3 file with no `[mail]` still parses.
+    #[serde(default)]
+    mail: MailSectionWire,
 }
 
 #[derive(Deserialize)]
@@ -102,6 +108,35 @@ struct ServiceInstanceWire {
 
 fn default_service_enabled() -> bool {
     true
+}
+
+/// The `[mail]` table. Both keys default (off / 2525) so a config written before
+/// v4 — which has no `[mail]` table at all — still deserialises.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MailSectionWire {
+    #[serde(default = "default_mail_enabled")]
+    enabled: bool,
+    #[serde(default = "default_mail_port")]
+    port: u16,
+}
+
+impl Default for MailSectionWire {
+    fn default() -> Self {
+        let m = MailSection::default();
+        Self {
+            enabled: m.enabled,
+            port: m.port,
+        }
+    }
+}
+
+fn default_mail_enabled() -> bool {
+    MailSection::default().enabled
+}
+
+fn default_mail_port() -> u16 {
+    MailSection::default().port
 }
 
 #[derive(Deserialize)]
@@ -233,6 +268,10 @@ impl TryFrom<Wire> for Config {
             s.set_web_subpath(sw.web_subpath);
             linked.push(s);
         }
+        let mail = MailSection {
+            enabled: w.mail.enabled,
+            port: w.mail.port,
+        };
         Ok(Config {
             version: crate::CURRENT_VERSION,
             tld,
@@ -243,6 +282,7 @@ impl TryFrom<Wire> for Config {
             linked,
             overrides,
             services,
+            mail,
         })
     }
 }
@@ -406,7 +446,7 @@ mod tests {
         match Config::from_toml("version = 99\n") {
             Err(ConfigError::UnsupportedVersion {
                 found: 99,
-                current: 3,
+                current: 4,
             }) => {}
             other => panic!("expected UnsupportedVersion, got {other:?}"),
         }

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -49,7 +49,7 @@ pub struct Config {
     pub overrides: BTreeMap<String, SiteOverride>,
     /// Optional services.
     pub services: ServicesSection,
-    /// Built-in mail-capture SMTP server (Herd-style). Off by default.
+    /// Built-in mail-capture SMTP server (Herd-style). Enabled by default.
     pub mail: MailSection,
 }
 

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -271,8 +271,9 @@ pub const DEFAULT_MAIL_PORT: u16 = 2525;
 /// Built-in mail-capture SMTP server settings (see [`Config::mail`]).
 ///
 /// A Herd-style capture sink: it accepts mail on a loopback port and stores it
-/// for inspection in the GUI. Off by default (opt-in, like every other
-/// subsystem); when enabled the daemon binds [`Self::port`] on `127.0.0.1`.
+/// for inspection in the GUI. Enabled by default; when enabled the daemon binds
+/// [`Self::port`] on `127.0.0.1` (a busy port is non-fatal — the daemon logs and
+/// runs with capture not listening).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MailSection {
     /// Whether the daemon starts the capture SMTP server on boot.
@@ -285,7 +286,7 @@ pub struct MailSection {
 impl Default for MailSection {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             port: DEFAULT_MAIL_PORT,
         }
     }

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -49,6 +49,8 @@ pub struct Config {
     pub overrides: BTreeMap<String, SiteOverride>,
     /// Optional services.
     pub services: ServicesSection,
+    /// Built-in mail-capture SMTP server (Herd-style). Off by default.
+    pub mail: MailSection,
 }
 
 impl Default for Config {
@@ -63,6 +65,7 @@ impl Default for Config {
             linked: Vec::new(),
             overrides: BTreeMap::new(),
             services: ServicesSection::default(),
+            mail: MailSection::default(),
         }
     }
 }
@@ -258,6 +261,32 @@ impl Default for ServiceInstance {
             version: None,
             port: None,
             enabled: true,
+        }
+    }
+}
+
+/// Default loopback port for the built-in mail-capture SMTP server.
+pub const DEFAULT_MAIL_PORT: u16 = 2525;
+
+/// Built-in mail-capture SMTP server settings (see [`Config::mail`]).
+///
+/// A Herd-style capture sink: it accepts mail on a loopback port and stores it
+/// for inspection in the GUI. Off by default (opt-in, like every other
+/// subsystem); when enabled the daemon binds [`Self::port`] on `127.0.0.1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MailSection {
+    /// Whether the daemon starts the capture SMTP server on boot.
+    pub enabled: bool,
+    /// Loopback port the capture server listens on. Default:
+    /// [`DEFAULT_MAIL_PORT`].
+    pub port: u16,
+}
+
+impl Default for MailSection {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            port: DEFAULT_MAIL_PORT,
         }
     }
 }

--- a/crates/yerd-config/src/serialize.rs
+++ b/crates/yerd-config/src/serialize.rs
@@ -34,6 +34,13 @@ struct WireSer<'a> {
     // extra tables). `BTreeMap` → deterministic lexicographic table order.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     services: BTreeMap<&'a str, ServiceInstanceSer<'a>>,
+    // v4: built-in mail-capture server (`[mail]`). MUST stay last — it is a
+    // sub-table region, so keeping it after `services` leaves the byte order of
+    // every existing table unchanged. `None` (skipped) when the section equals
+    // its default, so a default config emits no `[mail]` table (byte-shape
+    // goldens assume no extra tables).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mail: Option<MailSectionSer>,
 }
 
 #[derive(Serialize)]
@@ -73,6 +80,14 @@ struct ServiceInstanceSer<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     port: Option<u16>,
     enabled: bool,
+}
+
+/// `[mail]` table. Owned (not borrowed) — the fields are `Copy` scalars, so
+/// there's nothing to borrow. Emitted only when the section is non-default.
+#[derive(Serialize)]
+struct MailSectionSer {
+    enabled: bool,
+    port: u16,
 }
 
 #[derive(Serialize)]
@@ -131,6 +146,16 @@ pub(crate) fn to_toml(c: &Config) -> Result<String, ConfigError> {
                 )
             })
             .collect(),
+        // Emit `[mail]` only when it differs from the default, so a default
+        // config stays minimal (and the byte-shape goldens hold).
+        mail: if c.mail == crate::MailSection::default() {
+            None
+        } else {
+            Some(MailSectionSer {
+                enabled: c.mail.enabled,
+                port: c.mail.port,
+            })
+        },
     };
     toml::to_string_pretty(&w).map_err(Into::into)
 }
@@ -149,9 +174,33 @@ mod tests {
     fn default_to_toml_starts_with_version_line() {
         let s = to_toml(&Config::default()).unwrap();
         assert!(
-            s.starts_with("version = 3\n"),
-            "expected `version = 3` first line; got: {s}"
+            s.starts_with("version = 4\n"),
+            "expected `version = 4` first line; got: {s}"
         );
+    }
+
+    #[test]
+    fn default_config_emits_no_mail_table() {
+        // A default (disabled) mail section must not emit a `[mail]` table.
+        let s = to_toml(&Config::default()).unwrap();
+        assert!(
+            !s.contains("[mail]"),
+            "default config must omit the mail table; got: {s}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn non_default_mail_section_round_trips() {
+        let mut c = Config::default();
+        c.mail = crate::MailSection {
+            enabled: true,
+            port: 3030,
+        };
+        let s = to_toml(&c).unwrap();
+        assert!(s.contains("[mail]"), "enabled mail must emit a table: {s}");
+        let back = Config::from_toml(&s).unwrap();
+        assert_eq!(back, c);
     }
 
     #[test]

--- a/crates/yerd-config/tests/toml_byte_shape.rs
+++ b/crates/yerd-config/tests/toml_byte_shape.rs
@@ -56,8 +56,8 @@ fn populated() -> Config {
 fn default_config_starts_with_version_line() {
     let s = Config::default().to_toml().unwrap();
     assert!(
-        s.starts_with("version = 3\n"),
-        "expected first line `version = 3`; got: {s}"
+        s.starts_with("version = 4\n"),
+        "expected first line `version = 4`; got: {s}"
     );
 }
 
@@ -131,6 +131,16 @@ fn empty_overrides_emit_no_table() {
     assert!(
         !s.contains("[[overrides]]"),
         "empty overrides must omit the table; got: {s}"
+    );
+}
+
+#[test]
+fn default_config_emits_no_mail_table() {
+    // The default (disabled) mail section must not carry a `[mail]` table.
+    let s = Config::default().to_toml().unwrap();
+    assert!(
+        !s.contains("[mail]"),
+        "default mail section must omit the table; got: {s}"
     );
 }
 
@@ -213,7 +223,7 @@ fn service_instance_wire_shape_is_per_service_table() {
     assert_eq!(redis.get("port"), Some(&toml::Value::Integer(6380)));
     // An unset value must be omitted (no `version = ""` noise) — inspect the
     // service's own table, not the whole doc (which carries a top-level
-    // `version = 3` line).
+    // `version = 4` line).
     let mut c2 = Config::default();
     c2.services
         .instances

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -352,6 +352,7 @@ mod tests {
             load_avg: Some([10, 5, 1]),
             daemon_version: "2.0.1".into(),
             services: vec![],
+            mail: None,
         }
     }
 

--- a/crates/yerd-ipc/src/lib.rs
+++ b/crates/yerd-ipc/src/lib.rs
@@ -40,9 +40,9 @@ pub use message::{decode_message, encode_message};
 pub use request::Request;
 pub use response::{ErrorCode, PhpUpdate, Response};
 pub use status::{
-    CaStatus, DatabaseSummary, Diagnosis, DiagnosisCode, FixReport, FixResult, PhpPoolStatus,
-    PoolRunState, PortStatus, ServiceAvailability, ServiceRunState, ServiceStatus, Severity,
-    SiteCounts, StatusReport,
+    CaStatus, DatabaseSummary, Diagnosis, DiagnosisCode, FixReport, FixResult, MailDetail,
+    MailHeader, MailStatus, MailSummary, PhpPoolStatus, PoolRunState, PortStatus,
+    ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts, StatusReport,
 };
 
 /// Re-exports of the shared types that travel on the wire. Consumers

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -256,6 +256,12 @@ pub enum Request {
     },
     /// Delete every captured email.
     ClearMails,
+    /// Delete a specific set of captured emails by id (e.g. all the mail shown
+    /// for one application). Unknown ids are ignored.
+    DeleteMails {
+        /// The email ids to delete.
+        ids: Vec<String>,
+    },
     /// Set the mail-capture SMTP port. Takes effect on the next daemon
     /// start/restart (no implicit hot rebind), like [`Self::SetServicePort`].
     SetMailPort {
@@ -334,6 +340,7 @@ mod variant_name_pinning {
             Request::ListMails => {}
             Request::GetMail { .. } => {}
             Request::ClearMails => {}
+            Request::DeleteMails { .. } => {}
             Request::SetMailPort { .. } => {}
             Request::SetMailEnabled { .. } => {}
         }
@@ -449,6 +456,9 @@ mod variant_name_pinning {
         pin(Request::ListMails);
         pin(Request::GetMail { id: "000001".into() });
         pin(Request::ClearMails);
+        pin(Request::DeleteMails {
+            ids: vec!["000001".into()],
+        });
         pin(Request::SetMailPort { port: 2525 });
         pin(Request::SetMailEnabled { enabled: true });
     }

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -247,6 +247,27 @@ pub enum Request {
         /// The version to switch to.
         version: String,
     },
+    /// List captured emails (metadata only), newest first.
+    ListMails,
+    /// Fetch one captured email's full decoded content by id.
+    GetMail {
+        /// The email id (from [`super::Response::Mails`]).
+        id: String,
+    },
+    /// Delete every captured email.
+    ClearMails,
+    /// Set the mail-capture SMTP port. Takes effect on the next daemon
+    /// start/restart (no implicit hot rebind), like [`Self::SetServicePort`].
+    SetMailPort {
+        /// The new loopback port (must be non-zero).
+        port: u16,
+    },
+    /// Enable or disable the mail-capture server. Takes effect on the next
+    /// daemon start/restart.
+    SetMailEnabled {
+        /// The desired enabled state.
+        enabled: bool,
+    },
 }
 
 #[cfg(test)]
@@ -310,6 +331,11 @@ mod variant_name_pinning {
             Request::BackupDatabase { .. } => {}
             Request::RestoreDatabase { .. } => {}
             Request::ChangeServiceVersion { .. } => {}
+            Request::ListMails => {}
+            Request::GetMail { .. } => {}
+            Request::ClearMails => {}
+            Request::SetMailPort { .. } => {}
+            Request::SetMailEnabled { .. } => {}
         }
     }
 
@@ -420,5 +446,10 @@ mod variant_name_pinning {
             service: "redis".into(),
             version: "9.1.0".into(),
         });
+        pin(Request::ListMails);
+        pin(Request::GetMail { id: "000001".into() });
+        pin(Request::ClearMails);
+        pin(Request::SetMailPort { port: 2525 });
+        pin(Request::SetMailEnabled { enabled: true });
     }
 }

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -454,7 +454,9 @@ mod variant_name_pinning {
             version: "9.1.0".into(),
         });
         pin(Request::ListMails);
-        pin(Request::GetMail { id: "000001".into() });
+        pin(Request::GetMail {
+            id: "000001".into(),
+        });
         pin(Request::ClearMails);
         pin(Request::DeleteMails {
             ids: vec!["000001".into()],

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -135,9 +135,13 @@ pub enum Response {
         mails: Vec<MailSummary>,
     },
     /// Reply to [`crate::Request::GetMail`] — one captured email's full content.
+    ///
+    /// Boxed so the (large) `MailDetail` does not bloat every `Response` value —
+    /// the same treatment as [`Self::Status`]. `Box<T>` serializes transparently,
+    /// so the wire bytes are unchanged.
     Mail {
         /// The decoded email.
-        mail: MailDetail,
+        mail: Box<MailDetail>,
     },
 }
 
@@ -321,7 +325,7 @@ mod variant_name_pinning {
             }],
         });
         pin_response(Response::Mail {
-            mail: crate::status::MailDetail {
+            mail: Box::new(crate::status::MailDetail {
                 id: "000001".into(),
                 from: "Example <hello@example.com>".into(),
                 to: vec!["test@test.com".into()],
@@ -333,7 +337,7 @@ mod variant_name_pinning {
                 }],
                 html_body: Some("<p>Hi</p>".into()),
                 text_body: Some("Hi".into()),
-            },
+            }),
         });
         for c in [
             ErrorCode::NotFound,

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 use yerd_core::{PhpVersion, Site};
 
 use crate::status::{
-    DatabaseSummary, Diagnosis, FixReport, ServiceAvailability, ServiceStatus, StatusReport,
+    DatabaseSummary, Diagnosis, FixReport, MailDetail, MailSummary, ServiceAvailability,
+    ServiceStatus, StatusReport,
 };
 
 // Same rule: no per-field serde renames.
@@ -128,6 +129,16 @@ pub enum Response {
         /// One entry per database, sorted by name.
         databases: Vec<DatabaseSummary>,
     },
+    /// Reply to [`crate::Request::ListMails`] — captured email metadata, newest first.
+    Mails {
+        /// One entry per captured email.
+        mails: Vec<MailSummary>,
+    },
+    /// Reply to [`crate::Request::GetMail`] — one captured email's full content.
+    Mail {
+        /// The decoded email.
+        mail: MailDetail,
+    },
 }
 
 /// An available newer patch for an installed PHP minor.
@@ -197,6 +208,8 @@ mod variant_name_pinning {
             Response::AvailableServices { .. } => {}
             Response::ServiceLogs { .. } => {}
             Response::Databases { .. } => {}
+            Response::Mails { .. } => {}
+            Response::Mail { .. } => {}
         }
     }
 
@@ -212,6 +225,7 @@ mod variant_name_pinning {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)] // one constructor per variant; grows with the enum
     fn touch_every_variant() {
         pin_response(Response::Pong);
         pin_response(Response::Sites { sites: vec![] });
@@ -273,6 +287,7 @@ mod variant_name_pinning {
                 load_avg: Some([100, 50, 25]),
                 daemon_version: "9.9.9".into(),
                 services: vec![],
+                mail: None,
             }),
         });
         pin_response(Response::Diagnoses {
@@ -295,6 +310,30 @@ mod variant_name_pinning {
         pin_response(Response::ServiceLogs { lines: vec![] });
         pin_response(Response::Databases {
             databases: vec![DatabaseSummary { name: "app".into() }],
+        });
+        pin_response(Response::Mails {
+            mails: vec![crate::status::MailSummary {
+                id: "000001".into(),
+                from: "Example <hello@example.com>".into(),
+                to: vec!["test@test.com".into()],
+                subject: "Hi".into(),
+                date_epoch: 1_700_000_000,
+            }],
+        });
+        pin_response(Response::Mail {
+            mail: crate::status::MailDetail {
+                id: "000001".into(),
+                from: "Example <hello@example.com>".into(),
+                to: vec!["test@test.com".into()],
+                subject: "Hi".into(),
+                date_epoch: 1_700_000_000,
+                headers: vec![crate::status::MailHeader {
+                    name: "Subject".into(),
+                    value: "Hi".into(),
+                }],
+                html_body: Some("<p>Hi</p>".into()),
+                text_body: Some("Hi".into()),
+            },
         });
         for c in [
             ErrorCode::NotFound,

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -93,6 +93,79 @@ pub struct StatusReport {
     /// daemon by ignoring nothing (the field simply defaults to empty).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub services: Vec<ServiceStatus>,
+    /// Built-in mail-capture server status. `None` when the daemon predates the
+    /// feature; `#[serde(default, skip_serializing_if)]` keeps the wire additive
+    /// (an older daemon emits unchanged bytes; an older client ignores it).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mail: Option<MailStatus>,
+}
+
+/// Built-in mail-capture SMTP server status, surfaced in [`StatusReport::mail`].
+///
+/// Integer/bool only so the enclosing `Response` keeps its `Eq` derive.
+/// `enabled` and `listening` are distinct: `enabled && !listening` means the
+/// user turned mail on but the port could not be bound (e.g. already in use).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailStatus {
+    /// Whether mail capture is enabled in the config.
+    pub enabled: bool,
+    /// The configured loopback SMTP port.
+    pub port: u16,
+    /// Whether the capture server actually bound the port and is accepting mail.
+    pub listening: bool,
+    /// Number of captured emails currently stored on disk.
+    pub count: u32,
+}
+
+/// One captured email's metadata, returned in [`crate::Response::Mails`].
+///
+/// String/integer only (no `Cow`/lifetimes, no floats) — fully owned so it
+/// crosses the wire and keeps the enclosing `Response`'s `Eq` derive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailSummary {
+    /// Opaque stable id (also the on-disk `<id>.eml` stem).
+    pub id: String,
+    /// The `From:` header, raw display form (e.g. `Example <hello@example.com>`).
+    pub from: String,
+    /// The `To:` recipients, raw display form, one per address.
+    pub to: Vec<String>,
+    /// The `Subject:` header (empty when absent).
+    pub subject: String,
+    /// The message `Date:` as Unix epoch seconds; `0` when unparseable/absent.
+    pub date_epoch: u64,
+}
+
+/// A single decoded header line, for [`MailDetail::headers`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailHeader {
+    /// Header field name (e.g. `Content-Type`).
+    pub name: String,
+    /// Header field value, decoded to UTF-8.
+    pub value: String,
+}
+
+/// One captured email's full decoded content, returned in
+/// [`crate::Response::Mail`]. The bodies are already MIME-decoded (charset +
+/// transfer-encoding) and the HTML body has had `cid:` images rewritten to
+/// `data:` URLs, so a client can render it directly in a sandboxed frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailDetail {
+    /// Opaque stable id (matches the [`MailSummary::id`]).
+    pub id: String,
+    /// The `From:` header, raw display form.
+    pub from: String,
+    /// The `To:` recipients, raw display form.
+    pub to: Vec<String>,
+    /// The `Subject:` header (empty when absent).
+    pub subject: String,
+    /// The message `Date:` as Unix epoch seconds; `0` when unparseable/absent.
+    pub date_epoch: u64,
+    /// All header lines, in the order they appeared.
+    pub headers: Vec<MailHeader>,
+    /// Decoded `text/html` body, when the message has one.
+    pub html_body: Option<String>,
+    /// Decoded `text/plain` body, when the message has one.
+    pub text_body: Option<String>,
 }
 
 /// A listener's requested vs actually-bound port.

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -166,6 +166,7 @@ fn encode_then_decode_response_roundtrip() {
             load_avg: None,
             daemon_version: "2.0.1".into(),
             services: vec![],
+            mail: None,
         }),
     });
     assert_response_roundtrips(Response::Diagnoses {

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -19,8 +19,9 @@ use std::path::PathBuf;
 use yerd_ipc::{
     types::{PhpVersion, Site},
     CaStatus, DatabaseSummary, Diagnosis, DiagnosisCode, ErrorCode, FixReport, FixResult,
-    PhpPoolStatus, PoolRunState, PortStatus, Request, Response, ServiceAvailability,
-    ServiceRunState, ServiceStatus, Severity, SiteCounts, StatusReport,
+    MailDetail, MailHeader, MailStatus, MailSummary, PhpPoolStatus, PoolRunState, PortStatus,
+    Request, Response, ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts,
+    StatusReport,
 };
 
 // ---------- Request ----------
@@ -566,6 +567,9 @@ fn response_status_byte_shape() {
             load_avg: Some([100, 50, 25]),
             daemon_version: "2.0.1".into(),
             services: vec![],
+            // `None` + skip_serializing_if → omitted, so the byte shape is
+            // unchanged from before the mail field existed.
+            mail: None,
         }),
     };
     let s = serde_json::to_string(&r).unwrap();
@@ -665,6 +669,7 @@ fn sample_status_report() -> StatusReport {
         load_avg: None,
         daemon_version: "2.0.1".into(),
         services: vec![],
+        mail: None,
     }
 }
 
@@ -1097,4 +1102,111 @@ fn service_run_state_each_variant_byte_shape() {
     ] {
         assert_eq!(serde_json::to_string(&st).unwrap(), expected);
     }
+}
+
+// ---------- Mail ----------
+
+#[test]
+fn request_list_mails_byte_shape() {
+    let s = serde_json::to_string(&Request::ListMails).unwrap();
+    assert_eq!(s, r#"{"type":"list_mails"}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), Request::ListMails);
+}
+
+#[test]
+fn request_get_mail_byte_shape() {
+    let r = Request::GetMail {
+        id: "000001".into(),
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(s, r#"{"type":"get_mail","id":"000001"}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
+fn request_clear_mails_byte_shape() {
+    let s = serde_json::to_string(&Request::ClearMails).unwrap();
+    assert_eq!(s, r#"{"type":"clear_mails"}"#);
+    assert_eq!(
+        serde_json::from_str::<Request>(&s).unwrap(),
+        Request::ClearMails
+    );
+}
+
+#[test]
+fn request_set_mail_port_byte_shape() {
+    let r = Request::SetMailPort { port: 2525 };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(s, r#"{"type":"set_mail_port","port":2525}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
+fn request_set_mail_enabled_byte_shape() {
+    let r = Request::SetMailEnabled { enabled: true };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(s, r#"{"type":"set_mail_enabled","enabled":true}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
+fn response_mails_byte_shape() {
+    let r = Response::Mails {
+        mails: vec![MailSummary {
+            id: "000001".into(),
+            from: "Example <hello@example.com>".into(),
+            to: vec!["test@test.com".into()],
+            subject: "Hi".into(),
+            date_epoch: 1_700_000_000,
+        }],
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    let expected = r#"{"type":"mails","mails":[{"id":"000001","from":"Example <hello@example.com>","to":["test@test.com"],"subject":"Hi","date_epoch":1700000000}]}"#;
+    assert_eq!(s, expected);
+    assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+}
+
+#[test]
+fn response_mail_byte_shape() {
+    let r = Response::Mail {
+        mail: MailDetail {
+            id: "000001".into(),
+            from: "Example <hello@example.com>".into(),
+            to: vec!["test@test.com".into()],
+            subject: "Hi".into(),
+            date_epoch: 1_700_000_000,
+            headers: vec![MailHeader {
+                name: "Subject".into(),
+                value: "Hi".into(),
+            }],
+            html_body: Some("<p>Hi</p>".into()),
+            text_body: None,
+        },
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    let expected = r#"{"type":"mail","mail":{"id":"000001","from":"Example <hello@example.com>","to":["test@test.com"],"subject":"Hi","date_epoch":1700000000,"headers":[{"name":"Subject","value":"Hi"}],"html_body":"<p>Hi</p>","text_body":null}}"#;
+    assert_eq!(s, expected);
+    assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+}
+
+#[test]
+fn status_mail_appears_only_when_some() {
+    // `None` → omitted; `Some` → appended after `services`.
+    let mut report = sample_status_report();
+    let s = serde_json::to_string(&report).unwrap();
+    assert!(!s.contains("mail"), "empty mail must be omitted: {s}");
+
+    report.mail = Some(MailStatus {
+        enabled: true,
+        port: 2525,
+        listening: true,
+        count: 3,
+    });
+    let s = serde_json::to_string(&report).unwrap();
+    assert!(
+        s.contains(r#""mail":{"enabled":true,"port":2525,"listening":true,"count":3}"#),
+        "{s}"
+    );
+    let back: StatusReport = serde_json::from_str(&s).unwrap();
+    assert_eq!(back, report);
 }

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -1110,7 +1110,10 @@ fn service_run_state_each_variant_byte_shape() {
 fn request_list_mails_byte_shape() {
     let s = serde_json::to_string(&Request::ListMails).unwrap();
     assert_eq!(s, r#"{"type":"list_mails"}"#);
-    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), Request::ListMails);
+    assert_eq!(
+        serde_json::from_str::<Request>(&s).unwrap(),
+        Request::ListMails
+    );
 }
 
 #[test]
@@ -1179,7 +1182,7 @@ fn response_mails_byte_shape() {
 #[test]
 fn response_mail_byte_shape() {
     let r = Response::Mail {
-        mail: MailDetail {
+        mail: Box::new(MailDetail {
             id: "000001".into(),
             from: "Example <hello@example.com>".into(),
             to: vec!["test@test.com".into()],
@@ -1191,7 +1194,7 @@ fn response_mail_byte_shape() {
             }],
             html_body: Some("<p>Hi</p>".into()),
             text_body: None,
-        },
+        }),
     };
     let s = serde_json::to_string(&r).unwrap();
     let expected = r#"{"type":"mail","mail":{"id":"000001","from":"Example <hello@example.com>","to":["test@test.com"],"subject":"Hi","date_epoch":1700000000,"headers":[{"name":"Subject","value":"Hi"}],"html_body":"<p>Hi</p>","text_body":null}}"#;

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -1134,6 +1134,16 @@ fn request_clear_mails_byte_shape() {
 }
 
 #[test]
+fn request_delete_mails_byte_shape() {
+    let r = Request::DeleteMails {
+        ids: vec!["000001".into(), "000002".into()],
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(s, r#"{"type":"delete_mails","ids":["000001","000002"]}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
 fn request_set_mail_port_byte_shape() {
     let r = Request::SetMailPort { port: 2525 };
     let s = serde_json::to_string(&r).unwrap();

--- a/crates/yerd-mail/Cargo.toml
+++ b/crates/yerd-mail/Cargo.toml
@@ -14,9 +14,8 @@ serde       = { workspace = true }
 serde_json  = { workspace = true }
 tokio       = { workspace = true, features = ["net", "io-util", "rt", "sync", "time", "macros", "fs"] }
 tracing     = { workspace = true }
-# Pure-Rust MIME parser (no C deps). `full_encoding` pulls `encoding_rs` so
-# non-UTF-8 charsets decode; we do NOT enable its `serde` feature.
-mail-parser = { version = "0.11", default-features = false, features = ["full_encoding"] }
+# Pure-Rust MIME parser (no C deps); features pinned in the workspace table.
+mail-parser = { workspace = true }
 
 [dev-dependencies]
 tokio    = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }

--- a/crates/yerd-mail/Cargo.toml
+++ b/crates/yerd-mail/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name                   = "yerd-mail"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+publish.workspace      = true
+description            = "Built-in mail-capture SMTP server + on-disk store for Yerd (Herd-style)."
+
+[dependencies]
+yerd-ipc    = { path = "../yerd-ipc" }
+thiserror   = { workspace = true }
+serde       = { workspace = true }
+serde_json  = { workspace = true }
+tokio       = { workspace = true, features = ["net", "io-util", "rt", "sync", "time", "macros", "fs"] }
+tracing     = { workspace = true }
+# Pure-Rust MIME parser (no C deps). `full_encoding` pulls `encoding_rs` so
+# non-UTF-8 charsets decode; we do NOT enable its `serde` feature.
+mail-parser = { version = "0.11", default-features = false, features = ["full_encoding"] }
+
+[dev-dependencies]
+tokio    = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/yerd-mail/src/error.rs
+++ b/crates/yerd-mail/src/error.rs
@@ -1,0 +1,30 @@
+//! Error type for the mail-capture subsystem.
+
+use std::io;
+use std::path::PathBuf;
+
+/// Failures from binding the SMTP listener or reading/writing the store.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MailError {
+    /// Could not bind the loopback SMTP port. The daemon treats this as
+    /// non-fatal (logs a warning and runs with capture not listening).
+    #[error("could not bind mail port {port}: {source}")]
+    Bind {
+        /// The port that failed to bind.
+        port: u16,
+        /// The underlying OS error.
+        source: io::Error,
+    },
+    /// A filesystem operation on the store failed.
+    #[error("mail store I/O at {path}: {source}")]
+    Io {
+        /// The path involved.
+        path: PathBuf,
+        /// The underlying OS error.
+        source: io::Error,
+    },
+    /// The on-disk index could not be (de)serialised.
+    #[error("mail store index: {0}")]
+    Index(#[from] serde_json::Error),
+}

--- a/crates/yerd-mail/src/io/mod.rs
+++ b/crates/yerd-mail/src/io/mod.rs
@@ -1,0 +1,4 @@
+//! Side-effecting edges: the tokio SMTP server and the on-disk store.
+
+pub mod server;
+pub mod store;

--- a/crates/yerd-mail/src/io/server.rs
+++ b/crates/yerd-mail/src/io/server.rs
@@ -1,0 +1,195 @@
+//! The tokio SMTP capture server: an accept loop that drives the pure
+//! [`Session`](crate::pure::smtp::Session) per connection and persists each
+//! captured message to the [`Store`].
+
+use std::future::Future;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::error::MailError;
+use crate::io::store::Store;
+use crate::pure::smtp::{Reply, Session};
+
+/// Largest message we will buffer (defensive cap against a runaway sender).
+const MAX_MESSAGE_BYTES: usize = 25 * 1024 * 1024;
+
+/// Bind the capture SMTP listener on `127.0.0.1:<port>`.
+///
+/// # Errors
+/// [`MailError::Bind`] when the port can't be bound (e.g. already in use). The
+/// daemon treats this as non-fatal.
+pub async fn bind(port: u16) -> Result<TcpListener, MailError> {
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    TcpListener::bind(addr)
+        .await
+        .map_err(|source| MailError::Bind { port, source })
+}
+
+/// Accept connections and capture mail until `shutdown` resolves.
+///
+/// `S: Send + 'static` because the daemon `tokio::spawn`s this future.
+pub async fn serve<S>(listener: TcpListener, store: Arc<Store>, shutdown: S) -> Result<(), MailError>
+where
+    S: Future<Output = ()> + Send + 'static,
+{
+    tokio::pin!(shutdown);
+    loop {
+        tokio::select! {
+            biased;
+            () = &mut shutdown => break,
+            accepted = listener.accept() => match accepted {
+                Ok((stream, _peer)) => {
+                    let store = store.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conn(stream, store).await {
+                            tracing::debug!(error = %e, "mail connection ended with error");
+                        }
+                    });
+                }
+                Err(e) => tracing::debug!(error = %e, "mail accept failed"),
+            },
+        }
+    }
+    Ok(())
+}
+
+/// Drive one connection through the SMTP exchange, persisting each completed
+/// `DATA` payload.
+async fn handle_conn(stream: TcpStream, store: Arc<Store>) -> std::io::Result<()> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    write_half.write_all(Session::greeting().as_bytes()).await?;
+
+    let mut session = Session::new();
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        let n = reader.read_until(b'\n', &mut line).await?;
+        if n == 0 {
+            break; // client closed
+        }
+        let text = String::from_utf8_lossy(&line);
+        match session.command(&text) {
+            Reply::Line(r) => write_half.write_all(r.as_bytes()).await?,
+            Reply::Close(r) => {
+                write_half.write_all(r.as_bytes()).await?;
+                break;
+            }
+            Reply::StartData(r) => {
+                write_half.write_all(r.as_bytes()).await?;
+                let data = read_data(&mut reader).await?;
+                let msg = session.finish_data(&data);
+                match store.append(&msg.raw).await {
+                    Ok(()) => write_half.write_all(b"250 OK: queued\r\n").await?,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to store captured mail");
+                        write_half.write_all(b"451 storage error\r\n").await?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read `DATA` lines until the terminating `\r\n.\r\n` (a line that is just
+/// `.`). Returns the body bytes (still dot-stuffed; the session unstuffs them).
+async fn read_data<R>(reader: &mut BufReader<R>) -> std::io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut data = Vec::new();
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        let n = reader.read_until(b'\n', &mut line).await?;
+        if n == 0 {
+            break; // EOF mid-DATA — keep what we have
+        }
+        if line == b".\r\n" || line == b".\n" {
+            break; // end-of-data marker
+        }
+        if data.len() + line.len() > MAX_MESSAGE_BYTES {
+            // For a local capture sink, truncating an oversized message is
+            // acceptable; keep as much of this line as fits, then stop.
+            let take = MAX_MESSAGE_BYTES.saturating_sub(data.len());
+            data.extend_from_slice(line.get(..take).unwrap_or(&line));
+            break;
+        }
+        data.extend_from_slice(&line);
+    }
+    Ok(data)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::items_after_statements
+)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn captures_a_message_over_tcp() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(Store::open(dir.path().to_path_buf()).unwrap());
+        let listener = bind(0).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let serve_store = store.clone();
+        let handle = tokio::spawn(async move {
+            serve(listener, serve_store, async move {
+                let _ = rx.await;
+            })
+            .await
+            .unwrap();
+        });
+
+        // Speak SMTP as a client.
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        let mut buf = [0u8; 256];
+        // greeting
+        let n = client.read(&mut buf).await.unwrap();
+        assert!(buf[..n].starts_with(b"220 "));
+
+        async fn cmd(c: &mut TcpStream, line: &str) {
+            c.write_all(line.as_bytes()).await.unwrap();
+            let mut b = [0u8; 256];
+            let _ = c.read(&mut b).await.unwrap();
+        }
+        cmd(&mut client, "EHLO test\r\n").await;
+        cmd(&mut client, "MAIL FROM:<a@b.c>\r\n").await;
+        cmd(&mut client, "RCPT TO:<d@e.f>\r\n").await;
+        cmd(&mut client, "DATA\r\n").await;
+        client
+            .write_all(b"Subject: Hello\r\n\r\nWorld\r\n.\r\n")
+            .await
+            .unwrap();
+        let mut b = [0u8; 256];
+        let n = client.read(&mut b).await.unwrap();
+        assert!(b[..n].starts_with(b"250 "), "expected 250 after data");
+        cmd(&mut client, "QUIT\r\n").await;
+
+        // Give the spawned per-connection task a moment to persist, then assert.
+        for _ in 0..50 {
+            if store.count().await == 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let list = store.list().await;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].subject, "Hello");
+
+        let _ = tx.send(());
+        let _ = handle.await;
+    }
+}

--- a/crates/yerd-mail/src/io/server.rs
+++ b/crates/yerd-mail/src/io/server.rs
@@ -31,7 +31,11 @@ pub async fn bind(port: u16) -> Result<TcpListener, MailError> {
 /// Accept connections and capture mail until `shutdown` resolves.
 ///
 /// `S: Send + 'static` because the daemon `tokio::spawn`s this future.
-pub async fn serve<S>(listener: TcpListener, store: Arc<Store>, shutdown: S) -> Result<(), MailError>
+pub async fn serve<S>(
+    listener: TcpListener,
+    store: Arc<Store>,
+    shutdown: S,
+) -> Result<(), MailError>
 where
     S: Future<Output = ()> + Send + 'static,
 {
@@ -104,6 +108,7 @@ where
 {
     let mut data = Vec::new();
     let mut line = Vec::new();
+    let mut capped = false;
     loop {
         line.clear();
         let n = reader.read_until(b'\n', &mut line).await?;
@@ -111,14 +116,21 @@ where
             break; // EOF mid-DATA — keep what we have
         }
         if line == b".\r\n" || line == b".\n" {
-            break; // end-of-data marker
+            break; // end-of-data marker — always consumed
+        }
+        // Once oversized, stop *appending* but keep *consuming* lines until the
+        // terminating dot, so the leftover body is never re-read as SMTP commands
+        // (which would desync the connection for any subsequent message).
+        if capped {
+            continue;
         }
         if data.len() + line.len() > MAX_MESSAGE_BYTES {
             // For a local capture sink, truncating an oversized message is
-            // acceptable; keep as much of this line as fits, then stop.
+            // acceptable; keep as much of this line as fits, then drain the rest.
             let take = MAX_MESSAGE_BYTES.saturating_sub(data.len());
             data.extend_from_slice(line.get(..take).unwrap_or(&line));
-            break;
+            capped = true;
+            continue;
         }
         data.extend_from_slice(&line);
     }

--- a/crates/yerd-mail/src/io/store.rs
+++ b/crates/yerd-mail/src/io/store.rs
@@ -53,11 +53,13 @@ impl Store {
             source,
         })?;
         let entries = load_index(&dir)?;
-        let next_id = entries
-            .iter()
-            .filter_map(|e| e.id.parse::<u64>().ok())
-            .max()
-            .map_or(0, |m| m + 1);
+        // Seed the id counter from the max of the index AND any `.eml` on disk.
+        // Scanning the directory too means an `.eml` that was written but never
+        // recorded in `index.json` (e.g. a crash between the two writes) can never
+        // have its id reused, honouring the "ids never reused" guarantee.
+        let max_index = entries.iter().filter_map(|e| e.id.parse::<u64>().ok()).max();
+        let max_disk = max_eml_id(&dir);
+        let next_id = max_index.max(max_disk).map_or(0, |m| m + 1);
         Ok(Self {
             dir,
             cap,
@@ -121,6 +123,25 @@ impl Store {
         Ok(Some(mime::detail(id, &raw)))
     }
 
+    /// Delete a specific set of captured emails by id (others are kept). Unknown
+    /// ids are ignored. The id counter is not reset.
+    ///
+    /// # Errors
+    /// [`MailError::Io`] / [`MailError::Index`] on a filesystem failure.
+    pub async fn delete_many(&self, ids: &[String]) -> Result<(), MailError> {
+        let mut inner = self.inner.lock().await;
+        let remove: std::collections::HashSet<&str> = ids.iter().map(String::as_str).collect();
+        let (drop, keep): (Vec<MailSummary>, Vec<MailSummary>) = std::mem::take(&mut inner.entries)
+            .into_iter()
+            .partition(|e| remove.contains(e.id.as_str()));
+        inner.entries = keep;
+        for e in drop {
+            let p = self.eml_path(&e.id);
+            let _ = tokio::fs::remove_file(&p).await;
+        }
+        self.write_index(&inner.entries).await
+    }
+
     /// Delete every captured email. The id counter is **not** reset, so a later
     /// capture never reuses an id of a cleared message.
     ///
@@ -146,6 +167,21 @@ impl Store {
             .await
             .map_err(|source| MailError::Io { path, source })
     }
+}
+
+/// The largest numeric id among `<id>.eml` files on disk, or `None` if there are
+/// none. Used (with the index) to seed the monotonic id counter so a previously
+/// written `.eml` can never have its id reused after a restart.
+fn max_eml_id(dir: &Path) -> Option<u64> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name();
+            let name = name.to_str()?;
+            name.strip_suffix(".eml")?.parse::<u64>().ok()
+        })
+        .max()
 }
 
 /// Load `index.json` if present; an absent file is an empty store.
@@ -204,6 +240,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_many_removes_only_the_given_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().to_path_buf()).unwrap();
+        for s in ["a", "b", "c"] {
+            store.append(&msg(s)).await.unwrap();
+        }
+        // Delete "a" (000000) and "c" (000002); keep "b" (000001).
+        store
+            .delete_many(&["000000".to_string(), "000002".to_string()])
+            .await
+            .unwrap();
+        let list = store.list().await;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].subject, "b");
+        assert!(!dir.path().join("000000.eml").exists());
+        assert!(dir.path().join("000001.eml").exists());
+        assert!(!dir.path().join("000002.eml").exists());
+        // Unknown ids are ignored.
+        store.delete_many(&["999999".to_string()]).await.unwrap();
+        assert_eq!(store.count().await, 1);
+    }
+
+    #[tokio::test]
     async fn retention_cap_evicts_oldest() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_with_cap(dir.path().to_path_buf(), 2).unwrap();
@@ -232,6 +291,18 @@ mod tests {
         // Next id continues after the loaded max.
         store.append(&msg("Next")).await.unwrap();
         assert_eq!(store.list().await[0].id, "000001");
+    }
+
+    #[tokio::test]
+    async fn next_id_skips_orphaned_eml_not_in_index() {
+        // Simulate a crash between writing an `.eml` and updating index.json: an
+        // orphan `000007.eml` exists with no index entry. A reopened store must
+        // NOT reuse id 7 (or any id ≤ 7).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("000007.eml"), msg("orphan")).unwrap();
+        let store = Store::open(dir.path().to_path_buf()).unwrap();
+        store.append(&msg("fresh")).await.unwrap();
+        assert_eq!(store.list().await[0].id, "000008");
     }
 
     #[tokio::test]

--- a/crates/yerd-mail/src/io/store.rs
+++ b/crates/yerd-mail/src/io/store.rs
@@ -57,7 +57,10 @@ impl Store {
         // Scanning the directory too means an `.eml` that was written but never
         // recorded in `index.json` (e.g. a crash between the two writes) can never
         // have its id reused, honouring the "ids never reused" guarantee.
-        let max_index = entries.iter().filter_map(|e| e.id.parse::<u64>().ok()).max();
+        let max_index = entries
+            .iter()
+            .filter_map(|e| e.id.parse::<u64>().ok())
+            .max();
         let max_disk = max_eml_id(&dir);
         let next_id = max_index.max(max_disk).map_or(0, |m| m + 1);
         Ok(Self {
@@ -160,10 +163,21 @@ impl Store {
         self.dir.join(format!("{id}.eml"))
     }
 
+    /// Persist the index atomically: write a sibling temp file, then rename it
+    /// over `index.json`. A crash or partial write can therefore never leave a
+    /// truncated/corrupt index (same write-temp-then-rename discipline as
+    /// `yerd-config`/`yerd-php`). Rename is atomic on the same filesystem.
     async fn write_index(&self, entries: &[MailSummary]) -> Result<(), MailError> {
         let path = self.dir.join("index.json");
+        let tmp = self.dir.join("index.json.tmp");
         let json = serde_json::to_vec_pretty(entries)?;
-        tokio::fs::write(&path, json)
+        tokio::fs::write(&tmp, &json)
+            .await
+            .map_err(|source| MailError::Io {
+                path: tmp.clone(),
+                source,
+            })?;
+        tokio::fs::rename(&tmp, &path)
             .await
             .map_err(|source| MailError::Io { path, source })
     }
@@ -185,10 +199,23 @@ fn max_eml_id(dir: &Path) -> Option<u64> {
 }
 
 /// Load `index.json` if present; an absent file is an empty store.
+///
+/// A **corrupt** index (truncated/garbled JSON, e.g. from a crash mid-write on a
+/// pre-atomic-write store) is treated as recoverable, NOT fatal: the index is
+/// only a cache — the `.eml` files are the source of truth and `max_eml_id`
+/// reseeds the id counter from them — so we log a warning and start from empty
+/// rather than aborting `Store::open` (which would otherwise take down the whole
+/// daemon, since mail capture is meant to be best-effort).
 fn load_index(dir: &Path) -> Result<Vec<MailSummary>, MailError> {
     let path = dir.join("index.json");
     match std::fs::read(&path) {
-        Ok(bytes) => Ok(serde_json::from_slice(&bytes)?),
+        Ok(bytes) => match serde_json::from_slice(&bytes) {
+            Ok(entries) => Ok(entries),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "mail index corrupt; starting empty");
+                Ok(Vec::new())
+            }
+        },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
         Err(source) => Err(MailError::Io { path, source }),
     }

--- a/crates/yerd-mail/src/io/store.rs
+++ b/crates/yerd-mail/src/io/store.rs
@@ -1,0 +1,253 @@
+//! On-disk store of captured emails.
+//!
+//! Layout under the store directory:
+//! - `<id>.eml` — the verbatim captured message (one per email).
+//! - `index.json` — an ordered (oldest-first) list of [`MailSummary`] metadata,
+//!   so listing doesn't re-parse every `.eml`.
+//!
+//! All mutations go through a single [`tokio::sync::Mutex`] so concurrent SMTP
+//! connections appending at once can't lose an index update (advisory file locks
+//! / `fs2` are forbidden by the workspace dep-graph gate). Ids are a monotonic
+//! counter, zero-padded, so they never collide and sort in receipt order.
+
+use std::path::{Path, PathBuf};
+
+use tokio::sync::Mutex;
+use yerd_ipc::{MailDetail, MailSummary};
+
+use crate::error::MailError;
+use crate::pure::{mime, retention};
+
+/// A persistent capture store. Cheap to clone the `Arc` the daemon holds.
+pub struct Store {
+    dir: PathBuf,
+    cap: usize,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    /// Oldest-first metadata cache, mirrored to `index.json`.
+    entries: Vec<MailSummary>,
+    /// Next id to assign. Monotonic; never reused, even across `clear`.
+    next_id: u64,
+}
+
+impl Store {
+    /// Open (creating if absent) a store at `dir`, loading any existing index.
+    /// Uses the default retention cap ([`retention::DEFAULT_CAP`]).
+    ///
+    /// # Errors
+    /// Returns [`MailError::Io`] if the directory can't be created, or
+    /// [`MailError::Index`] if a present `index.json` is corrupt.
+    pub fn open(dir: PathBuf) -> Result<Self, MailError> {
+        Self::open_with_cap(dir, retention::DEFAULT_CAP)
+    }
+
+    /// Open with an explicit retention cap (used by tests).
+    ///
+    /// # Errors
+    /// As [`Self::open`].
+    pub fn open_with_cap(dir: PathBuf, cap: usize) -> Result<Self, MailError> {
+        std::fs::create_dir_all(&dir).map_err(|source| MailError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+        let entries = load_index(&dir)?;
+        let next_id = entries
+            .iter()
+            .filter_map(|e| e.id.parse::<u64>().ok())
+            .max()
+            .map_or(0, |m| m + 1);
+        Ok(Self {
+            dir,
+            cap,
+            inner: Mutex::new(Inner { entries, next_id }),
+        })
+    }
+
+    /// Capture a raw message: write its `.eml`, record its summary, and evict the
+    /// oldest entries beyond the cap.
+    ///
+    /// # Errors
+    /// [`MailError::Io`] / [`MailError::Index`] on a filesystem or serialise failure.
+    pub async fn append(&self, raw: &[u8]) -> Result<(), MailError> {
+        let mut inner = self.inner.lock().await;
+        let id = format!("{:06}", inner.next_id);
+        inner.next_id += 1;
+
+        let eml = self.eml_path(&id);
+        tokio::fs::write(&eml, raw)
+            .await
+            .map_err(|source| MailError::Io { path: eml, source })?;
+
+        inner.entries.push(mime::summary(&id, raw));
+
+        // Evict oldest beyond the cap.
+        let evict = retention::evict_count(inner.entries.len(), self.cap);
+        for old in inner.entries.drain(0..evict).collect::<Vec<_>>() {
+            let p = self.eml_path(&old.id);
+            let _ = tokio::fs::remove_file(&p).await;
+        }
+
+        self.write_index(&inner.entries).await
+    }
+
+    /// All captured emails (metadata only), newest first.
+    pub async fn list(&self) -> Vec<MailSummary> {
+        let inner = self.inner.lock().await;
+        inner.entries.iter().rev().cloned().collect()
+    }
+
+    /// The number of captured emails currently stored.
+    pub async fn count(&self) -> u32 {
+        let inner = self.inner.lock().await;
+        u32::try_from(inner.entries.len()).unwrap_or(u32::MAX)
+    }
+
+    /// Fetch one captured email's full decoded content by id, or `None` if no
+    /// such id is stored.
+    ///
+    /// # Errors
+    /// [`MailError::Io`] if the `.eml` exists in the index but can't be read.
+    pub async fn get(&self, id: &str) -> Result<Option<MailDetail>, MailError> {
+        let inner = self.inner.lock().await;
+        if !inner.entries.iter().any(|e| e.id == id) {
+            return Ok(None);
+        }
+        let eml = self.eml_path(id);
+        let raw = tokio::fs::read(&eml)
+            .await
+            .map_err(|source| MailError::Io { path: eml, source })?;
+        Ok(Some(mime::detail(id, &raw)))
+    }
+
+    /// Delete every captured email. The id counter is **not** reset, so a later
+    /// capture never reuses an id of a cleared message.
+    ///
+    /// # Errors
+    /// [`MailError::Io`] / [`MailError::Index`] on a filesystem failure.
+    pub async fn clear(&self) -> Result<(), MailError> {
+        let mut inner = self.inner.lock().await;
+        for e in inner.entries.drain(..).collect::<Vec<_>>() {
+            let p = self.eml_path(&e.id);
+            let _ = tokio::fs::remove_file(&p).await;
+        }
+        self.write_index(&inner.entries).await
+    }
+
+    fn eml_path(&self, id: &str) -> PathBuf {
+        self.dir.join(format!("{id}.eml"))
+    }
+
+    async fn write_index(&self, entries: &[MailSummary]) -> Result<(), MailError> {
+        let path = self.dir.join("index.json");
+        let json = serde_json::to_vec_pretty(entries)?;
+        tokio::fs::write(&path, json)
+            .await
+            .map_err(|source| MailError::Io { path, source })
+    }
+}
+
+/// Load `index.json` if present; an absent file is an empty store.
+fn load_index(dir: &Path) -> Result<Vec<MailSummary>, MailError> {
+    let path = dir.join("index.json");
+    match std::fs::read(&path) {
+        Ok(bytes) => Ok(serde_json::from_slice(&bytes)?),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(source) => Err(MailError::Io { path, source }),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    fn msg(subject: &str) -> Vec<u8> {
+        format!("From: a@b.c\r\nTo: d@e.f\r\nSubject: {subject}\r\n\r\nbody\r\n").into_bytes()
+    }
+
+    #[tokio::test]
+    async fn append_list_get_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().to_path_buf()).unwrap();
+        store.append(&msg("First")).await.unwrap();
+        store.append(&msg("Second")).await.unwrap();
+
+        let list = store.list().await;
+        assert_eq!(list.len(), 2);
+        // Newest first.
+        assert_eq!(list[0].subject, "Second");
+        assert_eq!(list[1].subject, "First");
+        assert_eq!(store.count().await, 2);
+
+        let detail = store.get(&list[0].id).await.unwrap().unwrap();
+        assert_eq!(detail.subject, "Second");
+        assert!(store.get("999999").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_empties_but_keeps_id_monotonic() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().to_path_buf()).unwrap();
+        store.append(&msg("A")).await.unwrap();
+        store.clear().await.unwrap();
+        assert_eq!(store.count().await, 0);
+        store.append(&msg("B")).await.unwrap();
+        // Id did not reset to 000000.
+        assert_eq!(store.list().await[0].id, "000001");
+    }
+
+    #[tokio::test]
+    async fn retention_cap_evicts_oldest() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_with_cap(dir.path().to_path_buf(), 2).unwrap();
+        for s in ["one", "two", "three"] {
+            store.append(&msg(s)).await.unwrap();
+        }
+        let list = store.list().await;
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].subject, "three");
+        assert_eq!(list[1].subject, "two");
+        // The evicted .eml is gone from disk.
+        assert!(!dir.path().join("000000.eml").exists());
+    }
+
+    #[tokio::test]
+    async fn reopen_loads_existing_index() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let store = Store::open(dir.path().to_path_buf()).unwrap();
+            store.append(&msg("Persisted")).await.unwrap();
+        }
+        let store = Store::open(dir.path().to_path_buf()).unwrap();
+        let list = store.list().await;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].subject, "Persisted");
+        // Next id continues after the loaded max.
+        store.append(&msg("Next")).await.unwrap();
+        assert_eq!(store.list().await[0].id, "000001");
+    }
+
+    #[tokio::test]
+    async fn concurrent_appends_do_not_lose_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(Store::open(dir.path().to_path_buf()).unwrap());
+        let mut handles = Vec::new();
+        for i in 0..20 {
+            let s = store.clone();
+            handles.push(tokio::spawn(async move {
+                s.append(&msg(&format!("m{i}"))).await.unwrap();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(store.count().await, 20);
+    }
+}

--- a/crates/yerd-mail/src/lib.rs
+++ b/crates/yerd-mail/src/lib.rs
@@ -1,0 +1,23 @@
+//! Built-in mail-capture SMTP server and on-disk store for Yerd.
+//!
+//! Herd-style: the daemon runs a tiny SMTP sink on a loopback port; everything
+//! it receives is stored as a raw `.eml` file and surfaced (decoded) to the GUI
+//! for inspection. There is no relaying — captured mail never leaves the box.
+//!
+//! ## Purity boundary
+//!
+//! Like the rest of the workspace, pure logic lives in [`pure`] (the SMTP
+//! command state machine, MIME decoding, retention policy — all sync and
+//! testable with no I/O) and the side-effecting edges live in [`io`] (the tokio
+//! TCP server and the disk store).
+
+#![forbid(unsafe_code)]
+
+pub mod error;
+pub mod io;
+pub mod pure;
+
+pub use error::MailError;
+pub use io::server::{bind, serve};
+pub use io::store::Store;
+pub use pure::smtp::RawMessage;

--- a/crates/yerd-mail/src/pure/mime.rs
+++ b/crates/yerd-mail/src/pure/mime.rs
@@ -78,7 +78,10 @@ fn date_epoch(msg: &Message) -> u64 {
 }
 
 fn render_from(msg: &Message) -> String {
-    render_addresses(msg.from()).into_iter().next().unwrap_or_default()
+    render_addresses(msg.from())
+        .into_iter()
+        .next()
+        .unwrap_or_default()
 }
 
 fn render_to(msg: &Message) -> Vec<String> {
@@ -139,8 +142,7 @@ fn rewrite_cids(msg: &Message, mut html: String) -> String {
 /// Minimal standard-alphabet base64 encoder (no padding-free / URL variants).
 /// Kept local to avoid pulling a base64 dependency for the one inline-image use.
 fn base64_encode(input: &[u8]) -> String {
-    const ALPHABET: &[u8; 64] =
-        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     // Mask to 6 bits then look up; `unwrap_or` keeps it panic-free for clippy.
     let sextet = |v: u32| ALPHABET.get((v & 0x3f) as usize).copied().unwrap_or(b'A') as char;
     let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
@@ -191,7 +193,10 @@ Your OTP is 416063.\r\n";
         assert_eq!(d.subject, "Password Reset");
         assert!(d.text_body.as_deref().unwrap().contains("416063"));
         assert!(d.html_body.is_none());
-        assert!(d.headers.iter().any(|h| h.name.eq_ignore_ascii_case("subject")));
+        assert!(d
+            .headers
+            .iter()
+            .any(|h| h.name.eq_ignore_ascii_case("subject")));
     }
 
     #[test]

--- a/crates/yerd-mail/src/pure/mime.rs
+++ b/crates/yerd-mail/src/pure/mime.rs
@@ -1,0 +1,247 @@
+//! Decode a captured `.eml` into the owned wire types ([`MailSummary`],
+//! [`MailDetail`]).
+//!
+//! `mail-parser` is a zero-copy parser (its output borrows the input via `Cow`
+//! and lifetimes), so nothing it returns can cross the IPC wire or be stored
+//! directly. Every field is cloned out into an owned `String`/`u64` here. The
+//! HTML body additionally has `cid:` references rewritten to inline `data:`
+//! URLs so a sandboxed viewer can render embedded images without network access.
+
+use mail_parser::{Addr, Address, Message, MessageParser, MessagePart, MimeHeaders};
+use yerd_ipc::{MailDetail, MailHeader, MailSummary};
+
+/// Decode just the metadata of a captured message.
+#[must_use]
+pub fn summary(id: &str, raw: &[u8]) -> MailSummary {
+    let msg = MessageParser::default().parse(raw).unwrap_or_default();
+    MailSummary {
+        id: id.to_string(),
+        from: render_from(&msg),
+        to: render_to(&msg),
+        subject: msg.subject().unwrap_or_default().to_string(),
+        date_epoch: date_epoch(&msg),
+    }
+}
+
+/// Decode the full content of a captured message (headers + decoded bodies).
+#[must_use]
+pub fn detail(id: &str, raw: &[u8]) -> MailDetail {
+    let msg = MessageParser::default().parse(raw).unwrap_or_default();
+
+    let headers = msg
+        .headers()
+        .iter()
+        .map(|h| MailHeader {
+            name: h.name().to_string(),
+            value: raw
+                .get(h.offset_start as usize..h.offset_end as usize)
+                .map(|b| String::from_utf8_lossy(b).trim().to_string())
+                .unwrap_or_default(),
+        })
+        .collect();
+
+    let text_body = msg.body_text(0).map(std::borrow::Cow::into_owned);
+    // `body_html` synthesises HTML from a text-only message; only surface a real
+    // HTML body when the message genuinely carries a `text/html` part, so the
+    // viewer can fall back to `text_body` otherwise.
+    let html_body = if msg.parts.iter().any(is_html_part) {
+        msg.body_html(0).map(|c| rewrite_cids(&msg, c.into_owned()))
+    } else {
+        None
+    };
+
+    MailDetail {
+        id: id.to_string(),
+        from: render_from(&msg),
+        to: render_to(&msg),
+        subject: msg.subject().unwrap_or_default().to_string(),
+        date_epoch: date_epoch(&msg),
+        headers,
+        html_body,
+        text_body,
+    }
+}
+
+/// Whether a part is a genuine `text/html` body (not a text part we'd synthesise
+/// HTML from).
+fn is_html_part(part: &MessagePart) -> bool {
+    part.content_type()
+        .and_then(mail_parser::ContentType::subtype)
+        .is_some_and(|s| s.eq_ignore_ascii_case("html"))
+}
+
+fn date_epoch(msg: &Message) -> u64 {
+    msg.date()
+        .map(mail_parser::DateTime::to_timestamp)
+        .and_then(|t| u64::try_from(t).ok())
+        .unwrap_or(0)
+}
+
+fn render_from(msg: &Message) -> String {
+    render_addresses(msg.from()).into_iter().next().unwrap_or_default()
+}
+
+fn render_to(msg: &Message) -> Vec<String> {
+    render_addresses(msg.to())
+}
+
+/// Render an [`Address`] (which may be a flat list or contain groups) into one
+/// display string per mailbox.
+fn render_addresses(addr: Option<&Address>) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(a) = addr {
+        for mailbox in a.iter() {
+            let s = render_addr(mailbox);
+            if !s.is_empty() {
+                out.push(s);
+            }
+        }
+    }
+    out
+}
+
+fn render_addr(addr: &Addr) -> String {
+    match (addr.name(), addr.address()) {
+        (Some(name), Some(email)) => format!("{name} <{email}>"),
+        (None, Some(email)) => email.to_string(),
+        (Some(name), None) => name.to_string(),
+        (None, None) => String::new(),
+    }
+}
+
+/// Replace `cid:` references in an HTML body with inline `data:` URLs built from
+/// the message's inline attachments, so the body renders without network access.
+/// Parts without a content-id (or the absence of any) leave the HTML unchanged.
+fn rewrite_cids(msg: &Message, mut html: String) -> String {
+    for part in msg.attachments() {
+        let Some(cid) = part.content_id() else {
+            continue;
+        };
+        let cid = cid.trim_matches(['<', '>']);
+        if cid.is_empty() {
+            continue;
+        }
+        let ctype = part.content_type().map_or_else(
+            || "application/octet-stream".to_string(),
+            |c| match c.subtype() {
+                Some(sub) => format!("{}/{}", c.ctype(), sub),
+                None => c.ctype().to_string(),
+            },
+        );
+        let data_url = format!("data:{};base64,{}", ctype, base64_encode(part.contents()));
+        html = html
+            .replace(&format!("cid:{cid}"), &data_url)
+            .replace(&format!("CID:{cid}"), &data_url);
+    }
+    html
+}
+
+/// Minimal standard-alphabet base64 encoder (no padding-free / URL variants).
+/// Kept local to avoid pulling a base64 dependency for the one inline-image use.
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    // Mask to 6 bits then look up; `unwrap_or` keeps it panic-free for clippy.
+    let sextet = |v: u32| ALPHABET.get((v & 0x3f) as usize).copied().unwrap_or(b'A') as char;
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk.first().copied().unwrap_or(0);
+        let b1 = chunk.get(1).copied().unwrap_or(0);
+        let b2 = chunk.get(2).copied().unwrap_or(0);
+        let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        out.push(sextet(n >> 18));
+        out.push(sextet(n >> 12));
+        out.push(if chunk.len() > 1 { sextet(n >> 6) } else { '=' });
+        out.push(if chunk.len() > 2 { sextet(n) } else { '=' });
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &[u8] = b"From: Example <hello@example.com>\r\n\
+To: test@test.com\r\n\
+Subject: Password Reset\r\n\
+Date: Mon, 21 Jul 2025 21:07:30 +0000\r\n\
+Content-Type: text/plain; charset=utf-8\r\n\
+\r\n\
+Your OTP is 416063.\r\n";
+
+    #[test]
+    fn summary_extracts_envelope() {
+        let s = summary("000001", SAMPLE);
+        assert_eq!(s.id, "000001");
+        assert_eq!(s.from, "Example <hello@example.com>");
+        assert_eq!(s.to, vec!["test@test.com".to_string()]);
+        assert_eq!(s.subject, "Password Reset");
+        assert!(s.date_epoch > 0, "date should parse to an epoch");
+    }
+
+    #[test]
+    fn detail_decodes_text_body_and_headers() {
+        let d = detail("000001", SAMPLE);
+        assert_eq!(d.subject, "Password Reset");
+        assert!(d.text_body.as_deref().unwrap().contains("416063"));
+        assert!(d.html_body.is_none());
+        assert!(d.headers.iter().any(|h| h.name.eq_ignore_ascii_case("subject")));
+    }
+
+    #[test]
+    fn quoted_printable_html_is_decoded() {
+        let raw = b"From: a@b.c\r\n\
+To: d@e.f\r\n\
+Subject: HTML\r\n\
+Content-Type: text/html; charset=utf-8\r\n\
+Content-Transfer-Encoding: quoted-printable\r\n\
+\r\n\
+<p>Hello =E2=9C=93 world</p>\r\n";
+        let d = detail("000002", raw);
+        let html = d.html_body.expect("html body");
+        assert!(html.contains('\u{2713}'), "QP should decode: {html}");
+    }
+
+    #[test]
+    fn base64_encode_matches_known_vector() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn cid_image_is_rewritten_to_data_url() {
+        let raw = b"From: a@b.c\r\n\
+To: d@e.f\r\n\
+Subject: Inline\r\n\
+MIME-Version: 1.0\r\n\
+Content-Type: multipart/related; boundary=\"BB\"\r\n\
+\r\n\
+--BB\r\n\
+Content-Type: text/html\r\n\
+\r\n\
+<img src=\"cid:img1\">\r\n\
+--BB\r\n\
+Content-Type: image/png\r\n\
+Content-Transfer-Encoding: base64\r\n\
+Content-ID: <img1>\r\n\
+\r\n\
+Zm9v\r\n\
+--BB--\r\n";
+        let d = detail("000003", raw);
+        let html = d.html_body.expect("html body");
+        assert!(
+            html.contains("data:image/png;base64,"),
+            "cid should become a data URL: {html}"
+        );
+        assert!(!html.contains("cid:img1"), "cid ref should be gone: {html}");
+    }
+}

--- a/crates/yerd-mail/src/pure/mod.rs
+++ b/crates/yerd-mail/src/pure/mod.rs
@@ -1,0 +1,7 @@
+//! Pure, side-effect-free logic: SMTP command handling, MIME decoding, and the
+//! retention policy. Everything here is sync and unit-testable without sockets
+//! or a filesystem.
+
+pub mod mime;
+pub mod retention;
+pub mod smtp;

--- a/crates/yerd-mail/src/pure/retention.rs
+++ b/crates/yerd-mail/src/pure/retention.rs
@@ -1,0 +1,30 @@
+//! Retention policy: bound the number of stored emails.
+
+/// Default maximum number of captured emails to keep on disk.
+pub const DEFAULT_CAP: usize = 200;
+
+/// Given the current count (oldest-first ordering assumed) and a cap, return how
+/// many of the oldest entries must be evicted to get back within the cap. Zero
+/// when already within bounds.
+#[must_use]
+pub fn evict_count(current_len: usize, cap: usize) -> usize {
+    current_len.saturating_sub(cap)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn under_cap_evicts_nothing() {
+        assert_eq!(evict_count(5, 200), 0);
+        assert_eq!(evict_count(200, 200), 0);
+    }
+
+    #[test]
+    fn over_cap_evicts_the_overflow() {
+        assert_eq!(evict_count(201, 200), 1);
+        assert_eq!(evict_count(250, 200), 50);
+    }
+}

--- a/crates/yerd-mail/src/pure/smtp.rs
+++ b/crates/yerd-mail/src/pure/smtp.rs
@@ -1,0 +1,236 @@
+//! A minimal, pure SMTP receiver state machine.
+//!
+//! It speaks just enough of RFC 5321 to capture mail from a local app's mailer:
+//! `EHLO`/`HELO`, `MAIL FROM`, `RCPT TO`, `DATA`, `RSET`, `NOOP`, `QUIT`. There
+//! is no AUTH, no TLS, and no relaying — every recipient is accepted and the
+//! message body is captured verbatim.
+//!
+//! This module owns no sockets. The I/O layer ([`crate::io::server`]) reads a
+//! line, calls [`Session::command`], and acts on the returned [`Reply`]; in
+//! `DATA` mode it accumulates raw bytes and finishes with [`Session::finish_data`].
+
+/// One captured message: the SMTP envelope plus the verbatim, dot-unstuffed
+/// `DATA` payload (an RFC 5322 message ready for MIME parsing).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawMessage {
+    /// The `MAIL FROM` address (between the angle brackets), if any.
+    pub envelope_from: String,
+    /// The `RCPT TO` addresses, in the order given.
+    pub recipients: Vec<String>,
+    /// The dot-unstuffed message bytes.
+    pub raw: Vec<u8>,
+}
+
+/// What the I/O layer should do after a command line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reply {
+    /// Write this reply (already CRLF-terminated) and keep reading commands.
+    Line(String),
+    /// Write this reply, then switch to collecting `DATA` until `\r\n.\r\n`.
+    StartData(String),
+    /// Write this reply, then close the connection (`QUIT`).
+    Close(String),
+}
+
+/// In-progress SMTP session state (envelope being built up).
+#[derive(Debug, Default)]
+pub struct Session {
+    from: Option<String>,
+    recipients: Vec<String>,
+}
+
+impl Session {
+    /// A fresh session.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The greeting to send immediately on connect.
+    #[must_use]
+    pub fn greeting() -> &'static str {
+        "220 yerd mail capture ready\r\n"
+    }
+
+    /// Handle one command line (without the trailing CRLF). Returns the reply to
+    /// send and whether to enter `DATA` mode or close.
+    // `NOOP` and the lenient catch-all intentionally share a reply; keeping them
+    // as separate arms documents the protocol surface.
+    #[allow(clippy::match_same_arms)]
+    pub fn command(&mut self, line: &str) -> Reply {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        let verb = trimmed
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_ascii_uppercase();
+        match verb.as_str() {
+            "HELO" | "EHLO" => Reply::Line("250 yerd\r\n".to_string()),
+            "MAIL" => {
+                self.from = Some(extract_address(trimmed));
+                Reply::Line("250 OK\r\n".to_string())
+            }
+            "RCPT" => {
+                self.recipients.push(extract_address(trimmed));
+                Reply::Line("250 OK\r\n".to_string())
+            }
+            "DATA" => {
+                if self.recipients.is_empty() {
+                    Reply::Line("503 RCPT first\r\n".to_string())
+                } else {
+                    Reply::StartData(
+                        "354 End data with <CR><LF>.<CR><LF>\r\n".to_string(),
+                    )
+                }
+            }
+            "RSET" => {
+                self.from = None;
+                self.recipients.clear();
+                Reply::Line("250 OK\r\n".to_string())
+            }
+            "NOOP" => Reply::Line("250 OK\r\n".to_string()),
+            "QUIT" => Reply::Close("221 Bye\r\n".to_string()),
+            // Be lenient: a capture sink accepts whatever a dev mailer sends.
+            "" => Reply::Line("500 Syntax error\r\n".to_string()),
+            _ => Reply::Line("250 OK\r\n".to_string()),
+        }
+    }
+
+    /// Consume the raw `DATA` bytes (everything between the `354` and the
+    /// terminating `\r\n.\r\n`, with that terminator already stripped by the I/O
+    /// layer) and produce the captured message. Resets the envelope so the same
+    /// connection may send another message.
+    pub fn finish_data(&mut self, data: &[u8]) -> RawMessage {
+        RawMessage {
+            envelope_from: self.from.take().unwrap_or_default(),
+            recipients: std::mem::take(&mut self.recipients),
+            raw: unstuff(data),
+        }
+    }
+}
+
+/// Undo SMTP dot-stuffing: a line that began with `.` was sent with an extra
+/// leading `.` (RFC 5321 §4.5.2). Strip one leading `.` from any line that has
+/// two or more. Operates on the raw `\r\n`-delimited payload.
+#[must_use]
+pub fn unstuff(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut at_line_start = true;
+    for &b in data {
+        if at_line_start && b == b'.' {
+            // Drop exactly one leading dot of a stuffed line; keep the rest.
+            at_line_start = false;
+            continue;
+        }
+        out.push(b);
+        at_line_start = b == b'\n';
+    }
+    out
+}
+
+/// Extract the address from a `MAIL FROM:<addr>` / `RCPT TO:<addr>` line. Falls
+/// back to the text after the first `:` (trimmed) when there are no brackets.
+fn extract_address(line: &str) -> String {
+    if let (Some(start), Some(end)) = (line.find('<'), line.rfind('>')) {
+        if let Some(inner) = line.get(start + 1..end) {
+            return inner.trim().to_string();
+        }
+    }
+    match line.split_once(':') {
+        Some((_, rest)) => rest.trim().to_string(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn greeting_is_220() {
+        assert!(Session::greeting().starts_with("220 "));
+    }
+
+    #[test]
+    fn full_session_captures_envelope_and_body() {
+        let mut s = Session::new();
+        assert_eq!(s.command("EHLO localhost"), Reply::Line("250 yerd\r\n".into()));
+        assert_eq!(
+            s.command("MAIL FROM:<hello@example.com>"),
+            Reply::Line("250 OK\r\n".into())
+        );
+        assert_eq!(
+            s.command("RCPT TO:<test@test.com>"),
+            Reply::Line("250 OK\r\n".into())
+        );
+        match s.command("DATA") {
+            Reply::StartData(r) => assert!(r.starts_with("354 ")),
+            other => panic!("expected StartData, got {other:?}"),
+        }
+        let msg = s.finish_data(b"Subject: Hi\r\n\r\nBody\r\n");
+        assert_eq!(msg.envelope_from, "hello@example.com");
+        assert_eq!(msg.recipients, vec!["test@test.com".to_string()]);
+        assert_eq!(msg.raw, b"Subject: Hi\r\n\r\nBody\r\n");
+    }
+
+    #[test]
+    fn data_requires_recipient() {
+        let mut s = Session::new();
+        assert_eq!(
+            s.command("DATA"),
+            Reply::Line("503 RCPT first\r\n".into())
+        );
+    }
+
+    #[test]
+    fn quit_closes() {
+        let mut s = Session::new();
+        match s.command("QUIT") {
+            Reply::Close(r) => assert!(r.starts_with("221 ")),
+            other => panic!("expected Close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rset_clears_envelope() {
+        let mut s = Session::new();
+        s.command("MAIL FROM:<a@b.c>");
+        s.command("RCPT TO:<d@e.f>");
+        s.command("RSET");
+        s.command("RCPT TO:<g@h.i>");
+        let msg = s.finish_data(b"x");
+        assert_eq!(msg.envelope_from, "");
+        assert_eq!(msg.recipients, vec!["g@h.i".to_string()]);
+    }
+
+    #[test]
+    fn unstuff_removes_one_leading_dot() {
+        // A body line ".hidden" is wire-encoded as "..hidden".
+        assert_eq!(unstuff(b"a\r\n..hidden\r\n"), b"a\r\n.hidden\r\n");
+        // A genuine single dot at line start (rare) is also de-stuffed by one.
+        assert_eq!(unstuff(b".x\r\n"), b"x\r\n");
+        // No dots → unchanged.
+        assert_eq!(unstuff(b"hello\r\nworld\r\n"), b"hello\r\nworld\r\n");
+    }
+
+    #[test]
+    fn extract_handles_missing_brackets() {
+        let mut s = Session::new();
+        s.command("MAIL FROM: bare@example.com");
+        s.command("RCPT TO:<x@y.z>");
+        let msg = s.finish_data(b"x");
+        assert_eq!(msg.envelope_from, "bare@example.com");
+    }
+
+    #[test]
+    fn unknown_command_is_accepted_leniently() {
+        let mut s = Session::new();
+        assert_eq!(s.command("XYZZY"), Reply::Line("250 OK\r\n".into()));
+    }
+}

--- a/crates/yerd-mail/src/pure/smtp.rs
+++ b/crates/yerd-mail/src/pure/smtp.rs
@@ -67,6 +67,10 @@ impl Session {
         match verb.as_str() {
             "HELO" | "EHLO" => Reply::Line("250 yerd\r\n".to_string()),
             "MAIL" => {
+                // `MAIL FROM` begins a new transaction (RFC 5321 §4.1.1.2): clear
+                // any recipients left over from an abandoned prior envelope so they
+                // can't leak into this message's captured metadata.
+                self.recipients.clear();
                 self.from = Some(extract_address(trimmed));
                 Reply::Line("250 OK\r\n".to_string())
             }
@@ -78,9 +82,7 @@ impl Session {
                 if self.recipients.is_empty() {
                     Reply::Line("503 RCPT first\r\n".to_string())
                 } else {
-                    Reply::StartData(
-                        "354 End data with <CR><LF>.<CR><LF>\r\n".to_string(),
-                    )
+                    Reply::StartData("354 End data with <CR><LF>.<CR><LF>\r\n".to_string())
                 }
             }
             "RSET" => {
@@ -160,7 +162,10 @@ mod tests {
     #[test]
     fn full_session_captures_envelope_and_body() {
         let mut s = Session::new();
-        assert_eq!(s.command("EHLO localhost"), Reply::Line("250 yerd\r\n".into()));
+        assert_eq!(
+            s.command("EHLO localhost"),
+            Reply::Line("250 yerd\r\n".into())
+        );
         assert_eq!(
             s.command("MAIL FROM:<hello@example.com>"),
             Reply::Line("250 OK\r\n".into())
@@ -182,10 +187,7 @@ mod tests {
     #[test]
     fn data_requires_recipient() {
         let mut s = Session::new();
-        assert_eq!(
-            s.command("DATA"),
-            Reply::Line("503 RCPT first\r\n".into())
-        );
+        assert_eq!(s.command("DATA"), Reply::Line("503 RCPT first\r\n".into()));
     }
 
     #[test]
@@ -207,6 +209,19 @@ mod tests {
         let msg = s.finish_data(b"x");
         assert_eq!(msg.envelope_from, "");
         assert_eq!(msg.recipients, vec!["g@h.i".to_string()]);
+    }
+
+    #[test]
+    fn second_mail_from_resets_recipients() {
+        // A new MAIL FROM before DATA must drop the prior envelope's recipients.
+        let mut s = Session::new();
+        s.command("MAIL FROM:<a@b.c>");
+        s.command("RCPT TO:<stale@old.test>");
+        s.command("MAIL FROM:<b@c.d>");
+        s.command("RCPT TO:<fresh@new.test>");
+        let msg = s.finish_data(b"x");
+        assert_eq!(msg.envelope_from, "b@c.d");
+        assert_eq!(msg.recipients, vec!["fresh@new.test".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces a new built-in mail capture and viewing feature to the Yerd desktop application. It adds backend support and a complete frontend workflow for capturing, listing, viewing, and managing emails sent by local applications. The implementation includes a dedicated "Mails" viewer window, new IPC commands, UI navigation updates, and TypeScript type definitions for mail data structures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Mail capture SMTP server: captures incoming emails on a configurable loopback port (default 2525), with enable/disable control.
- Mail viewer: a new dedicated “Mail”/“Mails” area to browse captured messages, open full details, and manage messages (delete or clear).
- GUI mail settings panel: toggle capture and set the SMTP port.
- CLI: new `mail` subcommands to list, view by id, and clear captured emails.
- Config update: added an optional `[mail]` section (schema v4) and enhanced web security policy for mail content rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->