### PR TITLE
[Feat] Pcov PHP support

### DIFF
--- a/bin/yerd/src/cover_shim.rs
+++ b/bin/yerd/src/cover_shim.rs
@@ -1,0 +1,210 @@
+//! pcov "cover" CLI shims (`phpcover`, `php<major>.<minor>cover`).
+//!
+//! These names are symlinks in `{data}/bin` pointing at *this* `yerd` binary.
+//! When `yerd` is invoked under such a name (detected from `argv[0]` before clap),
+//! it resolves the matching PHP CLI binary plus that version's `pcov.so` and
+//! `exec`s PHP with coverage enabled — leaving the clean `php`/`php<ver>` shims
+//! untouched. Unix-only: cover shims are never created on other platforms.
+
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use yerd_platform::{ActivePaths, Paths, PlatformDirs};
+
+/// Which PHP a cover alias targets.
+enum CoverSpec {
+    /// `phpcover` — the default version (resolved at run time).
+    Default,
+    /// `php<major>.<minor>cover` — an explicit version.
+    Version(u8, u8),
+}
+
+/// If `argv[0]` is a cover-alias name, run that PHP with pcov enabled and return
+/// its exit code (on success `exec` replaces the process and never returns);
+/// otherwise `None`, so `main` falls through to the normal CLI.
+#[must_use]
+pub fn dispatch() -> Option<ExitCode> {
+    let arg0 = std::env::args_os().next()?;
+    let name = Path::new(&arg0).file_name()?.to_str()?;
+    let spec = parse_cover_name(name)?;
+    Some(run(&spec))
+}
+
+/// Parse a cover-alias basename. Matches `phpcover` and `php<MAJOR>.<MINOR>cover`
+/// exactly; returns `None` for `php`, `php<ver>`, and anything else (so a normal
+/// `yerd` invocation, or a clean versioned shim, is never intercepted).
+fn parse_cover_name(name: &str) -> Option<CoverSpec> {
+    let rest = name.strip_prefix("php")?;
+    let rest = rest.strip_suffix("cover")?; // must end with `cover` to be a cover alias
+    if rest.is_empty() {
+        return Some(CoverSpec::Default);
+    }
+    let (maj, min) = rest.split_once('.')?;
+    if maj.is_empty() || min.is_empty() {
+        return None;
+    }
+    let major: u8 = maj.parse().ok()?;
+    let minor: u8 = min.parse().ok()?;
+    Some(CoverSpec::Version(major, minor))
+}
+
+fn run(spec: &CoverSpec) -> ExitCode {
+    let dirs = match ActivePaths::new().resolve() {
+        Ok(d) => d,
+        Err(e) => return fail(format!("cannot resolve yerd directories: {e}")),
+    };
+    let (php_bin, minor) = match resolve_target(&dirs, spec) {
+        Ok(t) => t,
+        Err(msg) => return fail(msg),
+    };
+    let pcov = dirs
+        .data
+        .join("php-ext")
+        .join(format!("php-{minor}"))
+        .join("pcov.so");
+    if !pcov.is_file() {
+        return fail(format!(
+            "pcov not installed for PHP {minor} — reinstall PHP or wait for the background fetch"
+        ));
+    }
+
+    // `exec` only returns on failure. argv[0] defaults to the real php path
+    // (correct: PHP reads PHP_BINARY from /proc/self/exe and $_SERVER['argv'][0]
+    // becomes the real php, not the cover name). pcov is a normal extension, so
+    // `-d extension=` (absolute path) is the right directive.
+    let err = Command::new(&php_bin)
+        .arg("-d")
+        .arg(format!("extension={}", pcov.display()))
+        .arg("-d")
+        .arg("pcov.enabled=1")
+        .args(std::env::args_os().skip(1))
+        .exec();
+    if err.kind() == std::io::ErrorKind::NotFound {
+        return fail(format!(
+            "cannot exec {} ({err}) — the `yerd` binary may have moved; restart `yerdd`",
+            php_bin.display()
+        ));
+    }
+    fail(format!("failed to exec {}: {err}", php_bin.display()))
+}
+
+/// Resolve `(php_binary, "major.minor")` for the spec.
+fn resolve_target(dirs: &PlatformDirs, spec: &CoverSpec) -> Result<(PathBuf, String), String> {
+    match spec {
+        CoverSpec::Version(maj, min) => {
+            let minor = format!("{maj}.{min}");
+            let php = cli_binary(dirs, &minor);
+            if php.is_file() {
+                Ok((php, minor))
+            } else {
+                Err(format!(
+                    "PHP {minor} is not installed — run `yerd install php {minor}`"
+                ))
+            }
+        }
+        CoverSpec::Default => default_from_shim(dirs)
+            .or_else(|| highest_installed(dirs))
+            .ok_or_else(|| "no PHP installed — run `yerd install php <version>`".to_owned()),
+    }
+}
+
+/// `{data}/php/php-<minor>/bin/php`.
+fn cli_binary(dirs: &PlatformDirs, minor: &str) -> PathBuf {
+    dirs.data
+        .join("php")
+        .join(format!("php-{minor}"))
+        .join("bin")
+        .join("php")
+}
+
+/// Default via the `php` shim's target (what `php` itself resolves to), if present
+/// and the derived binary exists.
+fn default_from_shim(dirs: &PlatformDirs) -> Option<(PathBuf, String)> {
+    let target = std::fs::read_link(dirs.data.join("bin").join("php")).ok()?;
+    let minor = minor_from_php_path(&target)?;
+    let php = cli_binary(dirs, &minor);
+    php.is_file().then_some((php, minor))
+}
+
+/// Extract `"major.minor"` from a `…/php/php-<major>.<minor>/…` path.
+fn minor_from_php_path(p: &Path) -> Option<String> {
+    p.components().find_map(|c| {
+        let rest = c.as_os_str().to_str()?.strip_prefix("php-")?;
+        let (maj, min) = rest.split_once('.')?;
+        let ok = !maj.is_empty()
+            && !min.is_empty()
+            && maj.bytes().all(|b| b.is_ascii_digit())
+            && min.bytes().all(|b| b.is_ascii_digit());
+        ok.then(|| rest.to_owned())
+    })
+}
+
+/// Highest installed minor under `{data}/php` whose CLI binary exists.
+fn highest_installed(dirs: &PlatformDirs) -> Option<(PathBuf, String)> {
+    let root = dirs.data.join("php");
+    let mut best: Option<(u8, u8)> = None;
+    for entry in std::fs::read_dir(&root).ok()?.flatten() {
+        let fname = entry.file_name();
+        let Some(name) = fname.to_str() else { continue };
+        let Some(rest) = name.strip_prefix("php-") else {
+            continue;
+        };
+        let Some((maj, min)) = rest.split_once('.') else {
+            continue;
+        };
+        let (Ok(maj), Ok(min)) = (maj.parse::<u8>(), min.parse::<u8>()) else {
+            continue;
+        };
+        if !cli_binary(dirs, rest).is_file() {
+            continue;
+        }
+        if best.map_or(true, |b| (maj, min) > b) {
+            best = Some((maj, min));
+        }
+    }
+    let (maj, min) = best?;
+    let minor = format!("{maj}.{min}");
+    Some((cli_binary(dirs, &minor), minor))
+}
+
+fn fail(msg: String) -> ExitCode {
+    eprintln!("yerd: {msg}");
+    ExitCode::FAILURE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_default_and_versioned_cover_names() {
+        assert!(matches!(
+            parse_cover_name("phpcover"),
+            Some(CoverSpec::Default)
+        ));
+        assert!(matches!(
+            parse_cover_name("php8.4cover"),
+            Some(CoverSpec::Version(8, 4))
+        ));
+    }
+
+    #[test]
+    fn ignores_non_cover_names() {
+        // Clean versioned + default names and foreign binaries must fall through.
+        assert!(parse_cover_name("php").is_none());
+        assert!(parse_cover_name("php8.4").is_none());
+        assert!(parse_cover_name("phpunit").is_none());
+        assert!(parse_cover_name("php8.cover").is_none());
+        assert!(parse_cover_name("phpx.4cover").is_none());
+    }
+
+    #[test]
+    fn minor_from_php_path_extracts_dotted_minor() {
+        assert_eq!(
+            minor_from_php_path(Path::new("/d/php/php-8.4/bin/php")).as_deref(),
+            Some("8.4")
+        );
+        assert_eq!(minor_from_php_path(Path::new("/d/bin/php")), None);
+    }
+}

--- a/bin/yerd/src/cover_shim.rs
+++ b/bin/yerd/src/cover_shim.rs
@@ -82,7 +82,7 @@ fn run(spec: &CoverSpec) -> ExitCode {
         .exec();
     if err.kind() == std::io::ErrorKind::NotFound {
         return fail(format!(
-            "cannot exec {} ({err}) — the `yerd` binary may have moved; restart `yerdd`",
+            "PHP binary not found at {} ({err}) — reinstall with `yerd install php {minor}`",
             php_bin.display()
         ));
     }

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -9,6 +9,8 @@
 #![forbid(unsafe_code)]
 
 pub mod cli;
+#[cfg(unix)]
+pub mod cover_shim;
 pub mod elevate;
 pub mod error;
 pub mod map;
@@ -178,6 +180,7 @@ fn print_php_path_hint() {
         "→ ensure {} is on your PATH for the `php` command",
         bin.display()
     );
+    println!("  (also provides `php<ver>` and `phpcover`/`php<ver>cover` for pcov coverage)");
     // Warn if a different `php` is found earlier on PATH (would shadow the shim).
     if let Some(existing) = first_php_on_path() {
         if existing != bin.join("php") {

--- a/bin/yerd/src/main.rs
+++ b/bin/yerd/src/main.rs
@@ -8,6 +8,14 @@ use clap::Parser;
 use yerd::cli::Cli;
 
 fn main() -> ExitCode {
+    // When invoked under a cover-alias name (`phpcover` / `php<ver>cover`), act as
+    // the pcov shim and exec PHP — before clap ever sees the args. On success
+    // `exec` replaces the process; we only get a code back on failure.
+    #[cfg(unix)]
+    if let Some(code) = yerd::cover_shim::dispatch() {
+        return code;
+    }
+
     let cli = Cli::parse();
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/bin/yerdd/src/ext_install.rs
+++ b/bin/yerdd/src/ext_install.rs
@@ -1,7 +1,8 @@
-//! Downloads the `yerd-dump` PHP extension (`.so`) per installed PHP version.
+//! Downloads PHP extension `.so`s (`yerd-dump`, `pcov`) per installed PHP version.
 //!
-//! Artifacts come from the `yerd-php-ext` GitHub releases, described by a
-//! `manifest.json` listing each file's `php`/`os`/`arch`/`sha256`. yerd resolves
+//! Both come from the same `yerd-php-ext` GitHub release, each described by its
+//! own manifest (`manifest.json` for dump, `pcov-manifest.json` for pcov) listing
+//! each file's `php`/`os`/`arch`/`sha256`. yerd resolves
 //! the file matching the host triple for each installed PHP minor, verifies the
 //! SHA-256, and places it at `{data}/php-ext/php-<ver>/yerd-dump.so` (a sibling
 //! of the PHP installs, so a PHP patch update — which wipes `{data}/php/php-<ver>`
@@ -39,19 +40,56 @@ struct Manifest {
     files: Vec<ManifestFile>,
 }
 
+/// One downloadable extension: which manifest names it in the (shared) release
+/// and what its `.so` is called on disk. Lets the same fetch loop serve both
+/// `yerd-dump` and `pcov` from the one `yerd-php-ext` release.
+struct ExtSpec {
+    /// Manifest filename within the release (e.g. `manifest.json`).
+    manifest_name: &'static str,
+    /// On-disk `.so` filename under `{data}/php-ext/php-<ver>/`.
+    so_name: &'static str,
+    /// Human label for log lines.
+    label: &'static str,
+}
+
+const DUMP_SPEC: ExtSpec = ExtSpec {
+    manifest_name: "manifest.json",
+    so_name: "yerd-dump.so",
+    label: "yerd-dump",
+};
+
+const PCOV_SPEC: ExtSpec = ExtSpec {
+    manifest_name: "pcov-manifest.json",
+    so_name: "pcov.so",
+    label: "pcov",
+};
+
 /// The host OS/arch as the manifest names them (`macos`/`linux`,
 /// `aarch64`/`x86_64`) — `std::env::consts` already uses these spellings.
 fn host_os_arch() -> (&'static str, &'static str) {
     (std::env::consts::OS, std::env::consts::ARCH)
 }
 
-/// Absolute path of the extension `.so` for `v` (present or not).
-#[must_use]
-pub fn so_path(dirs: &PlatformDirs, v: PhpVersion) -> PathBuf {
+/// Absolute path of a named extension `.so` for `v` (present or not).
+fn so_path_named(dirs: &PlatformDirs, v: PhpVersion, so_name: &str) -> PathBuf {
     dirs.data
         .join("php-ext")
         .join(format!("php-{v}"))
-        .join("yerd-dump.so")
+        .join(so_name)
+}
+
+/// Absolute path of the `yerd-dump` `.so` for `v` (present or not).
+#[must_use]
+pub fn so_path(dirs: &PlatformDirs, v: PhpVersion) -> PathBuf {
+    so_path_named(dirs, v, DUMP_SPEC.so_name)
+}
+
+/// Absolute path of the `pcov` `.so` for `v` (present or not). Sibling of the
+/// dump `.so`, so a PHP patch update (which wipes `{data}/php/php-<ver>`) leaves
+/// it intact.
+#[must_use]
+pub fn pcov_so_path(dirs: &PlatformDirs, v: PhpVersion) -> PathBuf {
+    so_path_named(dirs, v, PCOV_SPEC.so_name)
 }
 
 /// Installed PHP minors discovered from `{data}/php`.
@@ -62,10 +100,32 @@ pub fn installed_versions(dirs: &PlatformDirs) -> Vec<PhpVersion> {
         .unwrap_or_default()
 }
 
-/// Ensure the extension is present and current for every installed PHP version
-/// that has a published artifact for the host triple. Best-effort.
+/// Ensure the `yerd-dump` extension is present and current for every installed
+/// PHP version that has a published artifact for the host triple. Best-effort.
 pub async fn ensure_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader) {
-    let Some(manifest) = fetch_manifest(dl).await else {
+    ensure_for_installed_spec(dirs, dl, &DUMP_SPEC).await;
+}
+
+/// Ensure the `pcov` extension is present for every installed PHP version.
+///
+/// Used by the CLI cover shims (`phpcover`/`php<ver>cover`); ungated, unlike the
+/// dump fetch. Warm/offline starts skip the network entirely: if every installed
+/// version already has a `pcov.so`, return without touching GitHub. (The "present"
+/// check is a proxy for "current" — a stale `.so` won't refresh on a pure restart,
+/// which is fine: pcov is ABI-stable per PHP minor and any *missing* `.so` still
+/// forces a full manifest fetch + re-verify.)
+pub async fn ensure_pcov_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader) {
+    let versions = installed_versions(dirs);
+    if !versions.is_empty() && versions.iter().all(|v| pcov_so_path(dirs, *v).is_file()) {
+        return;
+    }
+    ensure_for_installed_spec(dirs, dl, &PCOV_SPEC).await;
+}
+
+/// Shared fetch loop: resolve the host triple in `spec`'s manifest for each
+/// installed PHP minor, sha-verify, and atomically place the `.so`. Best-effort.
+async fn ensure_for_installed_spec(dirs: &PlatformDirs, dl: &dyn Downloader, spec: &ExtSpec) {
+    let Some(manifest) = fetch_manifest(dl, spec.manifest_name, spec.label).await else {
         return;
     };
     let (os, arch) = host_os_arch();
@@ -76,34 +136,34 @@ pub async fn ensure_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader) {
             .iter()
             .find(|f| f.php == minor && f.os == os && f.arch == arch)
         else {
-            tracing::info!(php = %minor, os, arch, "no yerd-dump extension published for this triple");
+            tracing::info!(php = %minor, os, arch, ext = spec.label, "no extension published for this triple");
             continue;
         };
-        let dest = so_path(dirs, v);
+        let dest = so_path_named(dirs, v, spec.so_name);
         if existing_matches(&dest, &file.sha256) {
             continue; // already current
         }
         match download_and_place(dl, &file.name, &file.sha256, &dest).await {
-            Ok(()) => tracing::info!(php = %minor, "installed yerd-dump extension"),
+            Ok(()) => tracing::info!(php = %minor, ext = spec.label, "installed PHP extension"),
             Err(e) => {
-                tracing::warn!(php = %minor, error = %e, "failed to install yerd-dump extension");
+                tracing::warn!(php = %minor, ext = spec.label, error = %e, "failed to install PHP extension");
             }
         }
     }
 }
 
-async fn fetch_manifest(dl: &dyn Downloader) -> Option<Manifest> {
-    let url = format!("{RELEASE_BASE}/manifest.json");
+async fn fetch_manifest(dl: &dyn Downloader, manifest_name: &str, label: &str) -> Option<Manifest> {
+    let url = format!("{RELEASE_BASE}/{manifest_name}");
     match dl.download(&url).await {
         Ok(bytes) => match serde_json::from_slice::<Manifest>(&bytes) {
             Ok(m) => Some(m),
             Err(e) => {
-                tracing::warn!(error = %e, "yerd-dump manifest parse failed");
+                tracing::warn!(error = %e, ext = label, "manifest parse failed");
                 None
             }
         },
         Err(e) => {
-            tracing::warn!(error = %e, "yerd-dump manifest download failed");
+            tracing::warn!(error = %e, ext = label, "manifest download failed");
             None
         }
     }
@@ -183,6 +243,16 @@ mod tests {
         assert!(p.ends_with("php-ext/php-8.5/yerd-dump.so"));
         // Crucially NOT under {data}/php/php-8.5 (which is wiped on PHP update).
         assert!(!p.starts_with(dirs.data.join("php").join("php-8.5")));
+    }
+
+    #[test]
+    fn pcov_so_path_is_sibling_of_dump_so() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let p = pcov_so_path(&dirs, PhpVersion::new(8, 4));
+        assert!(p.ends_with("php-ext/php-8.4/pcov.so"));
+        // Same dir as yerd-dump.so (shared php-ext/php-<ver>/), distinct file.
+        assert_eq!(p.parent(), so_path(&dirs, PhpVersion::new(8, 4)).parent());
     }
 
     #[test]

--- a/bin/yerdd/src/ext_install.rs
+++ b/bin/yerdd/src/ext_install.rs
@@ -116,7 +116,9 @@ pub async fn ensure_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader) {
 /// forces a full manifest fetch + re-verify.)
 pub async fn ensure_pcov_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader) {
     let versions = installed_versions(dirs);
-    if !versions.is_empty() && versions.iter().all(|v| pcov_so_path(dirs, *v).is_file()) {
+    // Nothing to fetch when no PHP is installed, or when every version already
+    // has its `.so` — skip the manifest GET entirely.
+    if versions.is_empty() || versions.iter().all(|v| pcov_so_path(dirs, *v).is_file()) {
         return;
     }
     ensure_for_installed_spec(dirs, dl, &PCOV_SPEC).await;

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -634,6 +634,9 @@ async fn install_php(version: yerd_core::PhpVersion, state: &DaemonState) -> Res
             // the just-installed version so the proxy can spawn its FPM pool
             // without a daemon restart.
             refresh_php_binaries(state).await;
+            // Bundle pcov for the new version and (re)build its cover/clean
+            // shims. Best-effort; the install itself already succeeded.
+            refresh_pcov_and_shims(state).await;
             Response::Ok
         }
         Err(e) => Response::Error {
@@ -655,6 +658,44 @@ async fn refresh_php_binaries(state: &DaemonState) {
             }
         };
     state.php_manager.lock().await.set_binaries(binaries);
+}
+
+/// Absolute path to the `yerd` CLI binary, assumed a sibling of the running
+/// `yerdd` (mirrors `yerd`'s own `elevate::sibling_binaries`). This is the target
+/// the cover shims (`phpcover`/`php<ver>cover`) symlink to.
+fn yerd_sibling() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    Some(exe.parent()?.join("yerd"))
+}
+
+/// Run `reconcile_shims` for an explicit default, serialized behind the shim
+/// mutex. Best-effort: failures are logged. Callers must **not** hold the config
+/// lock (this takes no config lock; it's given the default directly).
+async fn reconcile_shims_for(state: &DaemonState, default: yerd_core::PhpVersion) {
+    let Some(yerd_bin) = yerd_sibling() else {
+        tracing::warn!("cannot locate the `yerd` binary; skipping cover-shim reconcile");
+        return;
+    };
+    let _guard = state.shim_reconcile.lock().await;
+    if let Err(e) = crate::php_install::reconcile_shims(&state.dirs, &yerd_bin, default) {
+        tracing::warn!(error = %e, "cover-shim reconcile failed");
+    }
+}
+
+/// Reconcile shims using the current config default (reads the config lock
+/// briefly, then releases it before reconciling).
+async fn reconcile_shims_now(state: &DaemonState) {
+    let default = state.config.lock().await.php.default;
+    reconcile_shims_for(state, default).await;
+}
+
+/// Best-effort: fetch the `pcov` `.so` for installed PHP versions, then rebuild
+/// the cover/clean versioned CLI shims. Ungated (pcov is always bundled). Used at
+/// startup and after a PHP install.
+pub(crate) async fn refresh_pcov_and_shims(state: &DaemonState) {
+    let dl = crate::php_install::ReqwestDownloader::new();
+    crate::ext_install::ensure_pcov_for_installed(&state.dirs, &dl).await;
+    reconcile_shims_now(state).await;
 }
 
 /// `restart php <ver>` — stop + ensure the version's FPM pool. Starts a stopped
@@ -751,7 +792,13 @@ async fn uninstall_php(version: yerd_core::PhpVersion, state: &DaemonState) -> R
     if let Err(e) = std::fs::remove_dir_all(&version_dir) {
         return internal(format!("failed to remove PHP {version}: {e}"));
     }
+    // Drop the orphaned pcov `.so` for this minor (a true uninstall, unlike a PHP
+    // patch update). Remove the file only — the `php-ext/php-<minor>` dir is shared
+    // with `yerd-dump.so`.
+    let _ = std::fs::remove_file(crate::ext_install::pcov_so_path(&state.dirs, version));
     refresh_php_binaries(state).await;
+    // Prune this version's now-dangling cover/clean shims.
+    reconcile_shims_now(state).await;
     tracing::info!(version = %version, "uninstalled PHP");
     php_versions_response(state).await
 }
@@ -765,16 +812,21 @@ async fn set_default_php(version: yerd_core::PhpVersion, state: &DaemonState) ->
             message: format!("PHP {version} is not installed — run `yerd install php {version}`"),
         };
     }
-    let mut cfg_guard = state.config.lock().await;
-    let mut new = cfg_guard.clone();
-    new.php.default = version;
-    if let Err(e) = new.save(&state.config_path) {
-        return internal(format!("config save failed: {e}"));
-    }
-    if let Err(e) = crate::php_install::set_default_shim(&state.dirs, version) {
-        return internal(format!("update php shim failed: {e}"));
-    }
-    *cfg_guard = new;
+    {
+        let mut cfg_guard = state.config.lock().await;
+        let mut new = cfg_guard.clone();
+        new.php.default = version;
+        if let Err(e) = new.save(&state.config_path) {
+            return internal(format!("config save failed: {e}"));
+        }
+        if let Err(e) = crate::php_install::set_default_shim(&state.dirs, version) {
+            return internal(format!("update php shim failed: {e}"));
+        }
+        *cfg_guard = new;
+    } // release the config lock before reconciling (reconcile reads no config lock,
+      // but we must not hold a non-reentrant guard across the call).
+      // Ensure `phpcover` + the versioned shim set track the new default.
+    reconcile_shims_for(state, version).await;
     tracing::info!(version = %version, "set default PHP");
     Response::Ok
 }
@@ -1186,6 +1238,7 @@ mod tests {
             detect_cache: std::sync::Arc::new(crate::detect_cache::DetectCache::new()),
             watch_dirty: tokio::sync::Notify::new(),
             dumps: std::sync::Arc::new(crate::dump_server::DumpStore::new()),
+            shim_reconcile: tokio::sync::Mutex::new(()),
         }
     }
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -816,11 +816,14 @@ async fn set_default_php(version: yerd_core::PhpVersion, state: &DaemonState) ->
         let mut cfg_guard = state.config.lock().await;
         let mut new = cfg_guard.clone();
         new.php.default = version;
-        if let Err(e) = new.save(&state.config_path) {
-            return internal(format!("config save failed: {e}"));
-        }
+        // Repoint the shim before persisting: it's the more failure-prone step,
+        // so doing it first means a shim failure persists nothing (disk + memory
+        // stay consistent), rather than leaving disk ahead of memory.
         if let Err(e) = crate::php_install::set_default_shim(&state.dirs, version) {
             return internal(format!("update php shim failed: {e}"));
+        }
+        if let Err(e) = new.save(&state.config_path) {
+            return internal(format!("config save failed: {e}"));
         }
         *cfg_guard = new;
     } // release the config lock before reconciling (reconcile reads no config lock,

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -193,6 +193,17 @@ async fn run_until_shutdown(
         })
     };
 
+    // Bundle pcov for installed PHP versions and (re)build the cover/clean
+    // versioned CLI shims (`phpcover`, `php<ver>`, `php<ver>cover`). Ungated and
+    // best-effort; also self-heals cover symlinks if the `yerd` binary moved
+    // between runs. Warm/offline starts skip the network (local presence check).
+    let _pcov_shims = {
+        let state = daemon.state.clone();
+        tokio::spawn(async move {
+            crate::ipc_server::refresh_pcov_and_shims(&state).await;
+        })
+    };
+
     // Serve until a shutdown is requested — a SIGTERM/Ctrl-C, or a
     // `RestartDaemon` IPC tripping the same channel. Without this wait the
     // daemon would fall straight through to the graceful-join timeouts below

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -251,27 +251,153 @@ pub fn shim_dir(dirs: &PlatformDirs) -> PathBuf {
     dirs.data.join("bin")
 }
 
+/// Atomically create/replace the symlink `link` → `target` (temp + rename, so a
+/// concurrent reader never sees a half-written link). The temp name embeds the
+/// link's own filename + pid, so reconciling many links at once never collides.
+#[cfg(unix)]
+fn place_symlink(link: &Path, target: &Path) -> Result<(), PhpError> {
+    let parent = link
+        .parent()
+        .ok_or_else(|| fs_err(link, &std::io::Error::other("shim link has no parent")))?;
+    let name = link
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| fs_err(link, &std::io::Error::other("shim link has no file name")))?;
+    let tmp = parent.join(format!(".{name}.tmp-{}", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    fs_ctx(std::os::unix::fs::symlink(target, &tmp), &tmp)?;
+    // rename is atomic and replaces any existing shim.
+    fs_ctx(std::fs::rename(&tmp, link), link)?;
+    Ok(())
+}
+
 /// Point the managed `php` shim at `version`'s CLI binary (unix symlink),
 /// created/replaced atomically. Returns the shim dir for PATH hints.
 #[cfg(unix)]
 pub fn set_default_shim(dirs: &PlatformDirs, version: PhpVersion) -> Result<PathBuf, PhpError> {
     let bin = shim_dir(dirs);
     fs_ctx(std::fs::create_dir_all(&bin), &bin)?;
-    let link = bin.join("php");
-    let tmp = bin.join(format!(".php.tmp-{}", std::process::id()));
-    let _ = std::fs::remove_file(&tmp);
-    fs_ctx(
-        std::os::unix::fs::symlink(cli_binary_path(dirs, version), &tmp),
-        &tmp,
-    )?;
-    // rename is atomic and replaces any existing shim.
-    fs_ctx(std::fs::rename(&tmp, &link), &link)?;
+    place_symlink(&bin.join("php"), &cli_binary_path(dirs, version))?;
     Ok(bin)
 }
 
 #[cfg(not(unix))]
 pub fn set_default_shim(dirs: &PlatformDirs, _version: PhpVersion) -> Result<PathBuf, PhpError> {
     Ok(shim_dir(dirs))
+}
+
+/// The shim filename for `v`: `php<major>.<minor>` (clean) or `…cover` (pcov).
+/// Dotted form matches the `PhpVersion` parser.
+#[cfg(unix)]
+fn versioned_shim_name(v: PhpVersion, cover: bool) -> String {
+    if cover {
+        format!("php{}.{}cover", v.major, v.minor)
+    } else {
+        format!("php{}.{}", v.major, v.minor)
+    }
+}
+
+/// Parse a yerd-managed shim filename back to its PHP version. Matches **exactly**
+/// `php<MAJOR>.<MINOR>` or `php<MAJOR>.<MINOR>cover`; returns `None` for `php`,
+/// `phpcover`, and any other name — so the pruner never touches foreign files.
+#[cfg(unix)]
+fn managed_shim_version(name: &str) -> Option<PhpVersion> {
+    let rest = name.strip_prefix("php")?;
+    let rest = rest.strip_suffix("cover").unwrap_or(rest);
+    let (maj, min) = rest.split_once('.')?;
+    if maj.is_empty() || min.is_empty() {
+        return None;
+    }
+    let major: u8 = maj.parse().ok()?;
+    let minor: u8 = min.parse().ok()?;
+    Some(PhpVersion::new(major, minor))
+}
+
+/// Reconcile the per-version CLI shims in `{data}/bin` against what's installed:
+///
+/// * for each installed `v`: `php<v>` → its CLI binary, `php<v>cover` → `yerd_bin`;
+/// * `phpcover` → `yerd_bin` (resolves the default at run time);
+/// * `php` → `default`'s CLI binary when `default` is installed and the link is
+///   missing/stale (covers "installed but never `yerd use`d");
+/// * prune managed `php<X.Y>`/`php<X.Y>cover` symlinks whose version is no longer
+///   installed.
+///
+/// A **single** `discover_bundled` snapshot drives both create and prune. Callers
+/// must serialize invocations (the daemon holds a dedicated mutex) so the
+/// scan→prune can't race a concurrent install's create. Unix-only; no-op elsewhere.
+#[cfg(unix)]
+pub fn reconcile_shims(
+    dirs: &PlatformDirs,
+    yerd_bin: &Path,
+    default: PhpVersion,
+) -> Result<(), PhpError> {
+    let bin = shim_dir(dirs);
+    fs_ctx(std::fs::create_dir_all(&bin), &bin)?;
+
+    // One snapshot drives create AND prune (a second scan could straddle a
+    // concurrent install's atomic rename and prune a just-created link).
+    let installed: Vec<PhpVersion> = yerd_php::discover_bundled(dirs)
+        .map_err(|e| {
+            fs_err(
+                &dirs.data.join("php"),
+                &std::io::Error::other(e.to_string()),
+            )
+        })?
+        .into_iter()
+        .map(|(v, _)| v)
+        .collect();
+
+    for &v in &installed {
+        place_symlink(
+            &bin.join(versioned_shim_name(v, false)),
+            &cli_binary_path(dirs, v),
+        )?;
+        place_symlink(&bin.join(versioned_shim_name(v, true)), yerd_bin)?;
+    }
+    place_symlink(&bin.join("phpcover"), yerd_bin)?;
+
+    if installed.contains(&default) {
+        let want = cli_binary_path(dirs, default);
+        let php = bin.join("php");
+        if std::fs::read_link(&php).ok().as_deref() != Some(want.as_path()) {
+            place_symlink(&php, &want)?;
+        }
+    }
+
+    // Prune from the same directory listing; touch only managed symlinks.
+    let entries = match std::fs::read_dir(&bin) {
+        Ok(e) => e,
+        Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(fs_err(&bin, &e)),
+    };
+    for entry in entries.flatten() {
+        let fname = entry.file_name();
+        let Some(name) = fname.to_str() else { continue };
+        if name == "php" || name == "phpcover" {
+            continue;
+        }
+        let Some(v) = managed_shim_version(name) else {
+            continue;
+        };
+        if installed.contains(&v) {
+            continue;
+        }
+        let path = entry.path();
+        let is_link = std::fs::symlink_metadata(&path).is_ok_and(|m| m.file_type().is_symlink());
+        if is_link {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn reconcile_shims(
+    _dirs: &PlatformDirs,
+    _yerd_bin: &Path,
+    _default: PhpVersion,
+) -> Result<(), PhpError> {
+    Ok(())
 }
 
 #[cfg(test)]
@@ -450,5 +576,94 @@ mod tests {
             cli_binary_path(&dirs, PhpVersion::new(8, 5)),
             PathBuf::from("/d/php/php-8.5/bin/php")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_shim_version_matches_only_canonical_names() {
+        assert_eq!(managed_shim_version("php8.4"), Some(PhpVersion::new(8, 4)));
+        assert_eq!(
+            managed_shim_version("php8.4cover"),
+            Some(PhpVersion::new(8, 4))
+        );
+        // Never the default/clean names or foreign files.
+        assert_eq!(managed_shim_version("php"), None);
+        assert_eq!(managed_shim_version("phpcover"), None);
+        assert_eq!(managed_shim_version("php8"), None);
+        assert_eq!(managed_shim_version("php8.4.1"), None);
+        assert_eq!(managed_shim_version("phpunit"), None);
+        assert_eq!(managed_shim_version("php8.4covers"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn versioned_shim_name_is_dotted() {
+        let v = PhpVersion::new(8, 4);
+        assert_eq!(versioned_shim_name(v, false), "php8.4");
+        assert_eq!(versioned_shim_name(v, true), "php8.4cover");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_creates_versioned_and_cover_shims_and_prunes_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let yerd_bin = tmp.path().join("yerd");
+        std::fs::write(&yerd_bin, b"#!fake").unwrap();
+
+        // Lay down an installed 8.4 (discover_bundled keys on the FPM binary).
+        let mk = |v: PhpVersion| {
+            let base = dirs
+                .data
+                .join("php")
+                .join(format!("php-{}.{}", v.major, v.minor));
+            std::fs::create_dir_all(base.join("bin")).unwrap();
+            std::fs::create_dir_all(base.join("sbin")).unwrap();
+            std::fs::write(base.join("bin").join("php"), b"cli").unwrap();
+            std::fs::write(base.join("sbin").join("php-fpm"), b"fpm").unwrap();
+        };
+        mk(PhpVersion::new(8, 4));
+
+        let bin = shim_dir(&dirs);
+        std::fs::create_dir_all(&bin).unwrap();
+        // A stale managed shim for an uninstalled 8.2 + a foreign file that must survive.
+        std::os::unix::fs::symlink(&yerd_bin, bin.join("php8.2cover")).unwrap();
+        std::fs::write(bin.join("keep.txt"), b"user file").unwrap();
+
+        reconcile_shims(&dirs, &yerd_bin, PhpVersion::new(8, 4)).unwrap();
+
+        // Created for 8.4.
+        assert!(bin.join("php8.4").exists());
+        assert!(bin.join("php8.4cover").exists());
+        assert!(bin.join("phpcover").exists());
+        // `php` repointed to the (installed) default.
+        assert_eq!(
+            std::fs::read_link(bin.join("php")).unwrap(),
+            cli_binary_path(&dirs, PhpVersion::new(8, 4))
+        );
+        // Stale 8.2 cover pruned; foreign file untouched.
+        assert!(!bin.join("php8.2cover").exists());
+        assert!(bin.join("keep.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_leaves_php_alone_when_default_not_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let yerd_bin = tmp.path().join("yerd");
+        std::fs::write(&yerd_bin, b"#!fake").unwrap();
+        // Install 8.4 only; configured default 8.3 is absent.
+        let base = dirs.data.join("php").join("php-8.4");
+        std::fs::create_dir_all(base.join("bin")).unwrap();
+        std::fs::create_dir_all(base.join("sbin")).unwrap();
+        std::fs::write(base.join("bin").join("php"), b"cli").unwrap();
+        std::fs::write(base.join("sbin").join("php-fpm"), b"fpm").unwrap();
+
+        reconcile_shims(&dirs, &yerd_bin, PhpVersion::new(8, 3)).unwrap();
+
+        // No `php` created for an uninstalled default; versioned shims still made.
+        assert!(!shim_dir(&dirs).join("php").exists());
+        assert!(shim_dir(&dirs).join("php8.4cover").exists());
     }
 }

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -253,9 +253,12 @@ pub fn shim_dir(dirs: &PlatformDirs) -> PathBuf {
 
 /// Atomically create/replace the symlink `link` → `target` (temp + rename, so a
 /// concurrent reader never sees a half-written link). The temp name embeds the
-/// link's own filename + pid, so reconciling many links at once never collides.
+/// link's filename + pid + a process-global sequence, so two writers racing on
+/// the same link name (e.g. an unsynchronized `set_default_shim` vs a reconcile,
+/// both touching `php`) never share a temp path.
 #[cfg(unix)]
 fn place_symlink(link: &Path, target: &Path) -> Result<(), PhpError> {
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let parent = link
         .parent()
         .ok_or_else(|| fs_err(link, &std::io::Error::other("shim link has no parent")))?;
@@ -263,7 +266,8 @@ fn place_symlink(link: &Path, target: &Path) -> Result<(), PhpError> {
         .file_name()
         .and_then(|s| s.to_str())
         .ok_or_else(|| fs_err(link, &std::io::Error::other("shim link has no file name")))?;
-    let tmp = parent.join(format!(".{name}.tmp-{}", std::process::id()));
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = parent.join(format!(".{name}.tmp-{}-{seq}", std::process::id()));
     let _ = std::fs::remove_file(&tmp);
     fs_ctx(std::os::unix::fs::symlink(target, &tmp), &tmp)?;
     // rename is atomic and replaces any existing shim.
@@ -310,6 +314,12 @@ fn managed_shim_version(name: &str) -> Option<PhpVersion> {
     }
     let major: u8 = maj.parse().ok()?;
     let minor: u8 = min.parse().ok()?;
+    // Reject non-canonical spellings (leading zeros, signs) so a foreign symlink
+    // like `php08.04` is never mistaken for one yerd created (`versioned_shim_name`
+    // only emits canonical `php8.4`).
+    if maj != major.to_string() || min != minor.to_string() {
+        return None;
+    }
     Some(PhpVersion::new(major, minor))
 }
 
@@ -593,6 +603,9 @@ mod tests {
         assert_eq!(managed_shim_version("php8.4.1"), None);
         assert_eq!(managed_shim_version("phpunit"), None);
         assert_eq!(managed_shim_version("php8.4covers"), None);
+        // Non-canonical (leading-zero) spellings are foreign, not managed.
+        assert_eq!(managed_shim_version("php08.04"), None);
+        assert_eq!(managed_shim_version("php8.04"), None);
     }
 
     #[cfg(unix)]

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -271,6 +271,7 @@ pub async fn bring_up_with_dirs(
         detect_cache,
         watch_dirty: tokio::sync::Notify::new(),
         dumps: Arc::new(crate::dump_server::DumpStore::new()),
+        shim_reconcile: tokio::sync::Mutex::new(()),
     });
 
     // Seed the extension's runtime state file from the persisted `[dumps]`

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -97,4 +97,8 @@ pub struct DaemonState {
     /// Dump-telemetry ring buffer + server control, shared with the dump-server
     /// task and the IPC dump handlers.
     pub dumps: Arc<crate::dump_server::DumpStore>,
+    /// Serializes `php_install::reconcile_shims` runs. IPC dispatch is
+    /// `tokio::spawn`-per-connection, so two clients can reconcile the `{data}/bin`
+    /// shims concurrently; this guard keeps the (sync) scan→prune from interleaving.
+    pub shim_reconcile: Mutex<()>,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Unix CLI aliases for running coverage via `phpcover` and `php<major>.<minor>cover` with pcov.
  * Automatically manage version-specific PHP and cover aliases (e.g., `php8.1`, `php8.2`) and keep them in sync as PHP versions are installed.
  * Automatically install, refresh, and clean up the pcov extension when PHP versions are added or removed.  
* **Bug Fixes**
  * Improved shim reconciliation to prune stale managed aliases while preserving unrelated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->