### PR TITLE
[Feat] Add Yerd uninstall command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5965,6 +5965,7 @@ version = "2.0.2-rc.3"
 dependencies = [
  "clap",
  "interprocess",
+ "nix",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6068,8 +6068,10 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "time",
  "yerd-core",
  "yerd-platform",
+ "yerd-tls",
 ]
 
 [[package]]
@@ -6125,6 +6127,8 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 1.0.69",
+ "time",
+ "x509-parser",
  "yerd-core",
  "yerd-tls",
 ]

--- a/bin/yerd-helper/Cargo.toml
+++ b/bin/yerd-helper/Cargo.toml
@@ -23,6 +23,11 @@ pem           = { workspace = true }
 [dev-dependencies]
 tempfile   = { workspace = true }
 serde_json = { workspace = true }
+# Test-only: mint CAs (and the Validity timestamps they need) to exercise the
+# yerd-ownership guard. Not a runtime dep — keeps rcgen/ring out of the
+# privileged binary.
+yerd-tls   = { path = "../../crates/yerd-tls" }
+time       = { workspace = true }
 
 [lints]
 workspace = true

--- a/bin/yerd-helper/src/error.rs
+++ b/bin/yerd-helper/src/error.rs
@@ -122,6 +122,15 @@ pub enum ValidationReason {
     /// PEM could not be parsed.
     #[error("PEM could not be parsed")]
     PemParseFailed,
+    /// A cert matched the fingerprint to uninstall, but it is not yerd's CA
+    /// (its Subject CN is not `yerd_core::CA_COMMON_NAME`). The helper refuses
+    /// to remove a certificate it can't confirm yerd installed. Not gated:
+    /// both the Linux and macOS uninstall paths can raise it.
+    #[error("certificate is not yerd's CA (subject CN {found_cn:?}); refusing to remove it")]
+    CertNotYerdOwned {
+        /// The Subject CN actually found (if any), for diagnostics.
+        found_cn: Option<String>,
+    },
     /// No recognised Linux CA anchor directory present. Linux-only.
     #[cfg(target_os = "linux")]
     #[error("no recognised CA anchor directory")]
@@ -200,6 +209,13 @@ mod tests {
         assert_eq!(
             exit_code(&HelperError::Validation {
                 reason: ValidationReason::BadFingerprintHex
+            }),
+            65
+        );
+        // The yerd-ownership refusal is a validation failure too → 65.
+        assert_eq!(
+            exit_code(&HelperError::Validation {
+                reason: ValidationReason::CertNotYerdOwned { found_cn: None }
             }),
             65
         );

--- a/bin/yerd-helper/src/ops/ca.rs
+++ b/bin/yerd-helper/src/ops/ca.rs
@@ -1,22 +1,27 @@
 //! `install-ca` and `uninstall-ca` for Linux + macOS.
 
-use std::path::Path;
-#[cfg(target_os = "linux")]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-#[cfg(target_os = "linux")]
-use yerd_platform::pure::pem_match;
+use yerd_platform::pure::{cert_identity, pem_match};
 use yerd_platform::CaFingerprint;
 
 #[cfg(target_os = "macos")]
 use crate::error::CommandReason;
-use crate::error::HelperError;
-#[cfg(target_os = "linux")]
-use crate::error::ValidationReason;
+use crate::error::{HelperError, ValidationReason};
 #[cfg(target_os = "linux")]
 use crate::ops::atomic_write;
 use crate::ops::run_command;
 use crate::validate;
+
+/// True iff `cert_der` is yerd's own CA — its Subject CN equals
+/// [`yerd_core::CA_COMMON_NAME`]. This is the ownership guard the privileged
+/// uninstall applies before removing a certificate from the system trust
+/// store, so a fingerprint that happens to match some *other* trusted root can
+/// never cause its deletion. An unparseable or CN-less cert is treated as
+/// not-yerd (refuse to delete).
+fn cert_is_yerd_owned(cert_der: &[u8]) -> bool {
+    cert_identity::subject_common_name(cert_der).as_deref() == Some(yerd_core::CA_COMMON_NAME)
+}
 
 /// Anchor directories Yerd searches on Linux. Order matches the
 /// distro family precedence.
@@ -155,6 +160,17 @@ pub fn uninstall_ca(fp: &CaFingerprint) -> Result<(), HelperError> {
         return Ok(());
     };
 
+    // Refuse unless the matched cert is yerd's own CA — a fingerprint that
+    // matches some other trusted anchor must never get it deleted.
+    let der = pem_match::cert_der_for_fingerprint(&blobs, fp.as_bytes());
+    if !der.as_deref().is_some_and(cert_is_yerd_owned) {
+        return Err(HelperError::Validation {
+            reason: ValidationReason::CertNotYerdOwned {
+                found_cn: der.as_deref().and_then(cert_identity::subject_common_name),
+            },
+        });
+    }
+
     std::fs::remove_file(&m.path).map_err(|source| HelperError::Io {
         path: m.path.clone(),
         source,
@@ -168,11 +184,46 @@ pub fn uninstall_ca(fp: &CaFingerprint) -> Result<(), HelperError> {
 
 #[cfg(target_os = "macos")]
 pub fn uninstall_ca(fp: &CaFingerprint) -> Result<(), HelperError> {
-    // Idempotent: if the fingerprint isn't in the System keychain there's
-    // nothing to remove.
-    if !macos_system_keychain_contains(fp)? {
+    // Dump every System-keychain cert as PEM, locate the one matching `fp`, and
+    // delete it ONLY if it is yerd's own CA. `find-certificate -a -p` emits all
+    // certs as concatenated PEM (distinct from the `-Z` presence probe used by
+    // `install_ca`, which lists `SHA-256 hash:` lines — don't conflate them).
+    let dump = run_command(
+        "security",
+        "/usr/bin/security",
+        [
+            "find-certificate",
+            "-a",
+            "-p",
+            "/Library/Keychains/System.keychain",
+        ],
+    );
+    let pem_bytes = match dump {
+        Ok(out) => out.stdout,
+        // `security` exits non-zero when no certs match → nothing to remove.
+        Err(HelperError::Command {
+            reason: CommandReason::NonZero(_),
+            ..
+        }) => return Ok(()),
+        Err(e) => return Err(e),
+    };
+
+    let blobs = vec![(
+        PathBuf::from("/Library/Keychains/System.keychain"),
+        pem_bytes,
+    )];
+    let Some(der) = pem_match::cert_der_for_fingerprint(&blobs, fp.as_bytes()) else {
+        // Idempotent: the fingerprint isn't in the System keychain.
         return Ok(());
+    };
+    if !cert_is_yerd_owned(&der) {
+        return Err(HelperError::Validation {
+            reason: ValidationReason::CertNotYerdOwned {
+                found_cn: cert_identity::subject_common_name(&der),
+            },
+        });
     }
+
     let fp_upper = hex::encode_upper(fp.as_bytes());
     run_command(
         "security",
@@ -242,6 +293,33 @@ pub fn macos_find_certificate_contains(stdout: &str, fp_upper: &str) -> bool {
 )]
 mod tests {
     use super::*;
+
+    /// Mint a CA with Subject CN `cn` via yerd-tls and return its DER body.
+    fn ca_der(cn: &str) -> Vec<u8> {
+        let nb = time::OffsetDateTime::UNIX_EPOCH;
+        let na = nb + time::Duration::days(365);
+        let validity = yerd_tls::Validity::new(nb, na).unwrap();
+        let ca = yerd_tls::CertAuthority::generate(cn, validity).unwrap();
+        pem::parse(ca.cert_pem().as_bytes())
+            .unwrap()
+            .into_contents()
+    }
+
+    #[test]
+    fn cert_is_yerd_owned_true_for_yerd_ca() {
+        assert!(cert_is_yerd_owned(&ca_der(yerd_core::CA_COMMON_NAME)));
+    }
+
+    #[test]
+    fn cert_is_yerd_owned_false_for_other_ca() {
+        // A different trusted root with the same op applied must be refused.
+        assert!(!cert_is_yerd_owned(&ca_der("DigiCert Global Root")));
+    }
+
+    #[test]
+    fn cert_is_yerd_owned_false_for_unparseable() {
+        assert!(!cert_is_yerd_owned(b"not a certificate"));
+    }
 
     #[cfg(target_os = "linux")]
     #[test]

--- a/bin/yerd/Cargo.toml
+++ b/bin/yerd/Cargo.toml
@@ -28,8 +28,9 @@ thiserror      = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 # `user` resolves the invoking user (home/shell) under sudo for the full
-# uninstall; `signal` lets it SIGTERM/SIGKILL a surviving daemon.
-nix            = { workspace = true, features = ["user", "signal"] }
+# uninstall (the daemon is reaped via `pkill`, so no `signal` feature is needed
+# here — the workspace already enables it for other crates anyway).
+nix            = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 yerdd          = { path = "../yerdd" }

--- a/bin/yerd/Cargo.toml
+++ b/bin/yerd/Cargo.toml
@@ -19,15 +19,20 @@ path = "src/lib.rs"
 yerd-core      = { path = "../../crates/yerd-core" }
 yerd-ipc       = { path = "../../crates/yerd-ipc", features = ["transport"] }
 yerd-platform  = { path = "../../crates/yerd-platform" }
+yerd-config    = { path = "../../crates/yerd-config" }
 clap           = { workspace = true }
 tokio          = { workspace = true, features = ["rt", "io-util", "net", "time"] }
 interprocess   = { workspace = true }
 serde_json     = { workspace = true }
 thiserror      = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+# `user` resolves the invoking user (home/shell) under sudo for the full
+# uninstall; `signal` lets it SIGTERM/SIGKILL a surviving daemon.
+nix            = { workspace = true, features = ["user", "signal"] }
+
 [dev-dependencies]
 yerdd          = { path = "../yerdd" }
-yerd-config    = { path = "../../crates/yerd-config" }
 tempfile       = { workspace = true }
 tokio          = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
 

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -77,11 +77,20 @@ pub enum Command {
         #[command(subcommand)]
         target: RestartTarget,
     },
-    /// Uninstall a component (currently: a PHP version).
+    /// Uninstall a component, or yerd itself.
+    ///
+    /// With a subcommand (`php`/`tool`) removes that component via the daemon.
+    /// With no subcommand, fully uninstalls yerd from this machine: config,
+    /// data, downloads, the PATH entry, the daemon service, and — when run with
+    /// `sudo` — the system-level trust/resolver/port changes from `elevate`.
+    /// Prompts for confirmation first unless `--yes` is given.
     Uninstall {
-        /// What to uninstall.
+        /// What to uninstall; omit to uninstall yerd entirely.
         #[command(subcommand)]
-        target: UninstallTarget,
+        target: Option<UninstallTarget>,
+        /// Skip the confirmation prompt (only affects the full uninstall).
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
     /// List installed components (currently: PHP versions).
     List {

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -168,6 +168,15 @@ mod unix_impl {
                 }
                 Ok(())
             }
+            // EX_DATAERR (65): the helper validated its input and declined.
+            // For `trust`+undo that means it refused to remove a trust-store
+            // cert it couldn't confirm is yerd's — surface it as a refusal, not
+            // a usage error, with a clear explanation.
+            Some(65) => Err(ClientError::Refused(
+                "yerd-helper declined: it refused to remove a certificate it couldn't \
+                 confirm is yerd's (or the input failed validation)"
+                    .to_owned(),
+            )),
             Some(code) => Err(ClientError::Usage(format!(
                 "yerd-helper exited with status {code}"
             ))),

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -20,6 +20,13 @@ pub async fn run_elevate(
 #[cfg(unix)]
 pub use unix_impl::run_elevate;
 
+// Small Unix helpers reused by `crate::uninstall` (root detection, the invoking
+// user's uid under sudo, sibling-binary resolution, and the audited helper
+// spawn) so the full-uninstall flow can revert the elevated system changes
+// without a running daemon.
+#[cfg(unix)]
+pub(crate) use unix_impl::{is_root, sibling_binaries, spawn_helper, sudo_uid};
+
 #[cfg(unix)]
 mod unix_impl {
     use std::net::SocketAddr;
@@ -315,7 +322,7 @@ mod unix_impl {
         ]
     }
 
-    fn sudo_uid() -> Option<u32> {
+    pub(crate) fn sudo_uid() -> Option<u32> {
         std::env::var("SUDO_UID").ok()?.parse().ok()
     }
 
@@ -328,7 +335,7 @@ mod unix_impl {
     /// Locate `yerd-helper` and `yerdd` as siblings of the running `yerd`
     /// binary. Deriving `yerdd` here (not from IPC) means a forged daemon can't
     /// point root's setcap at an arbitrary binary.
-    fn sibling_binaries() -> Result<(PathBuf, PathBuf), ClientError> {
+    pub(crate) fn sibling_binaries() -> Result<(PathBuf, PathBuf), ClientError> {
         let exe = std::env::current_exe()
             .map_err(|e| ClientError::Usage(format!("cannot resolve current exe: {e}")))?;
         let dir = exe
@@ -357,7 +364,10 @@ mod unix_impl {
         Ok(())
     }
 
-    fn spawn_helper(helper: &Path, inv: &HelperInvocation) -> Result<Option<i32>, ClientError> {
+    pub(crate) fn spawn_helper(
+        helper: &Path,
+        inv: &HelperInvocation,
+    ) -> Result<Option<i32>, ClientError> {
         let status = Command::new(helper)
             .env_clear()
             .args(inv.to_argv())
@@ -367,7 +377,7 @@ mod unix_impl {
     }
 
     #[cfg(target_os = "linux")]
-    fn is_root() -> bool {
+    pub(crate) fn is_root() -> bool {
         // /proc/self/status "Uid:\t<real>\t<effective>\t<saved>\t<fs>"
         std::fs::read_to_string("/proc/self/status")
             .ok()
@@ -381,7 +391,7 @@ mod unix_impl {
     }
 
     #[cfg(all(unix, not(target_os = "linux")))]
-    fn is_root() -> bool {
+    pub(crate) fn is_root() -> bool {
         Command::new("id")
             .arg("-u")
             .output()

--- a/bin/yerd/src/error.rs
+++ b/bin/yerd/src/error.rs
@@ -20,4 +20,9 @@ pub enum ClientError {
     /// The daemon reported a malformed CA fingerprint (used by `elevate`).
     #[error("{0}")]
     Fingerprint(#[from] yerd_platform::FingerprintParseError),
+    /// `yerd-helper` declined a privileged operation for a safety reason (e.g.
+    /// refused to remove a trust-store cert it couldn't confirm is yerd's).
+    /// Distinct from `Usage` — the invocation was well-formed; the helper said no.
+    #[error("{0}")]
+    Refused(String),
 }

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -22,6 +22,7 @@ pub mod path_cmd;
 #[cfg(unix)]
 pub mod shim;
 pub mod transport;
+pub mod uninstall;
 
 use std::process::ExitCode;
 
@@ -41,6 +42,10 @@ pub async fn run(cli: Cli) -> ExitCode {
         Command::Unelevate { target } => return elevate::run_elevate(*target, true).await,
         // `path` edits the user's shell rc file(s); fully local, no IPC.
         Command::Path { action } => return path_cmd::run(*action),
+        // Bare `yerd uninstall` (no target) tears yerd down locally: it stops
+        // the daemon and deletes files, so it can't go over IPC. `uninstall
+        // php/tool` keeps its daemon-mediated path below.
+        Command::Uninstall { target: None, yes } => return uninstall::run(*yes),
         // Stream the install output (Composer's, for the Laravel installer) line by
         // line. JSON mode keeps the plain blocking path for clean machine output.
         Command::Install {

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -96,13 +96,23 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
             target: crate::cli::RestartTarget::Daemon,
         } => Request::RestartDaemon,
         Command::Uninstall {
-            target: crate::cli::UninstallTarget::Php { version },
+            target: Some(crate::cli::UninstallTarget::Php { version }),
+            ..
         } => Request::UninstallPhp {
             version: parse_php(version)?,
         },
         Command::Uninstall {
-            target: crate::cli::UninstallTarget::Tool { id },
+            target: Some(crate::cli::UninstallTarget::Tool { id }),
+            ..
         } => Request::UninstallTool { tool: id.clone() },
+        // Bare `yerd uninstall` (no target) is the full self-uninstall, handled
+        // locally in `crate::uninstall` (it tears down the daemon + files). `run`
+        // branches before calling `to_request`; this arm keeps the match total.
+        Command::Uninstall { target: None, .. } => {
+            return Err(ClientError::Usage(
+                "full uninstall is handled locally, not over IPC".to_owned(),
+            ));
+        }
         Command::Tools => Request::ListTools,
         Command::List {
             target: crate::cli::ListTarget::Php { check, available },
@@ -979,9 +989,10 @@ mod tests {
         );
         assert_eq!(
             to_request(&Command::Uninstall {
-                target: crate::cli::UninstallTarget::Php {
+                target: Some(crate::cli::UninstallTarget::Php {
                     version: "8.5".into()
-                }
+                }),
+                yes: false
             })
             .unwrap(),
             Request::UninstallPhp {
@@ -1011,7 +1022,8 @@ mod tests {
         );
         assert_eq!(
             to_request(&Command::Uninstall {
-                target: crate::cli::UninstallTarget::Tool { id: "bun".into() }
+                target: Some(crate::cli::UninstallTarget::Tool { id: "bun".into() }),
+                yes: false
             })
             .unwrap(),
             Request::UninstallTool { tool: "bun".into() }

--- a/bin/yerd/src/path_cmd.rs
+++ b/bin/yerd/src/path_cmd.rs
@@ -46,6 +46,17 @@ pub fn ensure_installed_after_tool(quiet: bool) {
 #[cfg(not(unix))]
 pub fn ensure_installed_after_tool(_quiet: bool) {}
 
+/// Remove the yerd PATH block from an explicit user's shell rc file(s), given
+/// their home directory and login-shell basename (e.g. `zsh`). Unlike [`run`],
+/// this reads neither `$HOME` nor `$SHELL` — `yerd uninstall`, run under sudo,
+/// must target the *invoking* user, not root. Returns the list of files it
+/// edited (the block was present and removed). Best-effort: unreadable files
+/// are skipped.
+#[cfg(unix)]
+pub fn remove_block_for_user(home: &std::path::Path, shell_basename: &str) -> Vec<std::path::PathBuf> {
+    unix::remove_block_for_user(home, shell_basename)
+}
+
 #[cfg(unix)]
 mod unix {
     use std::path::{Path, PathBuf};
@@ -143,6 +154,29 @@ mod unix {
                 bin_dir.display()
             );
         }
+    }
+
+    /// Remove the yerd PATH block from `home`'s rc file(s) for the shell named
+    /// by `shell_basename`. Daemon-free and home-explicit (the uninstall path
+    /// runs under sudo, where `$HOME`/`$SHELL` point at root). `bin_dir` is
+    /// irrelevant to removal — `shell_profile::remove_block` matches the guarded
+    /// markers — so a placeholder is passed. Returns the files actually changed.
+    pub fn remove_block_for_user(home: &Path, shell_basename: &str) -> Vec<PathBuf> {
+        let Some(shell) = detect_shell(shell_basename) else {
+            return Vec::new();
+        };
+        let placeholder_bin = Path::new("");
+        let mut touched = Vec::new();
+        for rel in rc_relpaths(shell, host_os()) {
+            let rc = home.join(&rel);
+            if !rc.exists() {
+                continue;
+            }
+            if let Ok(true) = edit_one(&rc, shell, placeholder_bin, false) {
+                touched.push(rc);
+            }
+        }
+        touched
     }
 
     /// Edit one rc file. Returns `Ok(true)` if the file's contents changed.

--- a/bin/yerd/src/path_cmd.rs
+++ b/bin/yerd/src/path_cmd.rs
@@ -53,7 +53,10 @@ pub fn ensure_installed_after_tool(_quiet: bool) {}
 /// edited (the block was present and removed). Best-effort: unreadable files
 /// are skipped.
 #[cfg(unix)]
-pub fn remove_block_for_user(home: &std::path::Path, shell_basename: &str) -> Vec<std::path::PathBuf> {
+pub fn remove_block_for_user(
+    home: &std::path::Path,
+    shell_basename: &str,
+) -> Vec<std::path::PathBuf> {
     unix::remove_block_for_user(home, shell_basename)
 }
 

--- a/bin/yerd/src/uninstall.rs
+++ b/bin/yerd/src/uninstall.rs
@@ -199,9 +199,14 @@ mod unix_impl {
                 "remove the CA from the system trust store",
                 residue,
             ),
-            None => residue.push(
-                "CA in the system trust store (its cert was not on disk to identify it)".to_owned(),
-            ),
+            // The cert was already gone from disk, so we have no fingerprint to
+            // hand the helper. A yerd CA may still be trusted system-wide; give
+            // the concrete manual removal steps rather than a vague note.
+            None => residue.push(format!(
+                "a yerd CA may remain in the system trust store (its cert was \
+                 not on disk to identify it) — remove it manually: {}",
+                manual_ca_removal_hint()
+            )),
         }
 
         if let Some(tld) = &facts.tld {
@@ -303,16 +308,25 @@ mod unix_impl {
     /// Reap any still-running `yerdd` for this user: SIGTERM (graceful — it
     /// reaps its php-fpm/DB/mail children), wait a bounded grace, then SIGKILL
     /// any holdout. `pgrep`/`pkill -U <uid>` match by *real* uid on both
-    /// Linux and macOS; `-x yerdd` matches the exact process name.
+    /// Linux and macOS; `-x yerdd` matches the exact process name (so it never
+    /// touches the running `yerd` uninstaller or `yerd-helper`).
+    ///
+    /// The grace is deliberately generous (~30s). The daemon's own shutdown
+    /// (`bin/yerdd/src/lib.rs`) walks several task-join timeouts before it
+    /// gracefully stops (then force-kills) its php-fpm/DB/mail children; killing
+    /// the daemon too early would skip that and orphan those children. In
+    /// practice it exits in well under a second — we only wait the full budget
+    /// if one of its tasks is wedged.
     fn reap_daemon(uid: u32) {
         let uid = uid.to_string();
         let _ = run_quiet("pkill", &["-TERM", "-U", &uid, "-x", "yerdd"]);
-        for _ in 0..50 {
+        for _ in 0..300 {
             if !yerdd_running(&uid) {
                 return;
             }
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
+        // Still alive after the graceful budget — force it as a last resort.
         let _ = run_quiet("pkill", &["-KILL", "-U", &uid, "-x", "yerdd"]);
     }
 
@@ -345,10 +359,13 @@ mod unix_impl {
         }
     }
 
-    /// Remove the yerd binaries. Symlinks (e.g. a `~/.local/bin/yerd` pointing
-    /// elsewhere) are unlinked; real files in a package-managed system path are
-    /// left for `apt purge`. `yerd` (this running binary) is removed last —
-    /// unlinking a running executable is safe on Unix.
+    /// Remove the yerd binaries across the candidate dirs (the running exe's
+    /// dir — `current_exe` resolves symlinks, so this is the real install dir —
+    /// plus `~/.local/bin` and the system dirs). A symlink at a candidate path
+    /// is unlinked (its target is cleaned only if that target also lands in a
+    /// candidate dir); a real file in a package-managed system path is left for
+    /// `apt purge`; anything else is deleted. `yerd` (this running binary) is
+    /// removed last — unlinking a running executable is safe on Unix.
     fn remove_binaries(actor: &Actor, residue: &mut Vec<String>) {
         let mut dirs: Vec<PathBuf> = Vec::new();
         if let Ok(exe) = std::env::current_exe() {
@@ -475,6 +492,20 @@ mod unix_impl {
         }
     }
 
+    /// Per-OS one-liner for manually removing yerd's CA from the system trust
+    /// store. Shared by the not-root warning and the root-path residue note.
+    fn manual_ca_removal_hint() -> &'static str {
+        #[cfg(target_os = "macos")]
+        {
+            "open Keychain Access → System and delete the 'Yerd Local CA' certificate"
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            "remove yerd's CA from your trust anchors, then `sudo update-ca-certificates \
+             --fresh` (or `update-ca-trust`)"
+        }
+    }
+
     fn print_unelevate_warning(facts: &CapturedFacts) {
         let tld = facts.tld.as_deref().unwrap_or("<your-tld>");
         eprintln!();
@@ -483,11 +514,14 @@ mod unix_impl {
         eprintln!("  CANNOT be reverted after yerd is uninstalled (the binary will be gone).");
         eprintln!("  They will be left in place. Either abort and re-run as `sudo yerd uninstall`,");
         eprintln!("  or remove them manually afterwards:");
+        eprintln!("    • CA trust: {}", manual_ca_removal_hint());
+        // The cert is about to be deleted; print its fingerprint now so the CA
+        // stays identifiable in the trust store afterwards.
+        if let Some(fp) = facts.ca_fp {
+            eprintln!("                (yerd CA SHA-256 fingerprint: {})", fp.to_hex());
+        }
         #[cfg(target_os = "macos")]
         {
-            eprintln!(
-                "    • CA trust: open Keychain Access → System and delete the 'Yerd Local CA'"
-            );
             eprintln!("    • resolver: sudo rm /etc/resolver/{tld}");
             eprintln!(
                 "    • ports:    sudo launchctl bootout system/dev.yerd.pf 2>/dev/null; \
@@ -496,10 +530,6 @@ mod unix_impl {
         }
         #[cfg(not(target_os = "macos"))]
         {
-            eprintln!(
-                "    • CA trust: remove yerd's CA from your trust anchors, then \
-                 `sudo update-ca-certificates --fresh` (or `update-ca-trust`)"
-            );
             eprintln!(
                 "    • resolver: sudo rm /etc/systemd/resolved.conf.d/yerd-{tld}.conf && \
                  sudo systemctl restart systemd-resolved"

--- a/bin/yerd/src/uninstall.rs
+++ b/bin/yerd/src/uninstall.rs
@@ -1,0 +1,579 @@
+//! `yerd uninstall` (no subcommand) — remove yerd entirely from this machine.
+//!
+//! Fully local and daemon-independent: the daemon is usually the first thing to
+//! go, and may already be down. The flow is, in order:
+//!
+//! 1. Resolve the *invoking* user (under `sudo`, `$HOME`/`$SHELL` point at root,
+//!    so the user is recovered from `SUDO_UID` + the passwd database).
+//! 2. Capture the facts a manual/automatic unelevate needs (`tld`, CA
+//!    fingerprint) from disk **before** anything is deleted — otherwise deleting
+//!    the data dir would strand a trusted root CA with no way to identify it.
+//! 3. Confirm (unless `--yes`).
+//! 4. Root only: revert the system changes from `yerd elevate` (CA trust, DNS
+//!    resolver, macOS pf redirect) by driving `yerd-helper` directly. Without
+//!    root we print the exact manual steps and continue.
+//! 5. Stop + disable the daemon service and reap the daemon (a graceful SIGTERM
+//!    lets it reap its php-fpm / DB / mail children).
+//! 6. Remove the PATH block, the service unit files, the user dirs, and the
+//!    binaries (or advise `apt purge` for a `.deb` install).
+
+use std::process::ExitCode;
+
+/// Run the full self-uninstall. Returns the process exit code.
+#[cfg(unix)]
+pub fn run(yes: bool) -> ExitCode {
+    unix_impl::run(yes)
+}
+
+/// Non-Unix: the daemon service, sudo model, and shell rc handling are all
+/// Unix-shaped; mirror `elevate`/`path` and decline here.
+#[cfg(not(unix))]
+pub fn run(_yes: bool) -> ExitCode {
+    eprintln!("yerd: `yerd uninstall` (full) is only supported on Unix (macOS/Linux)");
+    ExitCode::from(78)
+}
+
+#[cfg(unix)]
+mod unix_impl {
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, ExitCode};
+
+    use yerd_platform::{CaFingerprint, HelperInvocation, PlatformDirs};
+
+    use crate::{elevate, path_cmd};
+
+    /// The user yerd is being uninstalled for — the invoking user, even under
+    /// sudo. All user-owned artefacts (dirs, rc files, `~/.local/bin`) live in
+    /// `home`; service teardown runs in this user's session.
+    struct Actor {
+        uid: u32,
+        name: String,
+        home: PathBuf,
+        shell: PathBuf,
+    }
+
+    /// Facts captured from disk before deletion, used to revert (or print the
+    /// manual steps to revert) the system changes made by `yerd elevate`.
+    struct CapturedFacts {
+        tld: Option<String>,
+        ca_fp: Option<CaFingerprint>,
+    }
+
+    impl CapturedFacts {
+        fn capture(dirs: &PlatformDirs) -> Self {
+            let tld = yerd_config::Config::load(&dirs.config.join("yerd.toml"))
+                .ok()
+                .map(|c| c.tld.as_str().to_owned());
+            let ca_fp = std::fs::read_to_string(dirs.data.join("ca.cert.pem"))
+                .ok()
+                .and_then(|pem| CaFingerprint::from_pem(&pem));
+            Self { tld, ca_fp }
+        }
+    }
+
+    pub fn run(yes: bool) -> ExitCode {
+        let actor = match resolve_actor() {
+            Ok(a) => a,
+            Err(e) => {
+                eprintln!("yerd: {e}");
+                return ExitCode::from(74);
+            }
+        };
+        let dirs = PlatformDirs::for_user(&actor.home, actor.uid);
+        let root = elevate::is_root();
+
+        // Capture before any deletion (data-safety: see module docs).
+        let facts = CapturedFacts::capture(&dirs);
+
+        print_header(&actor, &dirs, root);
+        if !root {
+            print_unelevate_warning(&facts);
+        }
+
+        if !yes && !confirm() {
+            println!("yerd: aborted — nothing was changed.");
+            return ExitCode::from(1);
+        }
+
+        // Things that couldn't be removed and need the user's attention.
+        let mut residue: Vec<String> = Vec::new();
+
+        // 1. System changes from `elevate` (root only; otherwise the warning
+        //    above already listed the manual steps).
+        if root {
+            revert_system_changes(&facts, &mut residue);
+        } else {
+            residue.push(
+                "system changes from `yerd elevate` (CA trust, DNS resolver, ports) — \
+                 see the manual steps printed above"
+                    .to_owned(),
+            );
+        }
+
+        // 2. Daemon service + process (graceful, so it reaps its children).
+        stop_daemon_service(&actor, root);
+        reap_daemon(actor.uid);
+
+        // 3. PATH block from the invoking user's shell rc files.
+        let touched = path_cmd::remove_block_for_user(&actor.home, &shell_basename(&actor.shell));
+        for f in &touched {
+            println!("  removed PATH entry from {}", f.display());
+        }
+
+        // 4. Service unit file.
+        remove_service_unit(&actor);
+
+        // 5. User dirs.
+        for dir in dirs_to_delete(&dirs, actor.uid) {
+            match std::fs::remove_dir_all(&dir) {
+                Ok(()) => println!("  removed {}", dir.display()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => residue.push(format!("{} ({e})", dir.display())),
+            }
+        }
+
+        // 6. Binaries (self last; never `rm` a packaged install).
+        remove_binaries(&actor, &mut residue);
+
+        print_summary(&residue);
+        ExitCode::SUCCESS
+    }
+
+    /// Resolve the invoking user. Under sudo, `SUDO_UID` + the passwd database
+    /// give the real user (the process env points at root). The uid comes from
+    /// `nix` (no `unsafe`; `bin/yerd` is `#![forbid(unsafe_code)]`).
+    fn resolve_actor() -> Result<Actor, String> {
+        use nix::unistd::{Uid, User};
+
+        let sudo = elevate::sudo_uid();
+        let uid = sudo.unwrap_or_else(|| Uid::current().as_raw());
+
+        if let Ok(Some(u)) = User::from_uid(Uid::from_raw(uid)) {
+            return Ok(Actor {
+                uid,
+                name: u.name,
+                home: u.dir,
+                shell: u.shell,
+            });
+        }
+
+        // No passwd entry. Falling back to the process env is only correct when
+        // we are NOT under sudo (then the env belongs to the invoking user).
+        if sudo.is_some() {
+            return Err(format!(
+                "cannot resolve the invoking user (uid {uid}) — no passwd entry"
+            ));
+        }
+        let home = std::env::var_os("HOME")
+            .filter(|h| !h.is_empty())
+            .map(PathBuf::from)
+            .ok_or_else(|| "cannot resolve your home directory ($HOME is unset)".to_owned())?;
+        let name = std::env::var("USER").unwrap_or_default();
+        let shell = std::env::var_os("SHELL")
+            .map_or_else(|| PathBuf::from("/bin/sh"), PathBuf::from);
+        Ok(Actor {
+            uid,
+            name,
+            home,
+            shell,
+        })
+    }
+
+    /// Revert the privileged system changes by driving `yerd-helper` directly
+    /// from the captured on-disk facts — no daemon needed. Best-effort: every
+    /// failure is recorded in `residue`, never fatal.
+    fn revert_system_changes(facts: &CapturedFacts, residue: &mut Vec<String>) {
+        let helper = match elevate::sibling_binaries() {
+            Ok((helper, _yerdd)) => helper,
+            Err(e) => {
+                residue
+                    .push(format!("could not locate yerd-helper to revert system changes: {e}"));
+                return;
+            }
+        };
+
+        match facts.ca_fp {
+            Some(fp) => run_helper(
+                &helper,
+                &HelperInvocation::UninstallCa { fp },
+                "remove the CA from the system trust store",
+                residue,
+            ),
+            None => residue.push(
+                "CA in the system trust store (its cert was not on disk to identify it)".to_owned(),
+            ),
+        }
+
+        if let Some(tld) = &facts.tld {
+            run_helper(
+                &helper,
+                &HelperInvocation::UninstallResolver { tld: tld.clone() },
+                "remove the DNS resolver entry",
+                residue,
+            );
+        }
+
+        // Ports: macOS removes the pf redirect (+ its boot LaunchDaemon). On
+        // Linux the `setcap` grant has no clean reverse, but it disappears with
+        // the binary (tarball) or via `apt purge` (deb) — nothing to do here.
+        #[cfg(target_os = "macos")]
+        run_helper(
+            &helper,
+            &HelperInvocation::UninstallPortRedirect,
+            "remove the pf port redirect",
+            residue,
+        );
+    }
+
+    /// Spawn the helper for one operation and classify the outcome.
+    fn run_helper(
+        helper: &Path,
+        inv: &HelperInvocation,
+        what: &str,
+        residue: &mut Vec<String>,
+    ) {
+        print!("==> {what} … ");
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+        match elevate::spawn_helper(helper, inv) {
+            Ok(Some(0)) => println!("ok"),
+            // EX_CONFIG (78): the helper deems it unsupported / not configured.
+            Ok(Some(78)) => println!("skipped (not configured)"),
+            Ok(Some(code)) => {
+                println!("failed (exit {code})");
+                residue.push(format!("{what} (yerd-helper exit {code})"));
+            }
+            Ok(None) => {
+                println!("failed (terminated by signal)");
+                residue.push(format!("{what} (yerd-helper was killed)"));
+            }
+            Err(e) => {
+                println!("failed");
+                residue.push(format!("{what} ({e})"));
+            }
+        }
+    }
+
+    /// Stop and disable the per-user daemon service, in the invoking user's
+    /// session. Best-effort — the service may not be installed.
+    fn stop_daemon_service(actor: &Actor, root: bool) {
+        #[cfg(target_os = "linux")]
+        {
+            // Under sudo, `systemctl --user` would hit root's bus; run it as the
+            // invoking user with their session env.
+            if root && elevate::sudo_uid().is_some() {
+                let xdg = format!("XDG_RUNTIME_DIR=/run/user/{}", actor.uid);
+                let dbus = format!(
+                    "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{}/bus",
+                    actor.uid
+                );
+                let _ = run_quiet(
+                    "runuser",
+                    &[
+                        "-u",
+                        &actor.name,
+                        "--",
+                        "env",
+                        &xdg,
+                        &dbus,
+                        "systemctl",
+                        "--user",
+                        "disable",
+                        "--now",
+                        "yerd",
+                    ],
+                );
+            } else {
+                let _ = run_quiet("systemctl", &["--user", "disable", "--now", "yerd"]);
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            // `bootout` stops AND unloads, so KeepAlive can't relaunch it. From
+            // root we can target the invoking user's gui domain by uid.
+            let _ = root;
+            let target = format!("gui/{}/dev.yerd.daemon", actor.uid);
+            let _ = run_quiet("launchctl", &["bootout", &target]);
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            let _ = (actor, root);
+        }
+    }
+
+    /// Reap any still-running `yerdd` for this user: SIGTERM (graceful — it
+    /// reaps its php-fpm/DB/mail children), wait a bounded grace, then SIGKILL
+    /// any holdout. `pgrep`/`pkill -U <uid>` match by *real* uid on both
+    /// Linux and macOS; `-x yerdd` matches the exact process name.
+    fn reap_daemon(uid: u32) {
+        let uid = uid.to_string();
+        let _ = run_quiet("pkill", &["-TERM", "-U", &uid, "-x", "yerdd"]);
+        for _ in 0..50 {
+            if !yerdd_running(&uid) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        let _ = run_quiet("pkill", &["-KILL", "-U", &uid, "-x", "yerdd"]);
+    }
+
+    fn yerdd_running(uid: &str) -> bool {
+        Command::new("pgrep")
+            .args(["-U", uid, "-x", "yerdd"])
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    /// Remove the daemon's service unit file (best-effort).
+    fn remove_service_unit(actor: &Actor) {
+        #[cfg(target_os = "linux")]
+        let unit = actor
+            .home
+            .join(".config/systemd/user/yerd.service");
+        #[cfg(target_os = "macos")]
+        let unit = actor
+            .home
+            .join("Library/LaunchAgents/dev.yerd.daemon.plist");
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let unit: PathBuf = {
+            let _ = actor;
+            return;
+        };
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if std::fs::remove_file(&unit).is_ok() {
+            println!("  removed {}", unit.display());
+        }
+    }
+
+    /// Remove the yerd binaries. Symlinks (e.g. a `~/.local/bin/yerd` pointing
+    /// elsewhere) are unlinked; real files in a package-managed system path are
+    /// left for `apt purge`. `yerd` (this running binary) is removed last —
+    /// unlinking a running executable is safe on Unix.
+    fn remove_binaries(actor: &Actor, residue: &mut Vec<String>) {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(d) = exe.parent() {
+                dirs.push(d.to_path_buf());
+            }
+        }
+        dirs.push(actor.home.join(".local").join("bin"));
+        dirs.push(PathBuf::from("/usr/local/bin"));
+        dirs.push(PathBuf::from("/usr/bin"));
+        let dirs = dedup(dirs);
+
+        let mut packaged = false;
+        for name in ["yerdd", "yerd-helper", "yerd"] {
+            for dir in &dirs {
+                let path = dir.join(name);
+                let Ok(md) = std::fs::symlink_metadata(&path) else {
+                    continue;
+                };
+                if md.file_type().is_symlink() {
+                    if std::fs::remove_file(&path).is_ok() {
+                        println!("  removed symlink {}", path.display());
+                    }
+                    continue;
+                }
+                if is_system_install_dir(dir) {
+                    packaged = true;
+                    continue;
+                }
+                match std::fs::remove_file(&path) {
+                    Ok(()) => println!("  removed {}", path.display()),
+                    Err(e) => residue.push(format!("{} ({e})", path.display())),
+                }
+            }
+        }
+        if packaged {
+            residue.push(
+                "system-installed binaries (a .deb install) — remove with: sudo apt purge yerd"
+                    .to_owned(),
+            );
+        }
+    }
+
+    // ── pure helpers (unit-tested) ───────────────────────────────────────────
+
+    /// The user dirs to delete, de-duplicated. On macOS config/data/state all
+    /// coincide; both Linux runtime candidates are included since the active one
+    /// can't be recovered from a stripped sudo env.
+    fn dirs_to_delete(dirs: &PlatformDirs, uid: u32) -> Vec<PathBuf> {
+        dedup(vec![
+            dirs.config.clone(),
+            dirs.data.clone(),
+            dirs.state.clone(),
+            dirs.cache.clone(),
+            dirs.runtime.clone(),
+            PathBuf::from(format!("/run/user/{uid}/yerd")),
+            PathBuf::from(format!("/tmp/yerd-{uid}")),
+        ])
+    }
+
+    /// A package-managed location whose binaries dpkg owns — advise `apt purge`
+    /// rather than `rm`.
+    fn is_system_install_dir(dir: &Path) -> bool {
+        matches!(
+            dir.to_str(),
+            Some("/usr/bin" | "/usr/local/bin" | "/usr/sbin" | "/bin" | "/sbin")
+        )
+    }
+
+    /// The shell's basename (e.g. `/bin/zsh` → `zsh`) for shell detection.
+    fn shell_basename(shell: &Path) -> String {
+        shell
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    }
+
+    fn dedup(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+        let mut seen = std::collections::HashSet::new();
+        paths.into_iter().filter(|p| seen.insert(p.clone())).collect()
+    }
+
+    fn run_quiet(program: &str, args: &[&str]) -> bool {
+        Command::new(program)
+            .args(args)
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    // ── interaction / output ─────────────────────────────────────────────────
+
+    fn confirm() -> bool {
+        use std::io::{IsTerminal, Write};
+        if !std::io::stdin().is_terminal() {
+            eprintln!(
+                "yerd: refusing to uninstall without confirmation — \
+                 re-run with --yes to proceed non-interactively."
+            );
+            return false;
+        }
+        print!("\nProceed with uninstalling yerd? Type 'yes' to confirm: ");
+        let _ = std::io::stdout().flush();
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line).is_err() {
+            return false;
+        }
+        matches!(line.trim(), "y" | "Y" | "yes" | "Yes" | "YES")
+    }
+
+    fn print_header(actor: &Actor, dirs: &PlatformDirs, root: bool) {
+        println!("This will uninstall yerd for user '{}'. It removes:", actor.name);
+        println!("  • config:  {}", dirs.config.display());
+        println!(
+            "  • data:    {}  (certs, installed PHP versions, tools, downloads)",
+            dirs.data.display()
+        );
+        println!("  • cache:   {}", dirs.cache.display());
+        println!("  • the yerd PATH entry from your shell startup files");
+        println!("  • the yerd daemon service and the yerd / yerdd / yerd-helper binaries");
+        if root {
+            println!(
+                "  • system changes from `yerd elevate` (CA trust, DNS resolver, ports)"
+            );
+        }
+    }
+
+    fn print_unelevate_warning(facts: &CapturedFacts) {
+        let tld = facts.tld.as_deref().unwrap_or("<your-tld>");
+        eprintln!();
+        eprintln!("WARNING: not running as root (sudo).");
+        eprintln!("  The system-level changes from `yerd elevate` need root to revert, and they");
+        eprintln!("  CANNOT be reverted after yerd is uninstalled (the binary will be gone).");
+        eprintln!("  They will be left in place. Either abort and re-run as `sudo yerd uninstall`,");
+        eprintln!("  or remove them manually afterwards:");
+        #[cfg(target_os = "macos")]
+        {
+            eprintln!(
+                "    • CA trust: open Keychain Access → System and delete the 'Yerd Local CA'"
+            );
+            eprintln!("    • resolver: sudo rm /etc/resolver/{tld}");
+            eprintln!(
+                "    • ports:    sudo launchctl bootout system/dev.yerd.pf 2>/dev/null; \
+                 sudo rm -f /Library/LaunchDaemons/dev.yerd.pf.plist"
+            );
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            eprintln!(
+                "    • CA trust: remove yerd's CA from your trust anchors, then \
+                 `sudo update-ca-certificates --fresh` (or `update-ca-trust`)"
+            );
+            eprintln!(
+                "    • resolver: sudo rm /etc/systemd/resolved.conf.d/yerd-{tld}.conf && \
+                 sudo systemctl restart systemd-resolved"
+            );
+            eprintln!(
+                "    • ports:    the setcap grant is dropped automatically when yerdd is deleted"
+            );
+        }
+    }
+
+    fn print_summary(residue: &[String]) {
+        println!();
+        if residue.is_empty() {
+            println!("yerd has been uninstalled.");
+        } else {
+            println!("yerd has been uninstalled, with some leftovers to handle manually:");
+            for r in residue {
+                println!("  • {r}");
+            }
+        }
+        println!("Open a new terminal so the PATH change takes effect.");
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::unwrap_used, clippy::panic, clippy::indexing_slicing)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn shell_basename_takes_file_name() {
+            assert_eq!(shell_basename(Path::new("/bin/zsh")), "zsh");
+            assert_eq!(shell_basename(Path::new("/usr/bin/fish")), "fish");
+            assert_eq!(shell_basename(Path::new("")), "");
+        }
+
+        #[test]
+        fn system_dirs_are_recognised() {
+            assert!(is_system_install_dir(Path::new("/usr/bin")));
+            assert!(is_system_install_dir(Path::new("/usr/local/bin")));
+            assert!(!is_system_install_dir(Path::new("/home/u/.local/bin")));
+        }
+
+        #[test]
+        fn dedup_preserves_order_and_drops_repeats() {
+            let v = dedup(vec![
+                PathBuf::from("/a"),
+                PathBuf::from("/b"),
+                PathBuf::from("/a"),
+                PathBuf::from("/c"),
+            ]);
+            assert_eq!(
+                v,
+                vec![
+                    PathBuf::from("/a"),
+                    PathBuf::from("/b"),
+                    PathBuf::from("/c")
+                ]
+            );
+        }
+
+        #[test]
+        fn dirs_to_delete_dedups_and_includes_both_runtime_candidates() {
+            let dirs = PlatformDirs::for_user(Path::new("/home/u"), 1000);
+            let out = dirs_to_delete(&dirs, 1000);
+            // No duplicates (macOS collapses config/data/state to one path).
+            let unique: std::collections::HashSet<_> = out.iter().collect();
+            assert_eq!(unique.len(), out.len());
+            // Both Linux runtime candidates present regardless of host.
+            assert!(out.contains(&PathBuf::from("/run/user/1000/yerd")));
+            assert!(out.contains(&PathBuf::from("/tmp/yerd-1000")));
+            // The persistent dirs are in the set.
+            assert!(out.contains(&dirs.config));
+            assert!(out.contains(&dirs.data));
+            assert!(out.contains(&dirs.cache));
+        }
+    }
+}

--- a/bin/yerd/src/uninstall.rs
+++ b/bin/yerd/src/uninstall.rs
@@ -169,8 +169,8 @@ mod unix_impl {
             .map(PathBuf::from)
             .ok_or_else(|| "cannot resolve your home directory ($HOME is unset)".to_owned())?;
         let name = std::env::var("USER").unwrap_or_default();
-        let shell = std::env::var_os("SHELL")
-            .map_or_else(|| PathBuf::from("/bin/sh"), PathBuf::from);
+        let shell =
+            std::env::var_os("SHELL").map_or_else(|| PathBuf::from("/bin/sh"), PathBuf::from);
         Ok(Actor {
             uid,
             name,
@@ -186,8 +186,9 @@ mod unix_impl {
         let helper = match elevate::sibling_binaries() {
             Ok((helper, _yerdd)) => helper,
             Err(e) => {
-                residue
-                    .push(format!("could not locate yerd-helper to revert system changes: {e}"));
+                residue.push(format!(
+                    "could not locate yerd-helper to revert system changes: {e}"
+                ));
                 return;
             }
         };
@@ -231,12 +232,7 @@ mod unix_impl {
     }
 
     /// Spawn the helper for one operation and classify the outcome.
-    fn run_helper(
-        helper: &Path,
-        inv: &HelperInvocation,
-        what: &str,
-        residue: &mut Vec<String>,
-    ) {
+    fn run_helper(helper: &Path, inv: &HelperInvocation, what: &str, residue: &mut Vec<String>) {
         print!("==> {what} … ");
         let _ = std::io::Write::flush(&mut std::io::stdout());
         match elevate::spawn_helper(helper, inv) {
@@ -340,9 +336,7 @@ mod unix_impl {
     /// Remove the daemon's service unit file (best-effort).
     fn remove_service_unit(actor: &Actor) {
         #[cfg(target_os = "linux")]
-        let unit = actor
-            .home
-            .join(".config/systemd/user/yerd.service");
+        let unit = actor.home.join(".config/systemd/user/yerd.service");
         #[cfg(target_os = "macos")]
         let unit = actor
             .home
@@ -402,9 +396,17 @@ mod unix_impl {
             }
         }
         if packaged {
+            // The only way a yerd binary lands in a dpkg-owned dir is the Debian
+            // `.deb` (installs to /usr/bin); advise the matching removal. On other
+            // OSes this is effectively unreachable, but keep the guidance correct.
+            #[cfg(target_os = "linux")]
             residue.push(
                 "system-installed binaries (a .deb install) — remove with: sudo apt purge yerd"
                     .to_owned(),
+            );
+            #[cfg(not(target_os = "linux"))]
+            residue.push(
+                "binaries in a system path — remove them with your package manager".to_owned(),
             );
         }
     }
@@ -426,12 +428,15 @@ mod unix_impl {
         ])
     }
 
-    /// A package-managed location whose binaries dpkg owns — advise `apt purge`
-    /// rather than `rm`.
+    /// A package-managed location whose binaries dpkg owns — advise removal via
+    /// the package manager rather than `rm`. `/usr/local/bin` is deliberately
+    /// excluded: Debian Policy reserves `/usr/local` for the local admin and no
+    /// package may own files there, so a yerd binary in `/usr/local/bin` is a
+    /// manual install we should unlink like any other.
     fn is_system_install_dir(dir: &Path) -> bool {
         matches!(
             dir.to_str(),
-            Some("/usr/bin" | "/usr/local/bin" | "/usr/sbin" | "/bin" | "/sbin")
+            Some("/usr/bin" | "/usr/sbin" | "/bin" | "/sbin")
         )
     }
 
@@ -445,7 +450,10 @@ mod unix_impl {
 
     fn dedup(paths: Vec<PathBuf>) -> Vec<PathBuf> {
         let mut seen = std::collections::HashSet::new();
-        paths.into_iter().filter(|p| seen.insert(p.clone())).collect()
+        paths
+            .into_iter()
+            .filter(|p| seen.insert(p.clone()))
+            .collect()
     }
 
     fn run_quiet(program: &str, args: &[&str]) -> bool {
@@ -476,7 +484,10 @@ mod unix_impl {
     }
 
     fn print_header(actor: &Actor, dirs: &PlatformDirs, root: bool) {
-        println!("This will uninstall yerd for user '{}'. It removes:", actor.name);
+        println!(
+            "This will uninstall yerd for user '{}'. It removes:",
+            actor.name
+        );
         println!("  • config:  {}", dirs.config.display());
         println!(
             "  • data:    {}  (certs, installed PHP versions, tools, downloads)",
@@ -486,9 +497,7 @@ mod unix_impl {
         println!("  • the yerd PATH entry from your shell startup files");
         println!("  • the yerd daemon service and the yerd / yerdd / yerd-helper binaries");
         if root {
-            println!(
-                "  • system changes from `yerd elevate` (CA trust, DNS resolver, ports)"
-            );
+            println!("  • system changes from `yerd elevate` (CA trust, DNS resolver, ports)");
         }
     }
 
@@ -512,13 +521,18 @@ mod unix_impl {
         eprintln!("WARNING: not running as root (sudo).");
         eprintln!("  The system-level changes from `yerd elevate` need root to revert, and they");
         eprintln!("  CANNOT be reverted after yerd is uninstalled (the binary will be gone).");
-        eprintln!("  They will be left in place. Either abort and re-run as `sudo yerd uninstall`,");
+        eprintln!(
+            "  They will be left in place. Either abort and re-run as `sudo yerd uninstall`,"
+        );
         eprintln!("  or remove them manually afterwards:");
         eprintln!("    • CA trust: {}", manual_ca_removal_hint());
         // The cert is about to be deleted; print its fingerprint now so the CA
         // stays identifiable in the trust store afterwards.
         if let Some(fp) = facts.ca_fp {
-            eprintln!("                (yerd CA SHA-256 fingerprint: {})", fp.to_hex());
+            eprintln!(
+                "                (yerd CA SHA-256 fingerprint: {})",
+                fp.to_hex()
+            );
         }
         #[cfg(target_os = "macos")]
         {
@@ -568,8 +582,10 @@ mod unix_impl {
         #[test]
         fn system_dirs_are_recognised() {
             assert!(is_system_install_dir(Path::new("/usr/bin")));
-            assert!(is_system_install_dir(Path::new("/usr/local/bin")));
             assert!(!is_system_install_dir(Path::new("/home/u/.local/bin")));
+            // `/usr/local/bin` is admin-owned, not dpkg-managed — a binary there
+            // is a manual install we should unlink, not defer to a package mgr.
+            assert!(!is_system_install_dir(Path::new("/usr/local/bin")));
         }
 
         #[test]

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -378,7 +378,7 @@ fn load_or_generate_ca(dirs: &PlatformDirs) -> Result<CertAuthority, DaemonError
         Ok(CertAuthority::from_pem(&cert_pem, &key_pem)?)
     } else {
         let validity = ca_validity()?;
-        let ca = CertAuthority::generate("Yerd Local CA", validity)?;
+        let ca = CertAuthority::generate(yerd_core::CA_COMMON_NAME, validity)?;
         std::fs::create_dir_all(&dirs.data).map_err(|source| DaemonError::Io {
             path: dirs.data.clone(),
             source,

--- a/crates/yerd-core/src/lib.rs
+++ b/crates/yerd-core/src/lib.rs
@@ -27,6 +27,15 @@ mod tld;
 /// Changing the value means updating both ends.
 pub const PROXY_SERVER_ID: &str = "yerd";
 
+/// Subject Common Name of yerd's local development CA.
+///
+/// A cross-crate contract: `bin/yerdd` stamps it onto the generated CA
+/// (`startup.rs`), and `yerd-helper` checks for it before removing a CA from
+/// the system trust store — so the privileged helper only ever deletes a cert
+/// it can confirm is yerd's, never an unrelated trusted root. Changing the
+/// value means re-generating existing users' CAs, so treat it as frozen.
+pub const CA_COMMON_NAME: &str = "Yerd Local CA";
+
 pub use detect::{detect, Detection, ProjectSignals};
 pub use error::{CoreError, PhpVersionErrorReason, SiteNameErrorReason, TldErrorReason};
 pub use php::PhpVersion;

--- a/crates/yerd-platform/Cargo.toml
+++ b/crates/yerd-platform/Cargo.toml
@@ -16,6 +16,7 @@ directories = { workspace = true }
 sha2        = { workspace = true }
 hex         = { workspace = true }
 pem         = { workspace = true }
+x509-parser = { workspace = true }
 serde_json  = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -24,6 +25,9 @@ security-framework = { workspace = true }
 [dev-dependencies]
 tempfile   = { workspace = true }
 serde_json = { workspace = true }
+# Minting test CAs (via yerd-tls, already a normal dep) needs a Validity, which
+# is built from `time` timestamps.
+time       = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/yerd-platform/src/paths.rs
+++ b/crates/yerd-platform/src/paths.rs
@@ -66,9 +66,22 @@ impl PlatformDirs {
                 runtime,
             }
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
         {
-            // XDG (Linux/other): `directories` lowercases the app name to `yerd`.
+            // XDG: `directories` lowercases the app name to `yerd`.
+            Self {
+                config: home.join(".config").join("yerd"),
+                data: home.join(".local").join("share").join("yerd"),
+                state: home.join(".local").join("state").join("yerd"),
+                cache: home.join(".cache").join("yerd"),
+                runtime,
+            }
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            // Unsupported targets: keep the deterministic XDG-style fallback
+            // (matches `os::unsupported`) until a dedicated layout is added. Per
+            // the per-OS convention in `os/mod.rs`, this branch is explicit.
             Self {
                 config: home.join(".config").join("yerd"),
                 data: home.join(".local").join("share").join("yerd"),

--- a/crates/yerd-platform/src/paths.rs
+++ b/crates/yerd-platform/src/paths.rs
@@ -31,6 +31,55 @@ pub struct PlatformDirs {
     pub runtime: PathBuf,
 }
 
+impl PlatformDirs {
+    /// Resolve the per-user directories for an explicit `home` + `uid`, without
+    /// reading `$HOME` or the XDG environment.
+    ///
+    /// [`Paths::resolve`] derives everything from the process environment, which
+    /// is wrong under `sudo` (it points at root). `yerd uninstall`, run as root,
+    /// uses this to target the *invoking* user's dirs instead. The layout
+    /// reproduces exactly what `directories` produces in `resolve` (a
+    /// drift-guard test asserts the two agree for the current home).
+    ///
+    /// `runtime` is the deterministic uid fallback (`/tmp/yerd-$uid`); a caller
+    /// that also wants the `XDG_RUNTIME_DIR` location (`/run/user/$uid/yerd`,
+    /// which `resolve` prefers when the env var is set) must add it itself,
+    /// since the real value can't be recovered from a stripped sudo environment.
+    #[must_use]
+    pub fn for_user(home: &std::path::Path, uid: u32) -> Self {
+        let runtime = PathBuf::from(format!("/tmp/yerd-{uid}"));
+        #[cfg(target_os = "macos")]
+        {
+            // `directories` v5 builds the macOS fragment as the reverse-DNS
+            // `io.yerd.Yerd` ("qualifier.org.app", joined by '.', no lowercasing).
+            let app = home
+                .join("Library")
+                .join("Application Support")
+                .join("io.yerd.Yerd");
+            let cache = home.join("Library").join("Caches").join("io.yerd.Yerd");
+            Self {
+                config: app.clone(),
+                data: app.clone(),
+                // macOS has no XDG state distinction; state coincides with data.
+                state: app,
+                cache,
+                runtime,
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            // XDG (Linux/other): `directories` lowercases the app name to `yerd`.
+            Self {
+                config: home.join(".config").join("yerd"),
+                data: home.join(".local").join("share").join("yerd"),
+                state: home.join(".local").join("state").join("yerd"),
+                cache: home.join(".cache").join("yerd"),
+                runtime,
+            }
+        }
+    }
+}
+
 /// OS path-discovery abstraction.
 pub trait Paths {
     /// Resolve every directory in one call.
@@ -39,4 +88,42 @@ pub trait Paths {
     /// guaranteed to exist on disk; the caller is responsible for
     /// `create_dir_all` before writing into them.
     fn resolve(&self) -> Result<PlatformDirs, PlatformError>;
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod for_user_tests {
+    use super::PlatformDirs;
+    use crate::{ActivePaths, Paths};
+
+    /// `for_user` must reproduce the home-derived dirs that `directories`
+    /// produces in `resolve` — guards against the macOS fragment (`io.yerd.Yerd`
+    /// vs bare `Yerd`) silently drifting. `runtime` is uid/env-derived and
+    /// handled separately, so it is not compared.
+    #[test]
+    fn for_user_layout_matches_resolve_for_current_home() {
+        let Some(home) = std::env::var_os("HOME") else {
+            return;
+        };
+        // A custom XDG base would make `resolve` legitimately differ from the
+        // default layout `for_user` assumes; skip rather than false-fail.
+        #[cfg(not(target_os = "macos"))]
+        for v in [
+            "XDG_CONFIG_HOME",
+            "XDG_DATA_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_STATE_HOME",
+        ] {
+            if std::env::var_os(v).is_some() {
+                return;
+            }
+        }
+        let home = std::path::PathBuf::from(home);
+        let r = ActivePaths::new().resolve().expect("resolve current dirs");
+        let f = PlatformDirs::for_user(&home, 0);
+        assert_eq!(f.config, r.config, "config dir");
+        assert_eq!(f.data, r.data, "data dir");
+        assert_eq!(f.cache, r.cache, "cache dir");
+        assert_eq!(f.state, r.state, "state dir");
+    }
 }

--- a/crates/yerd-platform/src/pure/cert_identity.rs
+++ b/crates/yerd-platform/src/pure/cert_identity.rs
@@ -1,0 +1,62 @@
+//! Read identifying fields out of a DER-encoded X.509 certificate.
+//!
+//! Used by the privileged `yerd-helper` to confirm a certificate it is about to
+//! remove from the system trust store is yerd's own CA (Subject CN ==
+//! [`yerd_core::CA_COMMON_NAME`]) before deleting it — so a bad fingerprint
+//! handed to the helper can never delete an unrelated trusted root.
+
+/// The Subject Common Name of a DER-encoded X.509 certificate, if present.
+///
+/// Returns `None` when the DER can't be parsed or carries no CN — callers
+/// treat that as "not confirmably yerd's" and refuse to delete. Never panics:
+/// every fallible step degrades to `None` (this runs as root).
+#[must_use]
+pub fn subject_common_name(cert_der: &[u8]) -> Option<String> {
+    let (_, cert) = x509_parser::parse_x509_certificate(cert_der).ok()?;
+    // Bind to a local so the iterator temporary (which borrows `cert`) is
+    // dropped before `cert` at end of scope.
+    let cn = cert
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(ToOwned::to_owned);
+    cn
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// Mint a CA with `cn` via yerd-tls and return its DER body.
+    fn ca_der(cn: &str) -> Vec<u8> {
+        let nb = time::OffsetDateTime::UNIX_EPOCH;
+        let na = nb + time::Duration::days(365);
+        let validity = yerd_tls::Validity::new(nb, na).unwrap();
+        let ca = yerd_tls::CertAuthority::generate(cn, validity).unwrap();
+        pem::parse(ca.cert_pem().as_bytes())
+            .unwrap()
+            .into_contents()
+    }
+
+    #[test]
+    fn reads_the_yerd_ca_common_name() {
+        let der = ca_der(yerd_core::CA_COMMON_NAME);
+        assert_eq!(
+            subject_common_name(&der).as_deref(),
+            Some(yerd_core::CA_COMMON_NAME)
+        );
+    }
+
+    #[test]
+    fn reads_a_different_common_name() {
+        let der = ca_der("Some Other CA");
+        assert_eq!(subject_common_name(&der).as_deref(), Some("Some Other CA"));
+    }
+
+    #[test]
+    fn none_for_non_certificate_bytes() {
+        assert_eq!(subject_common_name(b"not a der certificate"), None);
+    }
+}

--- a/crates/yerd-platform/src/pure/mod.rs
+++ b/crates/yerd-platform/src/pure/mod.rs
@@ -4,6 +4,7 @@
 //! clock reads, and environment lookups. Each submodule is unit-tested
 //! table-style.
 
+pub mod cert_identity;
 pub mod firefox;
 pub mod pem_match;
 pub mod pf_anchor;

--- a/crates/yerd-platform/src/pure/pem_match.rs
+++ b/crates/yerd-platform/src/pure/pem_match.rs
@@ -80,6 +80,33 @@ pub fn fingerprint_of_first_cert_in_pem(pem_text: &str) -> Option<[u8; 32]> {
     Some(sha256(cert.contents()))
 }
 
+/// DER body of the first `CERTIFICATE` block across `blobs` whose SHA-256
+/// matches `fingerprint`, or `None`.
+///
+/// Uses the same CERTIFICATE-only iteration as [`find_by_fingerprint`] but
+/// returns the matched cert's DER directly, so a caller can inspect the cert
+/// (e.g. its Subject CN) without re-parsing and risking a wrong-block pick. A
+/// blob that fails to parse contributes no match (collapses to "absent"); a
+/// caller needing to distinguish a parse error from a true miss uses
+/// [`find_by_fingerprint`], which surfaces the bad path.
+#[must_use]
+pub fn cert_der_for_fingerprint(
+    blobs: &[(PathBuf, Vec<u8>)],
+    fingerprint: &[u8; 32],
+) -> Option<Vec<u8>> {
+    for (_path, bytes) in blobs {
+        let Ok(parsed) = pem::parse_many(bytes) else {
+            continue;
+        };
+        for block in parsed {
+            if block.tag() == "CERTIFICATE" && sha256(block.contents()) == *fingerprint {
+                return Some(block.contents().to_vec());
+            }
+        }
+    }
+    None
+}
+
 /// DER body of the first `CERTIFICATE` block in `pem_bytes`, or `None`.
 /// Used by the macOS trust-settings probe to build a `SecCertificate`.
 #[must_use]
@@ -153,6 +180,33 @@ mod tests {
         let blobs = vec![(PathBuf::from("/etc/multi.crt"), combined.into_bytes())];
         let m = find_by_fingerprint(&blobs, &fp).unwrap().unwrap();
         assert_eq!(m.block_index, 1);
+    }
+
+    #[test]
+    fn cert_der_for_fingerprint_returns_matched_block_der() {
+        let target = b"target cert body";
+        let earlier = b"earlier cert body";
+        let fp = sha256(target);
+        // Multi-block file: the second CERTIFICATE block matches.
+        let mut combined = fake_cert_pem(earlier);
+        combined.push_str(&fake_cert_pem(target));
+        let blobs = vec![(PathBuf::from("/etc/multi.crt"), combined.into_bytes())];
+        assert_eq!(
+            cert_der_for_fingerprint(&blobs, &fp).as_deref(),
+            Some(&target[..])
+        );
+    }
+
+    #[test]
+    fn cert_der_for_fingerprint_none_when_absent_or_unparseable() {
+        let blobs = vec![
+            (
+                PathBuf::from("/etc/a.crt"),
+                fake_cert_pem(b"a").into_bytes(),
+            ),
+            (PathBuf::from("/etc/junk.crt"), b"not pem".to_vec()),
+        ];
+        assert!(cert_der_for_fingerprint(&blobs, &[0u8; 32]).is_none());
     }
 
     #[test]

--- a/crates/yerd-platform/src/trust_store.rs
+++ b/crates/yerd-platform/src/trust_store.rs
@@ -36,6 +36,23 @@ impl CaFingerprint {
         hex::encode(self.0)
     }
 
+    /// Compute the fingerprint of a raw DER certificate body (`sha256(der)`).
+    ///
+    /// This is the same definition the daemon uses (`yerd_tls`'s
+    /// `fingerprint_sha256`); deriving it on disk lets `yerd uninstall` revert
+    /// the trust store without a running daemon.
+    #[must_use]
+    pub fn from_der(der: &[u8]) -> Self {
+        Self(crate::pure::pem_match::sha256(der))
+    }
+
+    /// Compute the fingerprint of the first `CERTIFICATE` block in a PEM
+    /// document. Returns `None` if the text has no certificate block.
+    #[must_use]
+    pub fn from_pem(pem_text: &str) -> Option<Self> {
+        crate::pure::pem_match::fingerprint_of_first_cert_in_pem(pem_text).map(Self)
+    }
+
     /// Parse exactly 64 **lowercase** hex characters into a fingerprint — the
     /// inverse of [`Self::to_hex`]. Uppercase, wrong length, or non-hex input
     /// is rejected; this is the canonical wire form, so the strict lowercase
@@ -175,6 +192,22 @@ mod tests {
     fn fingerprint_from_hex_round_trips_to_hex() {
         let fp = CaFingerprint::new([0xAB; 32]);
         assert_eq!(CaFingerprint::from_hex(&fp.to_hex()).unwrap(), fp);
+    }
+
+    #[test]
+    fn from_der_matches_sha256_and_from_pem_round_trips() {
+        let der = b"\x30\x82\x01\x0a fake-der-body for fingerprint test";
+        let direct = CaFingerprint::from_der(der);
+        // `from_der` is exactly sha256 over the DER body.
+        assert_eq!(direct.as_bytes(), &crate::pure::pem_match::sha256(der));
+        // Wrapping the same DER in PEM and parsing it back yields the same fp.
+        let pem = crate::pure::pem_match::der_to_pem(der);
+        assert_eq!(CaFingerprint::from_pem(&pem), Some(direct));
+    }
+
+    #[test]
+    fn from_pem_returns_none_without_certificate_block() {
+        assert_eq!(CaFingerprint::from_pem("not a pem"), None);
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full `yerd uninstall` on Unix: removes yerd files, PATH block changes, per-user services/launch agents, and performs cleanup and leftovers reporting.
  * `uninstall` now works as either component removal or full uninstall when no target is provided; `--yes` applies only to the full uninstall flow.
  * Added deterministic per-user path layout support and expanded CA fingerprint utilities.

* **Bug Fixes / Safety Improvements**
  * CA uninstall is now gated by ownership (prevents removing non-yerd certificates); helper-denied operations are surfaced as refusals.

* **Tests**
  * Updated/extended coverage for uninstall behavior, certificate parsing/identity, and path layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->