### PR TITLE
[Fix] Laravel installer fix

### DIFF
--- a/bin/yerdd/src/create_site.rs
+++ b/bin/yerdd/src/create_site.rs
@@ -252,10 +252,13 @@ fn build_new_args(name: &str, o: &LaravelOptions) -> Vec<String> {
     }
     a.push("--database".to_owned());
     a.push(database_flag(o.database).to_owned());
+    // The installer has no skip-node flag: passing a package-manager flag makes
+    // it *run* install+build, while passing none defaults to npm without running
+    // it. So `Skip` simply omits the flag.
     match o.js {
         JsRuntime::Npm => a.push("--npm".to_owned()),
         JsRuntime::Bun => a.push("--bun".to_owned()),
-        JsRuntime::Skip => a.push("--no-node".to_owned()),
+        JsRuntime::Skip => {}
     }
     if o.git {
         a.push("--git".to_owned());
@@ -658,7 +661,6 @@ mod tests {
                 "--pest",
                 "--database",
                 "sqlite",
-                "--no-node",
                 "--no-boost",
             ]
         );

--- a/crates/yerd-ipc/src/create.rs
+++ b/crates/yerd-ipc/src/create.rs
@@ -72,7 +72,7 @@ pub struct LaravelOptions {
     pub testing: Testing,
     /// Database driver written into `.env` (`--database`).
     pub database: Database,
-    /// Frontend dependency install/build (`--npm`/`--bun`/`--no-node`).
+    /// Frontend dependency install/build (`--npm`/`--bun`/none-to-skip).
     pub js: JsRuntime,
     /// `--git` — initialise a git repository.
     pub git: bool,
@@ -142,7 +142,8 @@ pub enum JsRuntime {
     Npm,
     /// Install + build via Bun (`--bun`).
     Bun,
-    /// Skip frontend dependency install/build (`--no-node`).
+    /// Skip frontend dependency install/build (no package-manager flag passed,
+    /// so the installer does not run install/build).
     Skip,
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site creation now correctly omits frontend setup options when JavaScript is set to “skip,” instead of passing an extra install-related flag.
  * Updated the generated command behavior so new sites with no JS runtime avoid unnecessary dependency installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->