### PR TITLE
[Fix] Autostart processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6032,8 +6032,10 @@ dependencies = [
 name = "yerd-gui"
 version = "2.0.2-rc.5"
 dependencies = [
+ "block2",
  "core-foundation 0.9.4",
  "core-foundation-sys",
+ "dispatch2",
  "glib",
  "interprocess",
  "libc",

--- a/apps/yerd-gui/src-tauri/Cargo.toml
+++ b/apps/yerd-gui/src-tauri/Cargo.toml
@@ -54,6 +54,14 @@ webkit2gtk = "=2.0.2"
 # executable icon). Versions track what Tauri already resolves, so no duplicates.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2            = "0.6"
+# `block2` backs the NSNotificationCenter observer block in `launch_probe.rs`
+# (detects a login-item launch via NSApplicationLaunchIsDefaultLaunchKey). 0.6 is
+# ABI-matched to objc2 0.6.
+block2           = "0.6"
+# `dispatch2` defers the initial show/hide decision one main-runloop turn
+# (`DispatchQueue::main().exec_async`) so the login-launch probe is authoritative
+# — `run_on_main_thread` would run inline on the main thread and lose the race.
+dispatch2        = "0.3"
 objc2-app-kit    = { version = "0.3", features = ["NSApplication", "NSImage", "NSResponder", "NSGraphics", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3", features = ["NSData", "NSString", "NSError", "objc2-core-foundation"] }
 # In-process user-domain CA trust (mac_trust.rs). Versions track what

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -367,7 +367,13 @@ fn nudge_if_requires_approval() {
 #[cfg(target_os = "macos")]
 fn smapp_enable(nudge: bool) -> Result<(), GuiError> {
     if smapp_registered() {
-        return Ok(()); // already on — don't cleanup/re-register a live agent.
+        // Already registered — don't cleanup/re-register a live agent. But it may
+        // still be pending the user's Login-Items approval, so on a nudging caller
+        // (a retry / tray / General-tab start) re-open Login Items.
+        if nudge {
+            nudge_if_requires_approval();
+        }
+        return Ok(());
     }
     cleanup_legacy();
     crate::smappservice::register(crate::smappservice::Service::Daemon)?;
@@ -462,6 +468,10 @@ fn gui_cleanup_legacy() {
 fn gui_smapp_enable(nudge: bool) -> Result<(), GuiError> {
     if gui_smapp_registered() {
         gui_cleanup_legacy(); // already on — just clear any leftover loose plist
+                              // May still be pending approval; re-open Login Items on a nudging caller.
+        if nudge && gui_pending_approval() {
+            crate::smappservice::open_login_items_settings();
+        }
         return Ok(());
     }
     crate::smappservice::register(crate::smappservice::Service::MainApp)?;
@@ -499,7 +509,12 @@ pub(crate) fn migrate_gui_login_if_needed() {
         return;
     }
     let loose = gui_loose_plist_path().map(|p| p.exists()).unwrap_or(false);
-    if loose && !gui_smapp_registered() {
+    // If a loose `Yerd.plist` exists, migrate it even when SMAppService is already
+    // registered: `gui_smapp_enable`'s already-registered branch runs
+    // `gui_cleanup_legacy()`, so the legacy login item is removed rather than left
+    // behind forever. The flag is set only on success, so a failure retries next
+    // launch (the loose plist is still present).
+    if loose {
         if gui_smapp_enable(false).is_ok() {
             s.gui_login_migrated = true;
             let _ = save_settings(&s);

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -6,9 +6,14 @@
 //!   *single supervisor* — `start` goes through it so a later autostart-enable
 //!   can't end up with a second, competing daemon. Detached spawn is used only
 //!   when no service manager exists (then daemon-at-login is unsupported).
-//! - **GUI autostart**: `tauri-plugin-autostart` (the app's own login entry).
-//!   The "start minimized" preference can't ride on launch args (the plugin
-//!   fixes those at init), so it lives in a tiny Rust-readable settings file.
+//! - **GUI autostart**: the app's own login entry. On a bundled, non-translocated
+//!   macOS build this is `SMAppService.mainApp` (the "Open at Login" entry,
+//!   attributed to "Yerd"); elsewhere — and on dev/translocated macOS — it falls
+//!   back to `tauri-plugin-autostart`. A legacy loose `Yerd.plist` from the
+//!   plugin path is migrated to SMAppService on first launch
+//!   (`migrate_gui_login_if_needed`). The "start minimized" preference lives in
+//!   a Rust-readable settings file (no launch arg survives `mainApp`; `main`'s
+//!   `launch_probe` detects a login launch instead).
 //!
 //! Everything is host-side and threads failures through [`GuiError`].
 
@@ -38,6 +43,12 @@ struct GuiSettings {
     /// silently resets every preference to its default).
     #[serde(default)]
     onboarding_complete: bool,
+    /// macOS one-shot: the legacy loose `Yerd.plist` GUI login item has been
+    /// migrated to `SMAppService.mainApp` (so it shows as "Yerd" under Open at
+    /// Login, not the Developer-ID name). Guards `migrate_gui_login_if_needed` so
+    /// it runs once and never re-enables login for a user who later turned it off.
+    #[serde(default)]
+    gui_login_migrated: bool,
 }
 
 fn settings_path() -> Result<PathBuf, GuiError> {
@@ -309,7 +320,7 @@ fn embedded_plist_path() -> Option<PathBuf> {
 /// SMAppService. Read-only.
 #[cfg(target_os = "macos")]
 fn smapp_registered() -> bool {
-    crate::smappservice::status()
+    crate::smappservice::status(crate::smappservice::Service::Daemon)
         .map(crate::smappservice::status_means_registered)
         .unwrap_or(false)
 }
@@ -341,7 +352,7 @@ fn cleanup_legacy() {
 /// Login Items, take them there. Best-effort.
 #[cfg(target_os = "macos")]
 fn nudge_if_requires_approval() {
-    let pending = crate::smappservice::status()
+    let pending = crate::smappservice::status(crate::smappservice::Service::Daemon)
         .map(|s| s == crate::smappservice::STATUS_REQUIRES_APPROVAL)
         .unwrap_or(false);
     if pending {
@@ -350,16 +361,154 @@ fn nudge_if_requires_approval() {
 }
 
 /// Register the SMAppService agent if not already on (idempotent), migrating any
-/// loose legacy agent first, then nudge for approval if needed.
+/// loose legacy agent first, then nudge for approval if needed. `nudge = false`
+/// suppresses the System-Settings open so the onboarding flow (which enables the
+/// daemon *and* the GUI) doesn't open Login Items more than once.
 #[cfg(target_os = "macos")]
-fn smapp_enable() -> Result<(), GuiError> {
+fn smapp_enable(nudge: bool) -> Result<(), GuiError> {
     if smapp_registered() {
         return Ok(()); // already on — don't cleanup/re-register a live agent.
     }
     cleanup_legacy();
-    crate::smappservice::register()?;
-    nudge_if_requires_approval();
+    crate::smappservice::register(crate::smappservice::Service::Daemon)?;
+    if nudge {
+        nudge_if_requires_approval();
+    }
     Ok(())
+}
+
+// ── macOS: GUI login item via SMAppService.mainApp ───────────────────────────
+//
+// The GUI "launch at login" used to ride `tauri-plugin-autostart` in LaunchAgent
+// mode, which writes a *loose* `~/Library/LaunchAgents/Yerd.plist`. macOS files
+// loose agents under the signing identity's name (an individual's legal name),
+// not "Yerd". Registering the main app via `SMAppService.mainApp` puts it under
+// **Login Items → Open at Login** attributed to "Yerd". `mainApp` uses the app's
+// own `Info.plist`, so there is no embedded plist and no bundle-config change.
+
+/// The loose `~/Library/LaunchAgents/Yerd.plist` that `tauri-plugin-autostart`
+/// writes (Label `Yerd`). Present only on un-migrated installs.
+#[cfg(target_os = "macos")]
+fn gui_loose_plist_path() -> Result<PathBuf, GuiError> {
+    let home = crate::daemon::home_dir().ok_or_else(|| GuiError::internal("HOME is not set"))?;
+    Ok(home.join("Library").join("LaunchAgents").join("Yerd.plist"))
+}
+
+/// launchctl service target for the loose plist (its Label is `Yerd`).
+#[cfg(target_os = "macos")]
+fn gui_loose_service_target() -> String {
+    format!("gui/{}/Yerd", uid())
+}
+
+/// Whether to manage GUI login via SMAppService (vs the `tauri-plugin-autostart`
+/// fallback). Same gates as the daemon's [`use_smappservice`] *except* no
+/// embedded-plist check — `mainApp` registers the app's own `Info.plist`.
+#[cfg(target_os = "macos")]
+fn gui_use_smappservice() -> bool {
+    if std::env::var_os("YERD_NO_AUTO_DAEMON").is_some() {
+        return false;
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    exe.to_string_lossy().contains(".app/Contents/MacOS/") && !is_translocated()
+}
+
+/// Whether the GUI main-app login item is registered (or pending approval).
+#[cfg(target_os = "macos")]
+fn gui_smapp_registered() -> bool {
+    crate::smappservice::status(crate::smappservice::Service::MainApp)
+        .map(crate::smappservice::status_means_registered)
+        .unwrap_or(false)
+}
+
+/// macOS only: the GUI login item is registered but awaiting the user's approval
+/// in Login Items. Always false on the fallback path / other OSes.
+fn gui_pending_approval() -> bool {
+    #[cfg(target_os = "macos")]
+    if gui_use_smappservice() {
+        return crate::smappservice::status(crate::smappservice::Service::MainApp)
+            .map(|s| s == crate::smappservice::STATUS_REQUIRES_APPROVAL)
+            .unwrap_or(false);
+    }
+    false
+}
+
+/// Tear down the loose `tauri-plugin-autostart` login item (`Yerd.plist`).
+/// Best-effort, and a no-op when the file is absent. Safe even with a live
+/// `mainApp` registration: that item is keyed on the app bundle, not a launchd
+/// Label, so booting out `gui/{uid}/Yerd` cannot affect it.
+#[cfg(target_os = "macos")]
+fn gui_cleanup_legacy() {
+    let Ok(path) = gui_loose_plist_path() else {
+        return;
+    };
+    if !path.exists() {
+        return;
+    }
+    let target = gui_loose_service_target();
+    let _ = run_ok("launchctl", &["bootout", &target]);
+    let _ = std::fs::remove_file(&path);
+    let _ = run_ok("launchctl", &["enable", &target]);
+}
+
+/// Register the GUI as a login item via `SMAppService.mainApp` (idempotent).
+///
+/// Ordering matters: register **first**, then remove the loose `Yerd.plist` only
+/// on success — so a failed register leaves the old login item intact rather than
+/// silently de-registering the user, and a later attempt can still migrate it.
+/// `nudge = false` suppresses the Login-Items open (onboarding opens it once).
+#[cfg(target_os = "macos")]
+fn gui_smapp_enable(nudge: bool) -> Result<(), GuiError> {
+    if gui_smapp_registered() {
+        gui_cleanup_legacy(); // already on — just clear any leftover loose plist
+        return Ok(());
+    }
+    crate::smappservice::register(crate::smappservice::Service::MainApp)?;
+    gui_cleanup_legacy();
+    if nudge && gui_pending_approval() {
+        crate::smappservice::open_login_items_settings();
+    }
+    Ok(())
+}
+
+/// Unregister the GUI login item and remove any leftover loose plist.
+#[cfg(target_os = "macos")]
+fn gui_smapp_disable() -> Result<(), GuiError> {
+    if gui_smapp_registered() {
+        crate::smappservice::unregister(crate::smappservice::Service::MainApp)?;
+    }
+    gui_cleanup_legacy();
+    Ok(())
+}
+
+/// One-time startup migration of an existing loose `Yerd.plist` login item to
+/// `SMAppService.mainApp`, so already-"login-on" users stop showing under the
+/// Developer-ID name. Flag-guarded (`gui_login_migrated`) so it runs once and
+/// won't re-enable login for a user who later turned it off. Silent — never
+/// opens System Settings at startup (the General-tab banner surfaces approval).
+/// The one-shot flag is set only on success, so a failed register retries next
+/// launch with the loose plist still in place.
+#[cfg(target_os = "macos")]
+pub(crate) fn migrate_gui_login_if_needed() {
+    if !gui_use_smappservice() {
+        return;
+    }
+    let mut s = load_settings();
+    if s.gui_login_migrated {
+        return;
+    }
+    let loose = gui_loose_plist_path().map(|p| p.exists()).unwrap_or(false);
+    if loose && !gui_smapp_registered() {
+        if gui_smapp_enable(false).is_ok() {
+            s.gui_login_migrated = true;
+            let _ = save_settings(&s);
+        }
+    } else {
+        // Nothing to migrate — consume the one-shot so we don't probe every launch.
+        s.gui_login_migrated = true;
+        let _ = save_settings(&s);
+    }
 }
 
 /// Write the LaunchAgent plist and bootstrap it (idempotent — an already-loaded
@@ -409,9 +558,10 @@ fn ensure_bootstrapped() -> Result<(), GuiError> {
 // ── daemon start / stop / autostart (used by crate::daemon + the commands) ───
 
 /// Start the daemon via the service manager, or a detached spawn when none.
-pub(crate) fn daemon_start() -> Result<(), GuiError> {
+pub(crate) fn daemon_start(nudge: bool) -> Result<(), GuiError> {
     #[cfg(target_os = "linux")]
     {
+        let _ = nudge; // no SMAppService / Login-Items nudge on Linux
         if systemd_user_available() {
             write_unit()?;
             return run_ok("systemctl", &["--user", "start", "yerd"]);
@@ -425,7 +575,7 @@ pub(crate) fn daemon_start() -> Result<(), GuiError> {
             // kickstart for a fresh start even if it was already up. kickstart is
             // best-effort — when status is `requiresApproval` the job isn't loaded
             // yet, and that's fine (the user was sent to Login Items).
-            smapp_enable()?;
+            smapp_enable(nudge)?;
             let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);
             Ok(())
         } else {
@@ -435,6 +585,7 @@ pub(crate) fn daemon_start() -> Result<(), GuiError> {
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
+        let _ = nudge;
         Err(GuiError::internal(
             "starting the daemon is not supported on this platform",
         ))
@@ -456,10 +607,12 @@ pub(crate) fn daemon_stop() {
     }
 }
 
-/// Enable/disable launch at login.
-fn daemon_set_login(on: bool) -> Result<(), GuiError> {
+/// Enable/disable launch at login. `nudge` (macOS) gates the auto-open of Login
+/// Items on `requiresApproval` so onboarding can open it just once.
+fn daemon_set_login(on: bool, nudge: bool) -> Result<(), GuiError> {
     #[cfg(target_os = "linux")]
     {
+        let _ = nudge;
         if !systemd_user_available() {
             return Err(GuiError::internal(
                 "systemd --user is unavailable; cannot manage daemon autostart",
@@ -478,7 +631,7 @@ fn daemon_set_login(on: bool) -> Result<(), GuiError> {
             // register (→ "Yerd" Login Items entry + runs at login + now);
             // off = unregister (removes the entry + stops it).
             if on {
-                smapp_enable()
+                smapp_enable(nudge)
             } else {
                 // Unregister the SMAppService agent (only when actually
                 // registered — `unregister()` on a never-registered service is a
@@ -486,7 +639,7 @@ fn daemon_set_login(on: bool) -> Result<(), GuiError> {
                 // so the toggle doesn't appear stuck "on" for upgrade users who
                 // only ever had the pre-SMAppService loose plist.
                 if smapp_registered() {
-                    crate::smappservice::unregister()?;
+                    crate::smappservice::unregister(crate::smappservice::Service::Daemon)?;
                 }
                 cleanup_legacy();
                 Ok(())
@@ -501,7 +654,7 @@ fn daemon_set_login(on: bool) -> Result<(), GuiError> {
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
-        let _ = on;
+        let _ = (on, nudge);
         Err(GuiError::internal(
             "daemon autostart is not supported on this platform",
         ))
@@ -518,7 +671,8 @@ pub struct AutostartState {
     pub daemon: bool,
     /// Whether daemon autostart is even possible (a service manager exists).
     pub daemon_supported: bool,
-    /// GUI-at-login (from the autostart plugin — authoritative).
+    /// GUI-at-login: SMAppService.mainApp registration on the bundled macOS path,
+    /// else the autostart plugin's state.
     pub gui: bool,
     /// Start-the-GUI-minimized preference.
     pub gui_minimized: bool,
@@ -526,6 +680,10 @@ pub struct AutostartState {
     /// it in System Settings → Login Items** (SMAppService `requiresApproval`).
     /// Drives a first-run banner; always false elsewhere.
     pub daemon_pending_approval: bool,
+    /// macOS only: the GUI login item is registered but **waiting for the user to
+    /// enable it in System Settings → Login Items** (SMAppService
+    /// `requiresApproval`). Drives a banner; always false elsewhere.
+    pub gui_pending_approval: bool,
 }
 
 /// Current "run daemon at login" state for the General tab. On the macOS
@@ -548,40 +706,62 @@ fn daemon_enabled(settings: &GuiSettings, supported: bool) -> bool {
 fn daemon_pending_approval() -> bool {
     #[cfg(target_os = "macos")]
     if use_smappservice() {
-        return crate::smappservice::status()
+        return crate::smappservice::status(crate::smappservice::Service::Daemon)
             .map(|s| s == crate::smappservice::STATUS_REQUIRES_APPROVAL)
             .unwrap_or(false);
     }
     false
 }
 
+/// "Run the Yerd app at login" state for the General tab. On the bundled macOS
+/// path this is the live SMAppService.mainApp registration plus a read-only
+/// reconcile of a leftover loose `Yerd.plist` (so an un-migrated install doesn't
+/// read as off); elsewhere it's the autostart plugin's own state.
+fn gui_login_enabled(app: &tauri::AppHandle) -> Result<bool, GuiError> {
+    #[cfg(target_os = "macos")]
+    if gui_use_smappservice() {
+        let loose = gui_loose_plist_path().map(|p| p.exists()).unwrap_or(false);
+        return Ok(gui_smapp_registered() || loose);
+    }
+    app.autolaunch()
+        .is_enabled()
+        .map_err(|e| GuiError::internal(format!("could not query GUI autostart: {e}")))
+}
+
 #[tauri::command]
 pub fn get_autostart(app: tauri::AppHandle) -> Result<AutostartState, GuiError> {
     let settings = load_settings();
     let supported = manager_available();
-    let gui = app
-        .autolaunch()
-        .is_enabled()
-        .map_err(|e| GuiError::internal(format!("could not query GUI autostart: {e}")))?;
+    let gui = gui_login_enabled(&app)?;
     Ok(AutostartState {
         daemon: daemon_enabled(&settings, supported),
         daemon_supported: supported,
         gui,
         gui_minimized: settings.gui_minimized,
         daemon_pending_approval: daemon_pending_approval(),
+        gui_pending_approval: gui_pending_approval(),
     })
 }
 
 #[tauri::command]
-pub fn set_autostart_daemon(on: bool) -> Result<(), GuiError> {
-    daemon_set_login(on)?;
+pub fn set_autostart_daemon(on: bool, nudge: bool) -> Result<(), GuiError> {
+    daemon_set_login(on, nudge)?;
     let mut s = load_settings();
     s.daemon_autostart = on;
     save_settings(&s)
 }
 
 #[tauri::command]
-pub fn set_autostart_gui(app: tauri::AppHandle, on: bool) -> Result<(), GuiError> {
+pub fn set_autostart_gui(app: tauri::AppHandle, on: bool, nudge: bool) -> Result<(), GuiError> {
+    #[cfg(target_os = "macos")]
+    if gui_use_smappservice() {
+        return if on {
+            gui_smapp_enable(nudge)
+        } else {
+            gui_smapp_disable()
+        };
+    }
+    let _ = nudge; // the plugin fallback has no Login-Items approval flow
     let mgr = app.autolaunch();
     let r = if on { mgr.enable() } else { mgr.disable() };
     r.map_err(|e| GuiError::internal(format!("could not change GUI autostart: {e}")))

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -202,8 +202,8 @@ pub fn open_login_items() {
 /// available); falls back to a detached `yerdd serve` only when no service
 /// manager exists (in which case daemon-at-login is disabled in the UI). The
 /// blocking service call runs off the async worker so the tray/UI never stalls.
-pub(crate) async fn start() -> Result<(), GuiError> {
-    tokio::task::spawn_blocking(crate::autostart::daemon_start)
+pub(crate) async fn start(nudge: bool) -> Result<(), GuiError> {
+    tokio::task::spawn_blocking(move || crate::autostart::daemon_start(nudge))
         .await
         .map_err(|e| GuiError::internal(format!("start task failed: {e}")))?
 }
@@ -219,9 +219,13 @@ pub(crate) async fn stop() -> Result<(), GuiError> {
     Ok(())
 }
 
+/// Start the daemon. `nudge` (macOS) controls whether a `requiresApproval`
+/// SMAppService state opens Login Items — onboarding passes `false` so it opens
+/// at most once across the daemon + GUI enables; the General-tab button uses
+/// `true`.
 #[tauri::command]
-pub async fn start_daemon() -> Result<(), GuiError> {
-    start().await
+pub async fn start_daemon(nudge: bool) -> Result<(), GuiError> {
+    start(nudge).await
 }
 
 #[tauri::command]

--- a/apps/yerd-gui/src-tauri/src/launch_probe.rs
+++ b/apps/yerd-gui/src-tauri/src/launch_probe.rs
@@ -1,0 +1,118 @@
+//! macOS: detect whether this process was launched **at login** (an
+//! `SMAppService.mainApp` / login-item launch) versus a **manual** open, so the
+//! GUI can honor the "start minimized to the tray" preference.
+//!
+//! `SMAppService.mainApp` cannot inject a launch argument (the
+//! `--autostarted` marker the old plugin-LaunchAgent path relied on), so instead
+//! we read AppKit's `NSApplicationLaunchIsDefaultLaunchKey` from the
+//! `applicationDidFinishLaunching` notification: it is `false` for a login-item
+//! launch (and for state-restoration), `true` for a Finder/Dock/`open` launch.
+//!
+//! INVARIANT — the safe-failure guarantee below holds ONLY while Yerd registers
+//! no `CFBundleURLSchemes` and no `CFBundleDocumentTypes`. Those also launch with
+//! `LaunchIsDefault == false` and would be misread as a login launch (window
+//! wrongly hidden). Revisit this probe before adding any URL scheme / doc type.
+//!
+//! Mirrors the hand-rolled FFI style of `smappservice.rs`/`mac_trust.rs`: thin
+//! `unsafe` wrappers, no typed-binding feature creep — `userInfo`/`boolValue` are
+//! read via raw `msg_send!`.
+
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use block2::RcBlock;
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2_app_kit::{
+    NSApplicationDidFinishLaunchingNotification, NSApplicationLaunchIsDefaultLaunchKey,
+};
+
+const UNKNOWN: u8 = 0;
+const LOGIN: u8 = 1;
+const MANUAL: u8 = 2;
+
+/// Set once, from the `applicationDidFinishLaunching` observer block. Read later
+/// (on a deferred main-runloop turn) by [`is_login_launch`].
+static LAUNCH_KIND: AtomicU8 = AtomicU8::new(UNKNOWN);
+
+/// Register the launch-type observer. Call **before** `tauri::Builder::run()` so
+/// the observer exists when AppKit posts `applicationDidFinishLaunching`. Reading
+/// `LAUNCH_KIND` must be deferred one runloop turn after `setup` (the
+/// notification dispatch may not be complete when `setup` runs) — see
+/// `show_initial_window`. Best-effort: a failure to resolve the class leaves the
+/// state `UNKNOWN`, which [`is_login_launch`] treats as a manual open (safe).
+pub(crate) fn install_launch_probe() {
+    let Some(cls) = AnyClass::get(c"NSNotificationCenter") else {
+        return;
+    };
+    // SAFETY: `+defaultCenter` is a class singleton getter returning a non-null
+    // `NSNotificationCenter*`.
+    let center: Retained<AnyObject> = unsafe { msg_send![cls, defaultCenter] };
+
+    let block = RcBlock::new(move |note: NonNull<AnyObject>| {
+        // SAFETY: AppKit hands the block a valid, non-null `NSNotification*`.
+        let note: &AnyObject = unsafe { note.as_ref() };
+        // SAFETY: `-userInfo` is a getter returning `NSDictionary*` or nil.
+        let user_info: *mut AnyObject = unsafe { msg_send![note, userInfo] };
+        if user_info.is_null() {
+            return; // no userInfo → leave UNKNOWN (treated as manual)
+        }
+        // SAFETY: extern string constant from AppKit; a valid `&NSString`.
+        let key = unsafe { NSApplicationLaunchIsDefaultLaunchKey };
+        // SAFETY: `-objectForKey:` returns the `NSNumber*` value or nil.
+        let val: *mut AnyObject = unsafe { msg_send![user_info, objectForKey: key] };
+        if val.is_null() {
+            return; // key absent → leave UNKNOWN
+        }
+        // SAFETY: the value is an `NSNumber`; `-boolValue` returns its `BOOL`.
+        let is_default: bool = unsafe { msg_send![val, boolValue] };
+        LAUNCH_KIND.store(if is_default { MANUAL } else { LOGIN }, Ordering::Relaxed);
+    });
+
+    // SAFETY: standard `-addObserverForName:object:queue:usingBlock:`. `object`
+    // and `queue` are nil (observe every post, deliver synchronously on the
+    // posting thread). The returned observer token must outlive the observation,
+    // so we leak it for the process lifetime (there is nothing to unregister).
+    let name = unsafe { NSApplicationDidFinishLaunchingNotification };
+    let token: Option<Retained<AnyObject>> = unsafe {
+        msg_send![
+            &center,
+            addObserverForName: name,
+            object: None::<&AnyObject>,
+            queue: None::<&AnyObject>,
+            usingBlock: &*block,
+        ]
+    };
+    if let Some(token) = token {
+        std::mem::forget(token);
+    }
+}
+
+/// True only when we **positively** detected a login/system launch. `UNKNOWN`
+/// maps to `false` — the safe direction: a manual Finder/Dock/`open` launch
+/// always sets `LaunchIsDefault = true`, so the window is never wrongly hidden on
+/// a real user open; at worst a login launch is missed and the window shows.
+pub(crate) fn is_login_launch() -> bool {
+    LAUNCH_KIND.load(Ordering::Relaxed) == LOGIN
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// Runtime smoke test: registering the observer exercises the
+    /// `addObserverForName:…:usingBlock:` `msg_send!` and the block construction —
+    /// the spot a signature mistake would be UB at call time. Safe without a full
+    /// NSApplication (NSNotificationCenter always exists); the observer simply
+    /// never fires here. `#[ignore]` so plain `cargo test` never registers an
+    /// observer; run with `cargo test -p yerd-gui -- --ignored`.
+    #[test]
+    #[ignore = "registers a real NSNotificationCenter observer; run manually on macOS"]
+    fn install_probe_roundtrips() {
+        install_launch_probe();
+        // Before any launch notification fires in-test, the state is UNKNOWN.
+        assert!(!is_login_launch());
+    }
+}

--- a/apps/yerd-gui/src-tauri/src/launch_probe.rs
+++ b/apps/yerd-gui/src-tauri/src/launch_probe.rs
@@ -36,6 +36,18 @@ const MANUAL: u8 = 2;
 /// (on a deferred main-runloop turn) by [`is_login_launch`].
 static LAUNCH_KIND: AtomicU8 = AtomicU8::new(UNKNOWN);
 
+/// Pure mapping from AppKit's `NSApplicationLaunchIsDefaultLaunchKey` to a launch
+/// kind: a "default" launch (Finder/Dock/`open`) is `MANUAL`; everything else
+/// (login item, state-restoration) is `LOGIN`. Split out so it's unit-testable
+/// without AppKit firing a notification.
+const fn kind_for(is_default: bool) -> u8 {
+    if is_default {
+        MANUAL
+    } else {
+        LOGIN
+    }
+}
+
 /// Register the launch-type observer. Call **before** `tauri::Builder::run()` so
 /// the observer exists when AppKit posts `applicationDidFinishLaunching`. Reading
 /// `LAUNCH_KIND` must be deferred one runloop turn after `setup` (the
@@ -67,7 +79,7 @@ pub(crate) fn install_launch_probe() {
         }
         // SAFETY: the value is an `NSNumber`; `-boolValue` returns its `BOOL`.
         let is_default: bool = unsafe { msg_send![val, boolValue] };
-        LAUNCH_KIND.store(if is_default { MANUAL } else { LOGIN }, Ordering::Relaxed);
+        LAUNCH_KIND.store(kind_for(is_default), Ordering::Relaxed);
     });
 
     // SAFETY: standard `-addObserverForName:object:queue:usingBlock:`. `object`
@@ -101,6 +113,17 @@ pub(crate) fn is_login_launch() -> bool {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// Pure mapping coverage (runs in normal CI, unlike the `#[ignore]` FFI test):
+    /// a "default" launch is manual; a non-default launch (login item / restore)
+    /// is a login launch; the unset state is neither.
+    #[test]
+    fn kind_for_maps_default_and_login() {
+        assert_eq!(kind_for(true), MANUAL);
+        assert_eq!(kind_for(false), LOGIN);
+        assert_ne!(LOGIN, UNKNOWN);
+        assert_ne!(MANUAL, UNKNOWN);
+    }
 
     /// Runtime smoke test: registering the observer exercises the
     /// `addObserverForName:…:usingBlock:` `msg_send!` and the block construction —

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -8,6 +8,8 @@ mod elevate;
 mod error;
 mod ipc;
 #[cfg(target_os = "macos")]
+mod launch_probe;
+#[cfg(target_os = "macos")]
 mod mac_trust;
 mod mail_window;
 #[cfg(target_os = "macos")]
@@ -44,6 +46,13 @@ fn main() {
         glib::set_prgname(Some("yerd-gui"));
         glib::set_application_name("Yerd");
     }
+
+    // macOS: register the launch-type observer BEFORE the run loop starts, so it
+    // catches `applicationDidFinishLaunching` and we can tell a login-item launch
+    // (SMAppService.mainApp) from a manual open — the GUI uses it for the
+    // start-minimized-to-tray behavior now that there's no `--autostarted` arg.
+    #[cfg(target_os = "macos")]
+    launch_probe::install_launch_probe();
 
     tauri::Builder::default()
         // Must be the first plugin: a second launch focuses the existing
@@ -186,6 +195,12 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     disable_webview_zoom(app);
     build_tray(app.handle())?;
     show_initial_window(app);
+    // macOS: one-time migration of a legacy loose `Yerd.plist` GUI login item to
+    // SMAppService.mainApp (so it shows as "Yerd" under Open at Login). Off the
+    // main thread — it does `launchctl` + SMAppService XPC; flag-guarded so it
+    // runs once and stays silent (no System-Settings popup at startup).
+    #[cfg(target_os = "macos")]
+    std::thread::spawn(autostart::migrate_gui_login_if_needed);
     Ok(())
 }
 
@@ -237,24 +252,45 @@ fn disable_webview_zoom(app: &tauri::App) {
     });
 }
 
-/// Show the main window now — unless this is an autostart launch
-/// (`--autostarted`) AND the user chose "start minimized", in which case it stays
-/// in the tray. The window is born hidden (`"visible": false` in tauri.conf, to
-/// avoid an undecorated flash); a manual open and a non-minimized autostart both
-/// show.
-fn show_initial_window(app: &tauri::App) {
+/// Decide the initial window visibility. On macOS this is **deferred one
+/// main-runloop turn** (see [`show_initial_window`]) because the login-launch
+/// probe is only authoritative once `applicationDidFinishLaunching` has fully
+/// dispatched; elsewhere it runs inline.
+///
+/// Show the main window — unless this is a login/autostart launch AND the user
+/// chose "start minimized", in which case it stays in the tray (Dock hidden).
+/// The window is born hidden (`"visible": false` in tauri.conf, to avoid an
+/// undecorated flash); a manual open and a non-minimized autostart both show.
+fn decide_initial_window(app: &tauri::AppHandle) {
     let Some(win) = app.get_webview_window("main") else {
         return;
     };
+    // `--autostarted` covers the dev / plugin-LaunchAgent fallback; on the macOS
+    // SMAppService.mainApp path there's no arg, so consult the launch probe.
     let autostarted = std::env::args().any(|a| a == AUTOSTART_ARG);
+    #[cfg(target_os = "macos")]
+    let autostarted = autostarted || launch_probe::is_login_launch();
     if autostarted && autostart::gui_minimized() {
         // Launched hidden to the tray — start as a menu-bar-only app (no Dock
         // icon) until the user opens the window.
-        set_dock_visible(app.handle(), false);
+        set_dock_visible(app, false);
     } else {
         let _ = win.show();
         let _ = win.set_focus();
     }
+}
+
+/// Schedule the initial-window decision. On macOS it must wait until the
+/// `applicationDidFinishLaunching` notification has fully dispatched (so the
+/// launch probe is set), so it's posted to the main queue via GCD — which always
+/// drains on a *later* runloop turn. (Tauri's `run_on_main_thread` runs inline
+/// when already on the main thread, which `setup` is, so it would NOT defer.)
+fn show_initial_window(app: &tauri::App) {
+    let handle = app.handle().clone();
+    #[cfg(target_os = "macos")]
+    dispatch2::DispatchQueue::main().exec_async(move || decide_initial_window(&handle));
+    #[cfg(not(target_os = "macos"))]
+    decide_initial_window(&handle);
 }
 
 /// The four navigable views, mirroring the sidebar. Each tray item shows the
@@ -311,7 +347,8 @@ fn build_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
             // never stalls the menu; the GUI's status poller reflects the result.
             "daemon:start" => {
                 tauri::async_runtime::spawn(async {
-                    let _ = daemon::start().await;
+                    // Standalone start: nudge to Login Items if approval is pending.
+                    let _ = daemon::start(true).await;
                 });
             }
             "daemon:stop" => {

--- a/apps/yerd-gui/src-tauri/src/smappservice.rs
+++ b/apps/yerd-gui/src-tauri/src/smappservice.rs
@@ -22,9 +22,22 @@ use objc2_foundation::{NSError, NSString};
 
 use crate::error::GuiError;
 
-/// The agent plist filename, as embedded under `Contents/Library/LaunchAgents/`.
+/// The daemon agent plist filename, as embedded under
+/// `Contents/Library/LaunchAgents/`.
 /// `+[SMAppService agentServiceWithPlistName:]` keys on this exact filename.
-const PLIST_NAME: &str = "dev.yerd.daemon.plist";
+const DAEMON_PLIST: &str = "dev.yerd.daemon.plist";
+
+/// Which login item to manage. The **daemon** is a bundle-embedded launchd agent
+/// (`agentServiceWithPlistName:`); the **GUI** is the main app itself
+/// (`mainAppService`, Swift `SMAppService.mainApp`) → the "Open at Login" entry.
+/// Both register through the app bundle, so macOS attributes both to "Yerd".
+#[derive(Clone, Copy)]
+pub(crate) enum Service {
+    /// The `yerdd` background daemon agent (`dev.yerd.daemon.plist`).
+    Daemon,
+    /// The Yerd GUI itself, as a login item via `SMAppService.mainApp`.
+    MainApp,
+}
 
 // `SMAppServiceStatus` raw values (`NSInteger`).
 pub(crate) const STATUS_NOT_REGISTERED: isize = 0;
@@ -53,12 +66,20 @@ fn smappservice_class() -> Result<&'static AnyClass, GuiError> {
         .ok_or_else(|| GuiError::internal("SMAppService is unavailable (requires macOS 13+)"))
 }
 
+/// Resolve the `SMAppService*` for `svc` — the daemon agent or the main app.
+fn service_obj(svc: Service) -> Result<Retained<AnyObject>, GuiError> {
+    match svc {
+        Service::Daemon => agent_service(DAEMON_PLIST),
+        Service::MainApp => main_app_service(),
+    }
+}
+
 /// `+[SMAppService agentServiceWithPlistName:@"dev.yerd.daemon.plist"]`.
 /// Returns a non-null `SMAppService*` even when the plist is absent (its
 /// `status` is then `notFound`); we still guard against a null return.
-fn agent_service() -> Result<Retained<AnyObject>, GuiError> {
+fn agent_service(plist: &str) -> Result<Retained<AnyObject>, GuiError> {
     let cls = smappservice_class()?;
-    let name = NSString::from_str(PLIST_NAME);
+    let name = NSString::from_str(plist);
     // SAFETY: `agentServiceWithPlistName:` is a class factory returning an
     // autoreleased `SMAppService*`; objc2 takes ownership per ARC conventions.
     // `name` is a valid `NSString` alive across the call. Typed as `Option` so a
@@ -68,37 +89,57 @@ fn agent_service() -> Result<Retained<AnyObject>, GuiError> {
     svc.ok_or_else(|| GuiError::internal("SMAppService returned no agent service"))
 }
 
+/// `+[SMAppService mainAppService]` (Obj-C class property, Swift `mainApp`).
+/// The main-app login item registers the app's own `Info.plist`, so it appears
+/// under **Login Items → Open at Login** attributed to "Yerd". No plist filename.
+fn main_app_service() -> Result<Retained<AnyObject>, GuiError> {
+    let cls = smappservice_class()?;
+    // SAFETY: `mainAppService` is a class-property getter returning an
+    // autoreleased `SMAppService*`; objc2 takes ownership per ARC. Typed as
+    // `Option` so a (not expected) null is a recoverable error, never UB.
+    let svc: Option<Retained<AnyObject>> = unsafe { msg_send![cls, mainAppService] };
+    svc.ok_or_else(|| GuiError::internal("SMAppService returned no main-app service"))
+}
+
 /// Register (enable) the agent. On success the agent is registered as a login
 /// item; with `RunAtLoad` it also starts now. **Success includes the
 /// `requiresApproval` case** — `registerAndReturnError:` returns `true` and the
 /// user must enable it in Login Items; the caller reads [`status`] to decide
 /// whether to nudge the user. Idempotent: registering an already-registered
 /// service succeeds.
-pub(crate) fn register() -> Result<(), GuiError> {
-    let svc = agent_service()?;
+pub(crate) fn register(svc: Service) -> Result<(), GuiError> {
+    let obj = service_obj(svc)?;
+    let action = match svc {
+        Service::Daemon => "register the Yerd background daemon",
+        Service::MainApp => "register Yerd to launch at login",
+    };
     // SAFETY: `-registerAndReturnError:` returns `BOOL` with a trailing
     // `NSError**`; the `_` marker activates objc2's BOOL→Result handling.
-    let res: Result<(), Retained<NSError>> = unsafe { msg_send![&*svc, registerAndReturnError: _] };
-    res.map_err(|e| ns_err("register the Yerd background daemon", &e))
+    let res: Result<(), Retained<NSError>> = unsafe { msg_send![&*obj, registerAndReturnError: _] };
+    res.map_err(|e| ns_err(action, &e))
 }
 
 /// Unregister (disable) the agent: removes the login item / "Yerd" entry and
 /// unloads the job. `errSec`-style "not registered" is reported by the OS as
 /// success here, so a redundant unregister is harmless.
-pub(crate) fn unregister() -> Result<(), GuiError> {
-    let svc = agent_service()?;
+pub(crate) fn unregister(svc: Service) -> Result<(), GuiError> {
+    let obj = service_obj(svc)?;
+    let action = match svc {
+        Service::Daemon => "remove the Yerd background daemon registration",
+        Service::MainApp => "remove the Yerd launch-at-login registration",
+    };
     // SAFETY: as `register`, for `-unregisterAndReturnError:`.
     let res: Result<(), Retained<NSError>> =
-        unsafe { msg_send![&*svc, unregisterAndReturnError: _] };
-    res.map_err(|e| ns_err("remove the Yerd background daemon registration", &e))
+        unsafe { msg_send![&*obj, unregisterAndReturnError: _] };
+    res.map_err(|e| ns_err(action, &e))
 }
 
 /// The agent's `SMAppServiceStatus` (one of the `STATUS_*` constants). Read-only
 /// — safe to call at startup to populate the UI without mutating anything.
-pub(crate) fn status() -> Result<isize, GuiError> {
-    let svc = agent_service()?;
+pub(crate) fn status(svc: Service) -> Result<isize, GuiError> {
+    let obj = service_obj(svc)?;
     // SAFETY: `-status` is a property getter returning `NSInteger`.
-    let s: isize = unsafe { msg_send![&*svc, status] };
+    let s: isize = unsafe { msg_send![&*obj, status] };
     Ok(s)
 }
 
@@ -146,7 +187,7 @@ mod tests {
     #[test]
     #[ignore = "issues a read-only SMAppService query; run manually on macOS 13+"]
     fn status_ffi_roundtrips_readonly() {
-        let s = status().expect("status() should query without error");
+        let s = status(Service::Daemon).expect("status() should query without error");
         assert!(
             (STATUS_NOT_REGISTERED..=STATUS_NOT_FOUND).contains(&s),
             "unexpected SMAppServiceStatus {s}"

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -562,8 +562,13 @@ export async function untrustCa(): Promise<boolean> {
 
 // ── daemon lifecycle + autostart (host commands, NOT daemon IPC) ────────────
 
-export async function startDaemon(): Promise<void> {
-  await call<void>("start_daemon");
+/**
+ * Start the daemon. `nudge` (macOS) controls whether a pending Login-Items
+ * approval auto-opens System Settings; pass `false` from a flow that enables
+ * several login items so they don't each open it (the caller opens it once).
+ */
+export async function startDaemon(nudge = true): Promise<void> {
+  await call<void>("start_daemon", { nudge });
 }
 
 export async function stopDaemon(): Promise<void> {
@@ -574,12 +579,12 @@ export async function getAutostart(): Promise<AutostartState> {
   return call<AutostartState>("get_autostart");
 }
 
-export async function setAutostartDaemon(on: boolean): Promise<void> {
-  await call<void>("set_autostart_daemon", { on });
+export async function setAutostartDaemon(on: boolean, nudge = true): Promise<void> {
+  await call<void>("set_autostart_daemon", { on, nudge });
 }
 
-export async function setAutostartGui(on: boolean): Promise<void> {
-  await call<void>("set_autostart_gui", { on });
+export async function setAutostartGui(on: boolean, nudge = true): Promise<void> {
+  await call<void>("set_autostart_gui", { on, nudge });
 }
 
 export async function setAutostartGuiMinimized(on: boolean): Promise<void> {

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -470,6 +470,8 @@ export interface AutostartState {
   guiMinimized: boolean;
   /** macOS only: registered but awaiting approval in System Settings → Login Items. */
   daemonPendingApproval: boolean;
+  /** macOS only: the GUI login item is registered but awaiting approval in Login Items. */
+  guiPendingApproval: boolean;
 }
 
 /**

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -466,6 +466,23 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
         </Button>
       </div>
 
+      <!-- macOS: the GUI login item is registered but awaiting Login-Items approval. -->
+      <div
+        v-if="autostart?.guiPendingApproval"
+        class="flex items-start justify-between gap-4 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4"
+      >
+        <div class="space-y-1">
+          <p class="text-sm font-medium">Approve launching Yerd at login</p>
+          <p class="text-xs text-muted-foreground">
+            “Start the Yerd app at login” is set, but macOS needs you to enable it
+            under System Settings → Login Items (Open at Login).
+          </p>
+        </div>
+        <Button variant="outline" size="sm" @click="openApproval">
+          Open Login Items
+        </Button>
+      </div>
+
       <!-- Daemon + subsystems -->
       <Card>
         <CardHeader class="flex-row items-center justify-between space-y-0">

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -101,7 +101,7 @@ async function installDaemon(): Promise<void> {
       (autostart?.daemonPendingApproval ?? false) ||
       (autostart?.guiPendingApproval ?? false);
     if (pendingApproval.value) {
-      openLoginItems();
+      void openLoginItems(); // best-effort; don't await/block onboarding
     }
     // Keep the spinner running until the daemon actually CONNECTS (the poller
     // flips `connected` → the watch below clears it and shows "Running"). The

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -73,21 +73,36 @@ async function installDaemon(): Promise<void> {
   daemonStarting.value = true;
   pendingApproval.value = false;
   try {
-    await startDaemon();
+    // Suppress the per-call Login-Items nudge: enabling the daemon and the app
+    // could each open System Settings, so we open it once below instead.
+    await startDaemon(false);
     await refresh();
-    // macOS may need the user to approve the background item before it runs.
+    // Probe service support before enabling the login defaults.
     let autostart: AutostartState | null = null;
     try {
       autostart = await getAutostart();
     } catch {
       /* non-fatal */
     }
-    pendingApproval.value = autostart?.daemonPendingApproval ?? false;
     // Onboarding default: run the daemon AND the app at login, with the app
     // started minimized to the tray. Best-effort and idempotent — users change
     // all three later in Settings. A missing service manager just skips the
     // daemon toggle.
     await enableLoginDefaults(autostart?.daemonSupported ?? false);
+    // Re-read AFTER enabling: the GUI login item is only registered now, so its
+    // pending-approval state is meaningful. Open Login Items at most once if the
+    // daemon OR the GUI needs the user to approve a background item.
+    try {
+      autostart = await getAutostart();
+    } catch {
+      /* non-fatal */
+    }
+    pendingApproval.value =
+      (autostart?.daemonPendingApproval ?? false) ||
+      (autostart?.guiPendingApproval ?? false);
+    if (pendingApproval.value) {
+      openLoginItems();
+    }
     // Keep the spinner running until the daemon actually CONNECTS (the poller
     // flips `connected` → the watch below clears it and shows "Running"). The
     // only early-out is macOS pending-approval, where we can't connect until the
@@ -122,13 +137,14 @@ async function installDaemon(): Promise<void> {
 async function enableLoginDefaults(daemonSupported: boolean): Promise<void> {
   if (daemonSupported) {
     try {
-      await setAutostartDaemon(true);
+      // nudge=false: installDaemon opens Login Items once after all enables.
+      await setAutostartDaemon(true, false);
     } catch {
       /* no service manager / best-effort */
     }
   }
   try {
-    await setAutostartGui(true);
+    await setAutostartGui(true, false);
   } catch {
     /* best-effort */
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS launch-type detection (login item vs manual open) to improve startup behavior.
  * Introduced a new “Login Items” approval prompt for launching the app at login, in addition to the daemon prompt.
  * Enhanced onboarding to coordinate approvals in a single flow, showing the prompt only when needed.
* **Bug Fixes**
  * Improved initial window visibility reliability on macOS.
  * Refined autostart handling to better preserve user choices during migration and reduce repeated approval prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->