### PR TITLE
[Fix] PATH and Daemon Registration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,11 +227,18 @@ jobs:
           done
           echo "Embedded binaries + LaunchAgent: present, sealed, Developer-ID, team-matched, entitlement-clean, exec OK"
 
-          # The .dmg is signed but not stapled; its assessment needs an online
-          # notary lookup that can flake on CI — keep it advisory.
+          # The .dmg is Developer-ID signed but deliberately NOT notarized/stapled:
+          # Tauri only submits the inner .app to notarytool, never the disk image,
+          # so no ticket exists for the dmg's own cdhash. `stapler validate` fails
+          # ("no ticket") and `spctl` reports `source=Unnotarized Developer ID`
+          # deterministically — this is NOT a network flake. It's fine: Gatekeeper
+          # validates the stapled .app offline once it's copied out of the dmg, and
+          # that's the gate that matters at launch. (Notarizing the dmg itself would
+          # only smooth the mount-time prompt; see the release notes if we revisit.)
+          # Both checks are advisory, so a failure here never blocks a release.
           xcrun stapler validate "$DMG" || echo "::warning::dmg not stapled (expected; .app is the gate)"
           spctl -a -t open --context context:primary-signature -vvv "$DMG" \
-            || echo "::warning::dmg spctl assessment non-fatal (online check may flake)"
+            || echo "::warning::dmg not notarized (expected; spctl=Unnotarized Developer ID, .app is the gate)"
           # Prove the SHIPPED dmg (not just the loose build-dir .app) carries the
           # embedded daemon + agent plist — guards against a stale .app in the dmg.
           MP=$(mktemp -d)

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -376,7 +376,9 @@ fn smapp_enable(nudge: bool) -> Result<(), GuiError> {
         return Ok(());
     }
     cleanup_legacy();
-    crate::smappservice::register(crate::smappservice::Service::Daemon)?;
+    // `register_repairing`, not `register`: an in-place app upgrade can leave a
+    // stale BTM entry that makes `register` fail with EINVAL until it's cleared.
+    crate::smappservice::register_repairing(crate::smappservice::Service::Daemon)?;
     if nudge {
         nudge_if_requires_approval();
     }
@@ -474,7 +476,9 @@ fn gui_smapp_enable(nudge: bool) -> Result<(), GuiError> {
         }
         return Ok(());
     }
-    crate::smappservice::register(crate::smappservice::Service::MainApp)?;
+    // `register_repairing`: see the daemon path — an in-place upgrade can leave a
+    // stale BTM entry that makes a plain `register` fail with EINVAL.
+    crate::smappservice::register_repairing(crate::smappservice::Service::MainApp)?;
     gui_cleanup_legacy();
     if nudge && gui_pending_approval() {
         crate::smappservice::open_login_items_settings();

--- a/apps/yerd-gui/src-tauri/src/smappservice.rs
+++ b/apps/yerd-gui/src-tauri/src/smappservice.rs
@@ -119,6 +119,27 @@ pub(crate) fn register(svc: Service) -> Result<(), GuiError> {
     res.map_err(|e| ns_err(action, &e))
 }
 
+/// [`register`], self-healing a stale Background-Task-Management entry left by an
+/// **in-place app upgrade**. After the bundle is replaced (e.g. rc.5 → rc.6),
+/// macOS may report [`status`] as not-registered for the new generation while
+/// BTM still holds the prior generation's entry for the same Label; a fresh
+/// `registerAndReturnError:` then fails with `EINVAL` ("Invalid argument", macOS
+/// error 22). Apple's remedy is to clear the stale entry and register afresh, so
+/// on the first failure we `unregister` (best-effort — a genuinely-unregistered
+/// service is a harmless no-op) and retry once. Callers reach this only when
+/// [`status`] already read not-registered, so the unregister can't tear down a
+/// live, working registration. The retry's error (not the first) is propagated,
+/// since it reflects the actual end state after the repair attempt.
+pub(crate) fn register_repairing(svc: Service) -> Result<(), GuiError> {
+    match register(svc) {
+        Ok(()) => Ok(()),
+        Err(_stale) => {
+            let _ = unregister(svc);
+            register(svc)
+        }
+    }
+}
+
 /// Unregister (disable) the agent: removes the login item / "Yerd" entry and
 /// unloads the job. `errSec`-style "not registered" is reported by the OS as
 /// success here, so a redundant unregister is harmless.

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -347,6 +347,15 @@ mod unix_impl {
     pub(crate) fn sibling_binaries() -> Result<(PathBuf, PathBuf), ClientError> {
         let exe = std::env::current_exe()
             .map_err(|e| ClientError::Usage(format!("cannot resolve current exe: {e}")))?;
+        // Resolve symlinks first. When `yerd` is invoked via the installed
+        // `{data}/bin/yerd` PATH symlink, macOS `current_exe()` returns the
+        // symlink path itself — so the siblings would resolve to `{data}/bin`,
+        // which holds no `yerd-helper`/`yerdd` (only the `yerd` symlink + php
+        // shims), and the helper spawn fails with ENOENT. Canonicalizing points
+        // us at the real binary inside the app bundle, whose siblings exist. Fall
+        // back to the unresolved path if canonicalize fails (it shouldn't — the
+        // exe exists — but never abort elevation over it).
+        let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
         let dir = exe
             .parent()
             .ok_or_else(|| ClientError::Usage("current exe has no parent directory".to_owned()))?;

--- a/bin/yerd/src/path_cmd.rs
+++ b/bin/yerd/src/path_cmd.rs
@@ -312,10 +312,33 @@ mod unix {
     }
 
     fn shell_basename() -> String {
+        // Prefer `$SHELL` — always set in an interactive shell. When it's empty,
+        // fall back to the user's login shell from the passwd database: the GUI
+        // app is launched by launchd/Finder, which sets no `$SHELL`, so the
+        // `yerd path install` it shells out to would otherwise fail to detect the
+        // shell and never write the PATH block (the symlink lands, but new
+        // terminals can't find `yerd`).
         std::env::var_os("SHELL")
             .map(PathBuf::from)
-            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()))
+            .as_deref()
+            .and_then(basename)
+            .filter(|s| !s.is_empty())
+            .or_else(login_shell_basename)
             .unwrap_or_default()
+    }
+
+    /// The current user's login shell basename from the passwd database, or
+    /// `None` if it can't be resolved. Used only as a `$SHELL` fallback.
+    fn login_shell_basename() -> Option<String> {
+        let user = nix::unistd::User::from_uid(nix::unistd::Uid::current())
+            .ok()
+            .flatten()?;
+        basename(&user.shell).filter(|s| !s.is_empty())
+    }
+
+    /// File-name component of `p` as an owned `String`.
+    fn basename(p: &Path) -> Option<String> {
+        p.file_name().map(|s| s.to_string_lossy().into_owned())
     }
 
     fn host_os() -> HostOs {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS app updates so login items and background services are more likely to register correctly after in-place upgrades.
  * Prevented helper startup failures when the app is launched through a symlinked path.
  * Added a fallback for detecting the user’s shell when the environment variable is unavailable.
  * Refined macOS release verification checks to provide clearer warnings while keeping releases moving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->