### PR TITLE
[Feat] Daemon traceability/logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4040,6 +4040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4825,6 +4831,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6243,6 +6262,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "yerd-config",
  "yerd-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ tokio-rustls       = "0.26"
 rustls             = "0.23"
 tracing            = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "registry"] }
+tracing-appender   = { version = "0.2", default-features = false }
 http               = "1"
 interprocess       = { version = "2", features = ["tokio"] }
 fs4                = { version = "0.13", default-features = false, features = ["sync"] }

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -178,6 +178,89 @@ fn run_ok(program: &str, args: &[&str]) -> Result<(), GuiError> {
     }
 }
 
+/// Run a command and return its combined stdout+stderr regardless of exit
+/// status, truncated to `max` bytes. Unlike [`run_ok`], this keeps the output
+/// of commands that exit non-zero — `systemctl status` / `launchctl print`
+/// routinely do, and that text is exactly what diagnostics want. `None` if the
+/// command can't be launched at all. Only [`service_status_text`] uses it, on
+/// the two platforms with a service manager — gated so a Windows build (where
+/// that arm returns `None`) doesn't see it as dead code under `-D warnings`.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn capture(program: &str, args: &[&str], max: usize) -> Option<String> {
+    let out = Command::new(program).args(args).output().ok()?;
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    let err = String::from_utf8_lossy(&out.stderr);
+    if !err.trim().is_empty() {
+        if !s.is_empty() {
+            s.push('\n');
+        }
+        s.push_str(&err);
+    }
+    let s = s.trim().to_string();
+    if s.is_empty() {
+        return None;
+    }
+    if s.len() > max {
+        // Truncate on a char boundary to keep the string valid UTF-8.
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut t = s[..end].to_string();
+        t.push_str("\n… (truncated)");
+        Some(t)
+    } else {
+        Some(s)
+    }
+}
+
+/// Human-readable label for the mechanism that supervises the daemon on this
+/// host — surfaced in diagnostics so a user/support can see which path was used.
+pub(crate) fn service_manager_label() -> &'static str {
+    #[cfg(target_os = "linux")]
+    {
+        if systemd_user_available() {
+            "systemd --user"
+        } else {
+            "detached spawn"
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if use_smappservice() {
+            "launchd (SMAppService)"
+        } else {
+            "launchd (loose)"
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        "none"
+    }
+}
+
+/// The service manager's own status text for the daemon job (`systemctl --user
+/// status yerd` / `launchctl print gui/{uid}/dev.yerd.daemon`), truncated.
+/// `None` when no service manager applies or the query produced nothing.
+pub(crate) fn service_status_text() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        capture(
+            "systemctl",
+            &["--user", "status", "yerd", "--no-pager"],
+            4096,
+        )
+    }
+    #[cfg(target_os = "macos")]
+    {
+        capture("launchctl", &["print", &service_target()], 4096)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
 // ── service-manager availability ─────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]
@@ -722,7 +805,7 @@ fn daemon_enabled(settings: &GuiSettings, supported: bool) -> bool {
 
 /// macOS SMAppService `requiresApproval` — registered but pending the user's
 /// toggle in Login Items. Always false on the fallback path / other OSes.
-fn daemon_pending_approval() -> bool {
+pub(crate) fn daemon_pending_approval() -> bool {
     #[cfg(target_os = "macos")]
     if use_smappservice() {
         return crate::smappservice::status(crate::smappservice::Service::Daemon)

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -185,11 +185,52 @@ fn run_ok(program: &str, args: &[&str]) -> Result<(), GuiError> {
 /// command can't be launched at all. Only [`service_status_text`] uses it, on
 /// the two platforms with a service manager — gated so a Windows build (where
 /// that arm returns `None`) doesn't see it as dead code under `-D warnings`.
+///
+/// **Bounded.** This runs on a `spawn_blocking` thread in the diagnostics path,
+/// but a wedged `systemctl --user`/`launchctl` would still leave the UI's
+/// "diagnose" step stuck, so the wait is capped (the child is killed on expiry).
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub(crate) fn capture(program: &str, args: &[&str], max: usize) -> Option<String> {
-    let out = Command::new(program).args(args).output().ok()?;
-    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
-    let err = String::from_utf8_lossy(&out.stderr);
+    use std::io::Read as _;
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    // Status queries are quick; if one hasn't exited within the cap, kill it and
+    // report rather than block. (Output is small — well under the pipe buffer —
+    // so the child won't deadlock waiting for us to drain it before exiting.)
+    let deadline = Instant::now() + Duration::from_secs(4);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Some(format!("(`{program}` did not respond within 4s)"));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(_) => return None,
+        }
+    }
+
+    let mut out_buf = Vec::new();
+    let mut err_buf = Vec::new();
+    if let Some(mut so) = child.stdout.take() {
+        let _ = so.read_to_end(&mut out_buf);
+    }
+    if let Some(mut se) = child.stderr.take() {
+        let _ = se.read_to_end(&mut err_buf);
+    }
+
+    let mut s = String::from_utf8_lossy(&out_buf).into_owned();
+    let err = String::from_utf8_lossy(&err_buf);
     if !err.trim().is_empty() {
         if !s.is_empty() {
             s.push('\n');
@@ -201,12 +242,14 @@ pub(crate) fn capture(program: &str, args: &[&str], max: usize) -> Option<String
         return None;
     }
     if s.len() > max {
-        // Truncate on a char boundary to keep the string valid UTF-8.
-        let mut end = max;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
+        // Build a char-bounded prefix (no slicing) so truncation stays UTF-8 safe.
+        let mut t = String::new();
+        for ch in s.chars() {
+            if t.len() + ch.len_utf8() > max {
+                break;
+            }
+            t.push(ch);
         }
-        let mut t = s[..end].to_string();
         t.push_str("\n… (truncated)");
         Some(t)
     } else {

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -252,17 +252,42 @@ fn sigterm(pid: u32) {
     }
 }
 
+/// Build the detached daemon's stdout/stderr targets: a truncate-on-start
+/// `{cache}/yerdd-spawn.log` so a crash *before* the daemon's own tracing log is
+/// up (e.g. the tokio runtime-build failure) still leaves a trace. Both fds are
+/// `try_clone`d from one `File` so they share an open-file-description (one
+/// offset → interleave without clobbering). Best-effort: any failure
+/// (unresolvable cache, create/clone error) degrades to `/dev/null` rather than
+/// turning logging into a spawn failure.
+#[cfg(target_os = "linux")]
+fn spawn_log_stdio() -> (std::process::Stdio, std::process::Stdio) {
+    use yerd_platform::{ActivePaths, Paths};
+    let pair = (|| {
+        let dirs = ActivePaths::new().resolve().ok()?;
+        std::fs::create_dir_all(&dirs.cache).ok()?;
+        let file = std::fs::File::create(dirs.cache.join("yerdd-spawn.log")).ok()?;
+        let clone = file.try_clone().ok()?;
+        Some((file, clone))
+    })();
+    match pair {
+        Some((out, err)) => (out.into(), err.into()),
+        None => (std::process::Stdio::null(), std::process::Stdio::null()),
+    }
+}
+
 /// Spawn `yerdd serve` detached so it survives the GUI exiting (its own
-/// session, stdio to /dev/null). Used only on the no-service-manager path
-/// (Linux without systemd `--user`; macOS always has launchd).
+/// session). stdout/stderr go to `{cache}/yerdd-spawn.log` (or `/dev/null` if
+/// that can't be opened). Used only on the no-service-manager path (Linux
+/// without systemd `--user`; macOS always has launchd).
 #[cfg(target_os = "linux")]
 pub(crate) fn spawn_detached() -> Result<(), GuiError> {
     let yerdd = resolve_yerdd().ok_or_else(|| GuiError::internal("yerdd is not installed"))?;
+    let (stdout, stderr) = spawn_log_stdio();
     let mut cmd = std::process::Command::new(&yerdd);
     cmd.arg("serve")
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+        .stdout(stdout)
+        .stderr(stderr);
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt as _;
@@ -278,4 +303,248 @@ pub(crate) fn spawn_detached() -> Result<(), GuiError> {
     cmd.spawn()
         .map(|_| ())
         .map_err(|e| GuiError::internal(format!("could not start {}: {e}", yerdd.display())))
+}
+
+// ── diagnostics ───────────────────────────────────────────────────────────────
+//
+// When a start attempt fails to connect, the GUI calls `daemon_diagnostics` to
+// gather everything that explains *why* — both the ran-and-crashed case (the
+// daemon's rolling log tail) and the never-launched cases (the start error,
+// translocation, a missing sidecar, pending Login-Items approval), which are the
+// likely first-run reports where no daemon log exists yet.
+
+/// A host-side snapshot of daemon-start health. Serialises camelCase for the
+/// webview; see `DaemonDiagnostics` in `ipc/types.ts`.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DaemonDiagnostics {
+    /// The error `start_daemon` threw, passed back from the frontend — the top
+    /// signal for "never launched" failures (register / translocation / missing
+    /// binary), where the daemon log doesn't exist.
+    start_error: Option<String>,
+    /// Plain-English cause+fix lines computed from the signals below.
+    hints: Vec<String>,
+    /// Resolved `yerdd` path, or `None` if the bundled daemon is missing. On
+    /// macOS a translocated run reports the *stable* path (or `None`), never the
+    /// ephemeral `/AppTranslocation/…` one.
+    yerdd_path: Option<String>,
+    /// macOS App Translocation (running from a DMG / quarantine mount).
+    translocated: bool,
+    /// The IPC socket path the GUI connects to.
+    socket_path: String,
+    /// A real connect+`Status` exchange succeeded — not mere file existence (a
+    /// stale socket file can linger after a crash).
+    socket_responding: bool,
+    /// The connect error from the probe, when it failed.
+    last_connect_error: Option<String>,
+    /// Which mechanism supervises the daemon here.
+    service_manager: String,
+    /// The service manager's own status text for the job, truncated.
+    service_status: Option<String>,
+    /// macOS SMAppService `requiresApproval` — registered but awaiting the user.
+    pending_approval: bool,
+    /// Newest `{cache}/yerdd.<date>.log`, if any.
+    log_path: Option<String>,
+    /// Last lines of the daemon's rolling log.
+    log_tail: Vec<String>,
+    /// Last lines of `{cache}/yerdd-spawn.log` (Linux detached-spawn path).
+    spawn_log_tail: Vec<String>,
+}
+
+/// Gather daemon-start diagnostics. `start_error` is the message the frontend's
+/// `startDaemon` call threw (if any). Probes the socket (async), then does the
+/// filesystem/subprocess gathering off the runtime so the UI never stalls.
+#[tauri::command]
+pub async fn daemon_diagnostics(
+    start_error: Option<String>,
+) -> Result<DaemonDiagnostics, GuiError> {
+    let (socket_responding, last_connect_error) =
+        match crate::ipc::exchange(&yerd_ipc::Request::Status).await {
+            Ok(_) => (true, None),
+            Err(e) => (false, Some(e.message)),
+        };
+    tokio::task::spawn_blocking(move || {
+        build_diagnostics(start_error, socket_responding, last_connect_error)
+    })
+    .await
+    .map_err(|e| GuiError::internal(format!("diagnostics task failed: {e}")))
+}
+
+/// Number of trailing log lines surfaced in diagnostics.
+const LOG_TAIL_LINES: usize = 80;
+
+fn build_diagnostics(
+    start_error: Option<String>,
+    socket_responding: bool,
+    last_connect_error: Option<String>,
+) -> DaemonDiagnostics {
+    use yerd_platform::{ActivePaths, Paths};
+
+    let dirs = ActivePaths::new().resolve().ok();
+    let socket_path = dirs
+        .as_ref()
+        .map(|d| d.runtime.join("yerd.sock").display().to_string())
+        .unwrap_or_else(|| "<unresolved>".to_owned());
+    let cache = dirs.as_ref().map(|d| d.cache.clone());
+
+    let translocated = diag_translocated();
+    let yerdd_path = diag_yerdd_path();
+    let pending_approval = crate::autostart::daemon_pending_approval();
+    let service_manager = crate::autostart::service_manager_label().to_owned();
+    let service_status = crate::autostart::service_status_text();
+
+    let log_path = cache
+        .as_ref()
+        .and_then(|c| newest_rolling_log(c).map(|p| p.display().to_string()));
+    let log_tail = log_path
+        .as_ref()
+        .map(|p| tail_lines(std::path::Path::new(p), LOG_TAIL_LINES))
+        .unwrap_or_default();
+    let spawn_log_tail = cache
+        .as_ref()
+        .map(|c| tail_lines(&c.join("yerdd-spawn.log"), LOG_TAIL_LINES))
+        .unwrap_or_default();
+
+    let hints = compute_hints(
+        pending_approval,
+        translocated,
+        yerdd_path.is_none(),
+        start_error.as_deref(),
+        &service_manager,
+        &log_tail,
+        &spawn_log_tail,
+    );
+
+    DaemonDiagnostics {
+        start_error,
+        hints,
+        yerdd_path,
+        translocated,
+        socket_path,
+        socket_responding,
+        last_connect_error,
+        service_manager,
+        service_status,
+        pending_approval,
+        log_path,
+        log_tail,
+        spawn_log_tail,
+    }
+}
+
+/// macOS App Translocation flag (always false off-macOS).
+fn diag_translocated() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        crate::autostart::is_translocated()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// The `yerdd` path to report. On a translocated macOS run, resolve only from
+/// stable install dirs (the beside-exe candidate is an ephemeral mount that
+/// would mislead "installed at …"); otherwise the normal resolver.
+fn diag_yerdd_path() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    if crate::autostart::is_translocated() {
+        return resolve_yerdd_stable().map(|p| p.display().to_string());
+    }
+    resolve_yerdd().map(|p| p.display().to_string())
+}
+
+/// Newest `yerdd.<date>.log` under `dir` (the daily rolling appender's output).
+/// Matches `yerdd.` + `.log` so it never picks up `yerdd-spawn.log`. Chooses by
+/// modification time; tolerates a missing/unreadable dir.
+fn newest_rolling_log(dir: &std::path::Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !(name.starts_with("yerdd.") && name.ends_with(".log")) {
+            continue;
+        }
+        let Ok(modified) = entry.metadata().and_then(|m| m.modified()) else {
+            continue;
+        };
+        if best.as_ref().is_none_or(|(t, _)| modified > *t) {
+            best = Some((modified, entry.path()));
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+/// Last `n` lines of `path`. Best-effort: a missing/unreadable file → empty.
+/// Bounded inputs (daily rotation + truncate-on-start spawn log) make reading
+/// the whole file acceptable.
+fn tail_lines(path: &std::path::Path, n: usize) -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].iter().map(|s| (*s).to_owned()).collect()
+}
+
+/// Map the gathered signals to one actionable plain-English line each.
+fn compute_hints(
+    pending_approval: bool,
+    translocated: bool,
+    yerdd_missing: bool,
+    start_error: Option<&str>,
+    service_manager: &str,
+    log_tail: &[String],
+    spawn_log_tail: &[String],
+) -> Vec<String> {
+    let mut hints = Vec::new();
+    if pending_approval {
+        hints.push(
+            "Approve Yerd under System Settings → Login Items; it'll connect automatically."
+                .to_owned(),
+        );
+    }
+    if translocated {
+        hints.push(
+            "Yerd is running from a temporary location. Move Yerd.app to your Applications \
+             folder, then try again."
+                .to_owned(),
+        );
+    }
+    if yerdd_missing {
+        hints.push("The bundled daemon (yerdd) wasn't found — reinstall Yerd.".to_owned());
+    }
+    // Scan both logs for known fatal startup signals.
+    let logs = log_tail
+        .iter()
+        .chain(spawn_log_tail.iter())
+        .map(|l| l.to_lowercase())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if logs.contains("dns_port")
+        || logs.contains("address already in use")
+        || logs.contains("address in use")
+    {
+        hints.push(
+            "Another service is holding the DNS port. Change `dns_port` in yerd.toml or stop \
+             the conflicting resolver."
+                .to_owned(),
+        );
+    }
+    if logs.contains("already running") {
+        hints.push("Another Yerd daemon is already running.".to_owned());
+    }
+    if service_manager == "detached spawn" {
+        hints.push(
+            "systemd --user wasn't detected in this session, so the daemon was started \
+             detached and won't run at login."
+                .to_owned(),
+        );
+    }
+    if let Some(err) = start_error {
+        hints.push(format!("Start error: {err}"));
+    }
+    hints
 }

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -47,9 +47,44 @@ pub(crate) fn resolve_binary(name: &str) -> Option<PathBuf> {
             }
         }
     }
-    search_dirs()
+    if let Some(found) = search_dirs()
         .into_iter()
         .map(|d| d.join(name))
+        .find(|c| c.is_file())
+    {
+        return Some(found);
+    }
+    // Linux: the `.deb` installs the Tauri sidecars under `/usr/lib/<product>/`
+    // and the postinst *symlinks* them into `/usr/bin`. That symlink is not
+    // dpkg-tracked and the postinst fails closed (a leftover `/usr/bin/yerd`
+    // from the v1 Go project, or a Tauri path change, aborts it), so search the
+    // real install dir directly as a fallback — otherwise a postinst hiccup
+    // leaves `yerdd` present on disk but unfindable and the daemon "won't start".
+    #[cfg(target_os = "linux")]
+    {
+        lib_sidecar(name)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Find a Tauri sidecar in its real `.deb` install location: a `yerd*`-named
+/// directory under `/usr/lib` (e.g. `/usr/lib/Yerd/yerdd`). Restricted to
+/// yerd-named dirs so an unrelated `/usr/lib/<other>/yerd` can't be picked up.
+#[cfg(target_os = "linux")]
+fn lib_sidecar(name: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir("/usr/lib").ok()?;
+    entries
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .to_lowercase()
+                .contains("yerd")
+        })
+        .map(|e| e.path().join(name))
         .find(|c| c.is_file())
 }
 
@@ -439,11 +474,20 @@ fn build_diagnostics(
     }
 }
 
-/// macOS App Translocation flag (always false off-macOS).
+/// "Running from a non-installed location" flag for diagnostics (always false
+/// off-macOS). True for App Translocation *and* for launching straight from a
+/// mounted disk image (`/Volumes/…`): both make SMAppService registration fail,
+/// and both are fixed by moving Yerd to /Applications — so the same
+/// "move to Applications" hint applies. This drives only the hint, not the
+/// registration gating, so a legitimate read-write external-drive install still
+/// registers normally.
 fn diag_translocated() -> bool {
     #[cfg(target_os = "macos")]
     {
         crate::autostart::is_translocated()
+            || std::env::current_exe()
+                .map(|p| p.to_string_lossy().contains("/Volumes/"))
+                .unwrap_or(false)
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -358,10 +358,17 @@ pub struct DaemonDiagnostics {
 pub async fn daemon_diagnostics(
     start_error: Option<String>,
 ) -> Result<DaemonDiagnostics, GuiError> {
+    // Bound the probe: a *wedged* daemon (accepting the socket but not replying)
+    // would otherwise make this diagnose-a-sick-daemon command hang the UI.
+    let probe = crate::ipc::exchange(&yerd_ipc::Request::Status);
     let (socket_responding, last_connect_error) =
-        match crate::ipc::exchange(&yerd_ipc::Request::Status).await {
-            Ok(_) => (true, None),
-            Err(e) => (false, Some(e.message)),
+        match tokio::time::timeout(std::time::Duration::from_secs(3), probe).await {
+            Ok(Ok(_)) => (true, None),
+            Ok(Err(e)) => (false, Some(e.message)),
+            Err(_) => (
+                false,
+                Some("daemon did not respond within 3s (it may be wedged)".to_owned()),
+            ),
         };
     tokio::task::spawn_blocking(move || {
         build_diagnostics(start_error, socket_responding, last_connect_error)
@@ -523,10 +530,10 @@ fn compute_hints(
         .map(|l| l.to_lowercase())
         .collect::<Vec<_>>()
         .join("\n");
-    if logs.contains("dns_port")
-        || logs.contains("address already in use")
-        || logs.contains("address in use")
-    {
+    // Key only on the precise `dns_port` token the DNS-bind error logs
+    // (startup.rs). A bare "address in use" would also match the *non-fatal*
+    // mail-port conflict or an HTTP-port conflict and wrongly blame DNS.
+    if logs.contains("dns_port") {
         hints.push(
             "Another service is holding the DNS port. Change `dns_port` in yerd.toml or stop \
              the conflicting resolver."

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -146,6 +146,7 @@ fn main() {
             commands::job_cancel,
             show_dumps_window,
             daemon::daemon_installed,
+            daemon::daemon_diagnostics,
             daemon::start_daemon,
             daemon::stop_daemon,
             daemon::cli_path_status,

--- a/apps/yerd-gui/src/components/DaemonDiagnosticsPanel.vue
+++ b/apps/yerd-gui/src/components/DaemonDiagnosticsPanel.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { Copy, TriangleAlert } from "lucide-vue-next";
+import { computed } from "vue";
+
+import Button from "@/components/ui/Button.vue";
+import { useToast } from "@/composables/useToast";
+import type { DaemonDiagnostics } from "@/ipc/types";
+
+// Shown when a daemon start attempt fails to connect. Leads with the
+// host-computed `hints` (the actionable verdict), then an expandable raw section
+// (service-manager status + log tail) for support, plus a Copy button.
+const props = defineProps<{ diagnostics: DaemonDiagnostics }>();
+
+const toast = useToast();
+
+const hasRaw = computed(
+  () =>
+    !!props.diagnostics.serviceStatus ||
+    props.diagnostics.logTail.length > 0 ||
+    props.diagnostics.spawnLogTail.length > 0,
+);
+
+/** A flat, paste-able plain-text dump of the whole diagnostics struct. */
+function asText(): string {
+  const d = props.diagnostics;
+  const lines = [
+    "Yerd daemon diagnostics",
+    "=======================",
+    `service manager : ${d.serviceManager || "(unknown)"}`,
+    `socket          : ${d.socketPath} (${d.socketResponding ? "responding" : "not responding"})`,
+    `yerdd binary    : ${d.yerddPath ?? "(not found)"}`,
+    `translocated    : ${d.translocated}`,
+    `pending approval: ${d.pendingApproval}`,
+    `log file        : ${d.logPath ?? "(none)"}`,
+  ];
+  if (d.startError) lines.push(`start error     : ${d.startError}`);
+  if (d.lastConnectError) lines.push(`connect error   : ${d.lastConnectError}`);
+  if (d.hints.length) lines.push("", "Hints:", ...d.hints.map((h) => `  - ${h}`));
+  if (d.serviceStatus) lines.push("", "Service status:", d.serviceStatus);
+  if (d.logTail.length) lines.push("", "Daemon log (tail):", ...d.logTail);
+  if (d.spawnLogTail.length) lines.push("", "Spawn log (tail):", ...d.spawnLogTail);
+  return lines.join("\n");
+}
+
+async function copy(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(asText());
+    toast.success("Copied diagnostics", "Paste this when reporting the problem.");
+  } catch {
+    toast.error("Couldn't copy", "Your browser blocked clipboard access.");
+  }
+}
+</script>
+
+<template>
+  <div class="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+    <div class="flex items-start gap-2">
+      <TriangleAlert class="mt-0.5 size-4 shrink-0 text-destructive" />
+      <div class="min-w-0 flex-1">
+        <p class="font-medium">The daemon didn't come up</p>
+
+        <!-- Actionable verdict first. -->
+        <ul
+          v-if="diagnostics.hints.length"
+          class="mt-1 list-disc space-y-1 pl-4 text-muted-foreground"
+        >
+          <li v-for="(hint, i) in diagnostics.hints" :key="i">{{ hint }}</li>
+        </ul>
+        <p v-else class="mt-1 text-muted-foreground">
+          We couldn't determine the cause automatically. Open the details below
+          and copy them when reporting the problem.
+        </p>
+
+        <!-- Raw details for support. -->
+        <details v-if="hasRaw" class="mt-2">
+          <summary class="cursor-pointer select-none text-xs text-muted-foreground">
+            Show technical details
+          </summary>
+          <div class="mt-2 space-y-3">
+            <div v-if="diagnostics.serviceStatus">
+              <p class="text-xs font-medium text-muted-foreground">Service status</p>
+              <pre
+                class="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 font-mono text-xs"
+              >{{ diagnostics.serviceStatus }}</pre>
+            </div>
+            <div v-if="diagnostics.logTail.length">
+              <p class="text-xs font-medium text-muted-foreground">
+                Daemon log — {{ diagnostics.logPath }}
+              </p>
+              <pre
+                class="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 font-mono text-xs"
+              >{{ diagnostics.logTail.join("\n") }}</pre>
+            </div>
+            <div v-if="diagnostics.spawnLogTail.length">
+              <p class="text-xs font-medium text-muted-foreground">Spawn log</p>
+              <pre
+                class="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 font-mono text-xs"
+              >{{ diagnostics.spawnLogTail.join("\n") }}</pre>
+            </div>
+          </div>
+        </details>
+
+        <Button variant="outline" size="sm" class="mt-2" @click="copy">
+          <Copy class="size-4" /> Copy diagnostics
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/yerd-gui/src/components/DaemonDownHero.vue
+++ b/apps/yerd-gui/src/components/DaemonDownHero.vue
@@ -25,6 +25,12 @@ function onStart(): void {
   // nudge=true: a single-button start may open Login Items on pending approval.
   void start({ nudge: true });
 }
+
+// `openLoginItems` is an async IPC call; swallow any rejection so a raw `@click`
+// binding can't surface an unhandled promise rejection (it's best-effort UX).
+function onOpenLoginItems(): void {
+  void openLoginItems().catch(() => {});
+}
 </script>
 
 <template>
@@ -48,7 +54,7 @@ function onStart(): void {
         macOS needs you to allow Yerd in the background. Enable it under Login
         Items, then it'll connect automatically.
       </p>
-      <Button variant="outline" size="sm" class="mt-2" @click="openLoginItems">
+      <Button variant="outline" size="sm" class="mt-2" @click="onOpenLoginItems">
         <ExternalLink class="size-4" /> Open Login Items
       </Button>
     </div>

--- a/apps/yerd-gui/src/components/DaemonDownHero.vue
+++ b/apps/yerd-gui/src/components/DaemonDownHero.vue
@@ -1,65 +1,30 @@
 <script setup lang="ts">
-import { Play } from "lucide-vue-next";
-import { computed, onUnmounted, ref, watch } from "vue";
+import { ExternalLink, Play } from "lucide-vue-next";
+import { computed } from "vue";
 
+import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { useDaemon } from "@/composables/useDaemon";
-import { useToast } from "@/composables/useToast";
-import { IpcError, startDaemon } from "@/ipc/client";
+import { useDaemonStart } from "@/composables/useDaemonStart";
+import { openLoginItems } from "@/ipc/client";
 import logoUrl from "@/assets/logo.svg";
 
 // The shared "Yerd isn't running" hero + start affordance. Used by the Overview
 // page and as the blocked-page screen in AppShell, so every page shows the same
-// thing when the daemon is down. Keeps the button spinning until the daemon
-// actually connects — with a timeout so it can never stick forever.
-const { connected, report, refresh } = useDaemon();
-const toast = useToast();
-const starting = ref(false);
+// thing when the daemon is down. The start→wait→diagnose logic (with auto-clear
+// on connect) lives in useDaemonStart; on failure we show actionable diagnostics
+// instead of a blind toast, and on macOS pending-approval we show the Login-Items
+// affordance rather than a "failure".
+const { report } = useDaemon();
+const { starting, pendingApproval, diagnostics, start } = useDaemonStart();
 const tld = computed(() => report.value?.tld ?? "test");
 
-// If a started daemon never connects (e.g. crashed, or macOS Login-Items
-// approval pending), stop spinning after this so the button is clickable again.
-const START_TIMEOUT_MS = 20_000;
-let startTimer: ReturnType<typeof setTimeout> | undefined;
-function clearStartTimer(): void {
-  if (startTimer) {
-    clearTimeout(startTimer);
-    startTimer = undefined;
-  }
+function onStart(): void {
+  // nudge=true: a single-button start may open Login Items on pending approval.
+  void start({ nudge: true });
 }
-
-async function onStart(): Promise<void> {
-  starting.value = true;
-  try {
-    await startDaemon();
-    await refresh();
-    clearStartTimer();
-    startTimer = setTimeout(() => {
-      if (starting.value && connected.value !== true) {
-        starting.value = false;
-        toast.error(
-          "The daemon didn't come up",
-          "Try again, or check Settings → Login Items.",
-        );
-      }
-    }, START_TIMEOUT_MS);
-  } catch (e) {
-    starting.value = false;
-    toast.error("Couldn't start the daemon", (e as IpcError).message);
-  }
-}
-
-// Stop the spinner once the daemon is reachable.
-watch(connected, (c) => {
-  if (c === true) {
-    starting.value = false;
-    clearStartTimer();
-  }
-});
-
-onUnmounted(clearStartTimer);
 </script>
 
 <template>
@@ -72,6 +37,29 @@ onUnmounted(clearStartTimer);
         sites, PHP runtimes, and services.
       </p>
     </div>
+
+    <!-- macOS: registered but awaiting the user's Login-Items approval. -->
+    <div
+      v-if="pendingApproval"
+      class="mx-auto max-w-md rounded-md border border-warning/40 bg-warning/10 p-3 text-left text-sm"
+    >
+      <p class="font-medium">One more step</p>
+      <p class="mt-1 text-muted-foreground">
+        macOS needs you to allow Yerd in the background. Enable it under Login
+        Items, then it'll connect automatically.
+      </p>
+      <Button variant="outline" size="sm" class="mt-2" @click="openLoginItems">
+        <ExternalLink class="size-4" /> Open Login Items
+      </Button>
+    </div>
+
+    <!-- Why the daemon didn't come up. -->
+    <DaemonDiagnosticsPanel
+      v-else-if="diagnostics"
+      :diagnostics="diagnostics"
+      class="mx-auto max-w-md text-left"
+    />
+
     <Button :disabled="starting" @click="onStart">
       <Spinner v-if="starting" class="size-4" />
       <Play v-else class="size-4" /> Start Yerd

--- a/apps/yerd-gui/src/composables/useDaemonStart.ts
+++ b/apps/yerd-gui/src/composables/useDaemonStart.ts
@@ -1,0 +1,167 @@
+import { onUnmounted, ref } from "vue";
+import { watch } from "vue";
+
+import { useDaemon } from "@/composables/useDaemon";
+import { daemonDiagnostics, IpcError, startDaemon } from "@/ipc/client";
+import type { DaemonDiagnostics } from "@/ipc/types";
+
+/**
+ * Shared "start the daemon, wait for it to actually connect, and diagnose on
+ * failure" skeleton — used by the onboarding step 1 and the DaemonDownHero so
+ * both surface the same diagnostics instead of a blind 20 s toast.
+ *
+ * Deliberately narrow: it owns only the timeout / fast-poll / diagnose state.
+ * It does NOT own macOS login-item orchestration — that ordering is load-bearing
+ * in onboarding (enable the GUI login item, *then* re-probe approval) and must
+ * NOT run from the hero's "Start Yerd" button. Callers inject that via the
+ * `beforeProbe` hook, which runs after `startDaemon` and returns whether the
+ * daemon/GUI is now pending Login-Items approval.
+ *
+ * Per-instance state (declared here, in component setup scope) + a
+ * component-scoped `watch`/`onUnmounted`, so the two mount sites don't share a
+ * timer. `connected` only updates when the shared `useDaemon` poller ticks, so
+ * the fast-poll actively drives `refresh()` rather than passively reading it.
+ */
+
+export interface StartOptions {
+  /** macOS: open Login Items on a pending approval. Onboarding passes false. */
+  nudge?: boolean;
+  /**
+   * Runs after `startDaemon` resolves; returns whether the daemon/GUI is pending
+   * Login-Items approval. Onboarding injects its enable-login-defaults +
+   * re-probe here; the hero omits it (and so never enables login-at-boot).
+   */
+  beforeProbe?: () => Promise<boolean>;
+}
+
+const POLL_MS = 500;
+const CEILING_MS = 20_000;
+
+export function useDaemonStart() {
+  const { connected, refresh } = useDaemon();
+
+  const starting = ref(false);
+  const pendingApproval = ref(false);
+  const diagnostics = ref<DaemonDiagnostics | null>(null);
+
+  let pollTimer: ReturnType<typeof setTimeout> | undefined;
+  let elapsed = 0;
+
+  function clearPoll(): void {
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = undefined;
+    }
+  }
+
+  function reset(): void {
+    clearPoll();
+    starting.value = false;
+    pendingApproval.value = false;
+    diagnostics.value = null;
+  }
+
+  async function diagnose(startError?: string): Promise<void> {
+    try {
+      const d = await daemonDiagnostics(startError);
+      // A registered-but-unapproved daemon isn't a failure: show the approval
+      // affordance, not the diagnostics panel.
+      if (d.pendingApproval) {
+        pendingApproval.value = true;
+        diagnostics.value = null;
+      } else {
+        diagnostics.value = d;
+      }
+    } catch {
+      // Diagnostics gathering itself failed — still surface the start error so
+      // the panel isn't empty.
+      diagnostics.value = startError ? minimalDiagnostics(startError) : null;
+    }
+  }
+
+  function beginPolling(startError?: string): void {
+    clearPoll();
+    elapsed = 0;
+    const tick = async (): Promise<void> => {
+      if (!starting.value) return;
+      await refresh(); // drives the shared poller; updates `connected`
+      if (connected.value === true) return; // the watch below clears state
+      elapsed += POLL_MS;
+      if (elapsed >= CEILING_MS) {
+        await diagnose(startError);
+        starting.value = false;
+        return;
+      }
+      pollTimer = setTimeout(() => void tick(), POLL_MS);
+    };
+    pollTimer = setTimeout(() => void tick(), POLL_MS);
+  }
+
+  async function start(opts: StartOptions = {}): Promise<void> {
+    reset();
+    starting.value = true;
+    let startError: string | undefined;
+    try {
+      await startDaemon(opts.nudge ?? false);
+    } catch (e) {
+      // Launch threw outright (missing sidecar, translocation refusal, register
+      // failure) — capture the message and diagnose immediately.
+      startError = (e as IpcError).message;
+      await diagnose(startError);
+      starting.value = false;
+      return;
+    }
+    // Let the caller enable login items / re-probe approval, then read it.
+    if (opts.beforeProbe) {
+      try {
+        pendingApproval.value = await opts.beforeProbe();
+      } catch {
+        /* best-effort; treat as not-pending */
+      }
+    }
+    await refresh();
+    if (connected.value === true) {
+      starting.value = false;
+      return;
+    }
+    if (pendingApproval.value) {
+      // Can't connect until the user approves; show the affordance, not a panel.
+      starting.value = false;
+      return;
+    }
+    beginPolling(startError);
+  }
+
+  // Once the daemon is actually reachable, drop any failure/approval UI.
+  watch(connected, (c) => {
+    if (c === true) {
+      starting.value = false;
+      pendingApproval.value = false;
+      diagnostics.value = null;
+      clearPoll();
+    }
+  });
+
+  onUnmounted(clearPoll);
+
+  return { starting, pendingApproval, diagnostics, start, reset };
+}
+
+/** Minimal fallback when `daemon_diagnostics` itself can't run. */
+function minimalDiagnostics(startError: string): DaemonDiagnostics {
+  return {
+    startError,
+    hints: [`Start error: ${startError}`],
+    yerddPath: null,
+    translocated: false,
+    socketPath: "",
+    socketResponding: false,
+    lastConnectError: null,
+    serviceManager: "",
+    serviceStatus: null,
+    pendingApproval: false,
+    logPath: null,
+    logTail: [],
+    spawnLogTail: [],
+  };
+}

--- a/apps/yerd-gui/src/composables/useDaemonStart.ts
+++ b/apps/yerd-gui/src/composables/useDaemonStart.ts
@@ -46,6 +46,9 @@ export function useDaemonStart() {
 
   let pollTimer: ReturnType<typeof setTimeout> | undefined;
   let elapsed = 0;
+  // Set once the component unmounts so an in-flight `await` (refresh/diagnose)
+  // doesn't resume and reschedule a timer / mutate a dead component.
+  let disposed = false;
 
   function clearPoll(): void {
     if (pollTimer) {
@@ -61,9 +64,16 @@ export function useDaemonStart() {
     diagnostics.value = null;
   }
 
+  /** True once the daemon connected or the component went away — never show a
+   * failure panel in that case (avoids "Running" + failure panel together). */
+  function stale(): boolean {
+    return disposed || connected.value === true;
+  }
+
   async function diagnose(startError?: string): Promise<void> {
     try {
       const d = await daemonDiagnostics(startError);
+      if (stale()) return; // connected/unmounted while gathering — don't contradict
       // A registered-but-unapproved daemon isn't a failure: show the approval
       // affordance, not the diagnostics panel.
       if (d.pendingApproval) {
@@ -73,9 +83,12 @@ export function useDaemonStart() {
         diagnostics.value = d;
       }
     } catch {
-      // Diagnostics gathering itself failed — still surface the start error so
-      // the panel isn't empty.
-      diagnostics.value = startError ? minimalDiagnostics(startError) : null;
+      if (stale()) return;
+      // Diagnostics gathering itself failed — still surface something actionable
+      // rather than a silent dead-end.
+      diagnostics.value = minimalDiagnostics(
+        startError ?? "The daemon didn't come up, and diagnostics couldn't be gathered.",
+      );
     }
   }
 
@@ -83,8 +96,9 @@ export function useDaemonStart() {
     clearPoll();
     elapsed = 0;
     const tick = async (): Promise<void> => {
-      if (!starting.value) return;
+      if (disposed || !starting.value) return;
       await refresh(); // drives the shared poller; updates `connected`
+      if (disposed || !starting.value) return; // re-check after the await
       if (connected.value === true) return; // the watch below clears state
       elapsed += POLL_MS;
       if (elapsed >= CEILING_MS) {
@@ -142,16 +156,20 @@ export function useDaemonStart() {
     }
   });
 
-  onUnmounted(clearPoll);
+  onUnmounted(() => {
+    disposed = true;
+    clearPoll();
+  });
 
   return { starting, pendingApproval, diagnostics, start, reset };
 }
 
-/** Minimal fallback when `daemon_diagnostics` itself can't run. */
-function minimalDiagnostics(startError: string): DaemonDiagnostics {
+/** Minimal fallback when `daemon_diagnostics` itself can't run — the message
+ * doubles as the single actionable hint so the panel is never empty. */
+function minimalDiagnostics(message: string): DaemonDiagnostics {
   return {
-    startError,
-    hints: [`Start error: ${startError}`],
+    startError: message,
+    hints: [message],
     yerddPath: null,
     translocated: false,
     socketPath: "",

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -13,6 +13,7 @@ import type {
   CliPathStatus,
   AvailablePhpResponse,
   CreateSiteSpec,
+  DaemonDiagnostics,
   DatabaseSummary,
   Diagnosis,
   DoctorFixResponse,
@@ -573,6 +574,17 @@ export async function startDaemon(nudge = true): Promise<void> {
 
 export async function stopDaemon(): Promise<void> {
   await call<void>("stop_daemon");
+}
+
+/**
+ * Gather diagnostics explaining why the daemon isn't up — service-manager
+ * status, the daemon's rolling-log tail, binary/socket checks, and host-computed
+ * hints. Pass the message a prior `startDaemon` threw (if any) so the
+ * never-launched cases (missing binary, translocation, register failure) carry
+ * their most actionable signal.
+ */
+export async function daemonDiagnostics(startError?: string): Promise<DaemonDiagnostics> {
+  return call<DaemonDiagnostics>("daemon_diagnostics", { startError });
 }
 
 export async function getAutostart(): Promise<AutostartState> {

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -475,6 +475,29 @@ export interface AutostartState {
 }
 
 /**
+ * Why the daemon isn't up (host command `daemon_diagnostics`). Gathered when a
+ * start attempt fails to connect — covers both the ran-and-crashed case
+ * (`logTail`) and the never-launched cases (`startError`, `translocated`,
+ * `yerddPath === null`, `pendingApproval`). `hints` are ready-to-show
+ * plain-English cause+fix lines computed host-side.
+ */
+export interface DaemonDiagnostics {
+  startError: string | null;
+  hints: string[];
+  yerddPath: string | null;
+  translocated: boolean;
+  socketPath: string;
+  socketResponding: boolean;
+  lastConnectError: string | null;
+  serviceManager: string;
+  serviceStatus: string | null;
+  pendingApproval: boolean;
+  logPath: string | null;
+  logTail: string[];
+  spawnLogTail: string[];
+}
+
+/**
  * Whether the bundled `yerd` CLI is symlinked onto PATH (macOS host command
  * `cli_path_status`). On Linux the `.deb` already puts `yerd` on PATH, so the
  * control is hidden there.

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -9,6 +9,7 @@ import {
 } from "lucide-vue-next";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 
+import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import PageHeader from "@/components/PageHeader.vue";
 import StatusPill, { type Tone } from "@/components/StatusPill.vue";
 import Button from "@/components/ui/Button.vue";
@@ -28,6 +29,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useDaemon } from "@/composables/useDaemon";
+import { useDaemonStart } from "@/composables/useDaemonStart";
 import { useToast } from "@/composables/useToast";
 import {
   applyUpdate,
@@ -45,7 +47,6 @@ import {
   setAutostartGui,
   setAutostartGuiMinimized,
   setUpdateChannel,
-  startDaemon,
   stopDaemon,
 } from "@/ipc/client";
 import type {
@@ -60,6 +61,14 @@ import { useTheme, type ThemePref } from "@/lib/theme";
 import { humaniseBytes, humaniseUptime } from "@/lib/utils";
 
 const { connected, report, refresh: refreshStatus } = useDaemon();
+// Surfaces the same failure diagnostics here as onboarding / the down-hero, so a
+// start attempt from Settings (a screen shown while the daemon is down) isn't a
+// blind toast.
+const {
+  starting: daemonStarting,
+  diagnostics: startDiagnostics,
+  start: startDaemonFlow,
+} = useDaemonStart();
 const toast = useToast();
 const { pref, setTheme } = useTheme();
 
@@ -361,16 +370,11 @@ watch(running, (up) => {
 
 // ── daemon lifecycle ──
 async function onStart(): Promise<void> {
-  busy.value = "daemon";
-  try {
-    await startDaemon();
-    toast.success("Starting daemon…", "It should connect in a moment.");
-  } catch (e) {
-    toast.error("Couldn't start the daemon", (e as IpcError).message);
-  } finally {
-    busy.value = null;
-    await refreshStatus();
-  }
+  // Spinner + on-failure diagnostics are owned by the composable; it keeps
+  // spinning until the daemon connects (watch) or surfaces the panel.
+  await startDaemonFlow({ nudge: true });
+  // Refresh the approval banners (a fresh registration may now be pending).
+  await loadAutostart();
 }
 
 async function onStop(): Promise<void> {
@@ -490,8 +494,8 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
             <CardTitle>Daemon</CardTitle>
             <CardDescription>{{ daemonStatus }}</CardDescription>
           </div>
-          <Button v-if="!running" :disabled="busy === 'daemon'" @click="onStart">
-            <Spinner v-if="busy === 'daemon'" class="size-4" />
+          <Button v-if="!running" :disabled="daemonStarting" @click="onStart">
+            <Spinner v-if="daemonStarting" class="size-4" />
             <Play v-else class="size-4" /> Start
           </Button>
           <Button v-else variant="outline" :disabled="busy === 'daemon'" @click="onStop">
@@ -499,6 +503,10 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
             <Square v-else class="size-4" /> Stop
           </Button>
         </CardHeader>
+        <!-- Why a start attempt failed (only when the daemon is down). -->
+        <CardContent v-if="startDiagnostics && !running">
+          <DaemonDiagnosticsPanel :diagnostics="startDiagnostics" />
+        </CardContent>
         <CardContent v-if="report">
           <TooltipProvider :delay-duration="0">
             <div class="text-sm">

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -93,7 +93,8 @@ async function installDaemon(): Promise<void> {
       const pending =
         (autostart?.daemonPendingApproval ?? false) ||
         (autostart?.guiPendingApproval ?? false);
-      if (pending) void openLoginItems(); // best-effort; don't block onboarding
+      // best-effort; don't block onboarding, and swallow any IPC rejection.
+      if (pending) void openLoginItems().catch(() => {});
       return pending;
     },
   });
@@ -124,6 +125,12 @@ async function enableLoginDefaults(daemonSupported: boolean): Promise<void> {
   } catch {
     /* best-effort */
   }
+}
+
+// Swallow any rejection from the async `openLoginItems` IPC call so a raw
+// `@click` binding can't surface an unhandled promise rejection (best-effort UX).
+function onOpenLoginItems(): void {
+  void openLoginItems().catch(() => {});
 }
 
 // (Spinner/diagnostics auto-clear on connect is handled inside useDaemonStart.)
@@ -292,7 +299,7 @@ function onBack(): void {
                 macOS needs you to allow Yerd in the background. Enable it under
                 Login Items, then it'll connect automatically.
               </p>
-              <Button variant="outline" size="sm" class="mt-2" @click="openLoginItems">
+              <Button variant="outline" size="sm" class="mt-2" @click="onOpenLoginItems">
                 <ExternalLink class="size-4" /> Open Login Items
               </Button>
             </div>

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -8,9 +8,10 @@ import {
   FolderPlus,
   Rocket,
 } from "lucide-vue-next";
-import { computed, onUnmounted, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
+import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import EnvironmentCard from "@/components/EnvironmentCard.vue";
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
@@ -18,6 +19,7 @@ import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import logoUrl from "@/assets/logo.svg";
 import { useDaemon } from "@/composables/useDaemon";
+import { useDaemonStart } from "@/composables/useDaemonStart";
 import { useOnboarding } from "@/composables/useOnboarding";
 import { useToast } from "@/composables/useToast";
 import {
@@ -31,7 +33,6 @@ import {
   setAutostartDaemon,
   setAutostartGui,
   setAutostartGuiMinimized,
-  startDaemon,
 } from "@/ipc/client";
 import type { AutostartState, PhpVersion } from "@/ipc/types";
 
@@ -54,78 +55,48 @@ const STEPS = [
 const step = ref(1);
 
 // ── step 1: daemon ──
-const daemonStarting = ref(false);
-const pendingApproval = ref(false);
+// The start→wait→diagnose skeleton lives in the composable; onboarding injects
+// its login-item ordering via `beforeProbe` (see installDaemon).
+const {
+  starting: daemonStarting,
+  pendingApproval,
+  diagnostics,
+  start: startDaemonFlow,
+} = useDaemonStart();
 const daemonUp = computed(() => connected.value === true);
 
-// If a started daemon never connects (and isn't pending approval), stop spinning
-// after this so the button is clickable again rather than stuck forever.
-const START_TIMEOUT_MS = 20_000;
-let startTimer: ReturnType<typeof setTimeout> | undefined;
-function clearStartTimer(): void {
-  if (startTimer) {
-    clearTimeout(startTimer);
-    startTimer = undefined;
-  }
-}
-
 async function installDaemon(): Promise<void> {
-  daemonStarting.value = true;
-  pendingApproval.value = false;
-  try {
+  await startDaemonFlow({
     // Suppress the per-call Login-Items nudge: enabling the daemon and the app
-    // could each open System Settings, so we open it once below instead.
-    await startDaemon(false);
-    await refresh();
-    // Probe service support before enabling the login defaults.
-    let autostart: AutostartState | null = null;
-    try {
-      autostart = await getAutostart();
-    } catch {
-      /* non-fatal */
-    }
-    // Onboarding default: run the daemon AND the app at login, with the app
-    // started minimized to the tray. Best-effort and idempotent — users change
-    // all three later in Settings. A missing service manager just skips the
-    // daemon toggle.
-    await enableLoginDefaults(autostart?.daemonSupported ?? false);
-    // Re-read AFTER enabling: the GUI login item is only registered now, so its
-    // pending-approval state is meaningful. Open Login Items at most once if the
-    // daemon OR the GUI needs the user to approve a background item.
-    try {
-      autostart = await getAutostart();
-    } catch {
-      /* non-fatal */
-    }
-    pendingApproval.value =
-      (autostart?.daemonPendingApproval ?? false) ||
-      (autostart?.guiPendingApproval ?? false);
-    if (pendingApproval.value) {
-      void openLoginItems(); // best-effort; don't await/block onboarding
-    }
-    // Keep the spinner running until the daemon actually CONNECTS (the poller
-    // flips `connected` → the watch below clears it and shows "Running"). The
-    // only early-out is macOS pending-approval, where we can't connect until the
-    // user acts, so stop the spinner and show the approval hint.
-    if (pendingApproval.value) {
-      daemonStarting.value = false;
-    } else {
-      clearStartTimer();
-      startTimer = setTimeout(() => {
-        if (daemonStarting.value && connected.value !== true) {
-          daemonStarting.value = false;
-          toast.error(
-            "The daemon didn't come up",
-            "Try again, or check System Settings → Login Items.",
-          );
-        }
-      }, START_TIMEOUT_MS);
-    }
-  } catch (e) {
-    // Start failed outright — let the user retry.
-    daemonStarting.value = false;
-    toast.error("Couldn't start the daemon", (e as IpcError).message);
-  }
+    // could each open System Settings, so we open it once in beforeProbe instead.
+    nudge: false,
+    beforeProbe: async () => {
+      // Probe service support before enabling the login defaults.
+      let autostart: AutostartState | null = null;
+      try {
+        autostart = await getAutostart();
+      } catch {
+        /* non-fatal */
+      }
+      // Onboarding default: run the daemon AND the app at login, app minimized to
+      // the tray. Best-effort/idempotent — users change all three in Settings; a
+      // missing service manager just skips the daemon toggle.
+      await enableLoginDefaults(autostart?.daemonSupported ?? false);
+      // Re-read AFTER enabling: the GUI login item is only registered now, so its
+      // pending-approval state is meaningful. Open Login Items at most once if the
+      // daemon OR the GUI needs approval.
+      try {
+        autostart = await getAutostart();
+      } catch {
+        /* non-fatal */
+      }
+      const pending =
+        (autostart?.daemonPendingApproval ?? false) ||
+        (autostart?.guiPendingApproval ?? false);
+      if (pending) void openLoginItems(); // best-effort; don't block onboarding
+      return pending;
+    },
+  });
 }
 
 /**
@@ -155,16 +126,8 @@ async function enableLoginDefaults(daemonSupported: boolean): Promise<void> {
   }
 }
 
-// Stop the spinner once the daemon is actually reachable. No auto-advance — the
-// user clicks Continue (enabled once `daemonUp`).
-watch(connected, (c) => {
-  if (c === true) {
-    daemonStarting.value = false;
-    clearStartTimer();
-  }
-});
-
-onUnmounted(clearStartTimer);
+// (Spinner/diagnostics auto-clear on connect is handled inside useDaemonStart.)
+// No auto-advance — the user clicks Continue (enabled once `daemonUp`).
 
 // ── step 2: PHP ──
 const phpLoading = ref(false);
@@ -333,6 +296,9 @@ function onBack(): void {
                 <ExternalLink class="size-4" /> Open Login Items
               </Button>
             </div>
+
+            <!-- Why the daemon didn't come up (hints + log/service details). -->
+            <DaemonDiagnosticsPanel v-if="diagnostics" :diagnostics="diagnostics" />
 
             <!-- Action, below the content and right-aligned. -->
             <div class="flex justify-end">

--- a/bin/yerdd/Cargo.toml
+++ b/bin/yerdd/Cargo.toml
@@ -40,6 +40,7 @@ clap           = { workspace = true }
 tokio          = { workspace = true, features = ["net", "rt-multi-thread", "macros", "signal", "time", "io-util", "sync", "process"] }
 tracing        = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-appender = { workspace = true }
 interprocess   = { workspace = true }
 fs4            = { workspace = true }
 rustls         = { workspace = true, features = ["ring"] }

--- a/bin/yerdd/src/main.rs
+++ b/bin/yerdd/src/main.rs
@@ -6,6 +6,7 @@ use std::process::ExitCode;
 
 use clap::Parser;
 
+use yerd_platform::{ActivePaths, Paths};
 use yerdd::args::{Cli, Command, ServeArgs};
 use yerdd::{error, run, tracing_init, Outcome};
 
@@ -14,7 +15,16 @@ fn main() -> ExitCode {
     let Command::Serve(args) = cli
         .command
         .unwrap_or_else(|| Command::Serve(ServeArgs::default()));
-    tracing_init::init(args.verbose);
+
+    // Resolve the cache dir for the rolling daemon log *before* installing
+    // tracing, so an early failure (even the runtime-build error below) is
+    // captured. A resolve/create failure degrades to stderr-only logging.
+    let log_dir = resolve_log_dir();
+    // The guard MUST outlive every log call — it's declared before the runtime
+    // so locals drop in reverse order: `runtime` first (joining workers, which
+    // flushes their logs into the appender channel), this guard last. Named (not
+    // `_`-prefixed) because the Restart arm drops it explicitly before `exec`.
+    let log_guard = tracing_init::init(args.verbose, log_dir.as_deref());
 
     let runtime = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -22,7 +32,10 @@ fn main() -> ExitCode {
     {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("yerdd: cannot build tokio runtime: {e}");
+            // `tracing` is already installed, so this lands in the rolling log
+            // too (not just stderr) — otherwise this failure would be invisible
+            // under launchd/systemd.
+            tracing::error!(error = %e, "yerdd: cannot build tokio runtime");
             return ExitCode::from(70);
         }
     };
@@ -32,9 +45,12 @@ fn main() -> ExitCode {
         Ok(Outcome::Exit) => ExitCode::SUCCESS,
         Ok(Outcome::Restart) => {
             // Drop the runtime first so worker threads are joined and no
-            // residual fd survives into the new image, then re-exec in place.
+            // residual fd survives into the new image.
             drop(runtime);
             tracing::info!("restarting daemon (re-exec)");
+            // `exec` runs no destructors, so flush the log worker explicitly
+            // here — and only *after* the line above, or it's lost from the file.
+            drop(log_guard);
             match restart_in_place() {
                 Ok(()) => unreachable!("exec replaces the process on success"),
                 Err(e) => {
@@ -48,6 +64,24 @@ fn main() -> ExitCode {
             ExitCode::from(error::exit_code(&e))
         }
     }
+}
+
+/// Resolve `{cache}/` for the daemon log and ensure it exists. Returns `None`
+/// (→ stderr-only logging) if dirs can't be resolved or the directory can't be
+/// created — logging must never be a hard failure for the daemon.
+fn resolve_log_dir() -> Option<std::path::PathBuf> {
+    let dirs = match ActivePaths::new().resolve() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("yerdd: cannot resolve cache dir for logging: {e}");
+            return None;
+        }
+    };
+    if let Err(e) = std::fs::create_dir_all(&dirs.cache) {
+        eprintln!("yerdd: cannot create log dir {}: {e}", dirs.cache.display());
+        return None;
+    }
+    Some(dirs.cache)
 }
 
 /// Re-exec this binary in place with the original argv (same PID). On success

--- a/bin/yerdd/src/tracing_init.rs
+++ b/bin/yerdd/src/tracing_init.rs
@@ -1,22 +1,39 @@
 //! Idempotent tracing-subscriber installation.
 
+use std::path::Path;
+
+use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry;
 
-/// Install a compact stderr subscriber at the level implied by `verbose`.
+/// Install the tracing subscriber: a compact stderr layer (always) plus, when
+/// `log_dir` is given, a daily-rolling file layer at `{log_dir}/yerdd.<date>.log`.
+///
+/// The file layer is the load-bearing one: under launchd/systemd the daemon's
+/// stderr is discarded, so a durable log is the only way a start failure leaves
+/// a trace the GUI's diagnostics can surface.
 ///
 /// At the default level the embedded DNS server (`hickory_server`) is capped at
 /// `WARN`: it logs **every** inbound query at `INFO` (including the routine
 /// `NXDomain` for non-`.test` names the OS resolver forwards here), which floods
 /// the daemon log. Raising `verbose` lifts that cap so DNS traffic is visible
-/// when debugging.
+/// when debugging. The cap is shared by both layers (the filter is cloned).
 ///
-/// Idempotent: the `try_init` error is intentionally swallowed because
-/// it fires only when a global subscriber has already been installed
-/// (test re-entry, etc.) — the desired no-op.
-pub fn init(verbose: u8) {
+/// Returns the file appender's [`WorkerGuard`] when a file layer was installed;
+/// the caller **must keep it alive** for the lifetime of the process — dropping
+/// it stops the background flush worker and log lines are lost. Returns `None`
+/// when `log_dir` is `None` (unit tests, or dirs couldn't be resolved) or when
+/// the rolling appender could not be built.
+///
+/// Idempotency: with `log_dir = None` this is idempotent — the `try_init` error
+/// is swallowed because it fires only when a global subscriber already exists
+/// (test re-entry), the desired no-op. With `log_dir = Some(..)` it is **not**
+/// idempotent (the appender + its worker are created before `try_init`), which
+/// is fine: `main` calls it exactly once.
+#[must_use]
+pub fn init(verbose: u8, log_dir: Option<&Path>) -> Option<WorkerGuard> {
     let level = match verbose {
         0 => tracing::Level::INFO,
         1 => tracing::Level::DEBUG,
@@ -29,11 +46,55 @@ pub fn init(verbose: u8) {
     } else {
         level
     };
+    // Built once; `Targets` is `Clone`, so each layer gets its own copy and the
+    // hickory-WARN cap applies to both sinks independently.
     let filter = Targets::new()
         .with_default(level)
         .with_target("hickory_server", hickory_level);
-    let layer = fmt::layer().with_writer(std::io::stderr).compact();
-    let _ = registry().with(layer.with_filter(filter)).try_init();
+
+    let stderr_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .compact()
+        .with_filter(filter.clone());
+
+    // Try to add a rolling file layer. The builder returns a `Result` (no panic
+    // → clippy-safe); on failure we warn to stderr and degrade to stderr-only.
+    let (file_layer, guard) = match log_dir {
+        Some(dir) => match build_file_appender(dir) {
+            Ok(appender) => {
+                let (writer, guard) = tracing_appender::non_blocking(appender);
+                let layer = fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(writer)
+                    .with_filter(filter);
+                (Some(layer), Some(guard))
+            }
+            Err(e) => {
+                eprintln!(
+                    "yerdd: could not open log file in {}: {e}; logging to stderr only",
+                    dir.display()
+                );
+                (None, None)
+            }
+        },
+        None => (None, None),
+    };
+
+    let _ = registry().with(stderr_layer).with(file_layer).try_init();
+    guard
+}
+
+/// Build the daily-rolling `yerdd.<date>.log` appender, keeping at most a few
+/// days so the log can't grow without bound (this is a dev tool, not a server).
+fn build_file_appender(
+    dir: &Path,
+) -> Result<tracing_appender::rolling::RollingFileAppender, tracing_appender::rolling::InitError> {
+    tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .max_log_files(3)
+        .filename_prefix("yerdd")
+        .filename_suffix("log")
+        .build(dir)
 }
 
 #[cfg(test)]
@@ -48,8 +109,10 @@ mod tests {
 
     #[test]
     fn init_is_idempotent() {
-        init(0);
-        init(1);
-        init(2);
+        // `None` log dir keeps the test from writing files and preserves the
+        // try_init no-op on re-entry.
+        assert!(init(0, None).is_none());
+        assert!(init(1, None).is_none());
+        assert!(init(2, None).is_none());
     }
 }

--- a/crates/yerd-platform/src/os/macos.rs
+++ b/crates/yerd-platform/src/os/macos.rs
@@ -88,12 +88,23 @@ impl Paths for MacosPaths {
     }
 }
 
-/// Read the real UID via the `id -u` command, which is available on
-/// every macOS install. `std::process::Command` is acceptable here
-/// because (a) the input is constant, (b) the output is parsed as a
-/// `u32`, (c) no privilege boundary is crossed.
+/// Read the real UID via `/usr/bin/id -u`, which is present on every macOS
+/// install. `std::process::Command` is acceptable here because (a) the input is
+/// constant, (b) the output is parsed as a `u32`, (c) no privilege boundary is
+/// crossed.
+///
+/// **The path must be absolute.** When the daemon is launched by
+/// launchd/SMAppService its `PATH` is minimal and need not contain `/usr/bin`,
+/// so a bare `id` would fail to exec → `None` → the caller's `unwrap_or(0)` would
+/// silently bind the socket under `/tmp/yerd-0` while the GUI (full login `PATH`)
+/// resolves `/tmp/yerd-$realuid` — the daemon then looks "unreachable" though it
+/// is healthy. Matching the `/bin/ps` call below keeps this deterministic under
+/// the service manager's stripped environment.
 fn read_real_uid() -> Option<u32> {
-    let out = std::process::Command::new("id").arg("-u").output().ok()?;
+    let out = std::process::Command::new("/usr/bin/id")
+        .arg("-u")
+        .output()
+        .ok()?;
     if !out.status.success() {
         return None;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GUI startup diagnostics to explain why the daemon may not launch.
  - Added an expandable diagnostics panel with actionable hints and a “Copy diagnostics” button.
  - Improved onboarding and settings to use the new start flow and surface pending login-item approval on macOS.

- **Bug Fixes**
  - Retained more startup logs to help diagnose failures.
  - Added more reliable daemon binary discovery and more robust logging during early startup and restart.
  - Improved macOS UID resolution in restricted environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->