### PR TITLE
[Feat] Support apple intel devices 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,16 @@ jobs:
         working-directory: .
         run: |
           set -euo pipefail
+          # Universal-binary gate: assert a Mach-O carries BOTH arch slices.
+          # Call directly (never inside a $(...) subshell) so `exit 1` aborts the step.
+          require_universal() {
+            local archs
+            archs=$(lipo -archs "$1" 2>/dev/null || true)
+            case " $archs " in
+              *" x86_64 "*) case " $archs " in *" arm64 "*) ;; *) echo "::error::$2 missing arm64 slice (lipo -archs: '$archs')"; exit 1 ;; esac ;;
+              *) echo "::error::$2 missing x86_64 slice (lipo -archs: '$archs')"; exit 1 ;;
+            esac
+          }
           # Search only dirs that exist — `find` over a missing path exits non-zero
           # and would abort the step under `set -euo pipefail`.
           ROOTS=()
@@ -211,11 +221,7 @@ jobs:
             [ -f "$BIN" ] || { echo "::error::missing bundled binary $BIN"; exit 1; }
             # Universal: each embedded Mach-O must carry BOTH arch slices, else
             # the bundle is not Intel-capable.
-            archs=$(lipo -archs "$BIN" 2>/dev/null || true)
-            case " $archs " in
-              *" x86_64 "*) case " $archs " in *" arm64 "*) ;; *) echo "::error::$b missing arm64 slice (lipo -archs: '$archs')"; exit 1 ;; esac ;;
-              *) echo "::error::$b missing x86_64 slice (lipo -archs: '$archs')"; exit 1 ;;
-            esac
+            require_universal "$BIN" "$b"
             # Developer-ID signed, Hardened Runtime, timestamped, same team as the
             # app (SMAppService trusts the daemon by matching Team ID).
             codesign --verify --strict --verbose=2 "$BIN"
@@ -248,12 +254,8 @@ jobs:
           # The Tauri-built main binary must also be universal (Tauri lipos it for
           # --target universal-apple-darwin).
           MAIN_EXE=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
-          MAIN_ARCHS=$(lipo -archs "$APP/Contents/MacOS/$MAIN_EXE" 2>/dev/null || true)
-          case " $MAIN_ARCHS " in
-            *" x86_64 "*) case " $MAIN_ARCHS " in *" arm64 "*) ;; *) echo "::error::main binary $MAIN_EXE missing arm64 slice (lipo -archs: '$MAIN_ARCHS')"; exit 1 ;; esac ;;
-            *) echo "::error::main binary $MAIN_EXE missing x86_64 slice (lipo -archs: '$MAIN_ARCHS')"; exit 1 ;;
-          esac
-          echo "Main binary $MAIN_EXE is universal ($MAIN_ARCHS)"
+          require_universal "$APP/Contents/MacOS/$MAIN_EXE" "main binary $MAIN_EXE"
+          echo "Main binary $MAIN_EXE is universal"
 
           # The .dmg is Developer-ID signed but deliberately NOT notarized/stapled:
           # Tauri only submits the inner .app to notarytool, never the disk image,
@@ -271,6 +273,9 @@ jobs:
           # embedded daemon + agent plist — guards against a stale .app in the dmg.
           MP=$(mktemp -d)
           hdiutil attach -nobrowse -quiet -mountpoint "$MP" "$DMG"
+          # Detach on ANY exit (incl. a require_universal abort below) so the image
+          # never leaks if a check fails mid-block.
+          trap 'hdiutil detach -quiet "$MP" 2>/dev/null || true' EXIT
           DMG_APP=$(find "$MP" -maxdepth 1 -name 'Yerd.app' -type d | head -n1)
           miss=""
           for b in yerd yerdd yerd-helper; do
@@ -279,10 +284,19 @@ jobs:
           [ -f "$DMG_APP/Contents/Library/LaunchAgents/dev.yerd.daemon.plist" ] || miss="$miss plist"
           if [ -n "$miss" ]; then
             echo "::error::shipped DMG is missing:$miss"
-            hdiutil detach -quiet "$MP" || true; exit 1
+            exit 1
           fi
+          # Defense-in-depth: the SHIPPED dmg's binaries must be universal too, not
+          # just the loose build-dir .app (guards a stale/single-slice .app in the
+          # dmg). Resolve the main exe from the DMG's own Info.plist.
+          DMG_MAIN_EXE=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$DMG_APP/Contents/Info.plist")
+          require_universal "$DMG_APP/Contents/MacOS/$DMG_MAIN_EXE" "shipped DMG main binary $DMG_MAIN_EXE"
+          for b in yerd yerdd yerd-helper; do
+            require_universal "$DMG_APP/Contents/MacOS/$b" "shipped DMG $b"
+          done
           hdiutil detach -quiet "$MP" || true
-          echo "Shipped DMG carries the embedded binaries + LaunchAgent — OK"
+          trap - EXIT
+          echo "Shipped DMG carries the embedded binaries + LaunchAgent (all universal) — OK"
           # Launch test: a Hardened-Runtime/AMFI kill is SIGKILL (exit 137) and may
           # leave nothing in the app's own log, so also check the exit signal and
           # the system log. A clean early exit (single-instance/no-daemon/headless)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,32 +108,43 @@ jobs:
       # inside gates correctly. APPLE_CERTIFICATE is deliberately NOT passed: the
       # cert is already in the keychain from the step above, and passing it would
       # make Tauri spin up its own keychain and conflict. Unset/ignored on Linux.
-      # macOS only: build yerdd natively and stage it as the Tauri sidecar so
-      # `bundle.externalBin` embeds it at Contents/MacOS/yerdd (signed by Tauri
-      # as part of the bundle). Native build (no --target) shares the rust-cache
-      # with the rest and matches the `cli` job; the triple-suffixed filename is
-      # only Tauri's sidecar naming convention.
-      # Build the embedded binaries (daemon + CLI + helper) natively and stage
-      # them as Tauri externalBin sidecars (`name-<triple>`). Native build shares
-      # the rust-cache; the triple suffix is only Tauri's sidecar naming.
+      # Build the embedded binaries (daemon + CLI + helper) and stage them as Tauri
+      # externalBin sidecars (`name-<triple>`), signed by Tauri as part of the
+      # bundle at Contents/MacOS/<bin>.
+      #
+      # macOS: ship a UNIVERSAL (x86_64 + arm64) bundle. Tauri lipos its own main
+      # binary for `--target universal-apple-darwin` but NOT the sidecars — for a
+      # universal target it expects each sidecar as `<bin>-universal-apple-darwin`,
+      # so we build both slices and lipo-fuse them ourselves here.
+      #
+      # Linux: native build per runner — the triple suffix is only Tauri's sidecar
+      # naming, so it must match the arch cargo actually produced.
       - name: Stage embedded binaries (externalBin)
         working-directory: .
         run: |
           set -euo pipefail
-          cargo build --release -p yerd -p yerdd -p yerd-helper
           mkdir -p apps/yerd-gui/src-tauri/binaries
-          # Native build per runner — the triple suffix is only Tauri's sidecar
-          # naming, so it must match the arch cargo actually produced.
           if [ "$RUNNER_OS" = "macOS" ]; then
-            triple=aarch64-apple-darwin
-          elif [ "$(uname -m)" = "aarch64" ]; then
-            triple=aarch64-unknown-linux-gnu
+            rustup target add aarch64-apple-darwin x86_64-apple-darwin
+            cargo build --release --target aarch64-apple-darwin -p yerd -p yerdd -p yerd-helper
+            cargo build --release --target x86_64-apple-darwin  -p yerd -p yerdd -p yerd-helper
+            for b in yerd yerdd yerd-helper; do
+              lipo -create -output "apps/yerd-gui/src-tauri/binaries/$b-universal-apple-darwin" \
+                "target/aarch64-apple-darwin/release/$b" \
+                "target/x86_64-apple-darwin/release/$b"
+              lipo -info "apps/yerd-gui/src-tauri/binaries/$b-universal-apple-darwin"
+            done
           else
-            triple=x86_64-unknown-linux-gnu
+            cargo build --release -p yerd -p yerdd -p yerd-helper
+            if [ "$(uname -m)" = "aarch64" ]; then
+              triple=aarch64-unknown-linux-gnu
+            else
+              triple=x86_64-unknown-linux-gnu
+            fi
+            for b in yerd yerdd yerd-helper; do
+              cp "target/release/$b" "apps/yerd-gui/src-tauri/binaries/$b-$triple"
+            done
           fi
-          for b in yerd yerdd yerd-helper; do
-            cp "target/release/$b" "apps/yerd-gui/src-tauri/binaries/$b-$triple"
-          done
 
       - name: Build Tauri bundles (signed + notarised on macOS)
         env:
@@ -146,7 +157,7 @@ jobs:
         # (apps/yerd-gui), so the path is src-tauri-relative.
         run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
-            npm run tauri build -- --config src-tauri/tauri.bundle-macos.conf.json
+            npm run tauri build -- --target universal-apple-darwin --config src-tauri/tauri.bundle-macos.conf.json
           else
             npm run tauri build -- --config src-tauri/tauri.bundle-linux.conf.json
           fi
@@ -198,6 +209,13 @@ jobs:
           for b in yerd yerdd yerd-helper; do
             BIN="$APP/Contents/MacOS/$b"
             [ -f "$BIN" ] || { echo "::error::missing bundled binary $BIN"; exit 1; }
+            # Universal: each embedded Mach-O must carry BOTH arch slices, else
+            # the bundle is not Intel-capable.
+            archs=$(lipo -archs "$BIN" 2>/dev/null || true)
+            case " $archs " in
+              *" x86_64 "*) case " $archs " in *" arm64 "*) ;; *) echo "::error::$b missing arm64 slice (lipo -archs: '$archs')"; exit 1 ;; esac ;;
+              *) echo "::error::$b missing x86_64 slice (lipo -archs: '$archs')"; exit 1 ;;
+            esac
             # Developer-ID signed, Hardened Runtime, timestamped, same team as the
             # app (SMAppService trusts the daemon by matching Team ID).
             codesign --verify --strict --verbose=2 "$BIN"
@@ -226,6 +244,16 @@ jobs:
               || { echo "::error::$b was killed (exit $code) — signing/Hardened-Runtime failure"; exit 1; }
           done
           echo "Embedded binaries + LaunchAgent: present, sealed, Developer-ID, team-matched, entitlement-clean, exec OK"
+
+          # The Tauri-built main binary must also be universal (Tauri lipos it for
+          # --target universal-apple-darwin).
+          MAIN_EXE=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
+          MAIN_ARCHS=$(lipo -archs "$APP/Contents/MacOS/$MAIN_EXE" 2>/dev/null || true)
+          case " $MAIN_ARCHS " in
+            *" x86_64 "*) case " $MAIN_ARCHS " in *" arm64 "*) ;; *) echo "::error::main binary $MAIN_EXE missing arm64 slice (lipo -archs: '$MAIN_ARCHS')"; exit 1 ;; esac ;;
+            *) echo "::error::main binary $MAIN_EXE missing x86_64 slice (lipo -archs: '$MAIN_ARCHS')"; exit 1 ;;
+          esac
+          echo "Main binary $MAIN_EXE is universal ($MAIN_ARCHS)"
 
           # The .dmg is Developer-ID signed but deliberately NOT notarized/stapled:
           # Tauri only submits the inner .app to notarytool, never the disk image,
@@ -283,8 +311,9 @@ jobs:
           fi
 
       # Self-update artifact: a gzip'd tar of the signed+stapled .app that the
-      # in-app/`yerd update` applier swaps into /Applications. Apple-Silicon only
-      # (the build matrix produces no Intel .app). The mandatory gate below
+      # in-app/`yerd update` applier swaps into /Applications. The .app is now
+      # UNIVERSAL (x86_64 + arm64), so this one tarball serves both Mac arches.
+      # The mandatory gate below
       # extracts into a FRESH dir and re-asserts codesign + staple + OFFLINE
       # Gatekeeper assessment + a Team ID, proving the notarization survives the
       # tar round-trip. If a future macOS drops the staple through tar, switch the
@@ -300,7 +329,10 @@ jobs:
           [ -n "$APP" ] || { echo "::error::Yerd.app not found for tarball packaging"; exit 1; }
           OUT_DIR="apps/yerd-gui/src-tauri/target/release/bundle/updater"
           mkdir -p "$OUT_DIR"
-          # Apple-Silicon only; the publish job appends the version to this name.
+          # Universal bundle, but the name retains the legacy `AppleSilicon` token
+          # so pre-universal arm64 clients (whose updater matcher requires that
+          # token) can still self-update. TODO: rename to Universal once
+          # pre-universal clients are EOL. The publish job appends the version.
           OUT="$OUT_DIR/Yerd_MacOS_AppleSilicon.app.tar.gz"
           # bsdtar (macOS /usr/bin/tar) preserving permissions; the applier extracts
           # with the same bsdtar via `tar -xpf`.
@@ -352,8 +384,10 @@ jobs:
           path: |
             target/release/bundle/**/*.deb
             target/release/bundle/**/*.dmg
+            target/universal-apple-darwin/release/bundle/**/*.dmg
             apps/yerd-gui/src-tauri/target/release/bundle/**/*.deb
             apps/yerd-gui/src-tauri/target/release/bundle/**/*.dmg
+            apps/yerd-gui/src-tauri/target/universal-apple-darwin/release/bundle/**/*.dmg
             apps/yerd-gui/src-tauri/target/release/bundle/updater/*.app.tar.gz
 
   # The ONLY job that touches the release. Assemble everything, create it as a
@@ -395,7 +429,7 @@ jobs:
           # Drop the now-redundant nested dirs so `dist/*` is files-only.
           find . -mindepth 1 -type d -exec rm -rf {} +
           # Human-friendly release asset names:
-          #   Yerd_<OS>_<Arch>_v<version>.<ext>   (e.g. Yerd_MacOS_AppleSilicon_v2-0-2-rc-3.dmg)
+          #   Yerd_<OS>_<Arch>_v<version>.<ext>   (e.g. Yerd_MacOS_Universal_v2-0-2-rc-3.dmg)
           # Tauri emits Yerd_<ver>_<arch>.{dmg,deb}; the .app.tar.gz is already
           # Yerd_MacOS_AppleSilicon.app.tar.gz. We relabel OS+arch and dash the
           # version (dots → dashes) so the Releases page reads cleanly.
@@ -411,6 +445,9 @@ jobs:
             esac
             case "$f" in
               *AppleSilicon*|*aarch64*|*arm64*) [ "$os" = "MacOS" ] && arch="AppleSilicon" || arch="Arm64" ;;
+              # The universal macOS .dmg (Tauri emits `..._universal.dmg`); the
+              # .app.tar.gz keeps the AppleSilicon token above for updater compat.
+              *[Uu]niversal*)   arch="Universal" ;;
               *x86_64*|*amd64*)  arch="x86_64" ;;
               *) arch="unknown" ;;
             esac

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ runtime). Grab the latest build from the
 
 | Platform | Download | Install |
 |---|---|---|
-| macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` | open, drag to Applications |
+| macOS (Universal — Intel & Apple Silicon) | `Yerd_MacOS_Universal_v<ver>.dmg` | open, drag to Applications |
 | Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
 | Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -2702,11 +2702,13 @@ Subject: Captured\r\n\r\nhi\r\n";
     #[tokio::test]
     async fn stage_update_downloads_verifies_and_writes_artifact() {
         // Run only on platforms that actually have a fixture artifact below
-        // (Apple Silicon macOS + Linux x86_64). Intel macOS is not `Unsupported`
-        // but has no fixture, so skip it too.
+        // (macOS — both arches resolve the one universal `.app.tar.gz` — + Linux
+        // x86_64). Truly unsupported targets are skipped.
         if !matches!(
             yerd_update::Platform::current(),
-            yerd_update::Platform::MacOsAarch64 | yerd_update::Platform::LinuxX86_64
+            yerd_update::Platform::MacOsAarch64
+                | yerd_update::Platform::MacOsX86_64
+                | yerd_update::Platform::LinuxX86_64
         ) {
             return;
         }
@@ -2758,11 +2760,14 @@ Subject: Captured\r\n\r\nhi\r\n";
 
     #[tokio::test]
     async fn stage_update_rejects_verification_failure_and_writes_nothing() {
-        // Only platforms with a fixture artifact below (skip Intel macOS, which is
-        // not `Unsupported` but has no fixture, and any truly unsupported target).
+        // Only platforms with a fixture artifact below (macOS — both arches resolve
+        // the one universal `.app.tar.gz` — + Linux x86_64); skip truly unsupported
+        // targets.
         if !matches!(
             yerd_update::Platform::current(),
-            yerd_update::Platform::MacOsAarch64 | yerd_update::Platform::LinuxX86_64
+            yerd_update::Platform::MacOsAarch64
+                | yerd_update::Platform::MacOsX86_64
+                | yerd_update::Platform::LinuxX86_64
         ) {
             return;
         }

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -122,7 +122,7 @@ pub fn select_asset(
         }
         Platform::LinuxX86_64 => (ArtifactKind::Deb, is_linux_x86_64_artifact),
         Platform::Unsupported => {
-            return Err(AssetError::NoArtifactForPlatform(Platform::Unsupported));
+            return Err(AssetError::NoArtifactForPlatform(platform));
         }
     };
 

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -17,9 +17,10 @@ pub const UPDATE_PUBLIC_KEY: &str = "RWRXUQIpU8uZ3B6SV3yFsK3+aAWZX+efytjc8F+8PTu
 /// [`Platform::current`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Platform {
-    /// Apple Silicon macOS — the `.app.tar.gz` bundle.
+    /// Apple Silicon macOS — the universal `.app.tar.gz` bundle.
     MacOsAarch64,
-    /// Intel macOS — no artifact is published (Apple-Silicon-only for MVP).
+    /// Intel macOS — the same universal `.app.tar.gz` bundle (one fat bundle
+    /// serves both Mac arches).
     MacOsX86_64,
     /// `x86_64` Linux — the `.deb` package.
     LinuxX86_64,
@@ -81,7 +82,7 @@ pub struct ArtifactSelection<'a> {
 /// Why [`select_asset`] could not resolve a download set.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AssetError {
-    /// No artifact is published for this platform (e.g. Intel macOS, Windows).
+    /// No artifact is published for this platform (e.g. Windows, non-x86_64 Linux).
     NoArtifactForPlatform(Platform),
     /// The artifact is present but its `.sig` is missing.
     MissingSignature(String),
@@ -106,19 +107,22 @@ impl std::error::Error for AssetError {}
 /// Pick the artifact + signature + checksums for `platform` from `release`.
 ///
 /// Selection is by filename convention (the names the release workflow emits):
-/// the macOS artifact ends `.app.tar.gz` and is arch-tagged; the Linux artifact
-/// ends `.deb` and is x86_64-tagged; the signature is `<artifact>.sig`; the
-/// manifest is named `SHA256SUMS`. Intel macOS / unsupported platforms return
-/// [`AssetError::NoArtifactForPlatform`] rather than mis-selecting.
+/// the macOS artifact ends `.app.tar.gz` (a single universal bundle serving both
+/// Mac arches); the Linux artifact ends `.deb` and is x86_64-tagged; the
+/// signature is `<artifact>.sig`; the manifest is named `SHA256SUMS`. Unsupported
+/// platforms return [`AssetError::NoArtifactForPlatform`] rather than
+/// mis-selecting.
 pub fn select_asset(
     release: &ReleaseMeta,
     platform: Platform,
 ) -> Result<ArtifactSelection<'_>, AssetError> {
     let (kind, matches): (ArtifactKind, fn(&str) -> bool) = match platform {
-        Platform::MacOsAarch64 => (ArtifactKind::AppTarGz, is_macos_aarch64_artifact),
+        Platform::MacOsAarch64 | Platform::MacOsX86_64 => {
+            (ArtifactKind::AppTarGz, is_macos_app_tarball)
+        }
         Platform::LinuxX86_64 => (ArtifactKind::Deb, is_linux_x86_64_artifact),
-        p @ (Platform::MacOsX86_64 | Platform::Unsupported) => {
-            return Err(AssetError::NoArtifactForPlatform(p));
+        Platform::Unsupported => {
+            return Err(AssetError::NoArtifactForPlatform(Platform::Unsupported));
         }
     };
 
@@ -151,10 +155,15 @@ pub fn select_asset(
 
 // The release workflow controls these filenames and their exact (lowercase)
 // extensions, so a case-sensitive suffix check is correct here.
+//
+// macOS ships exactly one `.app.tar.gz` per release — a universal (x86_64 + arm64)
+// bundle — so we match it by extension alone and route both Mac arches to it. The
+// updater tarball keeps the legacy `AppleSilicon` token in its name (so
+// pre-universal arm64 clients, whose matcher requires that token, can still
+// self-update); this matcher is token-agnostic and works for Intel hosts too.
 #[allow(clippy::case_sensitive_file_extension_comparisons)]
-fn is_macos_aarch64_artifact(name: &str) -> bool {
+fn is_macos_app_tarball(name: &str) -> bool {
     name.ends_with(".app.tar.gz")
-        && (name.contains("AppleSilicon") || name.contains("aarch64") || name.contains("arm64"))
 }
 
 #[allow(clippy::case_sensitive_file_extension_comparisons)]
@@ -302,11 +311,26 @@ mod tests {
     }
 
     #[test]
-    fn intel_macos_has_no_artifact() {
+    fn intel_macos_selects_app_tarball() {
+        // The shipped tarball keeps the legacy `AppleSilicon` token (for old
+        // arm64 clients) but is universal; Intel must resolve it too.
+        let r = release_with(&[
+            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz",
+            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz.sig",
+            "SHA256SUMS",
+        ]);
+        let sel = select_asset(&r, Platform::MacOsX86_64).unwrap();
+        assert_eq!(sel.kind, ArtifactKind::AppTarGz);
+        assert!(sel.artifact.name.ends_with(".app.tar.gz"));
+        assert!(sel.signature.name.ends_with(".app.tar.gz.sig"));
+    }
+
+    #[test]
+    fn unsupported_platform_has_no_artifact() {
         let r = release_with(&["Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz", "SHA256SUMS"]);
         assert_eq!(
-            select_asset(&r, Platform::MacOsX86_64),
-            Err(AssetError::NoArtifactForPlatform(Platform::MacOsX86_64))
+            select_asset(&r, Platform::Unsupported),
+            Err(AssetError::NoArtifactForPlatform(Platform::Unsupported))
         );
     }
 

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -143,6 +143,13 @@ host you're on - which can *hide* a bug that only the real per-OS implementation
 would surface. When you change OS-specific code under `yerd-platform`, run the
 suite on the affected platform, not just your own. CI runs the full gate on both
 `ubuntu-22.04` and `macos-14` (Apple Silicon) for exactly this reason.
+
+The shipped macOS bundle is **Universal 2**, but its `x86_64` slice is
+cross-compiled on the Apple-Silicon runner and **not** natively exercised in CI —
+the release verify step only proves both slices are present and signed
+(`lipo -archs`), and the launch smoke runs the arm64 slice. If you touch
+arch-sensitive macOS code, test the Intel slice by hand (run the x86_64 build under
+Rosetta, or `cargo test --target x86_64-apple-darwin`).
 :::
 
 ## The CI gate (run this before pushing)
@@ -298,6 +305,15 @@ The shipped artifact is the **GUI bundle** (`.dmg` on macOS, `.deb` on Linux),
 built by Tauri with the three binaries (`yerd`/`yerdd`/`yerd-helper`) embedded via
 `externalBin` (per-platform overlays in `apps/yerd-gui/src-tauri/`). There is no
 standalone CLI tarball/`.deb`.
+
+The macOS bundle is a **Universal 2** build (`x86_64` + `arm64`), produced on the
+`macos-14` runner with `tauri build --target universal-apple-darwin`. Tauri lipos
+its own main binary, but **not** the `externalBin` sidecars — the release workflow
+builds each sidecar for both Apple targets and `lipo`-fuses them into
+`binaries/<bin>-universal-apple-darwin` before the Tauri build. The CI verify step
+asserts every embedded Mach-O carries both arch slices (`lipo -archs`). The single
+universal `.app.tar.gz` self-update artifact retains the legacy `AppleSilicon`
+token in its name so pre-universal Apple-Silicon clients can still self-update.
 
 `bump` keeps three files in sync - `Cargo.toml`,
 `apps/yerd-gui/src-tauri/tauri.conf.json`, and `apps/yerd-gui/package.json` - so

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -10,11 +10,11 @@ The app is the **only** artifact, with the daemon + CLI + helper embedded:
 
 | Platform | Artifact | Install |
 |---|---|---|
-| macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` | Open the DMG, drag Yerd to Applications |
+| macOS (Universal — Intel & Apple Silicon) | `Yerd_MacOS_Universal_v<ver>.dmg` | Open the DMG, drag Yerd to Applications |
 | Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
 | Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
 
-The macOS DMG targets Apple Silicon (`aarch64`) only; Intel (x86-64) Macs are not supported at this time. There's no Windows bundle yet: the daemon's named-pipe address isn't client-derivable.
+The macOS DMG is a Universal 2 build (`x86_64` + `arm64`), so it runs on both Intel and Apple Silicon Macs. There's no Windows bundle yet: the daemon's named-pipe address isn't client-derivable.
 
 ::: tip The GUI sets up the backend for you
 The GUI is a client of the [daemon](./daemon), and the daemon (`yerdd`), the `yerd` CLI, and `yerd-helper` are all **bundled inside the app** - nothing is downloaded at runtime. On first launch the app simply **starts its bundled daemon**, then lands you on the Overview dashboard. On macOS that makes setup essentially **drag-and-drop**: drag Yerd to Applications, launch it, done. On macOS the daemon registers as a background **SMAppService** login item (shown as "Yerd" in System Settings → Login Items); on Linux the `.deb` puts `yerd` on your `PATH` and grants the daemon its privileged-port capability.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -107,7 +107,7 @@ yerd doctor fix    # auto-repair the safe ones
 A Tauri v2 tray app (Vue 3 + TypeScript) ships as a single bundle: `.dmg` on macOS, `.deb` on Linux. It's the recommended way to run Yerd, surfacing the same data and actions as the CLI in a native tray UI.
 
 ::: tip The app sets up the backend for you
-The daemon, the `yerd` CLI, and `yerd-helper` are all **bundled inside the app** (Apple Silicon macOS · Linux x86-64 and arm64). On first launch it starts the daemon - no separate CLI install needed.
+The daemon, the `yerd` CLI, and `yerd-helper` are all **bundled inside the app** (Universal macOS — Intel & Apple Silicon · Linux x86-64 and arm64). On first launch it starts the daemon - no separate CLI install needed.
 :::
 
 [Desktop app guide →](./desktop-app)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -17,16 +17,11 @@ so they can't both own them at once. **Stop the other tool first**, then follow
 :::
 
 ::: info Supported platforms
-Yerd ships a single desktop app for **macOS** (Apple Silicon) and **Linux**
-(x86-64 and arm64, Debian/Ubuntu `.deb`). The daemon, the `yerd` CLI, and the privileged
-helper are all bundled inside it — there is nothing else to install. PHP itself is
-**not** bundled - Yerd downloads prebuilt static PHP builds on demand when you run
-`yerd install php`, so the install stays tiny and fast.
-:::
-
-::: warning Apple Intel not supported
-Intel (x86-64) Macs are not supported at this time. macOS builds target Apple
-Silicon (arm64) only.
+Yerd ships a single desktop app for **macOS** (Universal — Intel and Apple
+Silicon) and **Linux** (x86-64 and arm64, Debian/Ubuntu `.deb`). The daemon, the
+`yerd` CLI, and the privileged helper are all bundled inside it — there is nothing
+else to install. PHP itself is **not** bundled - Yerd downloads prebuilt static PHP
+builds on demand when you run `yerd install php`, so the install stays tiny and fast.
 :::
 
 ## Install
@@ -37,7 +32,7 @@ build from the [releases page](https://github.com/forjedio/yerd/releases):
 
 | Platform | Download | Install |
 |---|---|---|
-| macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` | open, drag Yerd to Applications |
+| macOS (Universal — Intel & Apple Silicon) | `Yerd_MacOS_Universal_v<ver>.dmg` | open, drag Yerd to Applications |
 | Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
 | Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
 

--- a/docs/guide/upgrading-from-v1.md
+++ b/docs/guide/upgrading-from-v1.md
@@ -46,7 +46,7 @@ After removing v1, reboot or flush DNS so the OS forgets v1's resolver before v2
 
 See [Getting Started](./getting-started) for platform-specific instructions. The short version: download the Yerd app from the [releases page](https://github.com/forjedio/yerd/releases/latest) -
 
-| macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` |
+| macOS (Universal — Intel & Apple Silicon) | `Yerd_MacOS_Universal_v<ver>.dmg` |
 | Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` |
 | Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` |
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS downloads now ship as a universal app, supporting both Intel and Apple Silicon Macs.
  * The updater now recognizes the universal macOS package on Intel systems as well.
* **Bug Fixes**
  * macOS release validation now checks that bundled app components include both architecture slices.
  * Intel macOS is now covered in update-related test coverage.
* **Documentation**
  * Updated installation, getting started, upgrade, and developer docs to reflect universal macOS support and new download naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->