### PR TITLE
[Feat] Linux arm updater

### DIFF
--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -2702,32 +2702,37 @@ Subject: Captured\r\n\r\nhi\r\n";
     #[tokio::test]
     async fn stage_update_downloads_verifies_and_writes_artifact() {
         // Run only on platforms that actually have a fixture artifact below
-        // (Apple Silicon macOS + Linux x86_64). Intel macOS is not `Unsupported`
-        // but has no fixture, so skip it too.
+        // (Apple Silicon macOS + Linux x86_64 + Linux arm64). Intel macOS is not
+        // `Unsupported` but has no fixture, so skip it too.
         if !matches!(
             yerd_update::Platform::current(),
-            yerd_update::Platform::MacOsAarch64 | yerd_update::Platform::LinuxX86_64
+            yerd_update::Platform::MacOsAarch64
+                | yerd_update::Platform::LinuxX86_64
+                | yerd_update::Platform::LinuxAarch64
         ) {
             return;
         }
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
 
-        // Release assets for BOTH platforms, so the test runs on macOS or Linux.
+        // Release assets for ALL platforms, so the test runs on macOS or either Linux arch.
         let mac = "Yerd_MacOS_AppleSilicon_v99-0-1.app.tar.gz";
         let deb = "Yerd_Linux_x86_64_v99-0-1.deb";
+        let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
         let releases = format!(
             r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
                 {{"name":"{mac}.sig","browser_download_url":"https://h/{mac}.sig","size":1}},
                 {{"name":"{deb}","browser_download_url":"https://h/{deb}","size":4}},
                 {{"name":"{deb}.sig","browser_download_url":"https://h/{deb}.sig","size":1}},
+                {{"name":"{arm}","browser_download_url":"https://h/{arm}","size":4}},
+                {{"name":"{arm}.sig","browser_download_url":"https://h/{arm}.sig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
             ]}}]"#
         );
-        // sha256("test") for both artifacts.
+        // sha256("test") for every artifact.
         let h = yerd_update::sha256_hex(b"test");
-        let sums = format!("{h}  {mac}\n{h}  {deb}\n");
+        let sums = format!("{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n");
         let dl = StageDl { releases, sums };
 
         let resp = crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await;
@@ -2744,7 +2749,7 @@ Subject: Captured\r\n\r\nhi\r\n";
                 // Kind matches the current platform's artifact.
                 let expected = if matches!(
                     yerd_update::Platform::current(),
-                    yerd_update::Platform::LinuxX86_64
+                    yerd_update::Platform::LinuxX86_64 | yerd_update::Platform::LinuxAarch64
                 ) {
                     yerd_ipc::StagedArtifact::Deb
                 } else {
@@ -2758,11 +2763,14 @@ Subject: Captured\r\n\r\nhi\r\n";
 
     #[tokio::test]
     async fn stage_update_rejects_verification_failure_and_writes_nothing() {
-        // Only platforms with a fixture artifact below (skip Intel macOS, which is
-        // not `Unsupported` but has no fixture, and any truly unsupported target).
+        // Only platforms with a fixture artifact below (Apple Silicon macOS + Linux
+        // x86_64 + Linux arm64). Skip Intel macOS, which is not `Unsupported` but has
+        // no fixture, and any truly unsupported target.
         if !matches!(
             yerd_update::Platform::current(),
-            yerd_update::Platform::MacOsAarch64 | yerd_update::Platform::LinuxX86_64
+            yerd_update::Platform::MacOsAarch64
+                | yerd_update::Platform::LinuxX86_64
+                | yerd_update::Platform::LinuxAarch64
         ) {
             return;
         }
@@ -2770,18 +2778,21 @@ Subject: Captured\r\n\r\nhi\r\n";
         let state = state_in(tmp.path());
         let mac = "Yerd_MacOS_AppleSilicon_v99-0-1.app.tar.gz";
         let deb = "Yerd_Linux_x86_64_v99-0-1.deb";
+        let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
         let releases = format!(
             r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
                 {{"name":"{mac}.sig","browser_download_url":"https://h/{mac}.sig","size":1}},
                 {{"name":"{deb}","browser_download_url":"https://h/{deb}","size":4}},
                 {{"name":"{deb}.sig","browser_download_url":"https://h/{deb}.sig","size":1}},
+                {{"name":"{arm}","browser_download_url":"https://h/{arm}","size":4}},
+                {{"name":"{arm}.sig","browser_download_url":"https://h/{arm}.sig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
             ]}}]"#
         );
         // Wrong checksums → verification fails before any minisign check or write.
         let bad = "0".repeat(64);
-        let sums = format!("{bad}  {mac}\n{bad}  {deb}\n");
+        let sums = format!("{bad}  {mac}\n{bad}  {deb}\n{bad}  {arm}\n");
         let dl = StageDl { releases, sums };
         match crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await {
             Response::Error { .. } => {}
@@ -2789,7 +2800,8 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
         assert!(
             !state.dirs.cache.join("update").join(mac).exists()
-                && !state.dirs.cache.join("update").join(deb).exists(),
+                && !state.dirs.cache.join("update").join(deb).exists()
+                && !state.dirs.cache.join("update").join(arm).exists(),
             "must not write an artifact when verification fails"
         );
     }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -2756,6 +2756,20 @@ Subject: Captured\r\n\r\nhi\r\n";
                     yerd_ipc::StagedArtifact::AppTarGz
                 };
                 assert_eq!(kind, expected);
+                // Stronger than `kind`: on arm64 both .debs are `Deb`, so assert
+                // the staged basename is the CURRENT platform's asset — proving the
+                // right arch was selected, not just the right artifact kind.
+                let expected_name = match yerd_update::Platform::current() {
+                    yerd_update::Platform::MacOsAarch64 => mac,
+                    yerd_update::Platform::LinuxX86_64 => deb,
+                    yerd_update::Platform::LinuxAarch64 => arm,
+                    other => panic!("unexpected platform for fixture: {other:?}"),
+                };
+                assert_eq!(
+                    p.file_name().and_then(|n| n.to_str()),
+                    Some(expected_name),
+                    "staged basename should be the current platform's asset"
+                );
             }
             other => panic!("expected Staged, got {other:?}"),
         }

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -23,13 +23,15 @@ pub enum Platform {
     MacOsX86_64,
     /// `x86_64` Linux — the `.deb` package.
     LinuxX86_64,
+    /// `aarch64` Linux — the arm64 `.deb` package.
+    LinuxAarch64,
     /// Any platform without a published self-update artifact.
     Unsupported,
 }
 
 impl Platform {
     /// The platform this binary was built for. `Unsupported` for anything we
-    /// don't publish a self-update artifact for (incl. Windows, Linux non-x86_64).
+    /// don't publish a self-update artifact for (incl. Windows and other arches).
     #[must_use]
     pub fn current() -> Self {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -44,10 +46,15 @@ impl Platform {
         {
             Self::LinuxX86_64
         }
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        {
+            Self::LinuxAarch64
+        }
         #[cfg(not(any(
             all(target_os = "macos", target_arch = "aarch64"),
             all(target_os = "macos", target_arch = "x86_64"),
             all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "aarch64"),
         )))]
         {
             Self::Unsupported
@@ -107,9 +114,9 @@ impl std::error::Error for AssetError {}
 ///
 /// Selection is by filename convention (the names the release workflow emits):
 /// the macOS artifact ends `.app.tar.gz` and is arch-tagged; the Linux artifact
-/// ends `.deb` and is x86_64-tagged; the signature is `<artifact>.sig`; the
-/// manifest is named `SHA256SUMS`. Intel macOS / unsupported platforms return
-/// [`AssetError::NoArtifactForPlatform`] rather than mis-selecting.
+/// ends `.deb` and is arch-tagged (`x86_64` or `arm64`); the signature is
+/// `<artifact>.sig`; the manifest is named `SHA256SUMS`. Intel macOS / unsupported
+/// platforms return [`AssetError::NoArtifactForPlatform`] rather than mis-selecting.
 pub fn select_asset(
     release: &ReleaseMeta,
     platform: Platform,
@@ -117,6 +124,7 @@ pub fn select_asset(
     let (kind, matches): (ArtifactKind, fn(&str) -> bool) = match platform {
         Platform::MacOsAarch64 => (ArtifactKind::AppTarGz, is_macos_aarch64_artifact),
         Platform::LinuxX86_64 => (ArtifactKind::Deb, is_linux_x86_64_artifact),
+        Platform::LinuxAarch64 => (ArtifactKind::Deb, is_linux_aarch64_artifact),
         p @ (Platform::MacOsX86_64 | Platform::Unsupported) => {
             return Err(AssetError::NoArtifactForPlatform(p));
         }
@@ -160,6 +168,14 @@ fn is_macos_aarch64_artifact(name: &str) -> bool {
 #[allow(clippy::case_sensitive_file_extension_comparisons)]
 fn is_linux_x86_64_artifact(name: &str) -> bool {
     name.ends_with(".deb") && (name.contains("x86_64") || name.contains("amd64"))
+}
+
+// The published arm64 .deb is named `Yerd_Linux_Arm64_*.deb` (capital "Arm64"), so
+// match case-insensitively — a lowercase `contains("arm64")` would miss it.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn is_linux_aarch64_artifact(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.ends_with(".deb") && (lower.contains("aarch64") || lower.contains("arm64"))
 }
 
 /// Why verification failed.
@@ -302,6 +318,43 @@ mod tests {
     }
 
     #[test]
+    fn selects_linux_aarch64_deb() {
+        // Capital "Arm64" — the real published name; locks in case-insensitive matching.
+        let r = release_with(&[
+            "Yerd_Linux_Arm64_v2-0-2.deb",
+            "Yerd_Linux_Arm64_v2-0-2.deb.sig",
+            "SHA256SUMS",
+        ]);
+        let sel = select_asset(&r, Platform::LinuxAarch64).unwrap();
+        assert_eq!(sel.kind, ArtifactKind::Deb);
+        assert_eq!(sel.artifact.name, "Yerd_Linux_Arm64_v2-0-2.deb");
+    }
+
+    #[test]
+    fn linux_arch_matchers_are_disjoint() {
+        // arm64 platform must not pick the x86_64 .deb...
+        let only_x86 = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.deb",
+            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&only_x86, Platform::LinuxAarch64),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxAarch64))
+        );
+        // ...and the x86_64 platform must not pick the arm64 .deb.
+        let only_arm = release_with(&[
+            "Yerd_Linux_Arm64_v2-0-2.deb",
+            "Yerd_Linux_Arm64_v2-0-2.deb.sig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&only_arm, Platform::LinuxX86_64),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+    }
+
+    #[test]
     fn intel_macos_has_no_artifact() {
         let r = release_with(&["Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz", "SHA256SUMS"]);
         assert_eq!(
@@ -399,6 +452,7 @@ mod tests {
         #[cfg(any(
             all(target_os = "macos", target_arch = "aarch64"),
             all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "aarch64"),
         ))]
         assert_ne!(p, Platform::Unsupported);
         let _ = p;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-update now supports Linux on ARM64 devices.
  * Update downloads can now select the correct Debian package for ARM64 systems.

* **Bug Fixes**
  * Improved selection and matching for release assets with ARM64 naming variations (including capitalization differences).
  * Expanded self-update coverage to better handle additional supported platforms, including macOS Apple Silicon and Linux x86_64/ARM64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->