### PR TITLE
[Feat] Degraded-mode daemon + configurable fallback ports

### DIFF
--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -378,6 +378,11 @@ pub async fn set_mail_port(port: u16) -> Result<Response, GuiError> {
 }
 
 #[tauri::command]
+pub async fn set_fallback_ports(http: u16, https: u16) -> Result<Response, GuiError> {
+    finish(exchange(&Request::SetFallbackPorts { http, https }).await?)
+}
+
+#[tauri::command]
 pub async fn set_mail_enabled(enabled: bool) -> Result<Response, GuiError> {
     finish(exchange(&Request::SetMailEnabled { enabled }).await?)
 }

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -115,6 +115,7 @@ fn main() {
             commands::clear_mails,
             commands::delete_mails,
             commands::set_mail_port,
+            commands::set_fallback_ports,
             commands::set_mail_enabled,
             mail_window::show_mails_window,
             commands::status,

--- a/apps/yerd-gui/src/components/EnvironmentCard.vue
+++ b/apps/yerd-gui/src/components/EnvironmentCard.vue
@@ -122,18 +122,26 @@ const envItems = computed<EnvItem[]>(() => {
     {
       key: "ports",
       label: "Privileged ports (80/443)",
-      // Degraded: the daemon bound no web ports, so elevation can't help yet
-      // (the redirect would point at nothing, and the CLI refuses) — show the
-      // problem and withhold the fix until working ports are set.
+      // Degraded: the daemon bound no web ports. On macOS elevation can't help
+      // yet (the pf redirect would point at the unbound ports, and the CLI
+      // refuses), so withhold the fix until working ports are set. On Linux the
+      // ports fix is `setcap`, which binds 80/443 DIRECTLY and doesn't depend on
+      // the fallback ports — it's the correct degraded recovery, so keep it
+      // offered there.
       value: r.web_unbound ? false : portsElevated(r),
-      fixable: !r.web_unbound && !portsElevated(r),
+      fixable: r.web_unbound ? !mac : !portsElevated(r),
       unelevatable: r.port_redirect === true && mac,
       target: "ports",
       yes: r.port_redirect === true && privilegedFallback(r) ? "redirected" : "bound",
-      no: r.web_unbound ? "not serving — set working ports first" : "fell back to high ports",
-      note: r.web_unbound
-        ? "Yerd couldn't bind its web ports. Set working ports in Settings, then elevate."
-        : undefined,
+      no: r.web_unbound
+        ? mac
+          ? "not serving — set working ports first"
+          : "not serving — elevate to bind 80/443"
+        : "fell back to high ports",
+      note:
+        r.web_unbound && mac
+          ? "Yerd couldn't bind its web ports. Set working ports in Settings, then elevate."
+          : undefined,
     },
   ];
 });

--- a/apps/yerd-gui/src/components/EnvironmentCard.vue
+++ b/apps/yerd-gui/src/components/EnvironmentCard.vue
@@ -122,12 +122,18 @@ const envItems = computed<EnvItem[]>(() => {
     {
       key: "ports",
       label: "Privileged ports (80/443)",
-      value: portsElevated(r),
-      fixable: !portsElevated(r),
+      // Degraded: the daemon bound no web ports, so elevation can't help yet
+      // (the redirect would point at nothing, and the CLI refuses) — show the
+      // problem and withhold the fix until working ports are set.
+      value: r.web_unbound ? false : portsElevated(r),
+      fixable: !r.web_unbound && !portsElevated(r),
       unelevatable: r.port_redirect === true && mac,
       target: "ports",
       yes: r.port_redirect === true && privilegedFallback(r) ? "redirected" : "bound",
-      no: "fell back to high ports",
+      no: r.web_unbound ? "not serving — set working ports first" : "fell back to high ports",
+      note: r.web_unbound
+        ? "Yerd couldn't bind its web ports. Set working ports in Settings, then elevate."
+        : undefined,
     },
   ];
 });

--- a/apps/yerd-gui/src/composables/useFallbackPorts.ts
+++ b/apps/yerd-gui/src/composables/useFallbackPorts.ts
@@ -1,0 +1,110 @@
+import { useDaemon } from "@/composables/useDaemon";
+import { IpcError, restartDaemon, setFallbackPorts } from "@/ipc/client";
+
+/**
+ * Shared logic for editing the daemon's rootless HTTP/HTTPS fallback ports,
+ * used by BOTH the Settings editor and the onboarding degraded-port panel so
+ * the validate → save → restart → re-check flow can't diverge between them.
+ *
+ * The restart detection is deliberately careful (see `saveAndRestart`): the
+ * shared `useDaemon` poller runs every 4 s, so a fast re-exec can complete
+ * inside one gap — meaning a passive watch on `connected` could never observe
+ * the drop, and `connected === true` holds at *both* ends of a restart. We
+ * therefore actively drive `refresh()` and key completion on a change in the
+ * daemon's per-process `boot_id` (the re-exec preserves the pid and
+ * `uptime_secs` has only one-second granularity, so neither is reliable).
+ */
+
+export const MIN_PORT = 1024;
+export const MAX_PORT = 65535;
+
+const POLL_MS = 500;
+const CEILING_MS = 20_000;
+
+export interface SaveResult {
+  /** True once the daemon came back up serving (no longer degraded). */
+  ok: boolean;
+  /** A user-facing reason when `ok` is false. */
+  message?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function useFallbackPorts() {
+  const { report, connected, refresh } = useDaemon();
+
+  /**
+   * Validate a candidate pair. Returns an error string to show the user, or
+   * `null` when the pair is acceptable. Mirrors the daemon's own `validate()`.
+   */
+  function validate(http: number, https: number): string | null {
+    for (const p of [http, https]) {
+      if (!Number.isInteger(p) || p < MIN_PORT || p > MAX_PORT) {
+        return `Ports must be whole numbers between ${MIN_PORT} and ${MAX_PORT} — a privileged port like 80/443 would need elevation, which the fallback exists to avoid.`;
+      }
+    }
+    if (http === https) {
+      return "The HTTP and HTTPS ports must be different.";
+    }
+    return null;
+  }
+
+  /**
+   * Persist the new fallback ports and restart the daemon, then wait for it to
+   * come back and report whether it is now serving. The daemon rejects invalid
+   * or elevated changes (thrown `IpcError`) — surfaced as `{ ok: false }` with
+   * its message; the caller never has to try/catch.
+   */
+  async function saveAndRestart(http: number, https: number): Promise<SaveResult> {
+    const local = validate(http, https);
+    if (local) return { ok: false, message: local };
+
+    // Snapshot the current process id so we can tell the restarted daemon apart
+    // from the still-running one. `boot_id` is the reliable key; fall back to
+    // `uptime_secs` only if an older daemon omits it.
+    const baselineBootId = report.value?.boot_id ?? null;
+    const baselineUptime = report.value?.uptime_secs ?? Number.MAX_SAFE_INTEGER;
+
+    try {
+      await setFallbackPorts(http, https);
+    } catch (e) {
+      return { ok: false, message: (e as IpcError).message };
+    }
+    try {
+      await restartDaemon();
+    } catch (e) {
+      return { ok: false, message: (e as IpcError).message };
+    }
+
+    // Actively poll until the *restarted* daemon answers (fresh boot_id), then
+    // read its degraded state. Bounded so a daemon that never returns can't hang.
+    let elapsed = 0;
+    while (elapsed < CEILING_MS) {
+      await sleep(POLL_MS);
+      elapsed += POLL_MS;
+      await refresh();
+      if (connected.value !== true || !report.value) continue;
+      const restarted =
+        baselineBootId !== null
+          ? report.value.boot_id != null && report.value.boot_id !== baselineBootId
+          : report.value.uptime_secs < baselineUptime;
+      if (!restarted) continue;
+      if (report.value.web_unbound == null) {
+        return { ok: true };
+      }
+      const u = report.value.web_unbound;
+      return {
+        ok: false,
+        message: `Yerd still couldn't bind ports ${u.http}/${u.https} — they may be in use too. Try different ports.`,
+      };
+    }
+    return {
+      ok: false,
+      message: "Timed out waiting for the daemon to restart. Check Settings, then try again.",
+    };
+  }
+
+  return { validate, saveAndRestart, MIN_PORT, MAX_PORT };
+}

--- a/apps/yerd-gui/src/composables/useFallbackPorts.ts
+++ b/apps/yerd-gui/src/composables/useFallbackPorts.ts
@@ -74,8 +74,13 @@ export function useFallbackPorts() {
     }
     try {
       await restartDaemon();
-    } catch (e) {
-      return { ok: false, message: (e as IpcError).message };
+    } catch {
+      // The restart tears down the socket, so `restartDaemon()` can reject with
+      // a dropped-connection error *even though the restart is underway* (the
+      // daemon may close the connection around its re-exec). The boot_id poll
+      // below is the authoritative completion check, so don't bail here — mirror
+      // GeneralView's restart flow, which also tolerates the throw. A daemon that
+      // genuinely didn't restart simply makes the poll time out.
     }
 
     // Actively poll until the *restarted* daemon answers (fresh boot_id), then

--- a/apps/yerd-gui/src/composables/useOnboarding.ts
+++ b/apps/yerd-gui/src/composables/useOnboarding.ts
@@ -59,6 +59,17 @@ export function useOnboarding() {
     return { reachable };
   }
 
+  /**
+   * Re-enter the welcome journey on demand (e.g. from the Overview banner shown
+   * when the environment looks empty). App.vue renders `WelcomeView` reactively
+   * off `needsOnboarding`, so flipping it here swaps the wizard in immediately.
+   * The journey handles an already-running daemon / already-onboarded machine
+   * fine: step 1 reads "Running" and `finish()` → `markOnboarded()` is idempotent.
+   */
+  function relaunch(): void {
+    needsOnboarding.value = true;
+  }
+
   /** Persist completion and leave the journey. Best-effort on the persist. */
   async function finish(): Promise<void> {
     try {
@@ -70,5 +81,5 @@ export function useOnboarding() {
     needsOnboarding.value = false;
   }
 
-  return { probing, needsOnboarding, probe, finish };
+  return { probing, needsOnboarding, probe, relaunch, finish };
 }

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -426,6 +426,15 @@ export async function setMailPort(port: number): Promise<void> {
   ensureOk(await call<Response>("set_mail_port", { port }));
 }
 
+/**
+ * Persist the rootless HTTP/HTTPS fallback ports; takes effect on the next
+ * daemon restart. The daemon rejects values < 1024, equal ports, or a change
+ * while ports are elevated (surfaced as a thrown IpcError).
+ */
+export async function setFallbackPorts(http: number, https: number): Promise<void> {
+  ensureOk(await call<Response>("set_fallback_ports", { http, https }));
+}
+
 /** Enable/disable mail capture; takes effect on the next daemon restart. */
 export async function setMailEnabled(enabled: boolean): Promise<void> {
   ensureOk(await call<Response>("set_mail_enabled", { enabled }));

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -171,6 +171,14 @@ export interface StatusReport {
    *  the feature (the Rust field is `#[serde(default, skip_serializing_if)]`, so
    *  it is never `null` on the wire — mirrors the `services?` convention). */
   mail?: MailStatus;
+  /** Set when the daemon could bind neither the desired nor the fallback web
+   *  ports: it runs degraded (no HTTP/HTTPS proxy). Carries the fallback ports
+   *  it failed on. Omitted (undefined) on a healthy daemon. */
+  web_unbound?: { http: number; https: number } | null;
+  /** A per-process id that changes on every (re)start. Clients use a *change* in
+   *  it to confirm a restart completed (the re-exec preserves the pid). Omitted
+   *  by a daemon predating the field. */
+  boot_id?: number | null;
 }
 
 export type Severity = "ok" | "warn" | "fail";
@@ -178,6 +186,7 @@ export type Severity = "ok" | "warn" | "fail";
 export type DiagnosisCode =
   | "daemon_down"
   | "port_fallback"
+  | "web_ports_unbound"
   | "foreign_web_listener"
   | "ca_not_trusted"
   | "resolver_not_installed"
@@ -337,6 +346,11 @@ export type Response =
        *  absent (0) against an older daemon. */
       http_port?: number;
       https_port?: number;
+      /** Configured rootless fallback ports (what Settings edits). Distinct from
+       *  `http_port`/`https_port`, which are the *bound* ports. `#[serde(default)]`
+       *  → may be absent (0) against an older daemon. */
+      fallback_http?: number;
+      fallback_https?: number;
     }
   | {
       type: "php_versions";

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -18,6 +18,7 @@ import CardContent from "@/components/ui/CardContent.vue";
 import CardDescription from "@/components/ui/CardDescription.vue";
 import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
+import Input from "@/components/ui/Input.vue";
 import Modal from "@/components/ui/Modal.vue";
 import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
@@ -30,11 +31,13 @@ import {
 } from "@/components/ui/tooltip";
 import { useDaemon } from "@/composables/useDaemon";
 import { useDaemonStart } from "@/composables/useDaemonStart";
+import { MIN_PORT, MAX_PORT, useFallbackPorts } from "@/composables/useFallbackPorts";
 import { useToast } from "@/composables/useToast";
 import {
   applyUpdate,
   checkUpdates,
   cliPathStatus,
+  daemonInfo,
   dumpsStatus,
   getAutostart,
   hostPlatform,
@@ -134,6 +137,17 @@ function portRow(
   which: "http" | "https",
 ): Row {
   const ps = r[which];
+  // Degraded: the daemon bound no web ports at all, so there's nothing serving.
+  if (r.web_unbound) {
+    return {
+      key,
+      name,
+      tone: "bad",
+      state: "not serving",
+      info: `couldn't bind the rootless port (tried :${ps.requested === ps.bound ? ps.requested : r.web_unbound[which]})`,
+      child: true,
+    };
+  }
   const privileged = ps.requested < PRIVILEGED_PORT_CEILING;
   const redirected = r.port_redirect === true;
   const viaRedirect = privileged && ps.fell_back && redirected;
@@ -353,7 +367,10 @@ onMounted(() => {
     .then((p) => (platform.value = p))
     .catch(() => {});
   loadCli();
-  if (running.value) loadDumps();
+  if (running.value) {
+    loadDumps();
+    void loadFallbackPorts();
+  }
   // No auto update-check on open — it only runs when the user clicks "Check now".
 });
 
@@ -362,6 +379,7 @@ onMounted(() => {
 watch(running, (up) => {
   if (up) {
     loadDumps();
+    void loadFallbackPorts();
   } else {
     dumps.value = null;
     updateStatus.value = null;
@@ -407,6 +425,64 @@ async function confirmRestartDaemon(close: () => void): Promise<void> {
     toast.info("Restarting daemon…", (e as IpcError).message);
   } finally {
     busy.value = null;
+  }
+}
+
+// ── rootless fallback ports ──
+const { saveAndRestart: saveFallbackPorts, validate: validateFallbackPorts } =
+  useFallbackPorts();
+const fbHttp = ref("");
+const fbHttps = ref("");
+// The values last loaded from / saved to the daemon, to detect a real change.
+const fbHttpSaved = ref("");
+const fbHttpsSaved = ref("");
+const fallbackPortsOpen = ref(false);
+
+async function loadFallbackPorts(): Promise<void> {
+  try {
+    const info = await daemonInfo();
+    fbHttp.value = info.fallback_http != null ? String(info.fallback_http) : "";
+    fbHttps.value = info.fallback_https != null ? String(info.fallback_https) : "";
+    fbHttpSaved.value = fbHttp.value;
+    fbHttpsSaved.value = fbHttps.value;
+  } catch {
+    /* daemon down / older daemon — the section just stays empty */
+  }
+}
+
+// macOS pf redirect is pinned to the current ports, so block edits until the
+// user un-elevates. Only fires on macOS (Linux reports null).
+const portsElevated = computed(() => report.value?.port_redirect === true);
+const fallbackPortsChanged = computed(
+  () => fbHttp.value !== fbHttpSaved.value || fbHttps.value !== fbHttpsSaved.value,
+);
+
+function openFallbackPorts(): void {
+  const err = validateFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+  if (err) {
+    toast.error("Invalid ports", err);
+    return;
+  }
+  void nextTick(() => {
+    fallbackPortsOpen.value = true;
+  });
+}
+
+async function confirmFallbackPorts(close: () => void): Promise<void> {
+  close();
+  busy.value = "fallback-ports";
+  try {
+    const res = await saveFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+    if (res.ok) {
+      fbHttpSaved.value = fbHttp.value;
+      fbHttpsSaved.value = fbHttps.value;
+      toast.success("Ports updated", `Yerd is now serving on ${fbHttp.value}/${fbHttps.value}.`);
+    } else {
+      toast.error("Couldn't apply the new ports", res.message ?? "The daemon is still degraded.");
+    }
+  } finally {
+    busy.value = null;
+    await refreshStatus();
   }
 }
 
@@ -560,6 +636,79 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
               </div>
             </div>
           </TooltipProvider>
+        </CardContent>
+      </Card>
+
+      <!-- Web ports (rootless fallback) -->
+      <Card v-if="running">
+        <CardHeader>
+          <CardTitle>Web ports</CardTitle>
+          <CardDescription>
+            The rootless ports Yerd serves on when 80/443 need elevation. Must be
+            {{ MIN_PORT }}+ — a privileged port like 80/443 would itself need
+            elevation, which the fallback exists to avoid.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-3">
+          <!-- Degraded: nothing bound. -->
+          <div
+            v-if="report?.web_unbound"
+            class="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm"
+          >
+            <p class="font-medium">Yerd isn't serving any sites</p>
+            <p class="mt-1 text-muted-foreground">
+              It couldn't bind ports {{ report.web_unbound.http }}/{{
+                report.web_unbound.https
+              }}
+              — they're in use by another process. Pick free ports below and save.
+            </p>
+          </div>
+          <!-- Elevated: editing would break the pinned redirect. -->
+          <p v-if="portsElevated" class="text-xs text-muted-foreground">
+            Ports are elevated, so the rootless ports are pinned to the active
+            redirect. Un-elevate ports (Doctor) before changing them, then
+            re-elevate.
+          </p>
+          <div class="flex flex-wrap items-end gap-4">
+            <div class="space-y-1">
+              <label for="fb-http" class="text-xs font-medium text-muted-foreground">HTTP</label>
+              <Input
+                id="fb-http"
+                v-model="fbHttp"
+                type="number"
+                inputmode="numeric"
+                :min="MIN_PORT"
+                :max="MAX_PORT"
+                :disabled="portsElevated || busy === 'fallback-ports'"
+                aria-label="Rootless HTTP port"
+                class="w-28 font-mono"
+                placeholder="8080"
+              />
+            </div>
+            <div class="space-y-1">
+              <label for="fb-https" class="text-xs font-medium text-muted-foreground">HTTPS</label>
+              <Input
+                id="fb-https"
+                v-model="fbHttps"
+                type="number"
+                inputmode="numeric"
+                :min="MIN_PORT"
+                :max="MAX_PORT"
+                :disabled="portsElevated || busy === 'fallback-ports'"
+                aria-label="Rootless HTTPS port"
+                class="w-28 font-mono"
+                placeholder="8443"
+              />
+            </div>
+            <Button
+              size="sm"
+              :disabled="!fallbackPortsChanged || portsElevated || busy === 'fallback-ports'"
+              @click="openFallbackPorts"
+            >
+              <Spinner v-if="busy === 'fallback-ports'" class="size-4" />
+              Save &amp; restart
+            </Button>
+          </div>
         </CardContent>
       </Card>
 
@@ -752,6 +901,20 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
       <template #footer="{ close }">
         <Button variant="ghost" @click="close">Cancel</Button>
         <Button @click="confirmRestartDaemon(close)">Restart</Button>
+      </template>
+    </Modal>
+
+    <Modal v-model:open="fallbackPortsOpen" title="Change web ports?">
+      <p class="text-sm text-muted-foreground">
+        Saving sets the rootless ports to
+        <strong class="text-foreground font-mono">{{ fbHttp }}/{{ fbHttps }}</strong>
+        and restarts the daemon — this briefly stops all
+        <strong class="text-foreground">.test</strong> sites, DNS, and this
+        connection. It returns in a few seconds.
+      </p>
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close">Cancel</Button>
+        <Button @click="confirmFallbackPorts(close)">Save &amp; restart</Button>
       </template>
     </Modal>
   </div>

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -446,7 +446,12 @@ async function loadFallbackPorts(): Promise<void> {
     fbHttpSaved.value = fbHttp.value;
     fbHttpsSaved.value = fbHttps.value;
   } catch {
-    /* daemon down / older daemon — the section just stays empty */
+    // Daemon down / older daemon — clear so a later transient fetch failure
+    // can't leave stale ports shown (or re-savable) under the "running" card.
+    fbHttp.value = "";
+    fbHttps.value = "";
+    fbHttpSaved.value = "";
+    fbHttpsSaved.value = "";
   }
 }
 

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -7,6 +7,7 @@ import {
   Lock,
   LockOpen,
   Mail,
+  Rocket,
   ShieldAlert,
   ShieldCheck,
   SquareCode,
@@ -18,9 +19,11 @@ import { RouterLink } from "vue-router";
 import DaemonDownHero from "@/components/DaemonDownHero.vue";
 import PageHeader from "@/components/PageHeader.vue";
 import StatusPill, { type Tone } from "@/components/StatusPill.vue";
+import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { useDaemon } from "@/composables/useDaemon";
+import { useOnboarding } from "@/composables/useOnboarding";
 import { listSites, openInBrowser } from "@/ipc/client";
 import type { Site, StatusReport } from "@/ipc/types";
 import { humaniseUptime } from "@/lib/utils";
@@ -29,6 +32,7 @@ import { humaniseUptime } from "@/lib/utils";
 // and shows the shared daemon-down hero, so it stays useful when the socket is
 // gone — the same surface that celebrates "serving N sites" becomes the start button.
 const { report, connected } = useDaemon();
+const { relaunch } = useOnboarding();
 
 const r = computed(() => report.value);
 const running = computed(() => connected.value === true);
@@ -184,6 +188,13 @@ const anyUnhealthy = computed(() => health.value.some((h) => h.value !== true));
 
 const uptime = computed(() => (r.value ? humaniseUptime(r.value.uptime_secs) : ""));
 const version = computed(() => r.value?.daemon_version ?? "");
+
+// Nothing installed and nothing parked → the environment looks freshly set up
+// (or wiped). Offer to re-run the guided onboarding. Driven off the live report,
+// so it only evaluates while the daemon is up (the down branch shows the hero).
+const emptyEnvironment = computed(
+  () => !!r.value && r.value.php.length === 0 && r.value.sites.parked === 0,
+);
 </script>
 
 <template>
@@ -201,6 +212,25 @@ const version = computed(() => r.value?.daemon_version ?? "");
 
       <!-- Daemon up: the serving console. -->
       <template v-else>
+        <!-- Empty environment (no PHP, nothing parked) → re-run guided setup. -->
+        <div
+          v-if="emptyEnvironment"
+          class="flex items-start gap-3 rounded-md border border-brand/40 bg-brand/5 p-4"
+        >
+          <Rocket class="mt-0.5 size-5 shrink-0 text-brand" />
+          <div class="min-w-0 flex-1">
+            <p class="text-sm font-medium">Let's get you set up</p>
+            <p class="mt-1 text-sm text-muted-foreground">
+              You don't have any PHP versions installed or folders parked yet.
+              Walk through the guided setup to install PHP and park your first
+              projects folder.
+            </p>
+          </div>
+          <Button class="shrink-0" @click="relaunch">
+            <Rocket class="size-4" /> Load onboarding
+          </Button>
+        </div>
+
         <Card class="relative overflow-hidden">
           <!-- A soft brand wash — the only place indigo gets a hero surface. -->
           <div

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -212,9 +212,32 @@ const emptyEnvironment = computed(
 
       <!-- Daemon up: the serving console. -->
       <template v-else>
+        <!-- Degraded: the daemon couldn't bind its web ports, so nothing serves. -->
+        <div
+          v-if="r?.web_unbound"
+          class="flex items-start gap-3 rounded-md border border-warning/40 bg-warning/10 p-4"
+        >
+          <ShieldAlert class="mt-0.5 size-5 shrink-0 text-warning" />
+          <div class="min-w-0 flex-1">
+            <p class="text-sm font-medium">Yerd isn't serving your sites</p>
+            <p class="mt-1 text-sm text-muted-foreground">
+              It couldn't bind its web ports ({{ r.web_unbound.http }}/{{
+                r.web_unbound.https
+              }}) — they're in use by another process. Change Yerd's ports to free
+              ones to start serving.
+            </p>
+          </div>
+          <RouterLink
+            to="/general"
+            class="shrink-0 self-center rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-brand-foreground hover:bg-brand/90"
+          >
+            Change ports
+          </RouterLink>
+        </div>
+
         <!-- Empty environment (no PHP, nothing parked) → re-run guided setup. -->
         <div
-          v-if="emptyEnvironment"
+          v-else-if="emptyEnvironment"
           class="flex items-start gap-3 rounded-md border border-brand/40 bg-brand/5 p-4"
         >
           <Rocket class="mt-0.5 size-5 shrink-0 text-brand" />

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -193,7 +193,11 @@ const version = computed(() => r.value?.daemon_version ?? "");
 // (or wiped). Offer to re-run the guided onboarding. Driven off the live report,
 // so it only evaluates while the daemon is up (the down branch shows the hero).
 const emptyEnvironment = computed(
-  () => !!r.value && r.value.php.length === 0 && r.value.sites.parked === 0,
+  () =>
+    !!r.value &&
+    r.value.php.length === 0 &&
+    r.value.sites.parked === 0 &&
+    r.value.sites.linked === 0,
 );
 </script>
 

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -15,11 +15,13 @@ import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import EnvironmentCard from "@/components/EnvironmentCard.vue";
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
+import Input from "@/components/ui/Input.vue";
 import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import logoUrl from "@/assets/logo.svg";
 import { useDaemon } from "@/composables/useDaemon";
 import { useDaemonStart } from "@/composables/useDaemonStart";
+import { MIN_PORT, MAX_PORT, useFallbackPorts } from "@/composables/useFallbackPorts";
 import { useOnboarding } from "@/composables/useOnboarding";
 import { useToast } from "@/composables/useToast";
 import {
@@ -41,7 +43,7 @@ import type { AutostartState, PhpVersion } from "@/ipc/types";
 // and elevation are each skippable. Finishing lands on the Overview.
 const router = useRouter();
 const toast = useToast();
-const { connected, refresh } = useDaemon();
+const { connected, report, refresh } = useDaemon();
 const { finish } = useOnboarding();
 
 const STEPS = [
@@ -64,6 +66,56 @@ const {
   start: startDaemonFlow,
 } = useDaemonStart();
 const daemonUp = computed(() => connected.value === true);
+
+// ── degraded web ports (shown in step 1 when the daemon came up but couldn't
+// bind its web ports) ──
+const { saveAndRestart: saveFallbackPorts, validate: validateFallbackPorts } =
+  useFallbackPorts();
+const fbHttp = ref("");
+const fbHttps = ref("");
+const fallbackBusy = ref(false);
+const fallbackError = ref<string | null>(null);
+const fallbackSkipped = ref(false);
+// Show the fix panel only once the daemon is up AND reports it bound no web
+// ports, and the user hasn't skipped. Seed the inputs from the ports it tried.
+const showPortFix = computed(
+  () => daemonUp.value && report.value?.web_unbound != null && !fallbackSkipped.value,
+);
+watch(
+  () => report.value?.web_unbound,
+  (u) => {
+    if (u && !fbHttp.value) {
+      fbHttp.value = String(u.http);
+      fbHttps.value = String(u.https);
+    }
+  },
+  { immediate: true },
+);
+
+async function savePortFix(): Promise<void> {
+  fallbackError.value = null;
+  const err = validateFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+  if (err) {
+    fallbackError.value = err;
+    return;
+  }
+  fallbackBusy.value = true;
+  try {
+    const res = await saveFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+    if (res.ok) {
+      toast.success("Yerd is serving", `On ports ${fbHttp.value}/${fbHttps.value}.`);
+      // `report.web_unbound` is now null, so the panel hides on its own.
+    } else {
+      fallbackError.value = res.message ?? "The daemon is still degraded.";
+    }
+  } finally {
+    fallbackBusy.value = false;
+  }
+}
+
+function skipPortFix(): void {
+  fallbackSkipped.value = true;
+}
 
 async function installDaemon(): Promise<void> {
   await startDaemonFlow({
@@ -307,6 +359,72 @@ function onBack(): void {
             <!-- Why the daemon didn't come up (hints + log/service details). -->
             <DaemonDiagnosticsPanel v-if="diagnostics" :diagnostics="diagnostics" />
 
+            <!-- Degraded: the daemon is up but couldn't bind its web ports. Let
+                 the user pick free ports (skippable). Stays visible across its own
+                 restart via `fallbackBusy` so the action below doesn't flash. -->
+            <div
+              v-if="showPortFix || fallbackBusy"
+              class="space-y-3 rounded-md border border-warning/40 bg-warning/10 p-3 text-sm"
+            >
+              <div>
+                <p class="font-medium">Yerd started, but isn't serving yet</p>
+                <p class="mt-1 text-muted-foreground">
+                  It couldn't bind its web ports — they're in use by another
+                  program. Pick free ports ({{ MIN_PORT }} or higher, so they don't
+                  need elevation) and Yerd will serve on those.
+                </p>
+              </div>
+              <div class="flex flex-wrap items-end gap-3">
+                <div class="space-y-1">
+                  <label for="ob-fb-http" class="text-xs font-medium text-muted-foreground">
+                    HTTP
+                  </label>
+                  <Input
+                    id="ob-fb-http"
+                    v-model="fbHttp"
+                    type="number"
+                    inputmode="numeric"
+                    :min="MIN_PORT"
+                    :max="MAX_PORT"
+                    :disabled="fallbackBusy"
+                    aria-label="Rootless HTTP port"
+                    class="w-24 font-mono"
+                    placeholder="8080"
+                  />
+                </div>
+                <div class="space-y-1">
+                  <label for="ob-fb-https" class="text-xs font-medium text-muted-foreground">
+                    HTTPS
+                  </label>
+                  <Input
+                    id="ob-fb-https"
+                    v-model="fbHttps"
+                    type="number"
+                    inputmode="numeric"
+                    :min="MIN_PORT"
+                    :max="MAX_PORT"
+                    :disabled="fallbackBusy"
+                    aria-label="Rootless HTTPS port"
+                    class="w-24 font-mono"
+                    placeholder="8443"
+                  />
+                </div>
+                <Button size="sm" :disabled="fallbackBusy" @click="savePortFix">
+                  <Spinner v-if="fallbackBusy" class="size-4" />
+                  Save &amp; validate
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  :disabled="fallbackBusy"
+                  @click="skipPortFix"
+                >
+                  Skip for now
+                </Button>
+              </div>
+              <p v-if="fallbackError" class="text-destructive">{{ fallbackError }}</p>
+            </div>
+
             <!-- Action, below the content and right-aligned. -->
             <div class="flex justify-end">
               <div
@@ -314,6 +432,12 @@ function onBack(): void {
                 class="flex items-center gap-2 rounded-md bg-success/10 px-3 py-1.5 text-sm font-medium text-success"
               >
                 <Check class="size-4" /> Running
+              </div>
+              <div
+                v-else-if="fallbackBusy"
+                class="flex items-center gap-2 rounded-md bg-muted px-3 py-1.5 text-sm font-medium text-muted-foreground"
+              >
+                <Spinner class="size-4" /> Restarting…
               </div>
               <Button v-else :disabled="daemonStarting" @click="installDaemon">
                 <Spinner v-if="daemonStarting" class="size-4" />

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -226,12 +226,26 @@ mod unix_impl {
             // macOS: install/remove a pf redirect 80→http_port, 443→https_port
             // (the daemon keeps binding its rootless ports). Reversible.
             #[cfg(target_os = "macos")]
-            (ElevateTarget::Ports, false) => HelperInvocation::InstallPortRedirect {
-                http_from: 80,
-                http_to: facts.http_port,
-                https_from: 443,
-                https_to: facts.https_port,
-            },
+            (ElevateTarget::Ports, false) => {
+                // A degraded daemon bound no web ports (`http_port`/`https_port`
+                // are 0), so a redirect would point at nothing. Refuse early with
+                // a clear message rather than installing a dead pf rule. (Linux
+                // maps to `setcap`, which ignores these and is the *correct*
+                // degraded recovery — hence this guard is macOS-only.)
+                if facts.http_port == 0 || facts.https_port == 0 {
+                    return Err(ClientError::Usage(
+                        "Yerd isn't serving any web ports yet (it couldn't bind them) — \
+                         set working fallback ports and restart before elevating"
+                            .to_owned(),
+                    ));
+                }
+                HelperInvocation::InstallPortRedirect {
+                    http_from: 80,
+                    http_to: facts.http_port,
+                    https_from: 443,
+                    https_to: facts.https_port,
+                }
+            }
             #[cfg(target_os = "macos")]
             (ElevateTarget::Ports, true) => HelperInvocation::UninstallPortRedirect,
         })
@@ -285,6 +299,9 @@ mod unix_impl {
                     ca_fingerprint,
                     http_port,
                     https_port,
+                    // `fallback_*` are config values Settings edits; the pf
+                    // redirect targets the *bound* ports, so they're not needed here.
+                    ..
                 }) => {
                     return Ok(Facts {
                         dns_addr,

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -758,8 +758,19 @@ fn format_status(r: &StatusReport) -> String {
     let _ = writeln!(s, "version   {version}");
     let _ = writeln!(s, "tld       .{}", r.tld);
     let redirected = r.port_redirect == Some(true);
-    let _ = writeln!(s, "http      {}", fmt_port(r.http, redirected));
-    let _ = writeln!(s, "https     {}", fmt_port(r.https, redirected));
+    if let Some(u) = r.web_unbound {
+        // Degraded: bound nothing, so `fmt_port` would print a misleading
+        // "80 → 0 (fallback)". Surface the real state instead.
+        let _ = writeln!(
+            s,
+            "http      not serving — couldn't bind {} (run `yerd doctor`)",
+            u.http
+        );
+        let _ = writeln!(s, "https     not serving — couldn't bind {}", u.https);
+    } else {
+        let _ = writeln!(s, "http      {}", fmt_port(r.http, redirected));
+        let _ = writeln!(s, "https     {}", fmt_port(r.https, redirected));
+    }
     if r.foreign_web_listener == Some(true) {
         let _ = writeln!(
             s,
@@ -1619,6 +1630,30 @@ mod tests {
             fell_back: false,
         };
         assert_eq!(fmt_port(bound, true), "80");
+    }
+
+    #[test]
+    fn status_degraded_web_ports_shows_not_serving() {
+        let mut r = sample_report();
+        r.http = PortStatus {
+            requested: 80,
+            bound: 0,
+            fell_back: true,
+        };
+        r.https = PortStatus {
+            requested: 443,
+            bound: 0,
+            fell_back: true,
+        };
+        r.web_unbound = Some(yerd_ipc::UnboundWeb {
+            http: 8080,
+            https: 8443,
+        });
+        let out = format_status(&r);
+        assert!(out.contains("not serving — couldn't bind 8080"), "{out}");
+        assert!(out.contains("not serving — couldn't bind 8443"), "{out}");
+        // The misleading "→ 0" fallback rendering must NOT appear.
+        assert!(!out.contains("→ 0"), "{out}");
     }
 
     #[test]

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -1596,6 +1596,8 @@ mod tests {
             daemon_version: "2.0.1".into(),
             services: vec![],
             mail: None,
+            web_unbound: None,
+            boot_id: None,
         }
     }
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -118,14 +118,19 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
                 .cloned()
                 .collect(),
         },
-        Request::DaemonInfo => Response::Info {
-            dns_addr: state.dns_addr,
-            tld: state.config.lock().await.tld.as_str().to_owned(),
-            ca_path: state.ca_path.clone(),
-            ca_fingerprint: state.ca_fingerprint.to_hex(),
-            http_port: state.http.bound,
-            https_port: state.https.bound,
-        },
+        Request::DaemonInfo => {
+            let cfg = state.config.lock().await;
+            Response::Info {
+                dns_addr: state.dns_addr,
+                tld: cfg.tld.as_str().to_owned(),
+                ca_path: state.ca_path.clone(),
+                ca_fingerprint: state.ca_fingerprint.to_hex(),
+                http_port: state.http.bound,
+                https_port: state.https.bound,
+                fallback_http: cfg.ports.fallback_http,
+                fallback_https: cfg.ports.fallback_https,
+            }
+        }
         Request::Park { .. }
         | Request::Link { .. }
         | Request::Unlink { .. }
@@ -253,6 +258,7 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
             Err(e) => internal(format!("mail delete failed: {e}")),
         },
         Request::SetMailPort { port } => set_mail_port(port, state).await,
+        Request::SetFallbackPorts { http, https } => set_fallback_ports(http, https, state).await,
         Request::SetMailEnabled { enabled } => set_mail_enabled(enabled, state).await,
         Request::ListTools => Response::Tools {
             tools: list_tools_with_external(state).await,
@@ -548,6 +554,8 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
             listening: state.mail.listening,
             count: state.mail_store.count().await,
         }),
+        web_unbound: state.web_unbound,
+        boot_id: Some(state.boot_id),
     }
 }
 
@@ -1134,6 +1142,49 @@ async fn set_mail_port(port: u16, state: &DaemonState) -> Response {
     Response::Ok
 }
 
+/// Set the rootless HTTP/HTTPS fallback ports. Persisted to config; takes effect
+/// on the next daemon restart (the client triggers it). Refused while a
+/// privileged-port redirect is active — it is pinned to the current ports, so
+/// changing them would break elevation until the user re-elevates.
+async fn set_fallback_ports(http: u16, https: u16, state: &DaemonState) -> Response {
+    // Probe the redirect off the executor (blocking connects) and *before*
+    // taking the config lock, so a worker thread and the config mutex aren't
+    // held during the ~hundreds-of-ms probe (mirrors the status path).
+    let redirect_active = tokio::task::spawn_blocking(|| {
+        use yerd_platform::PortRedirector;
+        yerd_platform::ActivePortRedirector::new().is_active()
+    })
+    .await
+    .unwrap_or(None);
+    if redirect_active == Some(true) {
+        return internal(
+            "ports are elevated — remove the privileged-port redirect first (un-elevate ports), \
+             change the ports, then re-elevate"
+                .to_owned(),
+        );
+    }
+
+    let mut cfg_guard = state.config.lock().await;
+    let mut new = cfg_guard.clone();
+    new.ports.fallback_http = http;
+    new.ports.fallback_https = https;
+    // `validate()` enforces the >=1024 / non-equal rules — the daemon is the
+    // authority even if a client skipped its own check.
+    if let Err(e) = new.validate() {
+        return internal(format!("config validation failed: {e}"));
+    }
+    if let Err(e) = new.save(&state.config_path) {
+        return internal(format!("config save failed: {e}"));
+    }
+    *cfg_guard = new;
+    tracing::info!(
+        http,
+        https,
+        "set fallback ports (effective on next restart)"
+    );
+    Response::Ok
+}
+
 /// Enable or disable mail capture. Persisted to config; takes effect on the next
 /// daemon start/restart.
 async fn set_mail_enabled(enabled: bool, state: &DaemonState) -> Response {
@@ -1520,6 +1571,8 @@ mod tests {
                 bound: 8443,
                 fell_back: true,
             },
+            web_unbound: None,
+            boot_id: 1,
             started_at: std::time::Instant::now(),
             shutdown_tx: tokio::sync::watch::channel(false).0,
             restart_requested: std::sync::atomic::AtomicBool::new(false),
@@ -2019,6 +2072,8 @@ Subject: Captured\r\n\r\nhi\r\n";
                 ca_fingerprint,
                 http_port,
                 https_port,
+                fallback_http,
+                fallback_https,
             } => {
                 assert_eq!(dns_addr, state.dns_addr);
                 assert_eq!(tld, "test");
@@ -2028,6 +2083,8 @@ Subject: Captured\r\n\r\nhi\r\n";
                 assert_eq!(ca_fingerprint.len(), 64);
                 assert_eq!(http_port, state.http.bound);
                 assert_eq!(https_port, state.https.bound);
+                assert_eq!(fallback_http, 8080);
+                assert_eq!(fallback_https, 8443);
             }
             other => panic!("expected Info, got {other:?}"),
         }

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -106,27 +106,36 @@ async fn run_until_shutdown(
         })
     };
 
-    // Proxy task.
-    let proxy_handle = {
+    // Proxy task. Skipped entirely when the daemon came up degraded (no web
+    // listeners) — IPC/DNS still run so the GUI/CLI can connect and the user can
+    // fix the ports. Mirrors the optional-mail task below.
+    let proxy_handle = if let (Some(http_listener), Some(tls_listener)) =
+        (daemon.http_listener, daemon.https_listener)
+    {
         let router = daemon.state.router.clone();
         let resolver = Arc::new(DaemonBackendResolver {
             php_manager: daemon.php_manager.clone(),
         });
         let https = yerd_proxy::HttpsBinding {
-            listener: daemon.https_listener,
+            listener: tls_listener,
             public_port: daemon.https_port,
             cert_store: daemon.cert_store.clone(),
         };
         let mut rx = shutdown_rx.clone();
-        tokio::spawn(yerd_proxy::ProxyServer::serve(
-            daemon.http_listener,
+        Some(tokio::spawn(yerd_proxy::ProxyServer::serve(
+            http_listener,
             Some(https),
             router,
             resolver,
             async move {
                 let _ = rx.changed().await;
             },
-        ))
+        )))
+    } else {
+        tracing::warn!(
+            "web proxy disabled (degraded): no HTTP/HTTPS listeners — sites won't be served until the fallback ports are fixed and the daemon restarts"
+        );
+        None
     };
 
     // IPC task.
@@ -235,7 +244,9 @@ async fn run_until_shutdown(
     // Now the subsystems are winding down (they watch the same channel); cap
     // each join so a stuck task can't hang the exit/restart.
     let _ = tokio::time::timeout(Duration::from_secs(10), dns_handle).await;
-    let _ = tokio::time::timeout(Duration::from_secs(10), proxy_handle).await;
+    if let Some(proxy_handle) = proxy_handle {
+        let _ = tokio::time::timeout(Duration::from_secs(10), proxy_handle).await;
+    }
     let _ = tokio::time::timeout(Duration::from_secs(5), ipc_handle).await;
     let _ = tokio::time::timeout(Duration::from_secs(5), dump_handle).await;
     let _ = tokio::time::timeout(Duration::from_secs(5), update_check_handle).await;

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -52,12 +52,13 @@ pub struct Daemon {
     pub php_manager: Arc<Mutex<DaemonPhpManager>>,
     /// TLS cert store for SNI lookups.
     pub cert_store: Arc<DaemonCertStore>,
-    /// Bound HTTP listener.
-    pub http_listener: tokio::net::TcpListener,
-    /// Bound HTTPS listener.
-    pub https_listener: tokio::net::TcpListener,
+    /// Bound HTTP listener. `None` when the daemon could bind neither the
+    /// desired nor the fallback web ports — it then runs degraded (no proxy).
+    pub http_listener: Option<tokio::net::TcpListener>,
+    /// Bound HTTPS listener. `None` in the same degraded case as `http_listener`.
+    pub https_listener: Option<tokio::net::TcpListener>,
     /// Port the redirect target should advertise (≠ `https_listener` port
-    /// when rootless fallback fires).
+    /// when rootless fallback fires). `0` when degraded.
     pub https_port: u16,
     /// IPC listener (Unix socket on Unix, named pipe on Windows).
     pub ipc_listener: IpcListener,
@@ -125,31 +126,66 @@ pub async fn bring_up_with_dirs(
     }
     let router = Arc::new(RwLock::new(router));
 
-    // Bind HTTP/HTTPS — fallback to 8080/8443 if 80/443 require elevation.
-    // Capture the *requested* ports before `config` is moved into `DaemonState`.
+    // Bind HTTP/HTTPS — fall back to the configured rootless pair if 80/443
+    // require elevation. Capture the *requested* + *fallback* ports before
+    // `config` is moved into `DaemonState`. A bind failure (both pairs busy) is
+    // **non-fatal**: the daemon comes up degraded (IPC/DNS only, no proxy) so the
+    // GUI/CLI can connect and the user can change the ports or free them.
     let cfg_http = config.ports.http;
     let cfg_https = config.ports.https;
+    let fb_http = config.ports.fallback_http;
+    let fb_https = config.ports.fallback_https;
     let binder = ActivePortBinder::new();
-    let pair = binder.bind_pair((cfg_http, cfg_https), (8080, 8443))?;
-    let bound_http = pair.http.port().map_err(|source| DaemonError::Io {
-        path: PathBuf::from("<http listener>"),
-        source,
-    })?;
-    let bound_https = pair.https.port().map_err(|source| DaemonError::Io {
-        path: PathBuf::from("<https listener>"),
-        source,
-    })?;
-    if (bound_http, bound_https) != (config.ports.http, config.ports.https) {
-        tracing::warn!(
-            http = bound_http,
-            https = bound_https,
-            wanted_http = config.ports.http,
-            wanted_https = config.ports.https,
-            "bound rootless fallback ports; .test URLs will need explicit ports until setcap or a port-redirector is configured"
-        );
-    }
-    let http_listener = into_tokio_listener(pair.http.listener)?;
-    let tls_listener = into_tokio_listener(pair.https.listener)?;
+    let (http_listener, tls_listener, bound_http, bound_https, web_unbound) = match binder
+        .bind_pair((cfg_http, cfg_https), (fb_http, fb_https))
+    {
+        Ok(pair) => {
+            let bound_http = pair.http.port().map_err(|source| DaemonError::Io {
+                path: PathBuf::from("<http listener>"),
+                source,
+            })?;
+            let bound_https = pair.https.port().map_err(|source| DaemonError::Io {
+                path: PathBuf::from("<https listener>"),
+                source,
+            })?;
+            if (bound_http, bound_https) != (cfg_http, cfg_https) {
+                tracing::warn!(
+                        http = bound_http,
+                        https = bound_https,
+                        wanted_http = cfg_http,
+                        wanted_https = cfg_https,
+                        "bound rootless fallback ports; .test URLs will need explicit ports until setcap or a port-redirector is configured"
+                    );
+            }
+            let http_listener = into_tokio_listener(pair.http.listener)?;
+            let tls_listener = into_tokio_listener(pair.https.listener)?;
+            (
+                Some(http_listener),
+                Some(tls_listener),
+                bound_http,
+                bound_https,
+                None,
+            )
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                fallback_http = fb_http,
+                fallback_https = fb_https,
+                "could not bind web ports; serving disabled — free the ports or change the fallback ports in Settings, then restart"
+            );
+            (
+                None,
+                None,
+                0,
+                0,
+                Some(yerd_ipc::UnboundWeb {
+                    http: fb_http,
+                    https: fb_https,
+                }),
+            )
+        }
+    };
 
     // PhpManager — instance_id = daemon PID disambiguates concurrent daemons
     // on the same host (different XDG_RUNTIME_DIRs notwithstanding).
@@ -264,6 +300,8 @@ pub async fn bring_up_with_dirs(
             bound: bound_https,
             fell_back: bound_https != cfg_https,
         },
+        web_unbound,
+        boot_id: rand_boot_id(),
         started_at: std::time::Instant::now(),
         // The shutdown broadcast lives in state so the IPC `RestartDaemon`
         // handler can trigger teardown; `run_with_daemon` subscribes from it.
@@ -548,6 +586,24 @@ fn build_parked_site(
     }
 
     Some(site)
+}
+
+/// A per-process id clients use to detect that a restart actually completed.
+/// Derived from the pid + wall-clock nanos (which differ across restarts), so
+/// it changes even though the in-place re-exec preserves the pid. Needs no RNG
+/// dependency; collisions are irrelevant — only a *change* is observed.
+fn rand_boot_id() -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    std::process::id().hash(&mut h);
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos())
+        .hash(&mut h);
+    // Mask to 52 bits so the value is always exactly representable as a JS
+    // double (the GUI compares it after `JSON.parse`); above 2^53 precision is
+    // lost and two distinct ids could round equal.
+    h.finish() & ((1u64 << 52) - 1)
 }
 
 fn into_tokio_listener(

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -82,6 +82,13 @@ pub struct DaemonState {
     pub http: PortStatus,
     /// HTTPS listener: requested vs actually-bound port (reported by `Status`).
     pub https: PortStatus,
+    /// Set when the daemon could bind neither the desired nor the fallback web
+    /// ports — it runs degraded (no proxy). Carries the fallback ports it failed
+    /// on, surfaced in `Status` (`web_unbound`) so the UI/doctor can name them.
+    pub web_unbound: Option<yerd_ipc::UnboundWeb>,
+    /// Per-process id (see `StatusReport::boot_id`) clients use to detect a
+    /// completed restart across the pid-preserving re-exec.
+    pub boot_id: u64,
     /// When the daemon finished bringing up (for `Status` uptime).
     pub started_at: Instant,
     /// Broadcast shutdown trigger. Owned by state so the `RestartDaemon` IPC

--- a/bin/yerdd/tests/lifecycle.rs
+++ b/bin/yerdd/tests/lifecycle.rs
@@ -289,15 +289,20 @@ mod tests {
             let resolver = Arc::new(yerdd::backend_resolver::DaemonBackendResolver {
                 php_manager: daemon.php_manager.clone(),
             });
+            // The test daemon always binds its ports, so the listeners are `Some`.
             let https = yerd_proxy::HttpsBinding {
-                listener: daemon.https_listener,
+                listener: daemon
+                    .https_listener
+                    .expect("test daemon binds its https listener"),
                 public_port: daemon.https_port,
                 cert_store: daemon.cert_store.clone(),
             };
             let router = daemon.state.router.clone();
             let mut rx = shutdown_rx.clone();
             tokio::spawn(yerd_proxy::ProxyServer::serve(
-                daemon.http_listener,
+                daemon
+                    .http_listener
+                    .expect("test daemon binds its http listener"),
                 Some(https),
                 router,
                 resolver,

--- a/crates/yerd-config/src/error.rs
+++ b/crates/yerd-config/src/error.rs
@@ -114,6 +114,11 @@ pub enum ValidateErrorReason {
     WebRootEscapes,
     /// `update_channel` was not one of the accepted values (`"stable"` / `"edge"`).
     InvalidUpdateChannel,
+    /// A `ports.fallback_*` value is below the first unprivileged port (1024).
+    /// The rootless fallback must not need elevation, so 80/443 is rejected.
+    FallbackPortPrivileged,
+    /// `ports.fallback_http == ports.fallback_https`.
+    FallbackPortsEqual,
 }
 
 impl fmt::Display for ValidateErrorReason {
@@ -133,6 +138,10 @@ impl fmt::Display for ValidateErrorReason {
                 "a web root must be a plain relative path (no leading '/' or '..')"
             }
             Self::InvalidUpdateChannel => "update_channel must be \"stable\" or \"edge\"",
+            Self::FallbackPortPrivileged => {
+                "ports.fallback_http and ports.fallback_https must be 1024 or higher"
+            }
+            Self::FallbackPortsEqual => "ports.fallback_http and ports.fallback_https must differ",
         };
         f.write_str(msg)
     }
@@ -196,6 +205,8 @@ mod tests {
             ValidateErrorReason::InvalidPhpSetting,
             ValidateErrorReason::WebRootEscapes,
             ValidateErrorReason::InvalidUpdateChannel,
+            ValidateErrorReason::FallbackPortPrivileged,
+            ValidateErrorReason::FallbackPortsEqual,
         ] {
             assert!(!r.to_string().is_empty());
             let _ = format!("{r:?}");

--- a/crates/yerd-config/src/lib.rs
+++ b/crates/yerd-config/src/lib.rs
@@ -48,8 +48,9 @@ pub use schema::{
 /// v4 added the optional `[mail]` section ([`MailSection`]) for the built-in
 /// mail-capture SMTP server. v5 added the optional `[dumps]` table
 /// ([`DumpsSection`]). v6 added the top-level `update_channel` scalar
-/// ([`Config::update_channel`]). All default when absent, so the v3→v4, v4→v5,
-/// and v5→v6 migrations are bare version bumps; each bump exists so an *older*
-/// binary rejects a file using the newer field cleanly as
+/// ([`Config::update_channel`]). v7 added the `[ports] fallback_http`/
+/// `fallback_https` keys ([`Ports`]). All default when absent, so the v3→v4,
+/// v4→v5, v5→v6, and v6→v7 migrations are bare version bumps; each bump exists so
+/// an *older* binary rejects a file using the newer field cleanly as
 /// [`ConfigError::UnsupportedVersion`] rather than failing on the unknown key.
-pub const CURRENT_VERSION: u32 = 6;
+pub const CURRENT_VERSION: u32 = 7;

--- a/crates/yerd-config/src/migrate.rs
+++ b/crates/yerd-config/src/migrate.rs
@@ -19,7 +19,7 @@ pub(crate) type MigrationStep = fn(&mut Value) -> Result<(), ConfigError>;
 /// Forward-migration steps, indexed so that **`STEPS[N]` walks `vN → v(N+1)`**.
 /// This matches [`up`], which indexes `STEPS[current]` (== the version being
 /// migrated *from*). Example: a v1 file is migrated by `STEPS[1]`. When
-/// `CURRENT_VERSION == 6`, `STEPS = [v0→v1, …, v4→v5, v5→v6]`, length 6.
+/// `CURRENT_VERSION == 7`, `STEPS = [v0→v1, …, v5→v6, v6→v7]`, length 7.
 ///
 /// `STEPS[0]` (v0→v1) is only reachable via a hand-crafted `version = 0` file —
 /// v0 was never written to disk — but it must exist so that `STEPS[1]` does.
@@ -30,6 +30,7 @@ pub(crate) const STEPS: &[MigrationStep] = &[
     migrate_v3_to_v4,
     migrate_v4_to_v5,
     migrate_v5_to_v6,
+    migrate_v6_to_v7,
 ];
 
 /// `v0 → v1`: bump the version. v0 predates any shipped config, so there is no
@@ -88,6 +89,13 @@ fn migrate_v4_to_v5(value: &mut Value) -> Result<(), ConfigError> {
 /// entire migration.
 fn migrate_v5_to_v6(value: &mut Value) -> Result<(), ConfigError> {
     set_version(value, 6)
+}
+
+/// `v6 → v7`: bump the version. v7 added the `[ports] fallback_http`/
+/// `fallback_https` keys, which default to `8080`/`8443` when absent, so an
+/// in-place version bump is the entire migration.
+fn migrate_v6_to_v7(value: &mut Value) -> Result<(), ConfigError> {
+    set_version(value, 7)
 }
 
 /// Set the top-level `version` key, erroring if the root is not a table.
@@ -160,8 +168,8 @@ mod tests {
     }
 
     #[test]
-    fn current_version_pinned_to_six() {
-        assert_eq!(crate::CURRENT_VERSION, 6);
+    fn current_version_pinned_to_seven() {
+        assert_eq!(crate::CURRENT_VERSION, 7);
     }
 
     #[test]
@@ -184,6 +192,14 @@ mod tests {
         let mut v: Value = toml::from_str("version = 5\n").unwrap();
         migrate_v5_to_v6(&mut v).unwrap();
         assert_eq!(read_version(&v).unwrap(), 6);
+    }
+
+    #[test]
+    fn v6_to_v7_is_a_bare_version_bump() {
+        // v7 only adds the optional `[ports] fallback_*` keys; the migration is a bump.
+        let mut v: Value = toml::from_str("version = 6\n").unwrap();
+        migrate_v6_to_v7(&mut v).unwrap();
+        assert_eq!(read_version(&v).unwrap(), 7);
     }
 
     #[test]

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -96,6 +96,20 @@ fn default_dump_port() -> u16 {
 struct PortsWire {
     http: u16,
     https: u16,
+    // Additive: configs written before rootless ports were configurable omit
+    // these, so each carries a field-level default (8080 / 8443).
+    #[serde(default = "default_fallback_http")]
+    fallback_http: u16,
+    #[serde(default = "default_fallback_https")]
+    fallback_https: u16,
+}
+
+fn default_fallback_http() -> u16 {
+    Ports::default().fallback_http
+}
+
+fn default_fallback_https() -> u16 {
+    Ports::default().fallback_https
 }
 
 impl Default for PortsWire {
@@ -104,6 +118,8 @@ impl Default for PortsWire {
         Self {
             http: p.http,
             https: p.https,
+            fallback_http: p.fallback_http,
+            fallback_https: p.fallback_https,
         }
     }
 }
@@ -258,6 +274,8 @@ impl TryFrom<Wire> for Config {
         let ports = Ports {
             http: w.ports.http,
             https: w.ports.https,
+            fallback_http: w.ports.fallback_http,
+            fallback_https: w.ports.fallback_https,
         };
         let parked = ParkedSection {
             paths: w.parked.paths,
@@ -372,6 +390,16 @@ fn validate_ports(c: &Config) -> Result<(), ConfigError> {
     }
     if c.ports.http == c.ports.https {
         return Err(ve(ValidateErrorReason::HttpHttpsPortsEqual));
+    }
+    // The rootless fallback exists to bind without elevation, so it must be a
+    // non-privileged port — this also structurally forbids 80/443 as a fallback.
+    if c.ports.fallback_http < crate::schema::FIRST_UNPRIVILEGED_PORT
+        || c.ports.fallback_https < crate::schema::FIRST_UNPRIVILEGED_PORT
+    {
+        return Err(ve(ValidateErrorReason::FallbackPortPrivileged));
+    }
+    if c.ports.fallback_http == c.ports.fallback_https {
+        return Err(ve(ValidateErrorReason::FallbackPortsEqual));
     }
     // The mail-capture port is bound on `127.0.0.1` when enabled; a zero port is
     // meaningless (it would bind an ephemeral port no sender could find).
@@ -812,6 +840,49 @@ php = "not-a-version"
                 reason: ValidateErrorReason::HttpsPortZero,
             }) => {}
             other => panic!("expected HttpsPortZero, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_privileged_fallback_port() {
+        // The rootless fallback must not require elevation — 80/443 (or any
+        // sub-1024 port) is rejected.
+        let mut c = Config::default();
+        c.ports.fallback_http = 80;
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::FallbackPortPrivileged,
+            }) => {}
+            other => panic!("expected FallbackPortPrivileged, got {other:?}"),
+        }
+        let mut c = Config::default();
+        c.ports.fallback_https = 443;
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::FallbackPortPrivileged,
+            }) => {}
+            other => panic!("expected FallbackPortPrivileged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_1024_fallback_boundary() {
+        let mut c = Config::default();
+        c.ports.fallback_http = 1024;
+        c.ports.fallback_https = 1025;
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_equal_fallback_ports() {
+        let mut c = Config::default();
+        c.ports.fallback_http = 9000;
+        c.ports.fallback_https = 9000;
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::FallbackPortsEqual,
+            }) => {}
+            other => panic!("expected FallbackPortsEqual, got {other:?}"),
         }
     }
 

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -547,7 +547,7 @@ mod tests {
         match Config::from_toml("version = 99\n") {
             Err(ConfigError::UnsupportedVersion {
                 found: 99,
-                current: 6,
+                current: 7,
             }) => {}
             other => panic!("expected UnsupportedVersion, got {other:?}"),
         }

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -169,6 +169,11 @@ pub const DEFAULT_UPDATE_CHANNEL: &str = "stable";
 /// The two accepted [`Config::update_channel`] values.
 pub const UPDATE_CHANNELS: &[&str] = &["stable", "edge"];
 
+/// The lowest non-privileged port. Ports below this need elevation on
+/// macOS / Linux, which is precisely what the rootless fallback exists to
+/// avoid — so `fallback_http`/`fallback_https` are required to be `>=` this.
+pub const FIRST_UNPRIVILEGED_PORT: u16 = 1024;
+
 /// HTTP and HTTPS ports.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ports {
@@ -176,25 +181,37 @@ pub struct Ports {
     pub http: u16,
     /// HTTPS listen port. Default: 443.
     pub https: u16,
+    /// Rootless HTTP port the daemon drops to when `http` can't bind without
+    /// elevation. Must be `>= FIRST_UNPRIVILEGED_PORT`. Default: 8080.
+    pub fallback_http: u16,
+    /// Rootless HTTPS port the daemon drops to when `https` can't bind without
+    /// elevation. Must be `>= FIRST_UNPRIVILEGED_PORT`. Default: 8443.
+    pub fallback_https: u16,
 }
 
 impl Ports {
-    /// IANA well-known pair, `80 / 443`. Default. Binding these may require
-    /// elevation on macOS / Linux; Windows does not gate them.
+    /// IANA well-known pair, `80 / 443`, with the `8080 / 8443` rootless
+    /// fallback. Default. Binding 80/443 may require elevation on macOS /
+    /// Linux; Windows does not gate them.
     #[must_use]
     pub const fn well_known() -> Self {
         Self {
             http: 80,
             https: 443,
+            fallback_http: 8080,
+            fallback_https: 8443,
         }
     }
 
-    /// Unprivileged fallback, `8080 / 8443`.
+    /// Unprivileged pair, `8080 / 8443`, used directly for `http`/`https` (the
+    /// fallback fields keep their `8080 / 8443` defaults).
     #[must_use]
     pub const fn unprivileged() -> Self {
         Self {
             http: 8080,
             https: 8443,
+            fallback_http: 8080,
+            fallback_https: 8443,
         }
     }
 }

--- a/crates/yerd-config/src/serialize.rs
+++ b/crates/yerd-config/src/serialize.rs
@@ -73,6 +73,8 @@ fn bool_map_is_empty(m: &&BTreeMap<String, bool>) -> bool {
 struct PortsSer<'a> {
     http: &'a u16,
     https: &'a u16,
+    fallback_http: &'a u16,
+    fallback_https: &'a u16,
 }
 
 #[derive(Serialize)]
@@ -138,6 +140,8 @@ pub(crate) fn to_toml(c: &Config) -> Result<String, ConfigError> {
         ports: PortsSer {
             http: &c.ports.http,
             https: &c.ports.https,
+            fallback_http: &c.ports.fallback_http,
+            fallback_https: &c.ports.fallback_https,
         },
         php: PhpSectionSer {
             default: &c.php.default,

--- a/crates/yerd-config/src/serialize.rs
+++ b/crates/yerd-config/src/serialize.rs
@@ -217,8 +217,8 @@ mod tests {
     fn default_to_toml_starts_with_version_line() {
         let s = to_toml(&Config::default()).unwrap();
         assert!(
-            s.starts_with("version = 6\n"),
-            "expected `version = 6` first line; got: {s}"
+            s.starts_with("version = 7\n"),
+            "expected `version = 7` first line; got: {s}"
         );
     }
 

--- a/crates/yerd-config/tests/roundtrip.rs
+++ b/crates/yerd-config/tests/roundtrip.rs
@@ -46,6 +46,9 @@ fn populated_expected() -> Config {
     c.ports = Ports {
         http: 8080,
         https: 8443,
+        // POPULATED omits the fallback keys → they take the 8080 / 8443 defaults.
+        fallback_http: 8080,
+        fallback_https: 8443,
     };
     c.php = PhpSection {
         default: PhpVersion::new(8, 2),

--- a/crates/yerd-config/tests/toml_byte_shape.rs
+++ b/crates/yerd-config/tests/toml_byte_shape.rs
@@ -56,8 +56,8 @@ fn populated() -> Config {
 fn default_config_starts_with_version_line() {
     let s = Config::default().to_toml().unwrap();
     assert!(
-        s.starts_with("version = 6\n"),
-        "expected first line `version = 6`; got: {s}"
+        s.starts_with("version = 7\n"),
+        "expected first line `version = 7`; got: {s}"
     );
 }
 

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -270,6 +270,25 @@ fn port_findings(report: &StatusReport) -> Vec<Diagnosis> {
             "Stop the other web server (e.g. Apache, nginx, Valet), then `sudo yerd elevate ports`",
         ));
     }
+    // The daemon couldn't bind either web port pair, so it's serving nothing —
+    // a hard failure that supersedes the plain "fell back" warning below.
+    if let Some(unbound) = report.web_unbound {
+        out.push(fail(
+            DiagnosisCode::WebPortsUnbound,
+            "Not serving any sites",
+            format!(
+                "Yerd couldn't bind its web ports (HTTP {}, HTTPS {}) — they're in use by \
+                 another process — so no .test sites are being served.",
+                unbound.http, unbound.https
+            ),
+            Some(
+                "Free those ports, or change Yerd's fallback ports in Settings (Yerd ▸ General), \
+                 then restart the daemon."
+                    .to_owned(),
+            ),
+        ));
+        return out;
+    }
     if privileged_fallback(report) && report.port_redirect != Some(true) && !foreign_listener {
         out.push(warn(
             DiagnosisCode::PortFallback,
@@ -370,6 +389,8 @@ mod tests {
             daemon_version: "2.0.1".into(),
             services: vec![],
             mail: None,
+            web_unbound: None,
+            boot_id: None,
         }
     }
 
@@ -421,6 +442,28 @@ mod tests {
         r2.http.bound = 8081;
         r2.http.fell_back = true;
         assert!(!codes(&diagnose(&r2, None)).contains(&DiagnosisCode::PortFallback));
+    }
+
+    #[test]
+    fn web_unbound_fails_and_supersedes_fallback() {
+        let mut r = healthy();
+        // Degraded: the desired ports fell back, but even the fallback couldn't
+        // bind. The Fail must appear and the plain PortFallback warning must not.
+        r.http.requested = 80;
+        r.http.bound = 0;
+        r.http.fell_back = true;
+        r.https.requested = 443;
+        r.https.bound = 0;
+        r.https.fell_back = true;
+        r.web_unbound = Some(yerd_ipc::UnboundWeb {
+            http: 8080,
+            https: 8443,
+        });
+        let cs = codes(&diagnose(&r, None));
+        assert!(cs.contains(&DiagnosisCode::WebPortsUnbound));
+        assert!(!cs.contains(&DiagnosisCode::PortFallback));
+        // It's a hard failure, so the report is not "all good".
+        assert!(!cs.contains(&DiagnosisCode::AllGood));
     }
 
     #[test]

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -277,8 +277,8 @@ fn port_findings(report: &StatusReport) -> Vec<Diagnosis> {
             DiagnosisCode::WebPortsUnbound,
             "Not serving any sites",
             format!(
-                "Yerd couldn't bind its web ports (HTTP {}, HTTPS {}) — they're in use by \
-                 another process — so no .test sites are being served.",
+                "Yerd couldn't bind its web ports (HTTP {}, HTTPS {}) — likely because \
+                 another process holds them — so no .test sites are being served.",
                 unbound.http, unbound.https
             ),
             Some(

--- a/crates/yerd-ipc/src/lib.rs
+++ b/crates/yerd-ipc/src/lib.rs
@@ -51,7 +51,7 @@ pub use status::{
     CaStatus, DatabaseSummary, Diagnosis, DiagnosisCode, FixReport, FixResult, MailDetail,
     MailHeader, MailStatus, MailSummary, PhpPoolStatus, PoolRunState, PortStatus,
     ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts, StatusReport,
-    ToolStatus,
+    ToolStatus, UnboundWeb,
 };
 pub use update::{Channel, StagedArtifact, UpdateSource};
 

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -309,6 +309,16 @@ pub enum Request {
         /// The new loopback port (must be non-zero).
         port: u16,
     },
+    /// Set the rootless HTTP/HTTPS fallback ports (the pair the daemon drops to
+    /// when 80/443 can't bind without elevation). Both must be `>= 1024` and
+    /// differ. Refused while a privileged-port redirect is active (it is pinned
+    /// to the current ports). Takes effect on the next daemon restart.
+    SetFallbackPorts {
+        /// New rootless HTTP port (`>= 1024`).
+        http: u16,
+        /// New rootless HTTPS port (`>= 1024`).
+        https: u16,
+    },
     /// Enable or disable the mail-capture server. Takes effect on the next
     /// daemon start/restart.
     SetMailEnabled {
@@ -458,6 +468,7 @@ mod variant_name_pinning {
             Request::ClearMails => {}
             Request::DeleteMails { .. } => {}
             Request::SetMailPort { .. } => {}
+            Request::SetFallbackPorts { .. } => {}
             Request::SetMailEnabled { .. } => {}
             Request::ListTools => {}
             Request::InstallTool { .. } => {}
@@ -599,6 +610,10 @@ mod variant_name_pinning {
             ids: vec!["000001".into()],
         });
         pin(Request::SetMailPort { port: 2525 });
+        pin(Request::SetFallbackPorts {
+            http: 8080,
+            https: 8443,
+        });
         pin(Request::SetMailEnabled { enabled: true });
         pin(Request::ListTools);
         pin(Request::InstallTool {

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -71,6 +71,15 @@ pub enum Response {
         /// The rootless HTTPS port the daemon actually bound (e.g. 8443).
         #[serde(default)]
         https_port: u16,
+        /// The configured rootless HTTP fallback port (e.g. 8080) — what Settings
+        /// edits. Distinct from `http_port`, which is the *bound* port and equals
+        /// the desired port when privileged binding succeeds. `#[serde(default)]`
+        /// keeps older daemons decodable; defaults to 0.
+        #[serde(default)]
+        fallback_http: u16,
+        /// The configured rootless HTTPS fallback port (e.g. 8443).
+        #[serde(default)]
+        fallback_https: u16,
     },
     /// Reply to [`crate::Request::ListPhp`] / `CheckPhpUpdates` / `UpdatePhp`.
     PhpVersions {
@@ -357,6 +366,8 @@ mod variant_name_pinning {
             ca_fingerprint: "ab".repeat(32),
             http_port: 8080,
             https_port: 8443,
+            fallback_http: 8080,
+            fallback_https: 8443,
         });
         pin_response(Response::PhpVersions {
             installed: vec![PhpVersion::new(8, 5)],
@@ -401,6 +412,8 @@ mod variant_name_pinning {
                 daemon_version: "9.9.9".into(),
                 services: vec![],
                 mail: None,
+                web_unbound: None,
+                boot_id: None,
             }),
         });
         pin_response(Response::Diagnoses {

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -98,6 +98,31 @@ pub struct StatusReport {
     /// (an older daemon emits unchanged bytes; an older client ignores it).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mail: Option<MailStatus>,
+    /// Set when the daemon could bind **neither** the desired nor the rootless
+    /// fallback web port pair: it runs degraded (IPC/DNS up, no HTTP/HTTPS
+    /// proxy). Carries the fallback ports it failed on so the UI/doctor can name
+    /// them. `None`/absent on a healthy daemon; `#[serde(default,
+    /// skip_serializing_if)]` keeps the wire additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_unbound: Option<UnboundWeb>,
+    /// A random id the daemon generates once per process at startup. Clients use
+    /// a *change* in this value to detect that a restart actually completed (the
+    /// re-exec preserves the PID and `uptime_secs` has only one-second
+    /// granularity, so neither is a reliable restart key). `None`/absent on an
+    /// older daemon; `#[serde(default, skip_serializing_if)]` keeps the wire
+    /// additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boot_id: Option<u64>,
+}
+
+/// The rootless fallback ports the daemon failed to bind, surfaced in
+/// [`StatusReport::web_unbound`] when it runs degraded (no web listeners).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnboundWeb {
+    /// The configured rootless HTTP port that could not be bound.
+    pub http: u16,
+    /// The configured rootless HTTPS port that could not be bound.
+    pub https: u16,
 }
 
 /// Built-in mail-capture SMTP server status, surfaced in [`StatusReport::mail`].
@@ -362,6 +387,9 @@ pub enum DiagnosisCode {
     DaemonDown,
     /// A privileged port fell back to its rootless equivalent.
     PortFallback,
+    /// The daemon could bind neither the desired nor the fallback web port pair,
+    /// so it is serving no sites (degraded). See [`StatusReport::web_unbound`].
+    WebPortsUnbound,
     /// A non-Yerd process is listening on a privileged web port (80/443).
     ForeignWebListener,
     /// The local CA is not trusted in the system store.

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -92,6 +92,8 @@ fn encode_then_decode_response_roundtrip() {
         ca_fingerprint: "ab".repeat(32),
         http_port: 8080,
         https_port: 8443,
+        fallback_http: 8080,
+        fallback_https: 8443,
     });
     assert_response_roundtrips(Response::PhpVersions {
         installed: vec![PhpVersion::new(8, 3), PhpVersion::new(8, 5)],
@@ -174,6 +176,11 @@ fn encode_then_decode_response_roundtrip() {
             daemon_version: "2.0.1".into(),
             services: vec![],
             mail: None,
+            web_unbound: Some(yerd_ipc::UnboundWeb {
+                http: 8080,
+                https: 8443,
+            }),
+            boot_id: Some(42),
         }),
     });
     assert_response_roundtrips(Response::Diagnoses {

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -378,10 +378,12 @@ fn response_info_byte_shape() {
         ca_fingerprint: "ab".repeat(32),
         http_port: 8080,
         https_port: 8443,
+        fallback_http: 8080,
+        fallback_https: 8443,
     };
     let s = serde_json::to_string(&r).unwrap();
     let expected = format!(
-        r#"{{"type":"info","dns_addr":"127.0.0.1:1053","tld":"test","ca_path":"/home/u/.local/share/yerd/ca.cert.pem","ca_fingerprint":"{}","http_port":8080,"https_port":8443}}"#,
+        r#"{{"type":"info","dns_addr":"127.0.0.1:1053","tld":"test","ca_path":"/home/u/.local/share/yerd/ca.cert.pem","ca_fingerprint":"{}","http_port":8080,"https_port":8443,"fallback_http":8080,"fallback_https":8443}}"#,
         "ab".repeat(32)
     );
     assert_eq!(s, expected);
@@ -399,6 +401,8 @@ fn response_info_byte_shape() {
         Response::Info {
             http_port: 0,
             https_port: 0,
+            fallback_http: 0,
+            fallback_https: 0,
             ..
         }
     ));
@@ -571,6 +575,9 @@ fn response_status_byte_shape() {
             // `None` + skip_serializing_if → omitted, so the byte shape is
             // unchanged from before the mail field existed.
             mail: None,
+            // Likewise omitted when `None`, keeping the byte shape unchanged.
+            web_unbound: None,
+            boot_id: None,
         }),
     };
     let s = serde_json::to_string(&r).unwrap();
@@ -671,6 +678,8 @@ fn sample_status_report() -> StatusReport {
         daemon_version: "2.0.1".into(),
         services: vec![],
         mail: None,
+        web_unbound: None,
+        boot_id: None,
     }
 }
 
@@ -780,6 +789,7 @@ fn diagnosis_code_each_variant_byte_shape() {
     let cases: &[(DiagnosisCode, &str)] = &[
         (DiagnosisCode::DaemonDown, r#""daemon_down""#),
         (DiagnosisCode::PortFallback, r#""port_fallback""#),
+        (DiagnosisCode::WebPortsUnbound, r#""web_ports_unbound""#),
         (
             DiagnosisCode::ForeignWebListener,
             r#""foreign_web_listener""#,
@@ -1308,6 +1318,20 @@ fn request_set_mail_port_byte_shape() {
     let r = Request::SetMailPort { port: 2525 };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(s, r#"{"type":"set_mail_port","port":2525}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
+fn request_set_fallback_ports_byte_shape() {
+    let r = Request::SetFallbackPorts {
+        http: 8080,
+        https: 8443,
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"set_fallback_ports","http":8080,"https":8443}"#
+    );
     assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable rootless fallback web ports (HTTP/HTTPS) with “Save & restart” support.
  * Introduced degraded-mode UI and onboarding guidance when web ports can’t be bound.
  * Added a way to re-enter onboarding from the overview screen.
* **Bug Fixes**
  * Improved diagnostics and status reporting for “web ports unbound” scenarios.
  * Refined save/restart and port-fix behavior to prevent misleading port states; added degraded startup handling on the daemon.
  * Updated elevation logic to refuse when the daemon isn’t serving web ports yet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->