### PR TITLE
[Fix] Allow mysql/mariadb login from localhost

### DIFF
--- a/crates/yerd-services/src/config_render.rs
+++ b/crates/yerd-services/src/config_render.rs
@@ -103,8 +103,12 @@ pub fn render_my_cnf(
 ///   when the account exists (so it never clobbers `MariaDB`'s own `root@127.0.0.1`
 ///   /`root@::1`, which `mariadb-install-db` already creates), and `GRANT` simply
 ///   re-asserts the privileges.
-/// - Each statement is on a **single line** — `--init-file` executes one
-///   statement per line and rejects multi-line statements.
+/// - **Any statement error aborts server startup** (the `init-file` runs on
+///   every normal start, not just init), so every statement must be safe to
+///   re-run — hence the `IF NOT EXISTS` guards and re-assertable `GRANT`s. The
+///   reader is `;`-delimited and folds the leading `--` comments into the first
+///   statement (the lexer then strips them); statements are kept one-per-line
+///   here for legibility, not because the reader requires it.
 /// - Only loopback hosts (`127.0.0.1`, `::1`) get accounts; `bind-address`
 ///   already pins the listener to loopback, so this widens nothing beyond it.
 #[must_use]
@@ -260,8 +264,9 @@ mod tests {
                 assert!(line.contains("IF NOT EXISTS"), "non-idempotent: {line}");
             }
         }
-        // --init-file executes one statement per line: no statement may span lines,
-        // so every non-comment, non-empty line must terminate with a semicolon.
+        // init-file aborts startup on any statement error, so keep each statement
+        // self-contained and ;-terminated on its own line (defence against a future
+        // multi-line edit silently changing what the `;`-delimited reader executes).
         for line in sql.lines() {
             let t = line.trim();
             if t.is_empty() || t.starts_with("--") {

--- a/crates/yerd-services/src/config_render.rs
+++ b/crates/yerd-services/src/config_render.rs
@@ -53,15 +53,27 @@ fn quote_conf_path(p: &Path) -> String {
 ///   localhost.
 /// - The empty root password is set by `mysqld --initialize-insecure` at init
 ///   time, so there is no password directive here.
+/// - `init-file` points at the bootstrap SQL from [`render_my_bootstrap_sql`],
+///   run on every start, which makes passwordless `root` reachable over TCP
+///   loopback (`--initialize-insecure` creates only the socket-matching
+///   `root@localhost`, so without this a TCP client on `127.0.0.1` is rejected
+///   with `[1130] Host '127.0.0.1' is not allowed`).
 /// - The server runs in the foreground (no `--daemonize`); see [`crate::manager`].
 /// - `pid-file` lives inside the datadir, whose parent `--initialize` creates,
 ///   so its directory always exists at start.
 #[must_use]
-pub fn render_my_cnf(port: u16, datadir: &Path, socket: &Path, log_path: &Path) -> String {
+pub fn render_my_cnf(
+    port: u16,
+    datadir: &Path,
+    socket: &Path,
+    log_path: &Path,
+    init_file: &Path,
+) -> String {
     let dir = quote_conf_path(datadir);
     let sock = quote_conf_path(socket);
     let log = quote_conf_path(log_path);
     let pid = quote_conf_path(&datadir.join("mysqld.pid"));
+    let init = quote_conf_path(init_file);
     format!(
         "# Managed by Yerd — do not edit by hand.\n\
          # Local development database (MySQL / MariaDB).\n\
@@ -72,8 +84,37 @@ pub fn render_my_cnf(port: u16, datadir: &Path, socket: &Path, log_path: &Path) 
          datadir = {dir}\n\
          socket = {sock}\n\
          pid-file = {pid}\n\
-         log-error = {log}\n"
+         log-error = {log}\n\
+         init-file = {init}\n"
     )
+}
+
+/// Render the `MySQL`/`MariaDB` bootstrap SQL the server runs on every start (via
+/// the `init-file` directive — see [`render_my_cnf`]).
+///
+/// It makes the passwordless `root` account reachable over **TCP loopback** so
+/// apps using `DB_HOST=127.0.0.1` (Laravel's default) connect out of the box.
+/// `mysqld --initialize-insecure` creates only `root@localhost`, which — under
+/// `skip-name-resolve` — matches the Unix socket but not a TCP client presenting
+/// the literal host `127.0.0.1`; that mismatch is the `[1130]` rejection.
+///
+/// Invariants that keep this safe to run on every start:
+/// - Every statement is **idempotent**: `CREATE USER IF NOT EXISTS` is a no-op
+///   when the account exists (so it never clobbers `MariaDB`'s own `root@127.0.0.1`
+///   /`root@::1`, which `mariadb-install-db` already creates), and `GRANT` simply
+///   re-asserts the privileges.
+/// - Each statement is on a **single line** — `--init-file` executes one
+///   statement per line and rejects multi-line statements.
+/// - Only loopback hosts (`127.0.0.1`, `::1`) get accounts; `bind-address`
+///   already pins the listener to loopback, so this widens nothing beyond it.
+#[must_use]
+pub fn render_my_bootstrap_sql() -> &'static str {
+    "-- Managed by Yerd — do not edit by hand.\n\
+     -- Make passwordless root reachable over TCP loopback (apps use DB_HOST=127.0.0.1).\n\
+     CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '';\n\
+     GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;\n\
+     CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED BY '';\n\
+     GRANT ALL PRIVILEGES ON *.* TO 'root'@'::1' WITH GRANT OPTION;\n"
 }
 
 /// Render a `postgresql.conf`: loopback TCP only, no Unix socket, no password.
@@ -167,6 +208,7 @@ mod tests {
             &PathBuf::from("/data/mysql"),
             &PathBuf::from("/run/mysql.sock"),
             &PathBuf::from("/log/mysql.log"),
+            &PathBuf::from("/cfg/mysql-init.sql"),
         );
         assert!(conf.contains("[mysqld]"));
         assert!(conf.contains("bind-address = 127.0.0.1"));
@@ -177,6 +219,8 @@ mod tests {
         assert!(conf.contains("log-error = \"/log/mysql.log\""));
         // pid-file is inside the datadir (parent always exists post-init).
         assert!(conf.contains("pid-file = \"/data/mysql/mysqld.pid\""));
+        // init-file points at the bootstrap SQL (TCP-loopback root grant).
+        assert!(conf.contains("init-file = \"/cfg/mysql-init.sql\""));
         // No password directive — root is left empty by --initialize-insecure.
         assert!(!conf.to_lowercase().contains("password"));
     }
@@ -188,11 +232,46 @@ mod tests {
             &PathBuf::from("/Users/a b/Library/Application Support/yerd/data"),
             &PathBuf::from("/run/u/mysql.sock"),
             &PathBuf::from("/Users/a b/log.log"),
+            &PathBuf::from("/Users/a b/mysql-init.sql"),
         );
         assert!(
             conf.contains("datadir = \"/Users/a b/Library/Application Support/yerd/data\""),
             "spaced datadir must be quoted intact: {conf}"
         );
+        assert!(
+            conf.contains("init-file = \"/Users/a b/mysql-init.sql\""),
+            "spaced init-file path must be quoted intact: {conf}"
+        );
+    }
+
+    #[test]
+    fn my_bootstrap_sql_grants_passwordless_root_over_tcp_loopback() {
+        let sql = render_my_bootstrap_sql();
+        // Both loopback hosts get a passwordless root with full privileges.
+        assert!(sql.contains("CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '';"));
+        assert!(
+            sql.contains("GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;")
+        );
+        assert!(sql.contains("CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED BY '';"));
+        assert!(sql.contains("GRANT ALL PRIVILEGES ON *.* TO 'root'@'::1' WITH GRANT OPTION;"));
+        // Idempotent: every CREATE USER is guarded so re-running on each start is safe.
+        for line in sql.lines() {
+            if line.trim_start().starts_with("CREATE USER") {
+                assert!(line.contains("IF NOT EXISTS"), "non-idempotent: {line}");
+            }
+        }
+        // --init-file executes one statement per line: no statement may span lines,
+        // so every non-comment, non-empty line must terminate with a semicolon.
+        for line in sql.lines() {
+            let t = line.trim();
+            if t.is_empty() || t.starts_with("--") {
+                continue;
+            }
+            assert!(
+                t.ends_with(';'),
+                "statement not single-line/terminated: {line}"
+            );
+        }
     }
 
     #[test]

--- a/crates/yerd-services/src/config_render.rs
+++ b/crates/yerd-services/src/config_render.rs
@@ -100,25 +100,24 @@ pub fn render_my_cnf(
 ///
 /// Invariants that keep this safe to run on every start:
 /// - Every statement is **idempotent**: `CREATE USER IF NOT EXISTS` is a no-op
-///   when the account exists (so it never clobbers `MariaDB`'s own `root@127.0.0.1`
-///   /`root@::1`, which `mariadb-install-db` already creates), and `GRANT` simply
-///   re-asserts the privileges.
+///   when the account exists (so it never clobbers `MariaDB`'s own `root@127.0.0.1`,
+///   which `mariadb-install-db` already creates), and `GRANT` simply re-asserts
+///   the privileges.
 /// - **Any statement error aborts server startup** (the `init-file` runs on
 ///   every normal start, not just init), so every statement must be safe to
 ///   re-run — hence the `IF NOT EXISTS` guards and re-assertable `GRANT`s. The
 ///   reader is `;`-delimited and folds the leading `--` comments into the first
 ///   statement (the lexer then strips them); statements are kept one-per-line
 ///   here for legibility, not because the reader requires it.
-/// - Only loopback hosts (`127.0.0.1`, `::1`) get accounts; `bind-address`
-///   already pins the listener to loopback, so this widens nothing beyond it.
+/// - Only the IPv4 loopback host `127.0.0.1` gets an account, matching the
+///   `bind-address = 127.0.0.1` listener (the server never accepts IPv6
+///   loopback, so a `root@::1` account would be dead privileged surface).
 #[must_use]
 pub fn render_my_bootstrap_sql() -> &'static str {
     "-- Managed by Yerd — do not edit by hand.\n\
      -- Make passwordless root reachable over TCP loopback (apps use DB_HOST=127.0.0.1).\n\
      CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '';\n\
-     GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;\n\
-     CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED BY '';\n\
-     GRANT ALL PRIVILEGES ON *.* TO 'root'@'::1' WITH GRANT OPTION;\n"
+     GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;\n"
 }
 
 /// Render a `postgresql.conf`: loopback TCP only, no Unix socket, no password.
@@ -251,13 +250,17 @@ mod tests {
     #[test]
     fn my_bootstrap_sql_grants_passwordless_root_over_tcp_loopback() {
         let sql = render_my_bootstrap_sql();
-        // Both loopback hosts get a passwordless root with full privileges.
+        // The IPv4 loopback host gets a passwordless root with full privileges.
+        // Only 127.0.0.1 — the listener is IPv4-only (`bind-address = 127.0.0.1`),
+        // so a `root@::1` account would be unreachable dead surface.
         assert!(sql.contains("CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '';"));
         assert!(
             sql.contains("GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;")
         );
-        assert!(sql.contains("CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED BY '';"));
-        assert!(sql.contains("GRANT ALL PRIVILEGES ON *.* TO 'root'@'::1' WITH GRANT OPTION;"));
+        assert!(
+            !sql.contains("::1"),
+            "no IPv6-loopback account (listener is IPv4-only)"
+        );
         // Idempotent: every CREATE USER is guarded so re-running on each start is safe.
         for line in sql.lines() {
             if line.trim_start().starts_with("CREATE USER") {

--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -169,8 +169,26 @@ where
         // Datadir + config/log (+ MySQL/MariaDB socket) parent directories.
         Self::prepare_dirs(service, &datadir, &config_path, &log_path, &socket)?;
 
+        // For MySQL/MariaDB, write the bootstrap SQL the server runs on every
+        // start (via the `init-file` directive) to grant passwordless root over
+        // TCP loopback. Written before the config so the path the cnf references
+        // always exists; its parent is the config dir `prepare_dirs` just made.
+        let init_file = version::init_file_path(&self.dirs, service);
+        if matches!(service, Service::MySql | Service::MariaDb) {
+            std::fs::write(
+                &init_file,
+                config_render::render_my_bootstrap_sql().as_bytes(),
+            )
+            .map_err(|source| ServiceError::ConfigWrite {
+                path: init_file.clone(),
+                service,
+                source,
+            })?;
+        }
+
         // Render + write the per-engine config.
-        let rendered = render_service_config(service, port, &datadir, &socket, &log_path);
+        let rendered =
+            render_service_config(service, port, &datadir, &socket, &log_path, &init_file);
         std::fs::write(&config_path, rendered.as_bytes()).map_err(|source| {
             ServiceError::ConfigWrite {
                 path: config_path.clone(),
@@ -737,11 +755,12 @@ fn render_service_config(
     datadir: &std::path::Path,
     socket: &std::path::Path,
     log_path: &std::path::Path,
+    init_file: &std::path::Path,
 ) -> String {
     match service {
         Service::Redis => config_render::render_redis_conf(port, datadir, log_path),
         Service::MySql | Service::MariaDb => {
-            config_render::render_my_cnf(port, datadir, socket, log_path)
+            config_render::render_my_cnf(port, datadir, socket, log_path, init_file)
         }
         Service::Postgres => config_render::render_postgresql_conf(port, datadir),
     }

--- a/crates/yerd-services/src/version.rs
+++ b/crates/yerd-services/src/version.rs
@@ -118,6 +118,19 @@ pub fn config_path(dirs: &PlatformDirs, service: Service) -> PathBuf {
         .join(format!("{}.conf", service.id()))
 }
 
+/// The `MySQL`/`MariaDB` bootstrap-SQL path: `state/services/<id>/<id>-init.sql`.
+///
+/// Referenced by the `init-file` directive in the rendered `my.cnf`; the server
+/// runs it on every start. Lives beside the config (rewritten each start), not in
+/// the datadir, so it persists independently of re-initialisation.
+#[must_use]
+pub fn init_file_path(dirs: &PlatformDirs, service: Service) -> PathBuf {
+    dirs.state
+        .join("services")
+        .join(service.id())
+        .join(format!("{}-init.sql", service.id()))
+}
+
 /// The server log-file path: `state/services/<id>/<id>.log`.
 #[must_use]
 pub fn log_path(dirs: &PlatformDirs, service: Service) -> PathBuf {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of bootstrap SQL for MySQL/MariaDB services on each start.
  * MySQL/MariaDB configuration now includes an `init-file` directive pointing to the generated SQL.
  * Introduced a dedicated persistent path for storing the bootstrap SQL.

* **Bug Fixes**
  * Ensures the bootstrap grants are idempotent and scoped to IPv4 loopback only (no IPv6 grants).

* **Tests**
  * Updated/extended coverage to validate the generated `init-file` line and SQL formatting/idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->