### PR TITLE
[Fix] Daemon update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,6 +6064,7 @@ dependencies = [
  "pem",
  "security-framework",
  "security-framework-sys",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/apps/yerd-gui/src-tauri/Cargo.toml
+++ b/apps/yerd-gui/src-tauri/Cargo.toml
@@ -34,6 +34,9 @@ tokio        = { workspace = true, features = ["rt", "rt-multi-thread", "io-util
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 libc         = "0.2"
+# Compare the GUI/daemon version (`env!("CARGO_PKG_VERSION")`) against the
+# last-registered daemon version for the upgrade self-repair + directional guard.
+semver       = { workspace = true }
 
 # SHA-256 for in-process CA fingerprint verification (mac_trust.rs). The daemon
 # is bundled (Tauri externalBin), so there's no runtime download — the former

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -659,6 +659,12 @@ pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
             s.daemon_registered_version = Some(gui.to_string());
             s.daemon_version_conflict = None;
             let _ = save_settings(&s);
+            // A fresh registration can land in `requiresApproval` (Login Items),
+            // in which case RunAtLoad/kickstart won't start the daemon until the
+            // user approves it. The automated-update path has no follow-on start
+            // to nudge (unlike a manual start), so prompt here when pending —
+            // else the user is left with a non-running daemon and no signal.
+            nudge_if_requires_approval();
             repair_log(&format!("self-repair: OK, daemon registered for {gui}"));
             Ok(())
         }

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -549,19 +549,48 @@ fn gui_version() -> semver::Version {
         .unwrap_or_else(|_| semver::Version::new(0, 0, 0))
 }
 
+/// Run `program args` discarding its output and return whether it exited
+/// successfully, bounded by `secs` (kill + `None` on timeout). The bounded
+/// sibling of [`capture`] for callers that only need the exit-status predicate —
+/// so a wedged `launchctl` can't hang the launch path (this runs from
+/// startup-repair and daemon start).
+#[cfg(target_os = "macos")]
+fn bounded_status(program: &str, args: &[&str], secs: u64) -> Option<bool> {
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        match child.try_wait() {
+            Ok(Some(st)) => return Some(st.success()),
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(_) => return None,
+        }
+    }
+}
+
 /// Whether launchd currently has the daemon job — by **exit status** (a missing
 /// job makes `launchctl print` exit non-zero). Unlike `service_status_text()`,
 /// which returns `Some("Could not find service…")` for a missing job, this is a
 /// true predicate: `true` for an upgrade victim (job exists), `false` for a
-/// never-registered fresh user.
+/// never-registered fresh user. Bounded so a wedged `launchctl` can't hang the
+/// launch path (timeout → `false`: treat an unresponsive launchctl as "no job",
+/// which skips re-registration rather than hanging).
 #[cfg(target_os = "macos")]
 fn daemon_launchd_job_exists() -> bool {
-    Command::new("launchctl")
-        .arg("print")
-        .arg(service_target())
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    bounded_status("launchctl", &["print", &service_target()], 4).unwrap_or(false)
 }
 
 /// Append a line to `{cache}/yerd-gui-repair.log`. The GUI has no `tracing`
@@ -604,6 +633,26 @@ pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
     let _guard = DAEMON_REG_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let gui = gui_version();
     let mut s = load_settings();
+
+    // Only trust the persisted marker when a daemon is *actually* registered.
+    // Keep an existing registration current — never opt a fresh user in. Crucially,
+    // do this BEFORE the version compare: if the daemon was unregistered (e.g. the
+    // autostart toggle turned off), the stored version is stale, and an older GUI
+    // must not be blocked "protecting" a daemon that no longer exists — so drop the
+    // stale marker. (`smapp_registered()` can read not-registered post-swap, so a
+    // live launchd job also counts. `daemon_autostart` — set whenever the user
+    // enables the daemon — keeps a transient launchctl false from clearing a real
+    // registration; the rare residual edge re-registers harmlessly next launch.)
+    let has_registration = s.daemon_autostart || smapp_registered() || daemon_launchd_job_exists();
+    if !has_registration {
+        if s.daemon_registered_version.is_some() || s.daemon_version_conflict.is_some() {
+            s.daemon_registered_version = None;
+            s.daemon_version_conflict = None;
+            let _ = save_settings(&s);
+        }
+        return Ok(()); // nothing registered → nothing to repair or protect
+    }
+
     let stored = s
         .daemon_registered_version
         .as_deref()
@@ -634,21 +683,9 @@ pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
         Decision::Reconcile => {}
     }
 
-    // Version advanced (or unknown). Keep an *existing* registration current —
-    // never opt a fresh user in. (`smapp_registered()` may read stale-not-
-    // registered post-swap, so also accept a live launchd job.)
-    let has_registration = s.daemon_autostart || smapp_registered() || daemon_launchd_job_exists();
-    if !has_registration {
-        if s.daemon_version_conflict.is_some() {
-            s.daemon_version_conflict = None;
-            let _ = save_settings(&s);
-        }
-        return Ok(()); // nothing registered → record nothing (so a later downgrade isn't a false conflict)
-    }
-
-    // Force a re-register so a stale BTM entry (in-place or automated upgrade) is
-    // re-pointed to THIS bundle: `register()` is an `Ok` no-op on a stale-enabled
-    // entry, so the explicit unregister is what forces the re-point.
+    // Version advanced. Force a re-register so a stale BTM entry (in-place or
+    // automated upgrade) is re-pointed to THIS bundle: `register()` is an `Ok`
+    // no-op on a stale-enabled entry, so the explicit unregister is what forces it.
     repair_log(&format!(
         "self-repair: re-registering daemon for {gui} (was {stored:?})"
     ));
@@ -656,6 +693,11 @@ pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
     match crate::smappservice::register_repairing(crate::smappservice::Service::Daemon) {
         Ok(()) => {
             let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);
+            // Reload right before saving: the unregister/register/kickstart above
+            // are slow OS calls during which a concurrent settings write could
+            // land; apply only our two fields to the latest on-disk state so we
+            // don't clobber it.
+            let mut s = load_settings();
             s.daemon_registered_version = Some(gui.to_string());
             s.daemon_version_conflict = None;
             let _ = save_settings(&s);
@@ -979,8 +1021,15 @@ fn daemon_set_login(on: bool, nudge: bool) -> Result<(), GuiError> {
         if use_smappservice() {
             // Unified model: the login toggle *is* registration. On =
             // register (→ "Yerd" Login Items entry + runs at login + now);
-            // off = unregister (removes the entry + stops it).
+            // off = unregister (removes the entry + stops it). Both honour the
+            // directional guard so an older GUI can't reconfigure/tear down a
+            // NEWER registered daemon.
             if on {
+                // `ensure` refuses (Err) when this GUI is older than the
+                // registered daemon, and self-repairs/has-registration-gates
+                // otherwise; for a fresh enable it no-ops and `smapp_enable`
+                // does the real register (recording the version).
+                ensure_daemon_registration()?;
                 smapp_enable(nudge)
             } else {
                 // Unregister the SMAppService agent (only when actually
@@ -989,6 +1038,21 @@ fn daemon_set_login(on: bool, nudge: bool) -> Result<(), GuiError> {
                 // so the toggle doesn't appear stuck "on" for upgrade users who
                 // only ever had the pre-SMAppService loose plist.
                 if smapp_registered() {
+                    // Don't let an older GUI tear down a newer registered daemon.
+                    let gui = gui_version();
+                    let stored = load_settings()
+                        .daemon_registered_version
+                        .as_deref()
+                        .and_then(|v| semver::Version::parse(v).ok());
+                    if let Some(reg) = stored {
+                        if gui < reg {
+                            return Err(GuiError::internal(format!(
+                                "This Yerd ({gui}) is older than the registered background \
+                                 daemon ({reg}); refusing to unregister it — install Yerd \
+                                 {reg} or newer."
+                            )));
+                        }
+                    }
                     crate::smappservice::unregister(crate::smappservice::Service::Daemon)?;
                 }
                 cleanup_legacy();

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -49,6 +49,49 @@ struct GuiSettings {
     /// it runs once and never re-enables login for a user who later turned it off.
     #[serde(default)]
     gui_login_migrated: bool,
+    /// macOS: the daemon version (= GUI version) that last *successfully*
+    /// (re)registered the SMAppService daemon agent. Drives the upgrade
+    /// self-repair (re-register from the new bundle when this advances) and the
+    /// directional guard (an older GUI must never reconfigure a newer daemon).
+    /// `#[serde(default)]` — additive; absent in pre-existing settings files.
+    #[serde(default)]
+    daemon_registered_version: Option<String>,
+    /// macOS: set when this (older) GUI found a *newer* registered daemon and
+    /// refused to downgrade it (carries the registered version); drives an
+    /// Overview banner. Cleared once the versions agree again.
+    #[serde(default)]
+    daemon_version_conflict: Option<String>,
+}
+
+/// Outcome of comparing the running GUI/daemon version against the version that
+/// last registered the daemon. Pure + unit-tested; the macOS reconcile acts on
+/// it. (Only the macOS reconcile calls `decide`, so it's dead code on other
+/// targets — silenced rather than `#[cfg]`-gated so it stays testable on Linux.)
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+enum Decision {
+    /// GUI is older than the registered daemon — refuse (carries the registered version).
+    Conflict(semver::Version),
+    /// The registered daemon already matches this GUI — nothing to do.
+    UpToDate,
+    /// Version advanced (or unknown) — (re)register the daemon from this bundle.
+    Reconcile,
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn decide(gui: &semver::Version, stored: Option<&semver::Version>) -> Decision {
+    match stored {
+        Some(reg) if gui < reg => Decision::Conflict(reg.clone()),
+        Some(reg) if gui == reg => Decision::UpToDate,
+        _ => Decision::Reconcile,
+    }
+}
+
+/// The persisted "this GUI is older than the registered daemon" marker, for the
+/// Overview banner. Cross-platform (always `None` off macOS, where it's never set).
+#[tauri::command]
+pub fn daemon_version_conflict() -> Option<String> {
+    load_settings().daemon_version_conflict
 }
 
 fn settings_path() -> Result<PathBuf, GuiError> {
@@ -486,12 +529,156 @@ fn nudge_if_requires_approval() {
     }
 }
 
+// ── macOS: version-stamped daemon registration self-repair ───────────────────
+//
+// Both a manual in-place app upgrade and the automated self-update replace the
+// whole bundle and relaunch the GUI, but neither re-registers the daemon — so
+// launchd keeps running the *old* `yerdd` from the stale BTM entry. `setup_app`
+// and `daemon_start` run `ensure_daemon_registration` on every launch: when the
+// app version has advanced it forces a fresh registration (re-pointing launchd
+// at the new bundle); an *older* GUI against a *newer* registered daemon is
+// refused outright. All SMAppService mutations are serialized by this lock.
+
+#[cfg(target_os = "macos")]
+static DAEMON_REG_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// This GUI's version (= the bundled `yerdd` version; both `version.workspace`).
+#[cfg(target_os = "macos")]
+fn gui_version() -> semver::Version {
+    semver::Version::parse(env!("CARGO_PKG_VERSION"))
+        .unwrap_or_else(|_| semver::Version::new(0, 0, 0))
+}
+
+/// Whether launchd currently has the daemon job — by **exit status** (a missing
+/// job makes `launchctl print` exit non-zero). Unlike `service_status_text()`,
+/// which returns `Some("Could not find service…")` for a missing job, this is a
+/// true predicate: `true` for an upgrade victim (job exists), `false` for a
+/// never-registered fresh user.
+#[cfg(target_os = "macos")]
+fn daemon_launchd_job_exists() -> bool {
+    Command::new("launchctl")
+        .arg("print")
+        .arg(service_target())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Append a line to `{cache}/yerd-gui-repair.log`. The GUI has no `tracing`
+/// subscriber and bundled-`.app` stderr isn't retrievable, so the self-repair
+/// trail goes to a file that `daemon_diagnostics` tails (and "Copy diagnostics"
+/// includes). Best-effort; capped so it can't grow unbounded.
+#[cfg(target_os = "macos")]
+fn repair_log(line: &str) {
+    use std::io::Write as _;
+    use yerd_platform::{ActivePaths, Paths};
+    let Ok(dirs) = ActivePaths::new().resolve() else {
+        return;
+    };
+    let _ = std::fs::create_dir_all(&dirs.cache);
+    let path = dirs.cache.join("yerd-gui-repair.log");
+    if std::fs::metadata(&path)
+        .map(|m| m.len() > 64 * 1024)
+        .unwrap_or(false)
+    {
+        let _ = std::fs::remove_file(&path);
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
+/// Re-assert the daemon registration from the *current* bundle when the app
+/// version has advanced (in-place or automated upgrade), and refuse an older GUI
+/// reconfiguring a newer daemon. Run from `setup_app` (covers both upgrade kinds)
+/// and `daemon_start`. Serialized by [`DAEMON_REG_LOCK`].
+#[cfg(target_os = "macos")]
+pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
+    if !use_smappservice() {
+        return Ok(());
+    }
+    let _guard = DAEMON_REG_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let gui = gui_version();
+    let mut s = load_settings();
+    let stored = s
+        .daemon_registered_version
+        .as_deref()
+        .and_then(|v| semver::Version::parse(v).ok());
+
+    match decide(&gui, stored.as_ref()) {
+        Decision::Conflict(reg) => {
+            repair_log(&format!(
+                "version conflict: GUI {gui} < registered daemon {reg}; refusing to reconfigure/downgrade"
+            ));
+            let reg_s = reg.to_string();
+            if s.daemon_version_conflict.as_deref() != Some(reg_s.as_str()) {
+                s.daemon_version_conflict = Some(reg_s);
+                let _ = save_settings(&s);
+            }
+            return Err(GuiError::internal(format!(
+                "This Yerd ({gui}) is older than the registered background daemon ({reg}). \
+                 Refusing to reconfigure or downgrade it — install Yerd {reg} or newer."
+            )));
+        }
+        Decision::UpToDate => {
+            if s.daemon_version_conflict.is_some() {
+                s.daemon_version_conflict = None;
+                let _ = save_settings(&s);
+            }
+            return Ok(());
+        }
+        Decision::Reconcile => {}
+    }
+
+    // Version advanced (or unknown). Keep an *existing* registration current —
+    // never opt a fresh user in. (`smapp_registered()` may read stale-not-
+    // registered post-swap, so also accept a live launchd job.)
+    let has_registration = s.daemon_autostart || smapp_registered() || daemon_launchd_job_exists();
+    if !has_registration {
+        if s.daemon_version_conflict.is_some() {
+            s.daemon_version_conflict = None;
+            let _ = save_settings(&s);
+        }
+        return Ok(()); // nothing registered → record nothing (so a later downgrade isn't a false conflict)
+    }
+
+    // Force a re-register so a stale BTM entry (in-place or automated upgrade) is
+    // re-pointed to THIS bundle: `register()` is an `Ok` no-op on a stale-enabled
+    // entry, so the explicit unregister is what forces the re-point.
+    repair_log(&format!(
+        "self-repair: re-registering daemon for {gui} (was {stored:?})"
+    ));
+    let _ = crate::smappservice::unregister(crate::smappservice::Service::Daemon);
+    match crate::smappservice::register_repairing(crate::smappservice::Service::Daemon) {
+        Ok(()) => {
+            let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);
+            s.daemon_registered_version = Some(gui.to_string());
+            s.daemon_version_conflict = None;
+            let _ = save_settings(&s);
+            repair_log(&format!("self-repair: OK, daemon registered for {gui}"));
+            Ok(())
+        }
+        Err(e) => {
+            repair_log(&format!("self-repair FAILED: {}", e.message));
+            Err(e)
+        }
+    }
+}
+
 /// Register the SMAppService agent if not already on (idempotent), migrating any
 /// loose legacy agent first, then nudge for approval if needed. `nudge = false`
 /// suppresses the System-Settings open so the onboarding flow (which enables the
 /// daemon *and* the GUI) doesn't open Login Items more than once.
 #[cfg(target_os = "macos")]
 fn smapp_enable(nudge: bool) -> Result<(), GuiError> {
+    // Same lock as `ensure_daemon_registration` so concurrent registration
+    // mutations can't overlap. Callers run `ensure` then `smapp_enable`
+    // sequentially (never nested), so this single non-reentrant lock is safe.
+    let _guard = DAEMON_REG_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     if smapp_registered() {
         // Already registered — don't cleanup/re-register a live agent. But it may
         // still be pending the user's Login-Items approval, so on a nudging caller
@@ -505,6 +692,14 @@ fn smapp_enable(nudge: bool) -> Result<(), GuiError> {
     // `register_repairing`, not `register`: an in-place app upgrade can leave a
     // stale BTM entry that makes `register` fail with EINVAL until it's cleared.
     crate::smappservice::register_repairing(crate::smappservice::Service::Daemon)?;
+    // Record the baseline version that registered the daemon — only on an actual
+    // successful register (never the early-return above), so it faithfully means
+    // "the registered daemon is version X" for the directional guard.
+    {
+        let mut s = load_settings();
+        s.daemon_registered_version = Some(gui_version().to_string());
+        let _ = save_settings(&s);
+    }
     if nudge {
         nudge_if_requires_approval();
     }
@@ -716,10 +911,14 @@ pub(crate) fn daemon_start(nudge: bool) -> Result<(), GuiError> {
     #[cfg(target_os = "macos")]
     {
         if use_smappservice() {
-            // Unified model: ensure registered (which RunAtLoad-starts it), then
-            // kickstart for a fresh start even if it was already up. kickstart is
-            // best-effort — when status is `requiresApproval` the job isn't loaded
-            // yet, and that's fine (the user was sent to Login Items).
+            // Self-repair a stale/upgraded registration first (re-points launchd at
+            // the current bundle; errors if this GUI is older than the registered
+            // daemon — surfaced via diagnostics). Then the unified model: ensure
+            // registered (which RunAtLoad-starts it), then kickstart for a fresh
+            // start even if it was already up. kickstart is best-effort — when
+            // status is `requiresApproval` the job isn't loaded yet, and that's fine
+            // (the user was sent to Login Items).
+            ensure_daemon_registration()?;
             smapp_enable(nudge)?;
             let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);
             Ok(())
@@ -917,4 +1116,46 @@ pub fn set_gui_minimized(on: bool) -> Result<(), GuiError> {
     let mut s = load_settings();
     s.gui_minimized = on;
     save_settings(&s)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{decide, Decision};
+    use semver::Version;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn decide_reconciles_on_advance_or_unknown() {
+        // Unknown (fresh / pre-fix daemon) → reconcile.
+        assert_eq!(decide(&v("2.0.3"), None), Decision::Reconcile);
+        // Newer GUI than the registered daemon → reconcile (the upgrade case).
+        assert_eq!(decide(&v("2.0.3"), Some(&v("2.0.2"))), Decision::Reconcile);
+        assert_eq!(
+            decide(&v("2.0.2"), Some(&v("2.0.2-rc.6"))),
+            Decision::Reconcile
+        );
+    }
+
+    #[test]
+    fn decide_is_up_to_date_on_equal() {
+        assert_eq!(decide(&v("2.0.3"), Some(&v("2.0.3"))), Decision::UpToDate);
+    }
+
+    #[test]
+    fn decide_conflicts_when_gui_is_older() {
+        // Older GUI than the registered daemon → never downgrade.
+        assert_eq!(
+            decide(&v("2.0.2"), Some(&v("2.0.3"))),
+            Decision::Conflict(v("2.0.3"))
+        );
+        // Pre-release ordering: rc.6 < rc.7 < release.
+        assert_eq!(
+            decide(&v("2.0.2-rc.6"), Some(&v("2.0.2-rc.7"))),
+            Decision::Conflict(v("2.0.2-rc.7"))
+        );
+    }
 }

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -11,7 +11,14 @@ use yerd_core::PhpVersion;
 use yerd_ipc::{ErrorCode, Request, Response};
 
 use crate::error::GuiError;
-use crate::ipc::exchange;
+use crate::ipc::{exchange, exchange_timeout};
+
+/// Bound for the liveness/probe commands (`status`/`ping`/`daemon_info`): a
+/// healthy in-memory reply returns in ms (the daemon serves connections
+/// concurrently, so an in-flight install doesn't block it), so 5 s only ever
+/// trips for a wedged/crash-looping daemon — letting the poller advance instead
+/// of hanging. Heavy/mutating commands deliberately stay unbounded.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Convert a daemon `Response::Error` into a `GuiError`; pass success through.
 fn finish(resp: Response) -> Result<Response, GuiError> {
@@ -34,7 +41,7 @@ fn code_str(code: &ErrorCode) -> String {
 
 #[tauri::command]
 pub async fn ping() -> Result<Response, GuiError> {
-    finish(exchange(&Request::Ping).await?)
+    finish(exchange_timeout(&Request::Ping, PROBE_TIMEOUT).await?)
 }
 
 // ── sites ──────────────────────────────────────────────────────────────────
@@ -391,7 +398,7 @@ pub async fn set_mail_enabled(enabled: bool) -> Result<Response, GuiError> {
 
 #[tauri::command]
 pub async fn status() -> Result<Response, GuiError> {
-    finish(exchange(&Request::Status).await?)
+    finish(exchange_timeout(&Request::Status, PROBE_TIMEOUT).await?)
 }
 
 #[tauri::command]
@@ -406,7 +413,7 @@ pub async fn doctor_fix() -> Result<Response, GuiError> {
 
 #[tauri::command]
 pub async fn daemon_info() -> Result<Response, GuiError> {
-    finish(exchange(&Request::DaemonInfo).await?)
+    finish(exchange_timeout(&Request::DaemonInfo, PROBE_TIMEOUT).await?)
 }
 
 // ── host-only helpers (no daemon IPC) ──────────────────────────────────────

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -238,9 +238,18 @@ pub fn open_login_items() {
 /// manager exists (in which case daemon-at-login is disabled in the UI). The
 /// blocking service call runs off the async worker so the tray/UI never stalls.
 pub(crate) async fn start(nudge: bool) -> Result<(), GuiError> {
-    tokio::task::spawn_blocking(move || crate::autostart::daemon_start(nudge))
-        .await
-        .map_err(|e| GuiError::internal(format!("start task failed: {e}")))?
+    // Bound the blocking service call so a hung `launchctl`/`systemctl`/
+    // SMAppService can't make `start_daemon` never resolve (the frontend awaits
+    // it before it even begins polling — another endless-spinner path). The
+    // blocking thread isn't cancellable; the timeout only frees the await.
+    let join = tokio::task::spawn_blocking(move || crate::autostart::daemon_start(nudge));
+    match tokio::time::timeout(std::time::Duration::from_secs(15), join).await {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(e)) => Err(GuiError::internal(format!("start task failed: {e}"))),
+        Err(_) => Err(GuiError::internal(
+            "starting the daemon timed out (the service manager did not respond)",
+        )),
+    }
 }
 
 /// Stop the daemon: via the service when one manages it, with a universal
@@ -270,7 +279,13 @@ pub async fn stop_daemon() -> Result<(), GuiError> {
 
 /// The running daemon's pid via a `status` IPC, or `None` if unreachable.
 async fn running_pid() -> Option<u32> {
-    match crate::ipc::exchange(&yerd_ipc::Request::Status).await {
+    // Bounded: this runs in the stop path; a wedged daemon mustn't hang it.
+    match crate::ipc::exchange_timeout(
+        &yerd_ipc::Request::Status,
+        std::time::Duration::from_secs(5),
+    )
+    .await
+    {
         Ok(yerd_ipc::Response::Status { report }) => Some(report.daemon_pid),
         _ => None,
     }
@@ -384,6 +399,11 @@ pub struct DaemonDiagnostics {
     log_tail: Vec<String>,
     /// Last lines of `{cache}/yerdd-spawn.log` (Linux detached-spawn path).
     spawn_log_tail: Vec<String>,
+    /// Last lines of `{cache}/yerd-gui-repair.log` — the GUI's daemon-registration
+    /// self-repair trail (macOS upgrade re-registration attempts + outcomes). The
+    /// GUI has no `tracing` subscriber, so this file is how the self-repair attempt
+    /// (and any technical failure) becomes retrievable via "Copy diagnostics".
+    repair_log_tail: Vec<String>,
 }
 
 /// Gather daemon-start diagnostics. `start_error` is the message the frontend's
@@ -446,6 +466,10 @@ fn build_diagnostics(
         .as_ref()
         .map(|c| tail_lines(&c.join("yerdd-spawn.log"), LOG_TAIL_LINES))
         .unwrap_or_default();
+    let repair_log_tail = cache
+        .as_ref()
+        .map(|c| tail_lines(&c.join("yerd-gui-repair.log"), LOG_TAIL_LINES))
+        .unwrap_or_default();
 
     let hints = compute_hints(
         pending_approval,
@@ -471,6 +495,7 @@ fn build_diagnostics(
         log_path,
         log_tail,
         spawn_log_tail,
+        repair_log_tail,
     }
 }
 
@@ -587,6 +612,16 @@ fn compute_hints(
     if logs.contains("already running") {
         hints.push("Another Yerd daemon is already running.".to_owned());
     }
+    // A running daemon older than the config it's reading (e.g. an upgrade left a
+    // stale background registration). The `ConfigError::UnsupportedVersion` text.
+    if logs.contains("incompatible with supported version") {
+        hints.push(
+            "The background daemon is running an older version of Yerd and can't read the \
+             current config — it may not have finished upgrading. Re-register it (toggle the \
+             daemon login item off then on in Settings) or remove any old Yerd.app copies."
+                .to_owned(),
+        );
+    }
     if service_manager == "detached spawn" {
         hints.push(
             "systemd --user wasn't detected in this session, so the daemon was started \
@@ -598,4 +633,30 @@ fn compute_hints(
         hints.push(format!("Start error: {err}"));
     }
     hints
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_hints;
+
+    #[test]
+    fn version_skew_log_yields_reregister_hint() {
+        // The `ConfigError::UnsupportedVersion` Display line in the daemon log.
+        let log = vec![
+            "ERROR yerdd: yerdd exiting with error error=config: config schema version 7 is \
+             incompatible with supported version 6"
+                .to_owned(),
+        ];
+        let hints = compute_hints(false, false, false, None, "launchd", &log, &[]);
+        assert!(
+            hints.iter().any(|h| h.contains("older version of Yerd")),
+            "expected a re-register hint, got {hints:?}"
+        );
+    }
+
+    #[test]
+    fn no_version_skew_hint_when_logs_clean() {
+        let hints = compute_hints(false, false, false, None, "launchd", &[], &[]);
+        assert!(!hints.iter().any(|h| h.contains("older version of Yerd")));
+    }
 }

--- a/apps/yerd-gui/src-tauri/src/ipc.rs
+++ b/apps/yerd-gui/src-tauri/src/ipc.rs
@@ -18,6 +18,27 @@ pub async fn exchange(req: &Request) -> Result<Response, GuiError> {
     exchange_at(&dirs.runtime.join("yerd.sock"), req).await
 }
 
+/// [`exchange`] bounded by a timeout. Used by the liveness/probe commands
+/// (`status`/`ping`/`daemon_info`) so a daemon that accepts the socket but never
+/// replies (crash-looping, wedged, mid-startup) can't make the `invoke` promise
+/// hang forever — the unbounded `read_message` in [`exchange_at`] otherwise never
+/// resolves, freezing the start spinner and the poller. On elapse this returns an
+/// `unreachable` error so the poller treats it as "Stopped" and the start flow
+/// advances to its diagnostics ceiling. NOT used for long-running ops (installs/
+/// updates legitimately block for minutes).
+pub async fn exchange_timeout(
+    req: &Request,
+    timeout: std::time::Duration,
+) -> Result<Response, GuiError> {
+    match tokio::time::timeout(timeout, exchange(req)).await {
+        Ok(res) => res,
+        Err(_) => Err(GuiError::unreachable(format!(
+            "daemon did not respond within {}s (it may be starting, wedged, or crash-looping)",
+            timeout.as_secs()
+        ))),
+    }
+}
+
 /// Connect at an explicit socket path and exchange one request/response.
 /// Factored out so tests can target a tempdir socket. Unix only.
 #[cfg(unix)]

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -160,6 +160,7 @@ fn main() {
             autostart::set_gui_minimized,
             autostart::setup_state,
             autostart::mark_onboarded,
+            autostart::daemon_version_conflict,
         ])
         .setup(setup_app)
         // Close-to-tray: hide the window instead of quitting; the tray's Quit
@@ -198,11 +199,19 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     build_tray(app.handle())?;
     show_initial_window(app);
     // macOS: one-time migration of a legacy loose `Yerd.plist` GUI login item to
-    // SMAppService.mainApp (so it shows as "Yerd" under Open at Login). Off the
-    // main thread — it does `launchctl` + SMAppService XPC; flag-guarded so it
-    // runs once and stays silent (no System-Settings popup at startup).
+    // SMAppService.mainApp (so it shows as "Yerd" under Open at Login), then
+    // re-assert the daemon registration if the app version advanced (an in-place
+    // OR automated upgrade swaps the bundle + relaunches this GUI, but neither
+    // re-registers the daemon — so launchd would keep running the old `yerdd`).
+    // One thread keeps the two SMAppService operations sequential; off the main
+    // thread because both do `launchctl`/SMAppService XPC.
     #[cfg(target_os = "macos")]
-    std::thread::spawn(autostart::migrate_gui_login_if_needed);
+    std::thread::spawn(|| {
+        autostart::migrate_gui_login_if_needed();
+        // Best-effort: a directional-guard error (older GUI vs newer daemon) is
+        // persisted for the Overview banner; the start path surfaces it loudly.
+        let _ = autostart::ensure_daemon_registration();
+    });
     Ok(())
 }
 

--- a/apps/yerd-gui/src/components/DaemonDiagnosticsPanel.vue
+++ b/apps/yerd-gui/src/components/DaemonDiagnosticsPanel.vue
@@ -17,7 +17,8 @@ const hasRaw = computed(
   () =>
     !!props.diagnostics.serviceStatus ||
     props.diagnostics.logTail.length > 0 ||
-    props.diagnostics.spawnLogTail.length > 0,
+    props.diagnostics.spawnLogTail.length > 0 ||
+    props.diagnostics.repairLogTail.length > 0,
 );
 
 /** A flat, paste-able plain-text dump of the whole diagnostics struct. */
@@ -39,6 +40,8 @@ function asText(): string {
   if (d.serviceStatus) lines.push("", "Service status:", d.serviceStatus);
   if (d.logTail.length) lines.push("", "Daemon log (tail):", ...d.logTail);
   if (d.spawnLogTail.length) lines.push("", "Spawn log (tail):", ...d.spawnLogTail);
+  if (d.repairLogTail.length)
+    lines.push("", "Daemon re-registration log (tail):", ...d.repairLogTail);
   return lines.join("\n");
 }
 
@@ -96,6 +99,14 @@ async function copy(): Promise<void> {
               <pre
                 class="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 font-mono text-xs"
               >{{ diagnostics.spawnLogTail.join("\n") }}</pre>
+            </div>
+            <div v-if="diagnostics.repairLogTail.length">
+              <p class="text-xs font-medium text-muted-foreground">
+                Daemon re-registration log
+              </p>
+              <pre
+                class="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 font-mono text-xs"
+              >{{ diagnostics.repairLogTail.join("\n") }}</pre>
             </div>
           </div>
         </details>

--- a/apps/yerd-gui/src/composables/useDaemonStart.ts
+++ b/apps/yerd-gui/src/composables/useDaemonStart.ts
@@ -181,5 +181,6 @@ function minimalDiagnostics(message: string): DaemonDiagnostics {
     logPath: null,
     logTail: [],
     spawnLogTail: [],
+    repairLogTail: [],
   };
 }

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -596,6 +596,15 @@ export async function daemonDiagnostics(startError?: string): Promise<DaemonDiag
   return call<DaemonDiagnostics>("daemon_diagnostics", { startError });
 }
 
+/**
+ * macOS: the version of a *newer* registered daemon that this (older) GUI refused
+ * to reconfigure/downgrade, or `null` when there's no conflict. Drives the
+ * Overview "this Yerd is older than your daemon" banner.
+ */
+export async function daemonVersionConflict(): Promise<string | null> {
+  return call<string | null>("daemon_version_conflict");
+}
+
 export async function getAutostart(): Promise<AutostartState> {
   return call<AutostartState>("get_autostart");
 }

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -509,6 +509,9 @@ export interface DaemonDiagnostics {
   logPath: string | null;
   logTail: string[];
   spawnLogTail: string[];
+  /** GUI daemon-registration self-repair trail ({cache}/yerd-gui-repair.log) —
+   *  macOS upgrade re-registration attempts + outcomes (incl. technical errors). */
+  repairLogTail: string[];
 }
 
 /**

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -24,7 +24,7 @@ import Card from "@/components/ui/Card.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { useDaemon } from "@/composables/useDaemon";
 import { useOnboarding } from "@/composables/useOnboarding";
-import { listSites, openInBrowser } from "@/ipc/client";
+import { daemonVersionConflict, listSites, openInBrowser } from "@/ipc/client";
 import type { Site, StatusReport } from "@/ipc/types";
 import { openTitle, siteUrl } from "@/lib/siteUrl";
 import { humaniseUptime } from "@/lib/utils";
@@ -54,8 +54,16 @@ async function loadSites(): Promise<void> {
   }
 }
 
+// macOS: set when this (older) GUI refused to reconfigure a NEWER registered
+// daemon. A GUI-vs-registered-daemon condition (independent of reachability), so
+// it shows above every branch below.
+const versionConflict = ref<string | null>(null);
+
 onMounted(() => {
   if (running.value) loadSites();
+  daemonVersionConflict()
+    .then((v) => (versionConflict.value = v))
+    .catch(() => {});
 });
 watch(running, (up) => {
   if (up) {
@@ -198,6 +206,24 @@ const emptyEnvironment = computed(
     <PageHeader title="Overview" subtitle="Your local environment at a glance" />
 
     <div class="flex-1 space-y-4 overflow-y-auto p-6">
+      <!-- Version conflict: this GUI is OLDER than the registered daemon. Shown
+           above every branch — it's independent of daemon reachability. -->
+      <div
+        v-if="versionConflict"
+        class="flex items-start gap-3 rounded-md border border-warning/40 bg-warning/10 p-4"
+      >
+        <ShieldAlert class="mt-0.5 size-5 shrink-0 text-warning" />
+        <div class="min-w-0 flex-1">
+          <p class="text-sm font-medium">This Yerd is older than your daemon</p>
+          <p class="mt-1 text-sm text-muted-foreground">
+            The background daemon is registered at version
+            <span class="font-mono">{{ versionConflict }}</span
+            >, newer than this app. Yerd won't reconfigure or downgrade it — update
+            Yerd to {{ versionConflict }} or newer.
+          </p>
+        </div>
+      </div>
+
       <!-- Connecting: first probe hasn't resolved yet. -->
       <div v-if="connecting" class="flex justify-center py-24">
         <Spinner class="size-6" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS daemon “version-stamped” self-repair to reconcile upgrade/downgrade situations and prevent unsafe unregister/reconfiguration.
  * Added an on-screen banner warning when the app is older than the registered daemon, based on a new version-conflict signal.
* **Bug Fixes**
  * Improved liveness/probe reliability by enforcing bounded IPC timeouts (avoiding hangs).
  * Expanded daemon diagnostics with repair-log tail details and improved version-skew hints.
* **Tests**
  * Added unit tests for version decision logic and hint generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->