### PR TITLE
[Fix] Fallback DNS port, logging and various other fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6076,6 +6076,8 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "webkit2gtk",
  "yerd-config",
  "yerd-core",

--- a/README.md
+++ b/README.md
@@ -93,9 +93,15 @@ its own Rust proxy + DNS. No Valet, no Homebrew.</sub>
 
 ## Installation
 
+> **Release status — Release Candidate.** Yerd is currently shipping **Release
+> Candidate** builds, available from the
+> [releases page](https://github.com/forjedio/yerd/releases). We're tracking a
+> **stable v2.0.2** release on **8 July 2026**. The RCs are ready for everyday use —
+> please [report any bugs on GitHub](https://github.com/forjedio/yerd/issues).
+
 Yerd is a **single desktop app** - the daemon (`yerdd`), the `yerd` CLI, and the
 privileged `yerd-helper` are all embedded inside it (nothing is downloaded at
-runtime). Grab the latest build from the
+runtime). Grab the latest **Release Candidate** build from the
 [releases page](https://github.com/forjedio/yerd/releases):
 
 | Platform | Download | Install |

--- a/apps/yerd-gui/src-tauri/Cargo.toml
+++ b/apps/yerd-gui/src-tauri/Cargo.toml
@@ -33,6 +33,11 @@ interprocess = { workspace = true }
 tokio        = { workspace = true, features = ["rt", "rt-multi-thread", "io-util", "net", "time"] }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
+# Per-session GUI diagnostic log (logging.rs): a truncate-on-launch tracing
+# subscriber writing {cache}/yerd-gui.log. No tracing-appender — the session file
+# uses a hand-rolled truncate/staleness MakeWriter the 'static registry owns.
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
 libc         = "0.2"
 # Compare the GUI/daemon version (`env!("CARGO_PKG_VERSION")`) against the
 # last-registered daemon version for the upgrade self-repair + directional guard.

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -1079,7 +1079,9 @@ pub(crate) fn plan_start(nudge: bool) -> Result<Vec<StartStep>, GuiError> {
             if unit_is_current() {
                 return Ok(vec![StartStep {
                     phase: StartPhase::Starting,
-                    budget: START_BUDGET,
+                    // Heavy: still rewrites the unit + daemon-reloads before the
+                    // start, so it needs the install budget, not the start one.
+                    budget: INSTALL_BUDGET,
                     run: Box::new(|| {
                         write_unit()?;
                         run_ok("systemctl", &["--user", "start", "yerd"])

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -1021,7 +1021,9 @@ pub(crate) struct StartStep {
 const INSTALL_BUDGET: std::time::Duration = std::time::Duration::from_secs(12);
 /// The macOS SMAppService ensure/register step: unregister + register_repairing +
 /// kickstart is the slowest single action (XPC), so it gets the largest slice
-/// regardless of the optimistic label `reg_phase` chose.
+/// regardless of the optimistic label `reg_phase` chose. macOS-only — the Linux
+/// start plan never uses it.
+#[cfg(target_os = "macos")]
 const REGISTER_BUDGET: std::time::Duration = std::time::Duration::from_secs(20);
 /// A plain service-manager start/kickstart.
 const START_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -94,6 +94,13 @@ pub fn daemon_version_conflict() -> Option<String> {
     load_settings().daemon_version_conflict
 }
 
+/// macOS: the daemon version (= GUI version) that last successfully registered
+/// the SMAppService agent — surfaced in the diagnostics payload. `None` where the
+/// field is unused (other OSes / never registered).
+pub(crate) fn daemon_registered_version() -> Option<String> {
+    load_settings().daemon_registered_version
+}
+
 fn settings_path() -> Result<PathBuf, GuiError> {
     use yerd_platform::{ActivePaths, Paths};
     let dirs = ActivePaths::new()
@@ -391,19 +398,40 @@ fn unit_path() -> Result<PathBuf, GuiError> {
     Ok(base.join("systemd").join("user").join("yerd.service"))
 }
 
+/// Render the systemd unit text (resolving the current `yerdd` path). Extracted
+/// so [`unit_is_current`] can compare against the on-disk file without
+/// duplicating the template.
 #[cfg(target_os = "linux")]
-fn write_unit() -> Result<(), GuiError> {
+fn render_unit() -> Result<String, GuiError> {
     let yerdd = crate::daemon::resolve_yerdd()
         .ok_or_else(|| GuiError::internal("yerdd is not installed"))?;
+    Ok(format!(
+        "[Unit]\nDescription=Yerd local PHP development daemon\n\n[Service]\nType=simple\nExecStart={} serve\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n",
+        yerdd.display()
+    ))
+}
+
+/// Whether the on-disk unit already matches what we'd write (same `ExecStart`
+/// etc.). Drives only the install-vs-start *label* — `write_unit` still runs
+/// unconditionally. Best-effort: any error → `false` (treat as needs-install).
+#[cfg(target_os = "linux")]
+fn unit_is_current() -> bool {
+    match (render_unit(), unit_path()) {
+        (Ok(rendered), Ok(path)) => std::fs::read_to_string(&path)
+            .map(|c| c == rendered)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn write_unit() -> Result<(), GuiError> {
+    let unit = render_unit()?;
     let path = unit_path()?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| GuiError::internal(format!("cannot create {}: {e}", parent.display())))?;
     }
-    let unit = format!(
-        "[Unit]\nDescription=Yerd local PHP development daemon\n\n[Service]\nType=simple\nExecStart={} serve\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n",
-        yerdd.display()
-    );
     std::fs::write(&path, unit)
         .map_err(|e| GuiError::internal(format!("cannot write {}: {e}", path.display())))?;
     let _ = run_ok("systemctl", &["--user", "daemon-reload"]);
@@ -945,34 +973,180 @@ fn ensure_bootstrapped() -> Result<(), GuiError> {
 
 // ── daemon start / stop / autostart (used by crate::daemon + the commands) ───
 
-/// Start the daemon via the service manager, or a detached spawn when none.
-pub(crate) fn daemon_start(nudge: bool) -> Result<(), GuiError> {
+/// A phase of "starting the daemon", surfaced to the GUI start button so it can
+/// show the current step. Rust emits only the phases that map to work it
+/// performs (install / upgrade / start); the frontend owns `running` (the
+/// readiness wait) and `idle`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StartPhase {
+    Installing,
+    Upgrading,
+    Starting,
+}
+
+impl StartPhase {
+    /// Wire string for the `daemon-start-phase` Tauri event.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            StartPhase::Installing => "installing",
+            StartPhase::Upgrading => "upgrading",
+            StartPhase::Starting => "starting",
+        }
+    }
+
+    /// Subject for a phase-named timeout error ("<subject> timed out …").
+    pub(crate) fn timed_out_subject(self) -> &'static str {
+        match self {
+            StartPhase::Installing => "installing the daemon",
+            StartPhase::Upgrading => "upgrading the daemon",
+            StartPhase::Starting => "starting the daemon",
+        }
+    }
+}
+
+/// One ordered step of the start sequence: a phase label (for the button), its
+/// OWN timeout budget, and the blocking work to run. `daemon.rs` emits the phase,
+/// then runs `run` inside a `spawn_blocking` bounded by `budget`. The budget is
+/// explicit (not derived from the label) so the slow macOS register/reconcile
+/// step gets the worst-case allowance even when its label is the optimistic
+/// "Starting". Independent per-step budgets replace the former single combined
+/// 15 s, so a hung `launchctl`/`systemctl` can't exceed one step's slice.
+pub(crate) struct StartStep {
+    pub phase: StartPhase,
+    pub budget: std::time::Duration,
+    pub run: Box<dyn FnOnce() -> Result<(), GuiError> + Send>,
+}
+
+/// Writing a unit/plist + service-manager start.
+const INSTALL_BUDGET: std::time::Duration = std::time::Duration::from_secs(12);
+/// The macOS SMAppService ensure/register step: unregister + register_repairing +
+/// kickstart is the slowest single action (XPC), so it gets the largest slice
+/// regardless of the optimistic label `reg_phase` chose.
+const REGISTER_BUDGET: std::time::Duration = std::time::Duration::from_secs(20);
+/// A plain service-manager start/kickstart.
+const START_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
+
+/// Map the macOS daemon-registration state to the phase *label* to show. Pure +
+/// unit-tested (kept cross-platform so it builds/tests on Linux); the step still
+/// calls the real [`ensure_daemon_registration`], which re-derives and acts on
+/// the same inputs.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn reg_plan(
+    has_registration: bool,
+    gui: &semver::Version,
+    stored: Option<&semver::Version>,
+) -> StartPhase {
+    if !has_registration {
+        return StartPhase::Installing; // fresh register
+    }
+    match stored {
+        // Version advanced → reconcile / re-register == an upgrade.
+        Some(s) if gui > s => StartPhase::Upgrading,
+        // Up to date, unknown, or older-than-registered (a conflict, surfaced by
+        // the step's own Err) → just a start.
+        _ => StartPhase::Starting,
+    }
+}
+
+/// Label for the macOS SMAppService register/ensure step (gathers the live
+/// registration inputs, then defers to the pure [`reg_plan`]). May block on a
+/// `launchctl print` probe — callers run it off the async runtime.
+#[cfg(target_os = "macos")]
+fn reg_phase() -> StartPhase {
+    let gui = gui_version();
+    let s = load_settings();
+    let has_registration = s.daemon_autostart || smapp_registered() || daemon_launchd_job_exists();
+    let stored = s
+        .daemon_registered_version
+        .as_deref()
+        .and_then(|v| semver::Version::parse(v).ok());
+    reg_plan(has_registration, &gui, stored.as_ref())
+}
+
+/// Build the ordered start steps for this platform. **May block** (the macOS
+/// label probes `launchctl`, the Linux label reads the unit file), so
+/// `daemon.rs` calls it inside `spawn_blocking`. Each step keeps the same work
+/// the former one-shot `daemon_start` did; only the timeout is now per-phase.
+pub(crate) fn plan_start(nudge: bool) -> Result<Vec<StartStep>, GuiError> {
     #[cfg(target_os = "linux")]
     {
         let _ = nudge; // no SMAppService / Login-Items nudge on Linux
         if systemd_user_available() {
-            write_unit()?;
-            return run_ok("systemctl", &["--user", "start", "yerd"]);
+            // `write_unit()` always runs (preserves the ExecStart refresh); only
+            // the label is conditional on whether the unit was already current.
+            if unit_is_current() {
+                return Ok(vec![StartStep {
+                    phase: StartPhase::Starting,
+                    budget: START_BUDGET,
+                    run: Box::new(|| {
+                        write_unit()?;
+                        run_ok("systemctl", &["--user", "start", "yerd"])
+                    }),
+                }]);
+            }
+            return Ok(vec![
+                StartStep {
+                    phase: StartPhase::Installing,
+                    budget: INSTALL_BUDGET,
+                    run: Box::new(write_unit),
+                },
+                StartStep {
+                    phase: StartPhase::Starting,
+                    budget: START_BUDGET,
+                    run: Box::new(|| run_ok("systemctl", &["--user", "start", "yerd"])),
+                },
+            ]);
         }
-        crate::daemon::spawn_detached()
+        Ok(vec![StartStep {
+            phase: StartPhase::Starting,
+            budget: START_BUDGET,
+            run: Box::new(crate::daemon::spawn_detached),
+        }])
     }
     #[cfg(target_os = "macos")]
     {
         if use_smappservice() {
-            // Self-repair a stale/upgraded registration first (re-points launchd at
-            // the current bundle; errors if this GUI is older than the registered
-            // daemon — surfaced via diagnostics). Then the unified model: ensure
-            // registered (which RunAtLoad-starts it), then kickstart for a fresh
-            // start even if it was already up. kickstart is best-effort — when
-            // status is `requiresApproval` the job isn't loaded yet, and that's fine
-            // (the user was sent to Login Items).
-            ensure_daemon_registration()?;
-            smapp_enable(nudge)?;
-            let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);
-            Ok(())
+            // Step A self-repairs a stale/upgraded registration (re-points launchd
+            // at the current bundle; errors if this GUI is older than the
+            // registered daemon — surfaced via diagnostics) then ensures it's
+            // registered (RunAtLoad-starts it). Step B kickstarts for a fresh
+            // start even if it was already up (best-effort — a `requiresApproval`
+            // job isn't loaded yet, and that's fine; the user was sent to Login
+            // Items).
+            Ok(vec![
+                StartStep {
+                    phase: reg_phase(),
+                    // The reconcile path runs even when the label is "Starting"
+                    // (e.g. registered-but-no-stored-version), so always allow the
+                    // worst-case register budget here, not the label's.
+                    budget: REGISTER_BUDGET,
+                    run: Box::new(move || {
+                        ensure_daemon_registration()?;
+                        smapp_enable(nudge)
+                    }),
+                },
+                StartStep {
+                    phase: StartPhase::Starting,
+                    budget: START_BUDGET,
+                    run: Box::new(|| {
+                        let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);
+                        Ok(())
+                    }),
+                },
+            ])
         } else {
-            ensure_bootstrapped()?;
-            run_ok("launchctl", &["kickstart", "-k", &service_target()])
+            Ok(vec![
+                StartStep {
+                    phase: StartPhase::Installing,
+                    budget: INSTALL_BUDGET,
+                    run: Box::new(ensure_bootstrapped),
+                },
+                StartStep {
+                    phase: StartPhase::Starting,
+                    budget: START_BUDGET,
+                    run: Box::new(|| run_ok("launchctl", &["kickstart", "-k", &service_target()])),
+                },
+            ])
         }
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -1191,11 +1365,45 @@ pub fn set_gui_minimized(on: bool) -> Result<(), GuiError> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{decide, Decision};
+    use super::{decide, reg_plan, Decision, StartPhase};
     use semver::Version;
 
     fn v(s: &str) -> Version {
         Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn reg_plan_installs_when_unregistered() {
+        // No registration → a fresh register, regardless of any stale stored ver.
+        assert_eq!(reg_plan(false, &v("2.0.3"), None), StartPhase::Installing);
+        assert_eq!(
+            reg_plan(false, &v("2.0.3"), Some(&v("2.0.1"))),
+            StartPhase::Installing
+        );
+    }
+
+    #[test]
+    fn reg_plan_upgrades_on_version_advance() {
+        assert_eq!(
+            reg_plan(true, &v("2.0.3"), Some(&v("2.0.2"))),
+            StartPhase::Upgrading
+        );
+    }
+
+    #[test]
+    fn reg_plan_starts_when_current_unknown_or_conflicting() {
+        // Equal → just start (no upgrade flash).
+        assert_eq!(
+            reg_plan(true, &v("2.0.3"), Some(&v("2.0.3"))),
+            StartPhase::Starting
+        );
+        // Unknown stored version → start (the step reconciles if needed).
+        assert_eq!(reg_plan(true, &v("2.0.3"), None), StartPhase::Starting);
+        // Older GUI than registered (a conflict) → start label; the step Errs.
+        assert_eq!(
+            reg_plan(true, &v("2.0.2"), Some(&v("2.0.3"))),
+            StartPhase::Starting
+        );
     }
 
     #[test]

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -158,6 +158,12 @@ pub async fn check_updates(channel: Option<String>) -> Result<Response, GuiError
     finish(exchange(&Request::CheckUpdate { channel }).await?)
 }
 
+/// Return the last persisted update-check result (no network) to pre-fill the UI.
+#[tauri::command]
+pub async fn cached_update_status() -> Result<Response, GuiError> {
+    finish(exchange(&Request::CachedUpdateStatus).await?)
+}
+
 /// Persist the self-update channel preference.
 #[tauri::command]
 pub async fn set_update_channel(channel: String) -> Result<Response, GuiError> {

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -390,6 +390,11 @@ pub async fn set_fallback_ports(http: u16, https: u16) -> Result<Response, GuiEr
 }
 
 #[tauri::command]
+pub async fn set_dns_port(port: u16) -> Result<Response, GuiError> {
+    finish(exchange(&Request::SetDnsPort { port }).await?)
+}
+
+#[tauri::command]
 pub async fn set_mail_enabled(enabled: bool) -> Result<Response, GuiError> {
     finish(exchange(&Request::SetMailEnabled { enabled }).await?)
 }

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -237,19 +237,35 @@ pub fn open_login_items() {
 /// available); falls back to a detached `yerdd serve` only when no service
 /// manager exists (in which case daemon-at-login is disabled in the UI). The
 /// blocking service call runs off the async worker so the tray/UI never stalls.
-pub(crate) async fn start(nudge: bool) -> Result<(), GuiError> {
-    // Bound the blocking service call so a hung `launchctl`/`systemctl`/
-    // SMAppService can't make `start_daemon` never resolve (the frontend awaits
-    // it before it even begins polling — another endless-spinner path). The
-    // blocking thread isn't cancellable; the timeout only frees the await.
-    let join = tokio::task::spawn_blocking(move || crate::autostart::daemon_start(nudge));
-    match tokio::time::timeout(std::time::Duration::from_secs(15), join).await {
-        Ok(Ok(inner)) => inner,
-        Ok(Err(e)) => Err(GuiError::internal(format!("start task failed: {e}"))),
-        Err(_) => Err(GuiError::internal(
-            "starting the daemon timed out (the service manager did not respond)",
-        )),
+pub(crate) async fn start(app: tauri::AppHandle, nudge: bool) -> Result<(), GuiError> {
+    use tauri::Emitter;
+
+    // Build the ordered step plan off the runtime: `plan_start` may block (the
+    // macOS label probes `launchctl`, the Linux label reads the unit file).
+    let plan = tokio::task::spawn_blocking(move || crate::autostart::plan_start(nudge))
+        .await
+        .map_err(|e| GuiError::internal(format!("start planning failed: {e}")))??;
+
+    // Run each phase with its OWN timeout budget and announce it to the button
+    // first, so a hung `launchctl`/`systemctl` can't exceed one phase's slice
+    // (the blocking thread isn't cancellable; the timeout only frees the await).
+    for step in plan {
+        let phase = step.phase;
+        let budget = step.budget;
+        let _ = app.emit("daemon-start-phase", phase.as_str());
+        let join = tokio::task::spawn_blocking(step.run);
+        match tokio::time::timeout(budget, join).await {
+            Ok(Ok(inner)) => inner?,
+            Ok(Err(e)) => return Err(GuiError::internal(format!("start task failed: {e}"))),
+            Err(_) => {
+                return Err(GuiError::internal(format!(
+                    "{} timed out (the service manager did not respond)",
+                    phase.timed_out_subject()
+                )))
+            }
+        }
     }
+    Ok(())
 }
 
 /// Stop the daemon: via the service when one manages it, with a universal
@@ -268,8 +284,8 @@ pub(crate) async fn stop() -> Result<(), GuiError> {
 /// at most once across the daemon + GUI enables; the General-tab button uses
 /// `true`.
 #[tauri::command]
-pub async fn start_daemon(nudge: bool) -> Result<(), GuiError> {
-    start(nudge).await
+pub async fn start_daemon(app: tauri::AppHandle, nudge: bool) -> Result<(), GuiError> {
+    start(app, nudge).await
 }
 
 #[tauri::command]
@@ -534,7 +550,7 @@ fn diag_yerdd_path() -> Option<String> {
 /// Newest `yerdd.<date>.log` under `dir` (the daily rolling appender's output).
 /// Matches `yerdd.` + `.log` so it never picks up `yerdd-spawn.log`. Chooses by
 /// modification time; tolerates a missing/unreadable dir.
-fn newest_rolling_log(dir: &std::path::Path) -> Option<PathBuf> {
+pub(crate) fn newest_rolling_log(dir: &std::path::Path) -> Option<PathBuf> {
     let entries = std::fs::read_dir(dir).ok()?;
     let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
     for entry in entries.flatten() {
@@ -556,7 +572,7 @@ fn newest_rolling_log(dir: &std::path::Path) -> Option<PathBuf> {
 /// Last `n` lines of `path`. Best-effort: a missing/unreadable file → empty.
 /// Bounded inputs (daily rotation + truncate-on-start spawn log) make reading
 /// the whole file acceptable.
-fn tail_lines(path: &std::path::Path, n: usize) -> Vec<String> {
+pub(crate) fn tail_lines(path: &std::path::Path, n: usize) -> Vec<String> {
     let Ok(content) = std::fs::read_to_string(path) else {
         return Vec::new();
     };

--- a/apps/yerd-gui/src-tauri/src/logging.rs
+++ b/apps/yerd-gui/src-tauri/src/logging.rs
@@ -1,0 +1,500 @@
+//! Per-session GUI diagnostic log + the tracing subscriber that feeds it.
+//!
+//! The GUI host process has no durable log of its own otherwise: under a bundled
+//! `.app` / login launch its stderr is discarded, so when the daemon won't come
+//! up there's nothing to inspect. This module installs a tracing subscriber that
+//! writes a single **truncate-on-launch** file at `{cache}/yerd-gui.log`
+//! (user-owned on macOS + Linux — no permission traps), capturing every
+//! command/action/warning/error in the daemon install/upgrade/start flow at
+//! `DEBUG`, interleaved with frontend lines pushed via [`gui_log`].
+//!
+//! Two reset triggers keep it from growing unbounded:
+//! - **Per session:** the file is truncated when the process starts (a fresh
+//!   `File::create` in [`SessionLog::create`]).
+//! - **Staleness:** if the file ages past [`MAX_AGE`] it is re-truncated on the
+//!   next write (a long-running GUI never accumulates more than an hour of logs).
+//!
+//! The `About → GUI Logs` dialog reads this file plus a tail of the daemon's own
+//! `yerdd.<date>.log` via [`get_gui_logs`].
+
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime};
+
+use tracing_subscriber::filter::{LevelFilter, Targets};
+use tracing_subscriber::fmt::{self, MakeWriter};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry;
+
+use crate::error::GuiError;
+
+/// Re-truncate the session log once it ages past this, so a long-running GUI
+/// session can never accumulate more than ~an hour of `DEBUG` output.
+const MAX_AGE: Duration = Duration::from_secs(60 * 60);
+
+/// Tail caps for the dialog. The session file is bounded by the 1 h reset but a
+/// busy hour at `DEBUG` can still be MBs, so the GUI tail is byte-bounded too.
+const GUI_TAIL_BYTES: u64 = 256 * 1024;
+const GUI_TAIL_LINES: usize = 2000;
+const DAEMON_TAIL_LINES: usize = 200;
+
+/// Mutable interior of a [`SessionLog`]: the current file handle and the instant
+/// it was (re)created, behind the lock so concurrent tracing writers serialise.
+struct State {
+    /// `None` if the file could not be (re)created — writes then degrade to a
+    /// no-op rather than erroring (logging must never break a UI flow).
+    file: Option<File>,
+    epoch: Instant,
+}
+
+/// A truncate-on-create, reset-when-stale session log file. Installed directly
+/// into the global `registry()` as a [`MakeWriter`]; the registry is `'static`
+/// and owns it for the whole process, so there is no flush guard to keep alive.
+pub struct SessionLog {
+    path: PathBuf,
+    max_age: Duration,
+    inner: Mutex<State>,
+}
+
+impl SessionLog {
+    /// Create the log at `path`, truncating any existing file (the per-session
+    /// reset). Best-effort: a create failure leaves `file: None` and the writer
+    /// degrades to a no-op.
+    fn create(path: PathBuf, max_age: Duration) -> Self {
+        let file = File::create(&path).ok();
+        Self {
+            path,
+            max_age,
+            inner: Mutex::new(State {
+                file,
+                epoch: Instant::now(),
+            }),
+        }
+    }
+}
+
+/// The per-event writer the fmt layer formats into. Holds the lock for the whole
+/// (single) log line, so the staleness check + write can't interleave with
+/// another thread's event.
+pub struct SessionWriter<'a>(std::sync::MutexGuard<'a, State>);
+
+impl io::Write for SessionWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.0.file.as_mut() {
+            Some(f) => f.write(buf),
+            None => Ok(buf.len()), // degrade silently; never error/panic
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self.0.file.as_mut() {
+            Some(f) => f.flush(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl<'a> MakeWriter<'a> for SessionLog {
+    type Writer = SessionWriter<'a>;
+    fn make_writer(&'a self) -> Self::Writer {
+        // Poison-tolerant: a panicked writer thread must not take logging down.
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        // Staleness reset — checked once per event (here), before the line's
+        // bytes, so it can never truncate between the partial writes of one line.
+        if state.epoch.elapsed() >= self.max_age {
+            state.file = File::create(&self.path).ok();
+            state.epoch = Instant::now();
+        }
+        SessionWriter(state)
+    }
+}
+
+/// Resolve `{cache}/yerd-gui.log`, creating the cache dir. Same dir as the
+/// daemon's `yerdd.<date>.log`, so the dialog reads both from one place.
+fn resolve_log_path() -> Result<PathBuf, GuiError> {
+    use yerd_platform::{ActivePaths, Paths};
+    let dirs = ActivePaths::new()
+        .resolve()
+        .map_err(|e| GuiError::internal(format!("cannot resolve cache dir: {e}")))?;
+    std::fs::create_dir_all(&dirs.cache)
+        .map_err(|e| GuiError::internal(format!("cannot create {}: {e}", dirs.cache.display())))?;
+    Ok(dirs.cache.join("yerd-gui.log"))
+}
+
+/// Install the GUI tracing subscriber: a compact stderr layer (so `cargo run`
+/// still shows logs live) plus the truncating session-file layer. Always
+/// `DEBUG`, independent of build profile, so release builds capture diagnostics
+/// too. Call once, as the first thing in `main()`. Degrades to stderr-only if
+/// the cache dir can't be resolved/created; never panics.
+pub fn init() {
+    let filter = Targets::new().with_default(LevelFilter::DEBUG);
+
+    let stderr_layer = fmt::layer()
+        .with_writer(io::stderr)
+        .compact()
+        .with_filter(filter.clone());
+
+    let file_layer = match resolve_log_path() {
+        Ok(path) => {
+            let session = SessionLog::create(path, MAX_AGE);
+            Some(
+                fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(session)
+                    .with_filter(filter),
+            )
+        }
+        Err(e) => {
+            eprintln!("yerd-gui: could not open session log: {e}; logging to stderr only");
+            None
+        }
+    };
+
+    // Swallow the `try_init` error: it only fires if a global subscriber already
+    // exists (nothing else in this crate installs one), the desired no-op.
+    let _ = registry().with(stderr_layer).with(file_layer).try_init();
+}
+
+/// Append a line to the session log from the frontend. Synchronous, infallible,
+/// no daemon IPC — it just emits into the global subscriber so the line lands in
+/// the same file, interleaved with the host's own events.
+#[tauri::command]
+pub fn gui_log(level: String, message: String) {
+    match level.as_str() {
+        "error" => tracing::error!(target: "yerd_gui::frontend", "{message}"),
+        "warn" => tracing::warn!(target: "yerd_gui::frontend", "{message}"),
+        "debug" => tracing::debug!(target: "yerd_gui::frontend", "{message}"),
+        _ => tracing::info!(target: "yerd_gui::frontend", "{message}"),
+    }
+}
+
+/// The GUI session log + a tail of the daemon's own rolling log, for the
+/// `About → GUI Logs` dialog. Paths are surfaced so the dialog can show "where".
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuiLogs {
+    gui_path: Option<String>,
+    gui_log: Vec<String>,
+    daemon_path: Option<String>,
+    daemon_log: Vec<String>,
+}
+
+/// Read both logs (off the runtime — filesystem work).
+#[tauri::command]
+pub async fn get_gui_logs() -> Result<GuiLogs, GuiError> {
+    tokio::task::spawn_blocking(read_gui_logs)
+        .await
+        .map_err(|e| GuiError::internal(format!("reading logs failed: {e}")))
+}
+
+fn read_gui_logs() -> GuiLogs {
+    use yerd_platform::{ActivePaths, Paths};
+    let cache = ActivePaths::new().resolve().ok().map(|d| d.cache);
+
+    let gui_path = cache.as_ref().map(|c| c.join("yerd-gui.log"));
+    let gui_log = gui_path
+        .as_ref()
+        .map(|p| tail_file_bounded(p, GUI_TAIL_BYTES, GUI_TAIL_LINES))
+        .unwrap_or_default();
+
+    // Reuse the daemon module's single rolling-log finder + line tail.
+    let daemon_path = cache
+        .as_ref()
+        .and_then(|c| crate::daemon::newest_rolling_log(c));
+    let daemon_log = daemon_path
+        .as_ref()
+        .map(|p| crate::daemon::tail_lines(p, DAEMON_TAIL_LINES))
+        .unwrap_or_default();
+
+    GuiLogs {
+        gui_path: gui_path.map(|p| p.display().to_string()),
+        gui_log,
+        daemon_path: daemon_path.map(|p| p.display().to_string()),
+        daemon_log,
+    }
+}
+
+/// Tail the last `max_lines` of `path`, reading at most the final `max_bytes`.
+/// Best-effort: a missing/unreadable file → empty. Decodes with
+/// `from_utf8_lossy` and drops the first (possibly partial) line when the read
+/// started mid-file, so a mid-codepoint seek start is safe. Takes no lock vs.
+/// the writer — a benign display race (worst case: a clipped final line).
+fn tail_file_bounded(path: &Path, max_bytes: u64, max_lines: usize) -> Vec<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let Ok(mut f) = File::open(path) else {
+        return Vec::new();
+    };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    let start = len.saturating_sub(max_bytes);
+    if start > 0 && f.seek(SeekFrom::Start(start)).is_err() {
+        return Vec::new();
+    }
+    let mut buf = Vec::new();
+    if f.read_to_end(&mut buf).is_err() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines: Vec<&str> = text.lines().collect();
+    if start > 0 && !lines.is_empty() {
+        lines.remove(0); // first line is partial when we seeked into the middle
+    }
+    let from = lines.len().saturating_sub(max_lines);
+    lines[from..].iter().map(|s| (*s).to_owned()).collect()
+}
+
+// ── Diagnostics payload (About → Diagnostics) ───────────────────────────────
+
+/// Cap on how many ERROR lines from each log to include in the payload.
+const DIAG_ERROR_LINES: usize = 100;
+/// Tail window scanned for ERROR lines (the daemon log can be a full day).
+const DIAG_SCAN_BYTES: u64 = 1024 * 1024;
+/// Trailing lines of the macOS self-repair log to include (it's capped at 64 KiB).
+const REPAIR_TAIL_LINES: usize = 200;
+/// Payload shape version, so a pasted blob is identifiable later.
+const DIAG_SCHEMA: u32 = 1;
+/// Bound for each diagnostics IPC probe — the daemon may be down/wedged (the
+/// common diagnostic case), and the probe must never hang the command.
+const DIAG_IPC_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Resolved on-disk locations, for the diagnostics payload.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagPaths {
+    config: Option<String>,
+    data: Option<String>,
+    state: Option<String>,
+    cache: Option<String>,
+    runtime: Option<String>,
+    socket: Option<String>,
+    socket_exists: bool,
+    yerdd: Option<String>,
+    gui_log: Option<String>,
+    daemon_log: Option<String>,
+    spawn_log: Option<String>,
+}
+
+/// A self-contained snapshot of everything useful for diagnosing why Yerd isn't
+/// behaving: versions, resolved paths, the service-manager configuration
+/// (`launchctl print` / `systemctl status`), the daemon's runtime status + doctor
+/// findings (when reachable), and the ERROR lines from each log.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Diagnostics {
+    /// Payload shape version, so a pasted blob is identifiable.
+    schema: u32,
+    /// Unix seconds when this snapshot was taken.
+    generated_at_unix: u64,
+    app_version: String,
+    host_os: String,
+    arch: String,
+    /// Whether the daemon answered an IPC probe. Diagnostics is most useful when
+    /// it's down, so this degrades gracefully and keeps every host-side field.
+    daemon_reachable: bool,
+    service_manager: String,
+    /// `launchctl print gui/<uid>/dev.yerd.daemon` (macOS) or `systemctl --user
+    /// status yerd` (Linux) — the daemon's service-manager configuration/status.
+    service_status: Option<String>,
+    pending_approval: bool,
+    translocated: bool,
+    daemon_registered_version: Option<String>,
+    daemon_version_conflict: Option<String>,
+    paths: DiagPaths,
+    /// The daemon's runtime status (ports, DNS, CA, PHP, services …) when
+    /// reachable. Carries no secrets — the CA section is path + fingerprint +
+    /// trust bool only, never key material. `None` when the daemon is down.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<Box<yerd_ipc::StatusReport>>,
+    /// Doctor findings (code / severity / title / detail / remedy). Empty when the
+    /// daemon is unreachable.
+    doctor: Vec<yerd_ipc::Diagnosis>,
+    gui_log_errors: Vec<String>,
+    daemon_log_errors: Vec<String>,
+    spawn_log_errors: Vec<String>,
+    /// Full tail of the macOS SMAppService self-repair trail — the GUI's only
+    /// record of re-registration attempts/outcomes (empty off macOS / when absent).
+    repair_log: Vec<String>,
+}
+
+/// Build the diagnostics JSON. Probes the daemon (bounded — it may be down),
+/// then does the host-side filesystem/subprocess gathering off the runtime.
+#[tauri::command]
+pub async fn get_diagnostics() -> Result<String, GuiError> {
+    let (status, doctor) = tokio::join!(probe_status(), probe_doctor());
+    tokio::task::spawn_blocking(move || build_diagnostics_json(status, doctor))
+        .await
+        .map_err(|e| GuiError::internal(format!("gathering diagnostics failed: {e}")))?
+}
+
+/// The daemon's runtime status via a bounded IPC probe, or `None` if unreachable.
+async fn probe_status() -> Option<Box<yerd_ipc::StatusReport>> {
+    match crate::ipc::exchange_timeout(&yerd_ipc::Request::Status, DIAG_IPC_TIMEOUT).await {
+        Ok(yerd_ipc::Response::Status { report }) => Some(report),
+        _ => None,
+    }
+}
+
+/// The doctor findings via a bounded IPC probe, or empty if unreachable.
+async fn probe_doctor() -> Vec<yerd_ipc::Diagnosis> {
+    match crate::ipc::exchange_timeout(&yerd_ipc::Request::Diagnose, DIAG_IPC_TIMEOUT).await {
+        Ok(yerd_ipc::Response::Diagnoses { items }) => items,
+        _ => Vec::new(),
+    }
+}
+
+fn build_diagnostics_json(
+    status: Option<Box<yerd_ipc::StatusReport>>,
+    doctor: Vec<yerd_ipc::Diagnosis>,
+) -> Result<String, GuiError> {
+    serde_json::to_string_pretty(&gather_diagnostics(status, doctor))
+        .map_err(|e| GuiError::internal(format!("serialize diagnostics: {e}")))
+}
+
+/// ERROR lines from the tail of `path` (best-effort; empty when absent).
+fn error_lines(path: Option<&Path>, max: usize) -> Vec<String> {
+    let Some(path) = path else {
+        return Vec::new();
+    };
+    // Scan a generous tail, then keep only the lines a `tracing` ERROR event
+    // prints (the level token appears verbatim in the compact/file format).
+    let mut errs: Vec<String> = tail_file_bounded(path, DIAG_SCAN_BYTES, usize::MAX)
+        .into_iter()
+        .filter(|l| l.contains("ERROR"))
+        .collect();
+    if errs.len() > max {
+        errs = errs.split_off(errs.len() - max);
+    }
+    errs
+}
+
+fn gather_diagnostics(
+    status: Option<Box<yerd_ipc::StatusReport>>,
+    doctor: Vec<yerd_ipc::Diagnosis>,
+) -> Diagnostics {
+    use yerd_platform::{ActivePaths, Paths};
+    let dirs = ActivePaths::new().resolve().ok();
+    let show = |p: &std::path::Path| p.display().to_string();
+
+    let socket = dirs.as_ref().map(|d| d.runtime.join("yerd.sock"));
+    let cache = dirs.as_ref().map(|d| d.cache.clone());
+    let gui_log = cache.as_ref().map(|c| c.join("yerd-gui.log"));
+    let daemon_log = cache
+        .as_ref()
+        .and_then(|c| crate::daemon::newest_rolling_log(c));
+    let spawn_log = cache.as_ref().map(|c| c.join("yerdd-spawn.log"));
+
+    let paths = DiagPaths {
+        config: dirs.as_ref().map(|d| show(&d.config)),
+        data: dirs.as_ref().map(|d| show(&d.data)),
+        state: dirs.as_ref().map(|d| show(&d.state)),
+        cache: cache.as_ref().map(|c| show(c)),
+        runtime: dirs.as_ref().map(|d| show(&d.runtime)),
+        socket_exists: socket.as_ref().map(|s| s.exists()).unwrap_or(false),
+        socket: socket.as_ref().map(|s| show(s)),
+        yerdd: crate::daemon::resolve_yerdd().as_ref().map(|p| show(p)),
+        gui_log: gui_log.as_ref().map(|p| show(p)),
+        daemon_log: daemon_log.as_ref().map(|p| show(p)),
+        spawn_log: spawn_log.as_ref().map(|p| show(p)),
+    };
+
+    let repair_log = cache
+        .as_ref()
+        .map(|c| crate::daemon::tail_lines(&c.join("yerd-gui-repair.log"), REPAIR_TAIL_LINES))
+        .unwrap_or_default();
+
+    let generated_at_unix = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    Diagnostics {
+        schema: DIAG_SCHEMA,
+        generated_at_unix,
+        app_version: env!("CARGO_PKG_VERSION").to_owned(),
+        host_os: std::env::consts::OS.to_owned(),
+        arch: std::env::consts::ARCH.to_owned(),
+        daemon_reachable: status.is_some(),
+        service_manager: crate::autostart::service_manager_label().to_owned(),
+        service_status: crate::autostart::service_status_text(),
+        pending_approval: crate::autostart::daemon_pending_approval(),
+        translocated: diag_translocated(),
+        daemon_registered_version: crate::autostart::daemon_registered_version(),
+        daemon_version_conflict: crate::autostart::daemon_version_conflict(),
+        paths,
+        status,
+        doctor,
+        gui_log_errors: error_lines(gui_log.as_deref(), DIAG_ERROR_LINES),
+        daemon_log_errors: error_lines(daemon_log.as_deref(), DIAG_ERROR_LINES),
+        spawn_log_errors: error_lines(spawn_log.as_deref(), DIAG_ERROR_LINES),
+        repair_log,
+    }
+}
+
+/// "Running from a non-installed location" (always false off macOS).
+fn diag_translocated() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        crate::autostart::is_translocated()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use std::io::Write as _;
+
+    use super::*;
+
+    #[test]
+    fn truncates_existing_file_on_create() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.log");
+        std::fs::write(&path, b"stale content from a previous session").unwrap();
+        let _log = SessionLog::create(path.clone(), MAX_AGE);
+        assert_eq!(
+            std::fs::read(&path).unwrap().len(),
+            0,
+            "create must truncate"
+        );
+    }
+
+    #[test]
+    fn resets_when_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.log");
+        // max_age = ZERO → every event is "stale" and re-truncates first.
+        let log = SessionLog::create(path.clone(), Duration::ZERO);
+        log.make_writer().write_all(b"a\n").unwrap();
+        log.make_writer().write_all(b"b\n").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "b\n");
+    }
+
+    #[test]
+    fn keeps_lines_within_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.log");
+        let log = SessionLog::create(path.clone(), MAX_AGE);
+        log.make_writer().write_all(b"a\n").unwrap();
+        log.make_writer().write_all(b"b\n").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "a\nb\n");
+    }
+
+    #[test]
+    fn bounded_tail_drops_partial_first_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.log");
+        std::fs::write(&path, b"line1\nline2\nline3\n").unwrap();
+        // Tiny byte budget forces a mid-file seek; the partial first line drops.
+        let out = tail_file_bounded(&path, 8, 100);
+        assert_eq!(out, vec!["line3".to_owned()]);
+    }
+}

--- a/apps/yerd-gui/src-tauri/src/logging.rs
+++ b/apps/yerd-gui/src-tauri/src/logging.rs
@@ -217,9 +217,11 @@ fn read_gui_logs() -> GuiLogs {
 
 /// Tail the last `max_lines` of `path`, reading at most the final `max_bytes`.
 /// Best-effort: a missing/unreadable file → empty. Decodes with
-/// `from_utf8_lossy` and drops the first (possibly partial) line when the read
-/// started mid-file, so a mid-codepoint seek start is safe. Takes no lock vs.
-/// the writer — a benign display race (worst case: a clipped final line).
+/// `from_utf8_lossy` and drops the first line **only when the read began
+/// mid-line** (the byte before the window isn't a newline), so a mid-codepoint
+/// seek start is safe while a boundary-aligned seek keeps its whole first line.
+/// Takes no lock vs. the writer — a benign display race (worst case: a clipped
+/// final line).
 fn tail_file_bounded(path: &Path, max_bytes: u64, max_lines: usize) -> Vec<String> {
     use std::io::{Read, Seek, SeekFrom};
     let Ok(mut f) = File::open(path) else {
@@ -227,20 +229,35 @@ fn tail_file_bounded(path: &Path, max_bytes: u64, max_lines: usize) -> Vec<Strin
     };
     let len = f.metadata().map(|m| m.len()).unwrap_or(0);
     let start = len.saturating_sub(max_bytes);
-    if start > 0 && f.seek(SeekFrom::Start(start)).is_err() {
+    // Seek one byte *before* the window (when not already at the file start) so
+    // the byte preceding it reveals whether the read began on a line boundary.
+    let seek_to = if start > 0 {
+        start.saturating_sub(1)
+    } else {
+        0
+    };
+    if start > 0 && f.seek(SeekFrom::Start(seek_to)).is_err() {
         return Vec::new();
     }
     let mut buf = Vec::new();
     if f.read_to_end(&mut buf).is_err() {
         return Vec::new();
     }
-    let text = String::from_utf8_lossy(&buf);
+    // When we seeked, `buf`'s first byte is the one before the window: a '\n'
+    // means the window starts exactly on a line boundary (first line is whole —
+    // keep it), anything else means the read began mid-line (first line is a
+    // partial tail — drop it). Peel that probe byte off either way.
+    let (drop_first, body) = match buf.split_first() {
+        Some((&first, rest)) if start > 0 => (first != b'\n', rest),
+        _ => (false, buf.as_slice()),
+    };
+    let text = String::from_utf8_lossy(body);
     let mut lines: Vec<&str> = text.lines().collect();
-    if start > 0 && !lines.is_empty() {
-        lines.remove(0); // first line is partial when we seeked into the middle
+    if drop_first && !lines.is_empty() {
+        lines.remove(0);
     }
     let from = lines.len().saturating_sub(max_lines);
-    lines[from..].iter().map(|s| (*s).to_owned()).collect()
+    lines.iter().skip(from).map(|s| (*s).to_owned()).collect()
 }
 
 // ── Diagnostics payload (About → Diagnostics) ───────────────────────────────
@@ -496,5 +513,17 @@ mod tests {
         // Tiny byte budget forces a mid-file seek; the partial first line drops.
         let out = tail_file_bounded(&path, 8, 100);
         assert_eq!(out, vec!["line3".to_owned()]);
+    }
+
+    #[test]
+    fn bounded_tail_keeps_boundary_aligned_first_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.log");
+        std::fs::write(&path, b"line1\nline2\nline3\n").unwrap();
+        // A 12-byte budget seeks to offset 6 — exactly after the first '\n', so the
+        // window opens on a line boundary and the whole first line must be kept
+        // (the old unconditional remove(0) wrongly dropped "line2" here).
+        let out = tail_file_bounded(&path, 12, 100);
+        assert_eq!(out, vec!["line2".to_owned(), "line3".to_owned()]);
     }
 }

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -123,6 +123,7 @@ fn main() {
             commands::delete_mails,
             commands::set_mail_port,
             commands::set_fallback_ports,
+            commands::set_dns_port,
             commands::set_mail_enabled,
             mail_window::show_mails_window,
             commands::status,

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod error;
 mod ipc;
 #[cfg(target_os = "macos")]
 mod launch_probe;
+mod logging;
 #[cfg(target_os = "macos")]
 mod mac_trust;
 mod mail_window;
@@ -37,6 +38,12 @@ const AUTOSTART_ARG: &str = "--autostarted";
 const TRAY_ICON_MAC: &[u8] = include_bytes!("../icons/tray-mac.png");
 
 fn main() {
+    // Install the per-session GUI log subscriber first, before any other startup
+    // work, so the macOS launch probe and the whole daemon install/start flow are
+    // captured. Truncates {cache}/yerd-gui.log for this session; degrades to
+    // stderr-only if the cache dir can't be resolved.
+    logging::init();
+
     // On Linux/Wayland the dock takes a window's icon from the .desktop file
     // matching its app_id — which GTK derives from the program name. Pin it
     // before GTK initialises so it deterministically matches `yerd-gui.desktop`
@@ -161,6 +168,9 @@ fn main() {
             autostart::setup_state,
             autostart::mark_onboarded,
             autostart::daemon_version_conflict,
+            logging::gui_log,
+            logging::get_gui_logs,
+            logging::get_diagnostics,
         ])
         .setup(setup_app)
         // Close-to-tray: hide the window instead of quitting; the tray's Quit
@@ -357,9 +367,10 @@ fn build_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
             // Start/Stop run off the event thread so a slow systemctl/launchctl
             // never stalls the menu; the GUI's status poller reflects the result.
             "daemon:start" => {
-                tauri::async_runtime::spawn(async {
+                let app = app.clone();
+                tauri::async_runtime::spawn(async move {
                     // Standalone start: nudge to Login Items if approval is pending.
-                    let _ = daemon::start(true).await;
+                    let _ = daemon::start(app, true).await;
                 });
             }
             "daemon:stop" => {

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -95,6 +95,7 @@ fn main() {
             commands::set_default_php,
             commands::update_php,
             commands::check_updates,
+            commands::cached_update_status,
             commands::set_update_channel,
             commands::apply_update,
             commands::set_php_settings,

--- a/apps/yerd-gui/src/App.vue
+++ b/apps/yerd-gui/src/App.vue
@@ -40,13 +40,13 @@ const standalone = computed(() => route.meta.standalone === true);
 
 // The daemon is bundled inside the app, so first run just *starts* it (no
 // download). If it's already reachable (e.g. autostarted, or `cargo run -p
-// yerdd`) we leave it alone — starting a second would compete for the socket.
+// yerdd`) we leave it alone - starting a second would compete for the socket.
 async function autoStart(): Promise<void> {
   try {
     await startDaemon();
   } catch (e) {
     // Non-fatal: on macOS the daemon may be pending Login-Items approval, or the
-    // user can start it from the General tab — both are surfaced there.
+    // user can start it from the General tab - both are surfaced there.
     toast.error("Couldn't start the Yerd daemon", (e as IpcError).message);
   } finally {
     await refresh();
@@ -55,11 +55,11 @@ async function autoStart(): Promise<void> {
 
 onMounted(async () => {
   // The dumps window and the standalone Mails viewer share this SPA bundle but
-  // must not duplicate the poller, the tray-nav listener, or the start flow —
+  // must not duplicate the poller, the tray-nav listener, or the start flow -
   // those belong to the main window.
   if (isDumpsWindow || isMailsWindow || standalone.value) return;
   start(4000);
-  // Run the probe FIRST and clear the splash before anything that can throw — a
+  // Run the probe FIRST and clear the splash before anything that can throw - a
   // failing `listen` below must never strand the user on the splash forever. One
   // shared probe decides between the first-run journey, the start screen, and
   // auto-starting the bundled daemon; the journey owns starting the daemon, so
@@ -91,7 +91,7 @@ onUnmounted(() => {
   <!-- The standalone mails window renders its viewer directly (no SideNav).
        Branch on the window label, not the route, to avoid the first-paint race. -->
   <MailsViewerView v-else-if="isMailsWindow" />
-  <!-- Other standalone routes render bare — no shell. -->
+  <!-- Other standalone routes render bare - no shell. -->
   <RouterView v-else-if="standalone" />
   <!-- First-run probe in flight: a brief splash so we never flash the wrong
        screen (the daemon-stopped panel) before the journey/app is decided. -->

--- a/apps/yerd-gui/src/assets/logo-mark.svg
+++ b/apps/yerd-gui/src/assets/logo-mark.svg
@@ -1,6 +1,6 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Yerd">
   <title>Yerd</title>
-  <!-- The bare Y mark in `currentColor`, transparent background — for inline /
+  <!-- The bare Y mark in `currentColor`, transparent background - for inline /
        monochrome use (sidebar, buttons, template tray icons). Inherits the
        surrounding text colour so it adapts to light/dark themes. -->
   <path d="M82 76 L128 140 L174 76 M128 140 L128 188"

--- a/apps/yerd-gui/src/components/AppShell.vue
+++ b/apps/yerd-gui/src/components/AppShell.vue
@@ -37,8 +37,17 @@ const pageSubtitle = computed(() =>
 
       <!-- Clip, don't scroll: every routed view is `h-full` and owns its own
            inner `overflow-y-auto`, so a scroll container here would be a second,
-           redundant scrollbar nested inside the view's own. -->
-      <main class="min-w-0 flex-1 overflow-hidden">
+           redundant scrollbar nested inside the view's own.
+           `relative` is load-bearing, not cosmetic: it makes `<main>` the
+           containing block for any absolutely-positioned descendant (e.g. the
+           Doctor page's `<thead class="sr-only">` a11y header). Without a
+           positioned ancestor, such an element's containing block is the
+           viewport, so it escapes this `overflow-hidden` clip, lands at its
+           static-flow Y deep in a scrolled list, and inflates the *document's*
+           scroll height — producing a second, window-level scrollbar that
+           reveals the desktop behind the transparent window. Pinning it here
+           keeps every stray abspos clipped to the content region. -->
+      <main class="relative min-w-0 flex-1 overflow-hidden">
         <!-- Daemon-dependent routes show the shared daemon-down screen when the
              socket is unreachable: the page's own header (no action buttons) plus
              the same hero the Overview uses. Overview / Settings / About are

--- a/apps/yerd-gui/src/components/AppShell.vue
+++ b/apps/yerd-gui/src/components/AppShell.vue
@@ -13,8 +13,8 @@ const { unreachable } = useDaemon();
 
 // Only three views work without a live daemon: Overview (owns its own
 // daemon-down hero + start affordance), Settings/General (can start/install it),
-// and About (pure build info). Every data-backed view — PHP, Sites, Tooling,
-// Services, Dumps, Mail, Doctor — is blocked by the daemon-down screen so none of
+// and About (pure build info). Every data-backed view - PHP, Sites, Tooling,
+// Services, Dumps, Mail, Doctor - is blocked by the daemon-down screen so none of
 // them mount, fire a doomed request, and strand the user on a blank table.
 const DAEMON_FREE = new Set(["overview", "general", "about"]);
 const showPanel = computed(
@@ -44,14 +44,14 @@ const pageSubtitle = computed(() =>
            positioned ancestor, such an element's containing block is the
            viewport, so it escapes this `overflow-hidden` clip, lands at its
            static-flow Y deep in a scrolled list, and inflates the *document's*
-           scroll height — producing a second, window-level scrollbar that
+           scroll height - producing a second, window-level scrollbar that
            reveals the desktop behind the transparent window. Pinning it here
            keeps every stray abspos clipped to the content region. -->
       <main class="relative min-w-0 flex-1 overflow-hidden">
         <!-- Daemon-dependent routes show the shared daemon-down screen when the
              socket is unreachable: the page's own header (no action buttons) plus
              the same hero the Overview uses. Overview / Settings / About are
-             exempt (see DAEMON_FREE) — they start/install it or degrade. -->
+             exempt (see DAEMON_FREE) - they start/install it or degrade. -->
         <div v-if="showPanel" class="flex h-full flex-col">
           <PageHeader :title="pageTitle" :subtitle="pageSubtitle" />
           <div class="flex-1 space-y-4 overflow-y-auto p-6">

--- a/apps/yerd-gui/src/components/ComingSoon.vue
+++ b/apps/yerd-gui/src/components/ComingSoon.vue
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
  */
 withDefaults(
   defineProps<{
-    /** Why it's disabled — shown on hover. */
+    /** Why it's disabled - shown on hover. */
     reason?: string;
     /** Render as a small inline pill instead of a button-sized control. */
     pill?: boolean;

--- a/apps/yerd-gui/src/components/DaemonDiagnosticsPanel.vue
+++ b/apps/yerd-gui/src/components/DaemonDiagnosticsPanel.vue
@@ -88,7 +88,7 @@ async function copy(): Promise<void> {
             </div>
             <div v-if="diagnostics.logTail.length">
               <p class="text-xs font-medium text-muted-foreground">
-                Daemon log — {{ diagnostics.logPath }}
+                Daemon log - {{ diagnostics.logPath }}
               </p>
               <pre
                 class="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 font-mono text-xs"

--- a/apps/yerd-gui/src/components/DaemonDownHero.vue
+++ b/apps/yerd-gui/src/components/DaemonDownHero.vue
@@ -18,7 +18,7 @@ import logoUrl from "@/assets/logo.svg";
 // instead of a blind toast, and on macOS pending-approval we show the Login-Items
 // affordance rather than a "failure".
 const { report } = useDaemon();
-const { starting, pendingApproval, diagnostics, start } = useDaemonStart();
+const { starting, activeLabel, pendingApproval, diagnostics, start } = useDaemonStart();
 const tld = computed(() => report.value?.tld ?? "test");
 
 function onStart(): void {
@@ -68,7 +68,7 @@ function onOpenLoginItems(): void {
 
     <Button :disabled="starting" @click="onStart">
       <Spinner v-if="starting" class="size-4" />
-      <Play v-else class="size-4" /> Start Yerd
+      <Play v-else class="size-4" /> {{ activeLabel ?? "Start Yerd" }}
     </Button>
   </Card>
 </template>

--- a/apps/yerd-gui/src/components/EnvironmentCard.vue
+++ b/apps/yerd-gui/src/components/EnvironmentCard.vue
@@ -27,7 +27,7 @@ import {
 import type { ElevateTarget, StatusReport } from "@/ipc/types";
 
 // Self-contained OS-privileges panel (CA trust, .test resolver, privileged
-// ports). Lives on the Doctor page alongside the health checks — it's the same
+// ports). Lives on the Doctor page alongside the health checks - it's the same
 // "diagnose and fix" job. Owns its own busy state and platform probe; reads the
 // shared daemon report and refreshes it after any elevation.
 const { connected, report, refresh: refreshStatus } = useDaemon();
@@ -40,9 +40,9 @@ const emit = defineEmits<{ elevated: [] }>();
 const busy = ref<string | null>(null);
 const platform = ref<string>("");
 // macOS only: set true when a GUI untrust left a system-wide trust (set via
-// `sudo yerd elevate trust`) in place — the GUI can't remove that without root.
+// `sudo yerd elevate trust`) in place - the GUI can't remove that without root.
 // Drives the trust row to hide the (now-useless) Revert button and show guidance.
-// Cleared once the CA actually reads not-trusted again — see the watcher below.
+// Cleared once the CA actually reads not-trusted again - see the watcher below.
 const systemTrustRemains = ref(false);
 const canElevate = computed(
   () => platform.value === "linux" || platform.value === "macos",
@@ -98,7 +98,7 @@ const envItems = computed<EnvItem[]>(() => {
       label: "Local CA trusted",
       value: r.ca.trusted_system,
       fixable: r.ca.trusted_system !== true,
-      // Hide Revert when a system-wide trust remains that the GUI can't undo —
+      // Hide Revert when a system-wide trust remains that the GUI can't undo -
       // a lingering Revert there does nothing and looks broken.
       unelevatable: r.ca.trusted_system === true && !(mac && systemTrustRemains.value),
       target: "trust",
@@ -126,7 +126,7 @@ const envItems = computed<EnvItem[]>(() => {
       // yet (the pf redirect would point at the unbound ports, and the CLI
       // refuses), so withhold the fix until working ports are set. On Linux the
       // ports fix is `setcap`, which binds 80/443 DIRECTLY and doesn't depend on
-      // the fallback ports — it's the correct degraded recovery, so keep it
+      // the fallback ports - it's the correct degraded recovery, so keep it
       // offered there.
       value: r.web_unbound ? false : portsElevated(r),
       fixable: r.web_unbound ? !mac : !portsElevated(r),
@@ -135,8 +135,8 @@ const envItems = computed<EnvItem[]>(() => {
       yes: r.port_redirect === true && privilegedFallback(r) ? "redirected" : "bound",
       no: r.web_unbound
         ? mac
-          ? "not serving — set working ports first"
-          : "not serving — elevate to bind 80/443"
+          ? "not serving - set working ports first"
+          : "not serving - elevate to bind 80/443"
         : "fell back to high ports",
       note:
         r.web_unbound && mac

--- a/apps/yerd-gui/src/components/NavLink.vue
+++ b/apps/yerd-gui/src/components/NavLink.vue
@@ -3,7 +3,7 @@ import type { Component } from "vue";
 import { RouterLink } from "vue-router";
 
 /**
- * One sidebar row. The icon is monochrome — muted by default, brand-indigo when
+ * One sidebar row. The icon is monochrome - muted by default, brand-indigo when
  * active or hovered. Colour is reserved for real status elsewhere; the nav never
  * uses it as decoration. Only the active row tints; the chip backgrounds the old
  * nav painted per-item are gone.

--- a/apps/yerd-gui/src/components/SideNav.vue
+++ b/apps/yerd-gui/src/components/SideNav.vue
@@ -21,7 +21,7 @@ import logoUrl from "@/assets/logo.svg";
 // Grouped left nav. Sections name the app's three real concerns: the runtime you
 // configure (Environment), what the daemon supervises (Services), and the system
 // itself (System). Overview sits above them as the home/dashboard. Icons are
-// monochrome — see NavLink; status colour is reserved for the pill below.
+// monochrome - see NavLink; status colour is reserved for the pill below.
 type Item = { to: string; label: string; icon: Component };
 
 const overview: Item = {
@@ -64,7 +64,7 @@ const { connected } = useDaemon();
   <nav
     class="flex h-full w-56 shrink-0 flex-col border-r bg-muted px-3 py-3 dark:bg-card/40"
   >
-    <!-- Brand lockup — the logo's indigo is the app's one accent. -->
+    <!-- Brand lockup - the logo's indigo is the app's one accent. -->
     <div class="mb-4 flex items-center gap-2 px-2 pt-1">
       <img :src="logoUrl" alt="" class="size-6 rounded-[7px]" />
       <span class="text-sm font-semibold tracking-tight">Yerd</span>

--- a/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
+++ b/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
@@ -154,7 +154,7 @@ async function appendInstallLog(lines: string[]): Promise<void> {
 }
 
 // A tool satisfies a prerequisite if it's Yerd-managed OR externally available
-// on the user's PATH — the scaffold can use either.
+// on the user's PATH - the scaffold can use either.
 function toolAvailable(id: string): boolean {
   return tools.value.some((t) => t.id === id && (t.installed || t.external));
 }
@@ -249,14 +249,14 @@ async function installAllMissing(): Promise<void> {
       if (!managedComposer.value) {
         toast.error(
           "Can't install the Laravel installer",
-          "Yerd needs its own Composer to build it — install Yerd's Composer, or run `composer global require laravel/installer`.",
+          "Yerd needs its own Composer to build it - install Yerd's Composer, or run `composer global require laravel/installer`.",
         );
         return;
       }
       if (!(await installPrereq("laravel"))) return;
     }
     // Reaching here means every missing tool installed successfully. Don't gate
-    // the toast on `ready` — it derives from the async `phpVersions` prop, which
+    // the toast on `ready` - it derives from the async `phpVersions` prop, which
     // may not have propagated yet.
     await nextTick();
     toast.success("Toolchain ready");
@@ -695,7 +695,7 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
       </div>
 
       <p v-if="kitChoice === 'none'" class="text-xs text-muted-foreground">
-        No starter kit — a plain Laravel application with no auth scaffolding.
+        No starter kit - a plain Laravel application with no auth scaffolding.
       </p>
     </div>
 

--- a/apps/yerd-gui/src/components/ui/AsyncState.vue
+++ b/apps/yerd-gui/src/components/ui/AsyncState.vue
@@ -10,7 +10,7 @@ import Spinner from "@/components/ui/Spinner.vue";
  * → the `#empty` slot (use an <EmptyState>); otherwise the default slot.
  *
  * This is what makes the daemon-down / loading / failed / empty stories
- * consistent across views — before this each view rolled its own spinner size,
+ * consistent across views - before this each view rolled its own spinner size,
  * silently swallowed poll errors, or left a blank table after a failed load.
  *
  * Pass `loading` only on the *first* load (no data yet); a background poll

--- a/apps/yerd-gui/src/components/ui/EmptyState.vue
+++ b/apps/yerd-gui/src/components/ui/EmptyState.vue
@@ -6,7 +6,7 @@ import type { Component } from "vue";
  * optional sentence, and a slot for a call-to-action. Replaces the per-view
  * hand-rolled "No X yet" panels so every empty list reads the same and always
  * invites the next action rather than showing a blank table. Copy should be an
- * invitation ("No sites yet — park a folder to get started"), never an apology.
+ * invitation ("No sites yet - park a folder to get started"), never an apology.
  */
 defineProps<{ icon?: Component; title: string; description?: string }>();
 </script>

--- a/apps/yerd-gui/src/composables/useDaemon.ts
+++ b/apps/yerd-gui/src/composables/useDaemon.ts
@@ -8,7 +8,7 @@ import type { StatusReport } from "@/ipc/types";
  *
  * One poller for the whole app (the global connection pill, the tray, and the
  * Services/PHP views all read this), so the daemon isn't hit by N independent
- * `status` loops. `status` doubles as the liveness probe — a successful report
+ * `status` loops. `status` doubles as the liveness probe - a successful report
  * means "connected". Started/stopped from App.vue's lifecycle.
  */
 const report = ref<StatusReport | null>(null);

--- a/apps/yerd-gui/src/composables/useDaemonStart.ts
+++ b/apps/yerd-gui/src/composables/useDaemonStart.ts
@@ -1,26 +1,36 @@
-import { onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { watch } from "vue";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 import { useDaemon } from "@/composables/useDaemon";
 import { daemonDiagnostics, IpcError, startDaemon } from "@/ipc/client";
 import type { DaemonDiagnostics } from "@/ipc/types";
+import { log } from "@/lib/log";
 
 /**
  * Shared "start the daemon, wait for it to actually connect, and diagnose on
- * failure" skeleton — used by the onboarding step 1 and the DaemonDownHero so
+ * failure" skeleton - used by the onboarding step 1 and the DaemonDownHero so
  * both surface the same diagnostics instead of a blind 20 s toast.
  *
- * Deliberately narrow: it owns only the timeout / fast-poll / diagnose state.
- * It does NOT own macOS login-item orchestration — that ordering is load-bearing
- * in onboarding (enable the GUI login item, *then* re-probe approval) and must
- * NOT run from the hero's "Start Yerd" button. Callers inject that via the
- * `beforeProbe` hook, which runs after `startDaemon` and returns whether the
- * daemon/GUI is now pending Login-Items approval.
+ * Deliberately narrow: it owns only the phase / timeout / fast-poll / diagnose
+ * state. It does NOT own macOS login-item orchestration - that ordering is
+ * load-bearing in onboarding (enable the GUI login item, *then* re-probe
+ * approval) and must NOT run from the hero's "Start Yerd" button. Callers inject
+ * that via the `beforeProbe` hook, which runs after `startDaemon` and returns
+ * whether the daemon/GUI is now pending Login-Items approval.
+ *
+ * Phased button: "starting the daemon" may install / upgrade / start it before
+ * the readiness wait. The Rust host emits a `daemon-start-phase` event as it
+ * walks those steps (each with its own per-phase timeout); we reflect it in
+ * `phase`, which drives a step label on the button ("Installing Daemon" →
+ * "Starting Daemon" → "Running Daemon"), resetting to idle on completion. The
+ * frontend owns the `running` (readiness wait) and `idle` phases; Rust owns the
+ * earlier ones.
  *
  * Per-instance state (declared here, in component setup scope) + a
- * component-scoped `watch`/`onUnmounted`, so the two mount sites don't share a
- * timer. `connected` only updates when the shared `useDaemon` poller ticks, so
- * the fast-poll actively drives `refresh()` rather than passively reading it.
+ * component-scoped `watch`/`onMounted`/`onUnmounted`, so the two mount sites
+ * don't share a timer OR a phase listener. `connected` only updates when the
+ * shared `useDaemon` poller ticks, so the fast-poll actively drives `refresh()`.
  */
 
 export interface StartOptions {
@@ -34,13 +44,39 @@ export interface StartOptions {
   beforeProbe?: () => Promise<boolean>;
 }
 
+/** Idle, the three Rust-driven service-manager phases, then the readiness wait. */
+export type StartPhase = "idle" | "installing" | "upgrading" | "starting" | "running";
+
 const POLL_MS = 500;
-const CEILING_MS = 20_000;
+// The readiness ("running") wait gets its own ceiling, separate from the
+// per-phase budgets the Rust host enforces on install/upgrade/start.
+const RUNNING_CEILING_MS = 20_000;
+
+/** Button label for a phase, or `null` when idle (callers fall back to their
+ * own resting label). */
+function labelFor(p: StartPhase): string | null {
+  switch (p) {
+    case "installing":
+      return "Installing Daemon";
+    case "upgrading":
+      return "Upgrading Daemon";
+    case "starting":
+      return "Starting Daemon";
+    case "running":
+      return "Running Daemon";
+    default:
+      return null;
+  }
+}
 
 export function useDaemonStart() {
   const { connected, refresh } = useDaemon();
 
-  const starting = ref(false);
+  // `phase` is the single source of truth; `starting` is derived so the existing
+  // `:disabled` / spinner bindings keep working unchanged.
+  const phase = ref<StartPhase>("idle");
+  const starting = computed(() => phase.value !== "idle");
+  const activeLabel = computed(() => labelFor(phase.value));
   const pendingApproval = ref(false);
   const diagnostics = ref<DaemonDiagnostics | null>(null);
 
@@ -49,6 +85,11 @@ export function useDaemonStart() {
   // Set once the component unmounts so an in-flight `await` (refresh/diagnose)
   // doesn't resume and reschedule a timer / mutate a dead component.
   let disposed = false;
+  // True only from `start()` entry until `startDaemon` resolves - the window in
+  // which the Rust host owns the phase label. Per-instance, so a non-initiating
+  // mounted instance ignores the global phase event.
+  let acceptRustPhases = false;
+  let unlistenPhase: UnlistenFn | undefined;
 
   function clearPoll(): void {
     if (pollTimer) {
@@ -59,12 +100,13 @@ export function useDaemonStart() {
 
   function reset(): void {
     clearPoll();
-    starting.value = false;
+    acceptRustPhases = false;
+    phase.value = "idle";
     pendingApproval.value = false;
     diagnostics.value = null;
   }
 
-  /** True once the daemon connected or the component went away — never show a
+  /** True once the daemon connected or the component went away - never show a
    * failure panel in that case (avoids "Running" + failure panel together). */
   function stale(): boolean {
     return disposed || connected.value === true;
@@ -73,7 +115,7 @@ export function useDaemonStart() {
   async function diagnose(startError?: string): Promise<void> {
     try {
       const d = await daemonDiagnostics(startError);
-      if (stale()) return; // connected/unmounted while gathering — don't contradict
+      if (stale()) return; // connected/unmounted while gathering - don't contradict
       // A registered-but-unapproved daemon isn't a failure: show the approval
       // affordance, not the diagnostics panel.
       if (d.pendingApproval) {
@@ -84,7 +126,7 @@ export function useDaemonStart() {
       }
     } catch {
       if (stale()) return;
-      // Diagnostics gathering itself failed — still surface something actionable
+      // Diagnostics gathering itself failed - still surface something actionable
       // rather than a silent dead-end.
       diagnostics.value = minimalDiagnostics(
         startError ?? "The daemon didn't come up, and diagnostics couldn't be gathered.",
@@ -95,15 +137,17 @@ export function useDaemonStart() {
   function beginPolling(startError?: string): void {
     clearPoll();
     elapsed = 0;
+    phase.value = "running"; // the readiness wait - frontend-owned
     const tick = async (): Promise<void> => {
       if (disposed || !starting.value) return;
       await refresh(); // drives the shared poller; updates `connected`
       if (disposed || !starting.value) return; // re-check after the await
       if (connected.value === true) return; // the watch below clears state
       elapsed += POLL_MS;
-      if (elapsed >= CEILING_MS) {
+      if (elapsed >= RUNNING_CEILING_MS) {
+        log.warn("daemon start: readiness wait timed out");
         await diagnose(startError);
-        starting.value = false;
+        phase.value = "idle";
         return;
       }
       pollTimer = setTimeout(() => void tick(), POLL_MS);
@@ -113,18 +157,27 @@ export function useDaemonStart() {
 
   async function start(opts: StartOptions = {}): Promise<void> {
     reset();
-    starting.value = true;
+    // Show the spinner immediately on click: the macOS plan can spend a few
+    // seconds probing launchctl before the first phase event arrives.
+    phase.value = "starting";
+    acceptRustPhases = true;
+    log.info("daemon start requested");
     let startError: string | undefined;
     try {
       await startDaemon(opts.nudge ?? false);
     } catch (e) {
       // Launch threw outright (missing sidecar, translocation refusal, register
-      // failure) — capture the message and diagnose immediately.
+      // failure) - capture the message and diagnose immediately.
+      acceptRustPhases = false;
       startError = (e as IpcError).message;
+      log.error(`daemon start failed: ${startError}`);
       await diagnose(startError);
-      starting.value = false;
+      phase.value = "idle";
       return;
     }
+    // Rust is done walking its steps; the frontend now owns running/idle so a
+    // straggler phase event can't flip the label back.
+    acceptRustPhases = false;
     // Let the caller enable login items / re-probe approval, then read it.
     if (opts.beforeProbe) {
       try {
@@ -135,12 +188,12 @@ export function useDaemonStart() {
     }
     await refresh();
     if (connected.value === true) {
-      starting.value = false;
+      phase.value = "idle";
       return;
     }
     if (pendingApproval.value) {
       // Can't connect until the user approves; show the affordance, not a panel.
-      starting.value = false;
+      phase.value = "idle";
       return;
     }
     beginPolling(startError);
@@ -149,22 +202,49 @@ export function useDaemonStart() {
   // Once the daemon is actually reachable, drop any failure/approval UI.
   watch(connected, (c) => {
     if (c === true) {
-      starting.value = false;
+      acceptRustPhases = false;
+      phase.value = "idle";
       pendingApproval.value = false;
       diagnostics.value = null;
       clearPoll();
+      log.debug("daemon connected");
+    }
+  });
+
+  // One always-on phase listener per instance; gated by `acceptRustPhases` so
+  // only the instance whose `start()` is in flight reflects the event.
+  onMounted(async () => {
+    try {
+      const un = await listen<string>("daemon-start-phase", (e) => {
+        if (!acceptRustPhases || disposed) return;
+        const p = e.payload;
+        if (p === "installing" || p === "upgrading" || p === "starting") {
+          phase.value = p;
+          log.debug(`daemon start phase: ${p}`);
+        }
+      });
+      // If we unmounted while `listen` was awaiting, onUnmounted already ran (and
+      // saw no handle) - drop this now-orphaned registration instead of leaking it.
+      if (disposed) un();
+      else unlistenPhase = un;
+    } catch {
+      /* events unavailable (non-Tauri/test context) - phases just won't update */
     }
   });
 
   onUnmounted(() => {
     disposed = true;
     clearPoll();
+    if (unlistenPhase) {
+      unlistenPhase();
+      unlistenPhase = undefined;
+    }
   });
 
-  return { starting, pendingApproval, diagnostics, start, reset };
+  return { starting, phase, activeLabel, pendingApproval, diagnostics, start, reset };
 }
 
-/** Minimal fallback when `daemon_diagnostics` itself can't run — the message
+/** Minimal fallback when `daemon_diagnostics` itself can't run - the message
  * doubles as the single actionable hint so the panel is never empty. */
 function minimalDiagnostics(message: string): DaemonDiagnostics {
   return {

--- a/apps/yerd-gui/src/composables/useFallbackPorts.ts
+++ b/apps/yerd-gui/src/composables/useFallbackPorts.ts
@@ -8,7 +8,7 @@ import { IpcError, restartDaemon, setFallbackPorts } from "@/ipc/client";
  *
  * The restart detection is deliberately careful (see `saveAndRestart`): the
  * shared `useDaemon` poller runs every 4 s, so a fast re-exec can complete
- * inside one gap — meaning a passive watch on `connected` could never observe
+ * inside one gap - meaning a passive watch on `connected` could never observe
  * the drop, and `connected === true` holds at *both* ends of a restart. We
  * therefore actively drive `refresh()` and key completion on a change in the
  * daemon's per-process `boot_id` (the re-exec preserves the pid and
@@ -42,7 +42,7 @@ export function useFallbackPorts() {
   function validate(http: number, https: number): string | null {
     for (const p of [http, https]) {
       if (!Number.isInteger(p) || p < MIN_PORT || p > MAX_PORT) {
-        return `Ports must be whole numbers between ${MIN_PORT} and ${MAX_PORT} — a privileged port like 80/443 would need elevation, which the fallback exists to avoid.`;
+        return `Ports must be whole numbers between ${MIN_PORT} and ${MAX_PORT} - a privileged port like 80/443 would need elevation, which the fallback exists to avoid.`;
       }
     }
     if (http === https) {
@@ -54,7 +54,7 @@ export function useFallbackPorts() {
   /**
    * Persist the new fallback ports and restart the daemon, then wait for it to
    * come back and report whether it is now serving. The daemon rejects invalid
-   * or elevated changes (thrown `IpcError`) — surfaced as `{ ok: false }` with
+   * or elevated changes (thrown `IpcError`) - surfaced as `{ ok: false }` with
    * its message; the caller never has to try/catch.
    */
   async function saveAndRestart(http: number, https: number): Promise<SaveResult> {
@@ -78,7 +78,7 @@ export function useFallbackPorts() {
       // The restart tears down the socket, so `restartDaemon()` can reject with
       // a dropped-connection error *even though the restart is underway* (the
       // daemon may close the connection around its re-exec). The boot_id poll
-      // below is the authoritative completion check, so don't bail here — mirror
+      // below is the authoritative completion check, so don't bail here - mirror
       // GeneralView's restart flow, which also tolerates the throw. A daemon that
       // genuinely didn't restart simply makes the poll time out.
     }
@@ -102,7 +102,7 @@ export function useFallbackPorts() {
       const u = report.value.web_unbound;
       return {
         ok: false,
-        message: `Yerd still couldn't bind ports ${u.http}/${u.https} — they may be in use too. Try different ports.`,
+        message: `Yerd still couldn't bind ports ${u.http}/${u.https} - they may be in use too. Try different ports.`,
       };
     }
     return {

--- a/apps/yerd-gui/src/composables/useFallbackPorts.ts
+++ b/apps/yerd-gui/src/composables/useFallbackPorts.ts
@@ -168,6 +168,18 @@ export function useFallbackPorts() {
           message: `Yerd still couldn't bind the DNS port ${report.value.dns_unbound} - it may be in use too. Try a different port.`,
         };
       }
+      // Mail has no test-bind and no dedicated `*_unbound` field; detect a busy
+      // port via the SMTP listener state (`enabled && !listening` = port busy).
+      if (
+        changes.mail != null &&
+        report.value.mail?.enabled === true &&
+        report.value.mail.listening === false
+      ) {
+        return {
+          ok: false,
+          message: `Yerd couldn't bind the mail port ${changes.mail} - it may be in use. Try a different port.`,
+        };
+      }
       return { ok: true };
     }
     return {
@@ -176,21 +188,11 @@ export function useFallbackPorts() {
     };
   }
 
-  /**
-   * Thin convenience wrapper for the common web-only case (a fallback pair).
-   * Equivalent to `applyAndRestart({ web: { http, https } })`.
-   */
-  function saveAndRestart(http: number, https: number): Promise<SaveResult> {
-    return applyAndRestart({ web: { http, https } });
-  }
-
   return {
     validate,
     validateLoopback,
     applyAndRestart,
-    saveAndRestart,
     MIN_PORT,
     MAX_PORT,
-    MIN_LOOPBACK_PORT,
   };
 }

--- a/apps/yerd-gui/src/composables/useFallbackPorts.ts
+++ b/apps/yerd-gui/src/composables/useFallbackPorts.ts
@@ -1,12 +1,20 @@
 import { useDaemon } from "@/composables/useDaemon";
-import { IpcError, restartDaemon, setFallbackPorts } from "@/ipc/client";
+import {
+  IpcError,
+  restartDaemon,
+  setDnsPort,
+  setDumpsPort,
+  setFallbackPorts,
+  setMailPort,
+} from "@/ipc/client";
 
 /**
- * Shared logic for editing the daemon's rootless HTTP/HTTPS fallback ports,
- * used by BOTH the Settings editor and the onboarding degraded-port panel so
- * the validate → save → restart → re-check flow can't diverge between them.
+ * Shared logic for editing the daemon's ports (rootless HTTP/HTTPS fallback,
+ * DNS, mail, dumps), used by BOTH the Settings "Application Ports" editor and
+ * the onboarding degraded-port panel so the validate → save → restart → re-check
+ * flow can't diverge between them.
  *
- * The restart detection is deliberately careful (see `saveAndRestart`): the
+ * The restart detection is deliberately careful (see `applyAndRestart`): the
  * shared `useDaemon` poller runs every 4 s, so a fast re-exec can complete
  * inside one gap - meaning a passive watch on `connected` could never observe
  * the drop, and `connected === true` holds at *both* ends of a restart. We
@@ -15,17 +23,34 @@ import { IpcError, restartDaemon, setFallbackPorts } from "@/ipc/client";
  * `uptime_secs` has only one-second granularity, so neither is reliable).
  */
 
+/** Minimum for the rootless HTTP/HTTPS fallback pair - a privileged port like
+ *  80/443 would itself need elevation, which the fallback exists to avoid. */
 export const MIN_PORT = 1024;
 export const MAX_PORT = 65535;
+/** Minimum for the DNS/mail/dumps loopback ports, which may legitimately be
+ *  below 1024 (the daemon binds them directly, no elevation involved). */
+export const MIN_LOOPBACK_PORT = 1;
 
 const POLL_MS = 500;
 const CEILING_MS = 20_000;
 
 export interface SaveResult {
-  /** True once the daemon came back up serving (no longer degraded). */
+  /** True once the daemon came back up without the changed port still degraded. */
   ok: boolean;
   /** A user-facing reason when `ok` is false. */
   message?: string;
+}
+
+/** A set of port changes to apply. Omit a field to leave that port untouched. */
+export interface PortChanges {
+  /** Rootless HTTP/HTTPS fallback pair. */
+  web?: { http: number; https: number };
+  /** DNS responder port. */
+  dns?: number;
+  /** Mail-capture SMTP port. */
+  mail?: number;
+  /** Dump-server port. */
+  dumps?: number;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -36,13 +61,14 @@ export function useFallbackPorts() {
   const { report, connected, refresh } = useDaemon();
 
   /**
-   * Validate a candidate pair. Returns an error string to show the user, or
-   * `null` when the pair is acceptable. Mirrors the daemon's own `validate()`.
+   * Validate a candidate fallback pair. Returns an error string to show the
+   * user, or `null` when the pair is acceptable. Mirrors the daemon's own
+   * `validate()`.
    */
   function validate(http: number, https: number): string | null {
     for (const p of [http, https]) {
       if (!Number.isInteger(p) || p < MIN_PORT || p > MAX_PORT) {
-        return `Ports must be whole numbers between ${MIN_PORT} and ${MAX_PORT} - a privileged port like 80/443 would need elevation, which the fallback exists to avoid.`;
+        return `The HTTP and HTTPS ports must be whole numbers between ${MIN_PORT} and ${MAX_PORT} - a privileged port like 80/443 would need elevation, which the fallback exists to avoid.`;
       }
     }
     if (http === https) {
@@ -51,40 +77,69 @@ export function useFallbackPorts() {
     return null;
   }
 
-  /**
-   * Persist the new fallback ports and restart the daemon, then wait for it to
-   * come back and report whether it is now serving. The daemon rejects invalid
-   * or elevated changes (thrown `IpcError`) - surfaced as `{ ok: false }` with
-   * its message; the caller never has to try/catch.
-   */
-  async function saveAndRestart(http: number, https: number): Promise<SaveResult> {
-    const local = validate(http, https);
-    if (local) return { ok: false, message: local };
+  /** Validate a single loopback port (DNS/mail/dumps): a whole number 1-65535. */
+  function validateLoopback(label: string, port: number): string | null {
+    if (!Number.isInteger(port) || port < MIN_LOOPBACK_PORT || port > MAX_PORT) {
+      return `The ${label} port must be a whole number between ${MIN_LOOPBACK_PORT} and ${MAX_PORT}.`;
+    }
+    return null;
+  }
 
-    // Snapshot the current process id so we can tell the restarted daemon apart
+  /**
+   * Persist a set of port changes and restart the daemon, then wait for it to
+   * come back and report whether the changed ports are now bound. The daemon
+   * rejects invalid changes (thrown `IpcError`) - surfaced as `{ ok: false }`
+   * with its message; the caller never has to try/catch.
+   */
+  async function applyAndRestart(changes: PortChanges): Promise<SaveResult> {
+    // 1. Pre-validate everything BEFORE any IPC call, so a bad value never
+    //    persists a partial change.
+    if (changes.web) {
+      const err = validate(changes.web.http, changes.web.https);
+      if (err) return { ok: false, message: err };
+    }
+    if (changes.dns != null) {
+      const err = validateLoopback("DNS", changes.dns);
+      if (err) return { ok: false, message: err };
+    }
+    if (changes.mail != null) {
+      const err = validateLoopback("mail", changes.mail);
+      if (err) return { ok: false, message: err };
+    }
+    if (changes.dumps != null) {
+      const err = validateLoopback("dumps", changes.dumps);
+      if (err) return { ok: false, message: err };
+    }
+
+    // Snapshot the current process so we can tell the restarted daemon apart
     // from the still-running one. `boot_id` is the reliable key; fall back to
     // `uptime_secs` only if an older daemon omits it.
     const baselineBootId = report.value?.boot_id ?? null;
     const baselineUptime = report.value?.uptime_secs ?? Number.MAX_SAFE_INTEGER;
 
+    // 2. Apply the setters. Order matters: `setDumpsPort` is the only setter
+    //    that test-binds at call time (can throw PortInUse), so do it FIRST -
+    //    a busy dumps port then aborts before any other config is written to
+    //    disk. The rest only clone→validate→save (fail only on a disk error).
     try {
-      await setFallbackPorts(http, https);
+      if (changes.dumps != null) await setDumpsPort(changes.dumps);
+      if (changes.web) await setFallbackPorts(changes.web.http, changes.web.https);
+      if (changes.dns != null) await setDnsPort(changes.dns);
+      if (changes.mail != null) await setMailPort(changes.mail);
     } catch (e) {
       return { ok: false, message: (e as IpcError).message };
     }
+
+    // 3. Restart and wait for the new process.
     try {
       await restartDaemon();
     } catch {
       // The restart tears down the socket, so `restartDaemon()` can reject with
-      // a dropped-connection error *even though the restart is underway* (the
-      // daemon may close the connection around its re-exec). The boot_id poll
-      // below is the authoritative completion check, so don't bail here - mirror
-      // GeneralView's restart flow, which also tolerates the throw. A daemon that
-      // genuinely didn't restart simply makes the poll time out.
+      // a dropped-connection error *even though the restart is underway*. The
+      // boot_id poll below is the authoritative completion check, so don't bail
+      // here - a daemon that genuinely didn't restart simply makes it time out.
     }
 
-    // Actively poll until the *restarted* daemon answers (fresh boot_id), then
-    // read its degraded state. Bounded so a daemon that never returns can't hang.
     let elapsed = 0;
     while (elapsed < CEILING_MS) {
       await sleep(POLL_MS);
@@ -96,14 +151,24 @@ export function useFallbackPorts() {
           ? report.value.boot_id != null && report.value.boot_id !== baselineBootId
           : report.value.uptime_secs < baselineUptime;
       if (!restarted) continue;
-      if (report.value.web_unbound == null) {
-        return { ok: true };
+
+      // 4. Scope the degraded check to what actually changed: a mail/dumps-only
+      //    save must not fail just because an *unrelated, pre-existing*
+      //    web/DNS conflict is still present.
+      if (changes.web && report.value.web_unbound != null) {
+        const u = report.value.web_unbound;
+        return {
+          ok: false,
+          message: `Yerd still couldn't bind ports ${u.http}/${u.https} - they may be in use too. Try different ports.`,
+        };
       }
-      const u = report.value.web_unbound;
-      return {
-        ok: false,
-        message: `Yerd still couldn't bind ports ${u.http}/${u.https} - they may be in use too. Try different ports.`,
-      };
+      if (changes.dns != null && report.value.dns_unbound != null) {
+        return {
+          ok: false,
+          message: `Yerd still couldn't bind the DNS port ${report.value.dns_unbound} - it may be in use too. Try a different port.`,
+        };
+      }
+      return { ok: true };
     }
     return {
       ok: false,
@@ -111,5 +176,21 @@ export function useFallbackPorts() {
     };
   }
 
-  return { validate, saveAndRestart, MIN_PORT, MAX_PORT };
+  /**
+   * Thin convenience wrapper for the common web-only case (a fallback pair).
+   * Equivalent to `applyAndRestart({ web: { http, https } })`.
+   */
+  function saveAndRestart(http: number, https: number): Promise<SaveResult> {
+    return applyAndRestart({ web: { http, https } });
+  }
+
+  return {
+    validate,
+    validateLoopback,
+    applyAndRestart,
+    saveAndRestart,
+    MIN_PORT,
+    MAX_PORT,
+    MIN_LOOPBACK_PORT,
+  };
 }

--- a/apps/yerd-gui/src/composables/useFallbackPorts.ts
+++ b/apps/yerd-gui/src/composables/useFallbackPorts.ts
@@ -133,11 +133,17 @@ export function useFallbackPorts() {
     // 3. Restart and wait for the new process.
     try {
       await restartDaemon();
-    } catch {
+    } catch (e) {
       // The restart tears down the socket, so `restartDaemon()` can reject with
-      // a dropped-connection error *even though the restart is underway*. The
-      // boot_id poll below is the authoritative completion check, so don't bail
-      // here - a daemon that genuinely didn't restart simply makes it time out.
+      // a dropped-connection error *even though the restart is underway*. That
+      // unreachable case is expected - the boot_id poll below is the
+      // authoritative completion check, so don't bail on it. Any *other* error
+      // means the daemon refused the restart (it never re-execs, so the poll
+      // would only time out with a useless message) - surface it immediately.
+      const err = e as IpcError;
+      if (!err.unreachable) {
+        return { ok: false, message: err.message };
+      }
     }
 
     let elapsed = 0;

--- a/apps/yerd-gui/src/composables/useOnboarding.ts
+++ b/apps/yerd-gui/src/composables/useOnboarding.ts
@@ -9,7 +9,7 @@ import { IpcError, markOnboarded, setupState, status } from "@/ipc/client";
 // The journey is shown only on a never-set-up machine: not previously onboarded,
 // no existing config/PHP/service, and the daemon currently unreachable. A real
 // `yerd uninstall` wipes the config dir (which holds the onboarding flag), so the
-// journey reappears afterwards — a plain Trash-drag of the app leaves the setup
+// journey reappears afterwards - a plain Trash-drag of the app leaves the setup
 // intact and correctly does not.
 
 /** True until the one-time probe resolves; gates the first paint. */

--- a/apps/yerd-gui/src/composables/usePoll.ts
+++ b/apps/yerd-gui/src/composables/usePoll.ts
@@ -14,14 +14,14 @@ export interface PollHandle<T> {
  * Poll `fn` every `intervalMs` while the component is mounted.
  *
  * Discipline that matters for the daemon (each `status` call reads the trust
- * store and live FPM state — see the plan's "poll cost" note):
+ * store and live FPM state - see the plan's "poll cost" note):
  *   - never overlaps in-flight calls,
  *   - pauses entirely while the document is hidden (background tab / tray),
  *   - stops on unmount (no leaked timers).
  *
  * Default cadence is 4s; callers should not go below ~3s for `status`.
  *
- * `pollWhileHidden` keeps polling when the document is hidden — needed for the
+ * `pollWhileHidden` keeps polling when the document is hidden - needed for the
  * standalone dumps window, which is usually unfocused (and reports `hidden` when
  * minimised/occluded) yet must keep streaming. Default `false` so the shared
  * status poller is unaffected.

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -21,6 +21,7 @@ import type {
   DumpsResponse,
   DumpsStatusResponse,
   ElevateTarget,
+  GuiLogs,
   InfoResponse,
   JobProgressResponse,
   MailDetail,
@@ -111,7 +112,7 @@ export async function listParked(): Promise<string[]> {
 
 /**
  * Un-park a directory root: removes it from the parked set and re-scans. Pass a
- * path verbatim from {@link listParked} — the daemon matches it exactly (no
+ * path verbatim from {@link listParked} - the daemon matches it exactly (no
  * canonicalisation), so a folder deleted from disk is still removable.
  */
 export async function unpark(path: string): Promise<void> {
@@ -177,7 +178,7 @@ export async function updatePhp(version: PhpVersion | null): Promise<void> {
 /**
  * Check for a Yerd self-update. `channel` overrides the saved preference for
  * this check only; omit (undefined) to use the saved default. Tolerant of
- * network failure — the daemon serves its cache (`source: "cached"`).
+ * network failure - the daemon serves its cache (`source: "cached"`).
  */
 export async function checkUpdates(channel?: UpdateChannel): Promise<UpdateStatusResponse> {
   return ensureOk(
@@ -194,7 +195,7 @@ export async function setUpdateChannel(channel: UpdateChannel): Promise<void> {
  * Download + verify the latest update and launch the applier. The GUI quits so
  * its bundle can be swapped; the applier relaunches it when done. `channel`
  * overrides the saved preference for this apply only. The returned promise
- * typically never resolves (the app exits) — callers should show an "updating"
+ * typically never resolves (the app exits) - callers should show an "updating"
  * state before awaiting and treat a thrown error as a staging failure.
  */
 export async function applyUpdate(channel?: UpdateChannel): Promise<void> {
@@ -258,7 +259,7 @@ export async function listTools(): Promise<ToolStatus[]> {
   return r.tools;
 }
 
-/** Install (or update to latest) a dev tool by id. Slow — downloads + verifies. */
+/** Install (or update to latest) a dev tool by id. Slow - downloads + verifies. */
 export async function installTool(tool: string): Promise<void> {
   ensureOk(await call<Response>("install_tool", { tool }));
 }
@@ -276,7 +277,7 @@ export async function installToolStreamed(tool: string): Promise<string> {
 
 /**
  * Poll a job to completion, delivering each batch of new log lines via
- * `onLines`. Resolves with the latest {@link JobProgressResponse} — either the
+ * `onLines`. Resolves with the latest {@link JobProgressResponse} - either the
  * terminal one, or the last seen when `shouldContinue()` returns false (e.g. the
  * viewing modal closed). `onLines` is the only log-delivery channel; the
  * returned `.log` is just the final batch.
@@ -473,7 +474,7 @@ export async function protocolVersion(): Promise<number> {
   return call<number>("protocol_version");
 }
 
-/** Host OS, e.g. `"linux"` / `"macos"` / `"windows"` — gates platform UI. */
+/** Host OS, e.g. `"linux"` / `"macos"` / `"windows"` - gates platform UI. */
 export async function hostPlatform(): Promise<string> {
   return call<string>("host_platform");
 }
@@ -527,7 +528,7 @@ export async function elevate(target: ElevateTarget): Promise<void> {
 }
 
 /**
- * Run `yerd elevate` with no target under OS elevation — applies every step
+ * Run `yerd elevate` with no target under OS elevation - applies every step
  * (trust, resolver, ports) in one prompt.
  */
 export async function elevateAll(): Promise<void> {
@@ -546,7 +547,7 @@ export async function elevateResolverPorts(): Promise<void> {
  * Revert `elevate` for `target` under the same OS elevation (`yerd unelevate
  * <target>`). On macOS, unelevating the resolver restores the pre-Yerd resolver
  * from its backup (or removes Yerd's file if none). `ports` is reversible on
- * macOS only — callers gate the button accordingly.
+ * macOS only - callers gate the button accordingly.
  */
 export async function unelevate(target: ElevateTarget): Promise<void> {
   await call<void>("unelevate", { target });
@@ -563,7 +564,7 @@ export async function trustCa(): Promise<void> {
 
 /**
  * Remove the current user's trust of the local CA (macOS only). Resolves to
- * `true` if the CA is *still* trusted afterwards — i.e. a system-wide trust set
+ * `true` if the CA is *still* trusted afterwards - i.e. a system-wide trust set
  * via the terminal remains, which the GUI can't remove without root.
  */
 export async function untrustCa(): Promise<boolean> {
@@ -586,7 +587,7 @@ export async function stopDaemon(): Promise<void> {
 }
 
 /**
- * Gather diagnostics explaining why the daemon isn't up — service-manager
+ * Gather diagnostics explaining why the daemon isn't up - service-manager
  * status, the daemon's rolling-log tail, binary/socket checks, and host-computed
  * hints. Pass the message a prior `startDaemon` threw (if any) so the
  * never-launched cases (missing binary, translocation, register failure) carry
@@ -718,4 +719,22 @@ export async function showDumpsWindow(): Promise<void> {
 
 function emptyDumpCounts(): DumpCounts {
   return { dumps: 0, queries: 0, jobs: 0, views: 0, requests: 0, logs: 0, cache: 0, http: 0 };
+}
+
+// ── GUI diagnostic logs (host-only; no daemon IPC) ──────────────────────────
+
+/** Append a line to the per-session GUI host log ({cache}/yerd-gui.log). */
+export async function guiLog(level: string, message: string): Promise<void> {
+  await call<void>("gui_log", { level, message });
+}
+
+/** The GUI session log + a tail of the daemon's own rolling log (About → Logs). */
+export async function getGuiLogs(): Promise<GuiLogs> {
+  return call<GuiLogs>("get_gui_logs");
+}
+
+/** A pretty-printed JSON diagnostics snapshot (paths, service config, ERROR
+ * lines from the logs) for the About → Diagnostics button. */
+export async function getDiagnostics(): Promise<string> {
+  return call<string>("get_diagnostics");
 }

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -186,6 +186,11 @@ export async function checkUpdates(channel?: UpdateChannel): Promise<UpdateStatu
   ) as UpdateStatusResponse;
 }
 
+/** Last persisted update-check result (no network) — pre-fills the UI on load. */
+export async function cachedUpdateStatus(): Promise<UpdateStatusResponse> {
+  return ensureOk(await call<Response>("cached_update_status")) as UpdateStatusResponse;
+}
+
 /** Persist the self-update channel preference. */
 export async function setUpdateChannel(channel: UpdateChannel): Promise<void> {
   ensureOk(await call<Response>("set_update_channel", { channel }));

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -436,6 +436,11 @@ export async function setFallbackPorts(http: number, https: number): Promise<voi
   ensureOk(await call<Response>("set_fallback_ports", { http, https }));
 }
 
+/** Set the embedded DNS responder port; takes effect on the next daemon restart. */
+export async function setDnsPort(port: number): Promise<void> {
+  ensureOk(await call<Response>("set_dns_port", { port }));
+}
+
 /** Enable/disable mail capture; takes effect on the next daemon restart. */
 export async function setMailEnabled(enabled: boolean): Promise<void> {
   ensureOk(await call<Response>("set_mail_enabled", { enabled }));

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -431,6 +431,9 @@ export type Response =
       ahead_of_stable: boolean;
       /** Whether these figures are from a live fetch or a cached fallback. */
       source: "live" | "cached";
+      /** Unix epoch (seconds) when this result was obtained, for a "last
+       *  checked …" display. Absent/undefined when never checked. */
+      checked_at_epoch?: number;
     };
 
 /** Self-update release channel (mirrors `yerd_ipc::Channel`). */

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -4,8 +4,8 @@
  * These are a *contract*, pinned by hand to the Rust source. Each type notes
  * its origin so review catches drift; `tests/wire_stability.rs` and the
  * `Request`/`Response` enums are the source of truth:
- *   - crates/yerd-ipc/src/request.rs   (Request — not consumed here; the GUI
- *     never builds raw Requests, the bridge does — kept for reference)
+ *   - crates/yerd-ipc/src/request.rs   (Request - not consumed here; the GUI
+ *     never builds raw Requests, the bridge does - kept for reference)
  *   - crates/yerd-ipc/src/response.rs  (Response, PhpUpdate, ErrorCode)
  *   - crates/yerd-ipc/src/status.rs    (StatusReport and friends)
  *   - crates/yerd-core/src/site.rs     (Site, SiteKind)
@@ -19,10 +19,10 @@
 /** A PHP minor version on the wire is the bare string, e.g. `"8.5"`. */
 export type PhpVersion = string;
 
-/** crates/yerd-core/src/site.rs — SiteKind. */
+/** crates/yerd-core/src/site.rs - SiteKind. */
 export type SiteKind = "parked" | "linked";
 
-/** crates/yerd-core/src/site.rs — Site (serialised field order is fixed). */
+/** crates/yerd-core/src/site.rs - Site (serialised field order is fixed). */
 export interface Site {
   name: string;
   document_root: string;
@@ -58,10 +58,10 @@ export interface SiteCounts {
 
 export type PoolRunState = "running" | "stopped" | "failed";
 
-/** crates/yerd-ipc/src/status.rs — ServiceRunState. */
+/** crates/yerd-ipc/src/status.rs - ServiceRunState. */
 export type ServiceRunState = "running" | "stopped" | "failed";
 
-/** crates/yerd-ipc/src/status.rs — ServiceStatus (integer-only fields). */
+/** crates/yerd-ipc/src/status.rs - ServiceStatus (integer-only fields). */
 export interface ServiceStatus {
   service: string;
   display_name: string;
@@ -75,7 +75,7 @@ export interface ServiceStatus {
   supports_databases: boolean;
 }
 
-/** crates/yerd-ipc/src/status.rs — ServiceAvailability. */
+/** crates/yerd-ipc/src/status.rs - ServiceAvailability. */
 export interface ServiceAvailability {
   service: string;
   available: string[];
@@ -92,7 +92,7 @@ export interface PhpPoolStatus {
   update_available: string | null;
 }
 
-/** crates/yerd-ipc/src/status.rs — MailStatus. */
+/** crates/yerd-ipc/src/status.rs - MailStatus. */
 export interface MailStatus {
   enabled: boolean;
   port: number;
@@ -101,7 +101,7 @@ export interface MailStatus {
   count: number;
 }
 
-/** crates/yerd-ipc/src/status.rs — MailSummary. */
+/** crates/yerd-ipc/src/status.rs - MailSummary. */
 export interface MailSummary {
   id: string;
   from: string;
@@ -111,13 +111,13 @@ export interface MailSummary {
   date_epoch: number;
 }
 
-/** crates/yerd-ipc/src/status.rs — MailHeader. */
+/** crates/yerd-ipc/src/status.rs - MailHeader. */
 export interface MailHeader {
   name: string;
   value: string;
 }
 
-/** crates/yerd-ipc/src/status.rs — MailDetail. */
+/** crates/yerd-ipc/src/status.rs - MailDetail. */
 export interface MailDetail {
   id: string;
   from: string;
@@ -140,14 +140,14 @@ export interface StatusReport {
   https: PortStatus;
   dns_addr: string;
   ca: CaStatus;
-  /** Tri-state — null means "unknown", never coerce to false. */
+  /** Tri-state - null means "unknown", never coerce to false. */
   resolver_installed: boolean | null;
   /** macOS: is the pf redirect carrying 80/443 to the rootless ports? true =
    *  privileged ports served via the redirect, false = not, null = unknown / not
    *  applicable (Linux binds directly after setcap). */
   port_redirect: boolean | null;
   /** True when a non-Yerd process is listening on a privileged web port (80/443)
-   *  — a foreign squatter. Confirmed via the proxy's Server marker, so it never
+   *  - a foreign squatter. Confirmed via the proxy's Server marker, so it never
    *  misreads Yerd as foreign. false = no conflict, null/undefined = not probed.
    *  Cross-platform (unlike port_redirect). */
   foreign_web_listener?: boolean | null;
@@ -169,7 +169,7 @@ export interface StatusReport {
   services?: ServiceStatus[];
   /** Built-in mail-capture status. Omitted (undefined) by a daemon predating
    *  the feature (the Rust field is `#[serde(default, skip_serializing_if)]`, so
-   *  it is never `null` on the wire — mirrors the `services?` convention). */
+   *  it is never `null` on the wire - mirrors the `services?` convention). */
   mail?: MailStatus;
   /** Set when the daemon could bind neither the desired nor the fallback web
    *  ports: it runs degraded (no HTTP/HTTPS proxy). Carries the fallback ports
@@ -221,7 +221,7 @@ export interface FixReport {
 
 // ── dumps (dump.rs) ─────────────────────────────────────────────────────────
 
-/** crates/yerd-ipc/src/dump.rs — DumpCategory (the viewer tabs). */
+/** crates/yerd-ipc/src/dump.rs - DumpCategory (the viewer tabs). */
 export type DumpCategory =
   | "dump"
   | "query"
@@ -233,7 +233,7 @@ export type DumpCategory =
   | "http";
 
 /**
- * crates/yerd-ipc/src/dump.rs — DumpEvent. `payload` is category-specific and
+ * crates/yerd-ipc/src/dump.rs - DumpEvent. `payload` is category-specific and
  * opaque to the daemon; the viewer renders it per `category` (see the
  * `yerd-php-ext` architecture doc for the per-category shape).
  */
@@ -249,7 +249,7 @@ export interface DumpEvent {
   payload: Record<string, unknown>;
 }
 
-/** crates/yerd-ipc/src/dump.rs — DumpCounts (current per-category buffer counts). */
+/** crates/yerd-ipc/src/dump.rs - DumpCounts (current per-category buffer counts). */
 export interface DumpCounts {
   dumps: number;
   queries: number;
@@ -261,7 +261,7 @@ export interface DumpCounts {
   http: number;
 }
 
-/** crates/yerd-ipc/src/dump.rs — DumpExtStatus (per-version extension presence). */
+/** crates/yerd-ipc/src/dump.rs - DumpExtStatus (per-version extension presence). */
 export interface DumpExtStatus {
   version: PhpVersion;
   present: boolean;
@@ -281,7 +281,7 @@ export type Testing = "pest" | "php_unit";
 export type Database = "sqlite" | "mysql" | "mariadb" | "pgsql" | "sqlsrv";
 export type JsRuntime = "npm" | "bun" | "skip";
 
-/** crates/yerd-ipc/src/create.rs — LaravelOptions. */
+/** crates/yerd-ipc/src/create.rs - LaravelOptions. */
 export interface LaravelOptions {
   starter_kit: StarterKit;
   auth: AuthProvider;
@@ -297,7 +297,7 @@ export interface LaravelOptions {
 /** Framework is internally tagged on `framework`. Only Laravel today. */
 export type Framework = { framework: "laravel"; options: LaravelOptions };
 
-/** crates/yerd-ipc/src/create.rs — CreateSiteSpec. */
+/** crates/yerd-ipc/src/create.rs - CreateSiteSpec. */
 export interface CreateSiteSpec {
   name: string;
   /** Directory the new project dir is created inside (parked root or any folder). */
@@ -307,7 +307,7 @@ export interface CreateSiteSpec {
   framework: Framework;
 }
 
-/** crates/yerd-ipc/src/create.rs — JobState. */
+/** crates/yerd-ipc/src/create.rs - JobState. */
 export type JobState = "running" | "succeeded" | "failed" | "cancelled";
 
 // ── response variants (response.rs) ────────────────────────────────────────
@@ -428,7 +428,7 @@ export type Response =
 /** Self-update release channel (mirrors `yerd_ipc::Channel`). */
 export type UpdateChannel = "stable" | "edge";
 
-/** crates/yerd-ipc/src/status.rs — ToolStatus. */
+/** crates/yerd-ipc/src/status.rs - ToolStatus. */
 export interface ToolStatus {
   id: string;
   display_name: string;
@@ -490,7 +490,7 @@ export interface AutostartState {
 
 /**
  * Why the daemon isn't up (host command `daemon_diagnostics`). Gathered when a
- * start attempt fails to connect — covers both the ran-and-crashed case
+ * start attempt fails to connect - covers both the ran-and-crashed case
  * (`logTail`) and the never-launched cases (`startError`, `translocated`,
  * `yerddPath === null`, `pendingApproval`). `hints` are ready-to-show
  * plain-English cause+fix lines computed host-side.
@@ -509,7 +509,7 @@ export interface DaemonDiagnostics {
   logPath: string | null;
   logTail: string[];
   spawnLogTail: string[];
-  /** GUI daemon-registration self-repair trail ({cache}/yerd-gui-repair.log) —
+  /** GUI daemon-registration self-repair trail ({cache}/yerd-gui-repair.log) -
    *  macOS upgrade re-registration attempts + outcomes (incl. technical errors). */
   repairLogTail: string[];
 }
@@ -531,4 +531,16 @@ export interface CliPathStatus {
 export interface SetupState {
   onboarded: boolean;
   isSetUp: boolean;
+}
+
+/**
+ * The GUI diagnostic logs surfaced in About → GUI Logs (host command
+ * `get_gui_logs`): the per-session GUI host log plus a tail of the daemon's own
+ * rolling log. Paths are shown so the dialog can say where each lives.
+ */
+export interface GuiLogs {
+  guiPath: string | null;
+  guiLog: string[];
+  daemonPath: string | null;
+  daemonLog: string[];
 }

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -143,9 +143,11 @@ export interface StatusReport {
   /** Tri-state - null means "unknown", never coerce to false. */
   resolver_installed: boolean | null;
   /** macOS: is the pf redirect carrying 80/443 to the rootless ports? true =
-   *  privileged ports served via the redirect, false = not, null = unknown / not
-   *  applicable (Linux binds directly after setcap). */
-  port_redirect: boolean | null;
+   *  privileged ports served via the redirect, false = not, null/undefined =
+   *  unknown / not applicable (Linux binds directly after setcap). Omitted on the
+   *  wire when not set (the Rust field is `#[serde(default, skip_serializing_if)]`,
+   *  so it can be absent against a Linux/older daemon). */
+  port_redirect?: boolean | null;
   /** True when a non-Yerd process is listening on a privileged web port (80/443)
    *  - a foreign squatter. Confirmed via the proxy's Server marker, so it never
    *  misreads Yerd as foreign. false = no conflict, null/undefined = not probed.

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -175,6 +175,10 @@ export interface StatusReport {
    *  ports: it runs degraded (no HTTP/HTTPS proxy). Carries the fallback ports
    *  it failed on. Omitted (undefined) on a healthy daemon. */
   web_unbound?: { http: number; https: number } | null;
+  /** Set when the daemon couldn't bind its DNS responder port: it runs degraded
+   *  (`*.test` names won't resolve through Yerd). Carries the configured DNS port
+   *  it failed on. Omitted (undefined) on a healthy daemon. */
+  dns_unbound?: number | null;
   /** A per-process id that changes on every (re)start. Clients use a *change* in
    *  it to confirm a restart completed (the re-exec preserves the pid). Omitted
    *  by a daemon predating the field. */
@@ -351,6 +355,10 @@ export type Response =
        *  → may be absent (0) against an older daemon. */
       fallback_http?: number;
       fallback_https?: number;
+      /** Configured DNS responder port (what Settings edits). Distinct from
+       *  `dns_addr`, which is the *bound* address. `#[serde(default)]` → may be
+       *  absent (0) against an older daemon. */
+      dns_port?: number;
     }
   | {
       type: "php_versions";

--- a/apps/yerd-gui/src/lib/log.ts
+++ b/apps/yerd-gui/src/lib/log.ts
@@ -1,0 +1,26 @@
+/**
+ * Fire-and-forget frontend logger. Pushes a line into the GUI host's per-session
+ * log file (`{cache}/yerd-gui.log`) via the `gui_log` command, so the About →
+ * GUI Logs dialog shows frontend phase transitions and caught errors interleaved
+ * with the Rust-side daemon install/upgrade/start trail.
+ *
+ * Every call is best-effort and MUST never throw: we use `.catch()` (not
+ * try/catch) so an un-awaited `invoke` rejection can't re-enter the global
+ * `unhandledrejection` handler and recurse.
+ */
+import { invoke } from "@tauri-apps/api/core";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+function emit(level: LogLevel, message: string): void {
+  // Swallow everything: logging failures are never worth surfacing, and a throw
+  // here (especially from inside an error handler) could loop.
+  void invoke("gui_log", { level, message }).catch(() => {});
+}
+
+export const log = {
+  debug: (message: string): void => emit("debug", message),
+  info: (message: string): void => emit("info", message),
+  warn: (message: string): void => emit("warn", message),
+  error: (message: string): void => emit("error", message),
+};

--- a/apps/yerd-gui/src/lib/siteUrl.ts
+++ b/apps/yerd-gui/src/lib/siteUrl.ts
@@ -5,12 +5,15 @@ import type { Site, StatusReport } from "@/ipc/types";
 export type SiteLike = Pick<Site, "name" | "secure">;
 
 /**
- * True when the OS `.test` resolver is not active, so sites must be reached via
- * the `http://localhost/~{domain}` fallback rather than their `.test` domain.
- * Tri-state aware: `resolver_installed` is only "on" when strictly `true`.
+ * True when `.test` resolution is unavailable, so sites must be reached via the
+ * `http://localhost/~{domain}` fallback rather than their `.test` domain. This
+ * covers both the OS resolver not being active (`resolver_installed` is only
+ * "on" when strictly `true`, tri-state aware) *and* the daemon failing to bind
+ * its DNS responder port (`dns_unbound` set) - in which case names won't resolve
+ * through Yerd even when the resolver is installed.
  */
 export function isUnbound(report: StatusReport | null | undefined): boolean {
-  return report?.resolver_installed !== true;
+  return report?.resolver_installed !== true || report?.dns_unbound != null;
 }
 
 interface UnboundOpts {

--- a/apps/yerd-gui/src/lib/siteUrl.ts
+++ b/apps/yerd-gui/src/lib/siteUrl.ts
@@ -1,6 +1,6 @@
 import type { Site, StatusReport } from "@/ipc/types";
 
-/** The minimal site shape the URL helpers need — satisfied by a full `Site` and
+/** The minimal site shape the URL helpers need - satisfied by a full `Site` and
  *  by the create wizard's in-progress form (which has no real `Site` yet). */
 export type SiteLike = Pick<Site, "name" | "secure">;
 
@@ -58,6 +58,6 @@ export function siteUrl(s: SiteLike, report: StatusReport | null | undefined): s
 export function openTitle(s: SiteLike, report: StatusReport | null | undefined): string {
   const url = siteUrl(s, report);
   return isUnbound(report)
-    ? `Open ${url} — served over http://localhost (forced-HTTPS sites may not load)`
+    ? `Open ${url} - served over http://localhost (forced-HTTPS sites may not load)`
     : `Open ${url}`;
 }

--- a/apps/yerd-gui/src/lib/theme.ts
+++ b/apps/yerd-gui/src/lib/theme.ts
@@ -24,7 +24,7 @@ const THEME_EVENT = "yerd:theme-changed";
 
 /** The user's preference (reactive, persisted). */
 const pref = ref<ThemePref>(loadPref());
-/** Latest OS dark-mode signal — only consulted while `pref === "system"`. */
+/** Latest OS dark-mode signal - only consulted while `pref === "system"`. */
 let osDark = false;
 
 function loadPref(): ThemePref {
@@ -32,7 +32,7 @@ function loadPref(): ThemePref {
     const v = localStorage.getItem(STORAGE_KEY);
     if (v === "light" || v === "dark" || v === "system") return v;
   } catch {
-    // localStorage unavailable (e.g. unit env) — fall through to default.
+    // localStorage unavailable (e.g. unit env) - fall through to default.
   }
   return "system";
 }
@@ -67,7 +67,7 @@ export function setTheme(p: ThemePref): void {
   applyPref(p);
   // Other webviews don't see this window's localStorage write, so tell them.
   void emit(THEME_EVENT, p).catch(() => {
-    // Not in Tauri (unit/dev) — nothing to broadcast.
+    // Not in Tauri (unit/dev) - nothing to broadcast.
   });
 }
 
@@ -102,7 +102,7 @@ export function initTheme(): void {
         reapply();
       });
     } catch {
-      // Not running inside Tauri (unit tests, plain Vite) — step 1 stands.
+      // Not running inside Tauri (unit tests, plain Vite) - step 1 stands.
     }
   })();
 
@@ -113,6 +113,6 @@ export function initTheme(): void {
   void listen<ThemePref>(THEME_EVENT, ({ payload }) => {
     if (payload !== pref.value) applyPref(payload);
   }).catch(() => {
-    // Not in Tauri — single context, nothing to sync.
+    // Not in Tauri - single context, nothing to sync.
   });
 }

--- a/apps/yerd-gui/src/lib/utils.ts
+++ b/apps/yerd-gui/src/lib/utils.ts
@@ -14,7 +14,7 @@ export type StatusTone = "ok" | "warn" | "bad" | "unknown" | "muted";
 /**
  * Human label for an FPM pool's run state. PHP-FPM is started **on demand** when
  * a site first uses a version, so an installed-but-not-serving version is
- * `stopped` on the wire — which reads as alarming. Show it as "idle" instead;
+ * `stopped` on the wire - which reads as alarming. Show it as "idle" instead;
  * reserve "failed" (red) for a pool that actually crashed. A version not yet in
  * the status report (e.g. just installed, before the next poll) is also "idle"
  * rather than a transient "not started".
@@ -70,7 +70,7 @@ export function humaniseBytes(bytes: number | null | undefined): string {
 }
 
 /**
- * Render the daemon's `load_avg` (each value is load × 100, i.e. hundredths —
+ * Render the daemon's `load_avg` (each value is load × 100, i.e. hundredths -
  * see yerd-ipc status.rs) back to the conventional `x.xx` triple.
  */
 export function formatLoadAvg(load: [number, number, number] | null): string {

--- a/apps/yerd-gui/src/lib/utils.ts
+++ b/apps/yerd-gui/src/lib/utils.ts
@@ -61,11 +61,14 @@ export function humaniseUptime(secs: number): string {
 export function humaniseAgo(epochSecs: number, nowSecs: number = Date.now() / 1000): string {
   const diff = Math.floor(nowSecs - epochSecs);
   if (!Number.isFinite(diff) || diff < 45) return "just now";
-  const mins = Math.round(diff / 60);
+  // Floor within each unit so age isn't overstated (e.g. 59m31s stays minutes,
+  // 23h31m stays hours) rather than rounding up into the next unit. `mins` is
+  // clamped to >= 1 since the sub-45s window is already "just now".
+  const mins = Math.max(1, Math.floor(diff / 60));
   if (mins < 60) return `${mins} minute${mins === 1 ? "" : "s"} ago`;
-  const hours = Math.round(diff / 3_600);
+  const hours = Math.floor(diff / 3_600);
   if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
-  const days = Math.round(diff / 86_400);
+  const days = Math.floor(diff / 86_400);
   return `${days} day${days === 1 ? "" : "s"} ago`;
 }
 

--- a/apps/yerd-gui/src/lib/utils.ts
+++ b/apps/yerd-gui/src/lib/utils.ts
@@ -56,6 +56,20 @@ export function humaniseUptime(secs: number): string {
   return parts.join(" ");
 }
 
+/** Render a past Unix-epoch (seconds) as a coarse, single-unit "… ago" string
+ *  (e.g. "5 minutes ago", "2 hours ago", "3 days ago"). */
+export function humaniseAgo(epochSecs: number, nowSecs: number = Date.now() / 1000): string {
+  const diff = Math.floor(nowSecs - epochSecs);
+  if (!Number.isFinite(diff) || diff < 45) return "just now";
+  if (diff < 90) return "a minute ago";
+  const mins = Math.round(diff / 60);
+  if (mins < 60) return `${mins} minutes ago`;
+  const hours = Math.round(diff / 3_600);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.round(diff / 86_400);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
 /** Render bytes as a short human string (e.g. `1536` -> `1.5 MB` base-2). */
 export function humaniseBytes(bytes: number | null | undefined): string {
   if (bytes == null || !Number.isFinite(bytes)) return "-";

--- a/apps/yerd-gui/src/lib/utils.ts
+++ b/apps/yerd-gui/src/lib/utils.ts
@@ -61,9 +61,8 @@ export function humaniseUptime(secs: number): string {
 export function humaniseAgo(epochSecs: number, nowSecs: number = Date.now() / 1000): string {
   const diff = Math.floor(nowSecs - epochSecs);
   if (!Number.isFinite(diff) || diff < 45) return "just now";
-  if (diff < 90) return "a minute ago";
   const mins = Math.round(diff / 60);
-  if (mins < 60) return `${mins} minutes ago`;
+  if (mins < 60) return `${mins} minute${mins === 1 ? "" : "s"} ago`;
   const hours = Math.round(diff / 3_600);
   if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
   const days = Math.round(diff / 86_400);

--- a/apps/yerd-gui/src/main.ts
+++ b/apps/yerd-gui/src/main.ts
@@ -3,6 +3,7 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import { router } from "./router";
 import { initDesktopChrome } from "./lib/desktop";
+import { log } from "./lib/log";
 import { initTheme } from "./lib/theme";
 import "./style.css";
 
@@ -10,4 +11,23 @@ import "./style.css";
 initTheme();
 initDesktopChrome();
 
-createApp(App).use(router).mount("#app");
+// Funnel uncaught frontend errors into the GUI session log so they show up in
+// About → GUI Logs. A reentrancy guard keeps a logging failure from looping back
+// through `unhandledrejection`.
+let inErrorHandler = false;
+function logUncaught(prefix: string, detail: unknown): void {
+  if (inErrorHandler) return;
+  inErrorHandler = true;
+  try {
+    const msg = detail instanceof Error ? `${detail.message}\n${detail.stack ?? ""}` : String(detail);
+    log.error(`${prefix}: ${msg}`);
+  } finally {
+    inErrorHandler = false;
+  }
+}
+window.addEventListener("error", (e) => logUncaught("uncaught error", e.error ?? e.message));
+window.addEventListener("unhandledrejection", (e) => logUncaught("unhandled rejection", e.reason));
+
+const app = createApp(App);
+app.config.errorHandler = (err) => logUncaught("vue error", err);
+app.use(router).mount("#app");

--- a/apps/yerd-gui/src/router.ts
+++ b/apps/yerd-gui/src/router.ts
@@ -22,7 +22,7 @@ export const router = createRouter({
     },
     // `title`/`subtitle` mirror each view's own PageHeader so the daemon-down
     // screen (rendered by AppShell when the socket is unreachable) shows the same
-    // page header — without the view's action buttons.
+    // page header - without the view's action buttons.
     {
       path: "/php",
       name: "php",

--- a/apps/yerd-gui/src/style.css
+++ b/apps/yerd-gui/src/style.css
@@ -6,7 +6,7 @@
   :root {
     /* Neutral grays (no blue tint), mirroring the charcoal dark theme for a
        native macOS / Herd feel. The main content area is white (`--background`);
-       the chrome — titlebar + sidebar — is the soft gray (`--muted`), applied in
+       the chrome - titlebar + sidebar - is the soft gray (`--muted`), applied in
        those components, so the content reads as the bright focus framed by gray
        chrome. */
     /* Tell the UA to render native controls (number-input spin buttons, etc.)
@@ -34,7 +34,7 @@
     --warning-foreground: 0 0% 9%;
     /* Brand indigo, lifted straight from the logo's gradient (#6366F1). The one
        signal colour: active nav, focus rings, links, and the live "serving"
-       state. Used with restraint — status (success/warning/destructive) still
+       state. Used with restraint - status (success/warning/destructive) still
        owns green/amber/red. */
     --brand: 239 84% 67%;
     --brand-foreground: 0 0% 100%;
@@ -46,7 +46,7 @@
 
   .dark {
     /* Neutral charcoal grays (no blue tint), lifted off pure-black so panels and
-       borders read clearly — closer to a native macOS / Herd dark surface. */
+       borders read clearly - closer to a native macOS / Herd dark surface. */
     color-scheme: dark;
     --background: 0 0% 11%;
     --foreground: 0 0% 98%;
@@ -106,7 +106,7 @@
   #app {
     height: 100%;
   }
-  /* The opaque, rounded surface — its overflow clip gives every child (the
+  /* The opaque, rounded surface - its overflow clip gives every child (the
      titlebar, sidebar) native macOS-style rounded corners. */
   #app {
     @apply overflow-hidden bg-background;
@@ -129,7 +129,7 @@
   }
 
   /* Slim, neutral scrollbars. Light thumb on the light theme, dark thumb on the
-     dark theme — a single hardcoded gray looked heavy on white. */
+     dark theme - a single hardcoded gray looked heavy on white. */
   ::-webkit-scrollbar {
     width: 12px;
     height: 12px;

--- a/apps/yerd-gui/src/views/AboutView.vue
+++ b/apps/yerd-gui/src/views/AboutView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getVersion } from "@tauri-apps/api/app";
-import { FileText, Stethoscope } from "lucide-vue-next";
+import { Download, FileText, RefreshCw, Stethoscope } from "lucide-vue-next";
 import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import logoUrl from "@/assets/logo.svg";
@@ -8,25 +8,128 @@ import PageHeader from "@/components/PageHeader.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import CardContent from "@/components/ui/CardContent.vue";
+import CardDescription from "@/components/ui/CardDescription.vue";
 import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
 import Modal from "@/components/ui/Modal.vue";
+import Select from "@/components/ui/Select.vue";
+import Spinner from "@/components/ui/Spinner.vue";
+import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import {
+  applyUpdate,
+  cachedUpdateStatus,
+  checkUpdates,
   getDiagnostics,
   getGuiLogs,
   IpcError,
   openInBrowser,
   protocolVersion,
+  setUpdateChannel,
   status,
 } from "@/ipc/client";
-import type { GuiLogs } from "@/ipc/types";
+import type { GuiLogs, UpdateChannel, UpdateStatusResponse } from "@/ipc/types";
+import { humaniseAgo } from "@/lib/utils";
 
 const toast = useToast();
+const { connected } = useDaemon();
+const running = computed(() => connected.value === true);
 
 const appVersion = ref("");
 const protocol = ref<number | null>(null);
 const daemonVersion = ref("");
+
+// ── self-update ──
+const channelOptions = [
+  { value: "stable", label: "Stable" },
+  { value: "edge", label: "Edge (pre-release)" },
+] as const;
+const updateChannel = ref<UpdateChannel>("stable");
+const updateStatus = ref<UpdateStatusResponse | null>(null);
+const checkingUpdates = ref(false);
+const applyingUpdate = ref(false);
+
+const updateSummary = computed(() => {
+  const s = updateStatus.value;
+  if (!s) return "";
+  if (s.available && s.target) return `Update available: ${s.target}`;
+  if (s.ahead_of_stable) return "Up to date (on a pre-release ahead of stable)";
+  return "Up to date";
+});
+
+// "Last checked …" from the persisted timestamp on the (cached or live) result.
+const lastCheckedAgo = computed(() => {
+  const at = updateStatus.value?.checked_at_epoch;
+  return at ? humaniseAgo(at) : null;
+});
+
+// Pre-fill the section from the daemon's persisted last-check result (no network)
+// so the channel + status + "last checked" show immediately on load.
+async function loadCachedUpdate(): Promise<void> {
+  try {
+    const s = await cachedUpdateStatus();
+    updateStatus.value = s;
+    updateChannel.value = s.channel;
+  } catch {
+    // Daemon down / older daemon: leave the section in its "Not checked" state.
+  }
+}
+
+// Notify only on an explicit "Check now" (notify=true). A check triggered any
+// other way (channel change) updates the shown status silently.
+async function runUpdateCheck(notify = false): Promise<void> {
+  checkingUpdates.value = true;
+  try {
+    const s = await checkUpdates();
+    updateStatus.value = s;
+    updateChannel.value = s.channel;
+    if (!notify) return;
+    if (s.available && s.target) {
+      toast.success("Update available", `Version ${s.target} can be installed.`);
+    } else if (s.ahead_of_stable) {
+      toast.info("Up to date", "You're on a pre-release ahead of stable.");
+    } else if (s.source === "cached") {
+      // The daemon couldn't reach the update server and served its last cached
+      // result - don't claim "latest version" off possibly-stale data.
+      toast.info(
+        "Couldn't reach the update server",
+        "Showing the last cached result - you may be offline.",
+      );
+    } else {
+      toast.success("Up to date", "You're on the latest version.");
+    }
+  } catch (e) {
+    if (notify) toast.error("Couldn't check for updates", (e as IpcError).message);
+  } finally {
+    checkingUpdates.value = false;
+  }
+}
+
+// Download + verify + apply. The app quits during the swap and the applier
+// relaunches it, so `applyUpdate` usually never returns; a thrown error means
+// staging failed (offline, verification, or a non-writable /Applications).
+async function onUpdateNow(): Promise<void> {
+  applyingUpdate.value = true;
+  try {
+    await applyUpdate(updateChannel.value);
+  } catch (e) {
+    applyingUpdate.value = false;
+    toast.error("Couldn't apply the update", (e as IpcError).message);
+  }
+}
+
+// Persist the channel on change, then re-check so the shown status reflects it.
+async function onUpdateChannelChange(value: UpdateChannel): Promise<void> {
+  const previous = updateChannel.value;
+  updateChannel.value = value; // optimistic
+  try {
+    await setUpdateChannel(value);
+    await runUpdateCheck();
+  } catch (e) {
+    updateChannel.value = previous; // revert on failure
+    toast.error("Couldn't change the update channel", (e as IpcError).message);
+  }
+}
 
 onMounted(async () => {
   try {
@@ -44,6 +147,7 @@ onMounted(async () => {
     const err = e as IpcError;
     if (!err.unreachable) toast.error("Couldn't load daemon info", err.message);
   }
+  void loadCachedUpdate();
 });
 
 // ── GUI Logs dialog ─────────────────────────────────────────────────────────
@@ -176,6 +280,76 @@ async function copyDiagnostics(): Promise<void> {
         </CardContent>
       </Card>
 
+      <!-- Updates -->
+      <Card>
+        <CardHeader>
+          <CardTitle>Updates</CardTitle>
+          <CardDescription>
+            Keep Yerd up to date. Choose a release channel and check for new
+            versions.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="text-sm font-medium">Release channel</p>
+              <p class="text-xs text-muted-foreground">
+                Stable tracks final releases; Edge opts in to pre-releases and
+                release candidates.
+              </p>
+            </div>
+            <Select
+              :model-value="updateChannel"
+              :options="channelOptions"
+              aria-label="Update channel"
+              :disabled="!running"
+              @update:model-value="(v: UpdateChannel) => onUpdateChannelChange(v)"
+            />
+          </div>
+
+          <div class="flex items-center justify-between gap-4">
+            <div class="min-w-0 text-sm">
+              <template v-if="updateStatus && updateStatus.checked_at_epoch">
+                <p class="font-medium">{{ updateSummary }}</p>
+                <p class="text-xs text-muted-foreground">
+                  Current {{ updateStatus.current }} · stable
+                  {{ updateStatus.latest_stable ?? "-" }} · edge
+                  {{ updateStatus.latest_edge ?? "-" }}
+                </p>
+                <p class="text-xs text-muted-foreground">Last checked {{ lastCheckedAgo }}.</p>
+              </template>
+              <p v-else class="text-xs text-muted-foreground">
+                {{ running ? "Not checked yet." : "Start the daemon to check for updates." }}
+              </p>
+            </div>
+            <Button variant="outline" :disabled="!running || checkingUpdates" @click="runUpdateCheck(true)">
+              <Spinner v-if="checkingUpdates" class="size-4" />
+              <RefreshCw v-else class="size-4" />
+              Check now
+            </Button>
+          </div>
+
+          <div
+            v-if="updateStatus?.available"
+            class="flex items-center justify-between gap-4 rounded-lg border border-success/40 bg-success/10 p-3"
+          >
+            <p class="text-sm">
+              <template v-if="applyingUpdate">
+                Updating to <strong>{{ updateStatus.target }}</strong> - Yerd will restart…
+              </template>
+              <template v-else>
+                Yerd <strong>{{ updateStatus.target }}</strong> is available.
+              </template>
+            </p>
+            <Button :disabled="!running || applyingUpdate" @click="onUpdateNow">
+              <Spinner v-if="applyingUpdate" class="size-4" />
+              <Download v-else class="size-4" />
+              {{ applyingUpdate ? "Updating…" : "Update" }}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
       <!-- Troubleshooting -->
       <Card>
         <CardHeader><CardTitle>Troubleshooting</CardTitle></CardHeader>
@@ -186,7 +360,7 @@ async function copyDiagnostics(): Promise<void> {
             happened, or generate a diagnostics snapshot to share when reporting
             a problem.
           </p>
-          <div class="flex flex-wrap gap-2">
+          <div class="flex flex-wrap justify-end gap-2">
             <Button variant="outline" @click="openLogs">
               <FileText class="size-4" /> Logs
             </Button>

--- a/apps/yerd-gui/src/views/AboutView.vue
+++ b/apps/yerd-gui/src/views/AboutView.vue
@@ -1,15 +1,26 @@
 <script setup lang="ts">
 import { getVersion } from "@tauri-apps/api/app";
-import { onMounted, ref } from "vue";
+import { FileText, Stethoscope } from "lucide-vue-next";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import logoUrl from "@/assets/logo.svg";
 import PageHeader from "@/components/PageHeader.vue";
+import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import CardContent from "@/components/ui/CardContent.vue";
 import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
+import Modal from "@/components/ui/Modal.vue";
 import { useToast } from "@/composables/useToast";
-import { IpcError, openInBrowser, protocolVersion, status } from "@/ipc/client";
+import {
+  getDiagnostics,
+  getGuiLogs,
+  IpcError,
+  openInBrowser,
+  protocolVersion,
+  status,
+} from "@/ipc/client";
+import type { GuiLogs } from "@/ipc/types";
 
 const toast = useToast();
 
@@ -21,19 +32,96 @@ onMounted(async () => {
   try {
     appVersion.value = await getVersion();
   } catch {
-    /* not in a Tauri context (e.g. tests) — leave blank */
+    /* not in a Tauri context (e.g. tests) - leave blank */
   }
   try {
     const [p, report] = await Promise.all([protocolVersion(), status()]);
     protocol.value = p;
     daemonVersion.value = report.daemon_version;
   } catch (e) {
-    // The page degrades gracefully (daemon fields read "unknown"/"—"), so a
-    // down daemon needs no alarm here — only surface a real, unexpected error.
+    // The page degrades gracefully (daemon fields read "unknown"/"-"), so a
+    // down daemon needs no alarm here - only surface a real, unexpected error.
     const err = e as IpcError;
     if (!err.unreachable) toast.error("Couldn't load daemon info", err.message);
   }
 });
+
+// ── GUI Logs dialog ─────────────────────────────────────────────────────────
+
+const logsOpen = ref(false);
+const logs = ref<GuiLogs | null>(null);
+const activeTab = ref<"gui" | "daemon">("gui");
+let logsTimer: ReturnType<typeof setInterval> | undefined;
+
+const activeLines = computed(() =>
+  activeTab.value === "gui" ? (logs.value?.guiLog ?? []) : (logs.value?.daemonLog ?? []),
+);
+const activePath = computed(() =>
+  activeTab.value === "gui" ? logs.value?.guiPath : logs.value?.daemonPath,
+);
+
+async function fetchLogs(): Promise<void> {
+  try {
+    logs.value = await getGuiLogs();
+  } catch (e) {
+    toast.error("Couldn't read logs", (e as IpcError).message);
+  }
+}
+
+function openLogs(): void {
+  logsOpen.value = true;
+  void fetchLogs();
+  // Light polling while open so a live daemon-start trail streams in.
+  stopLogPolling();
+  logsTimer = setInterval(() => void fetchLogs(), 2000);
+}
+
+function stopLogPolling(): void {
+  if (logsTimer) {
+    clearInterval(logsTimer);
+    logsTimer = undefined;
+  }
+}
+
+async function copyActive(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(activeLines.value.join("\n"));
+    toast.success("Copied logs", "Paste this when reporting the problem.");
+  } catch {
+    toast.error("Couldn't copy", "Your browser blocked clipboard access.");
+  }
+}
+
+onUnmounted(stopLogPolling);
+
+// ── Diagnostics dialog ──────────────────────────────────────────────────────
+
+const diagOpen = ref(false);
+const diagText = ref("");
+const diagLoading = ref(false);
+
+async function openDiagnostics(): Promise<void> {
+  diagOpen.value = true;
+  diagLoading.value = true;
+  diagText.value = "";
+  try {
+    diagText.value = await getDiagnostics();
+  } catch (e) {
+    toast.error("Couldn't gather diagnostics", (e as IpcError).message);
+    diagText.value = "";
+  } finally {
+    diagLoading.value = false;
+  }
+}
+
+async function copyDiagnostics(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(diagText.value);
+    toast.success("Copied diagnostics", "Paste this when reporting the problem.");
+  } catch {
+    toast.error("Couldn't copy", "Your browser blocked clipboard access.");
+  }
+}
 </script>
 
 <template>
@@ -87,6 +175,90 @@ onMounted(async () => {
           </div>
         </CardContent>
       </Card>
+
+      <!-- Troubleshooting -->
+      <Card>
+        <CardHeader><CardTitle>Troubleshooting</CardTitle></CardHeader>
+        <CardContent class="space-y-3">
+          <p class="text-sm text-muted-foreground">
+            The GUI logs everything it does this session - including the daemon
+            install, upgrade, and start steps. Open the logs to see what
+            happened, or generate a diagnostics snapshot to share when reporting
+            a problem.
+          </p>
+          <div class="flex flex-wrap gap-2">
+            <Button variant="outline" @click="openLogs">
+              <FileText class="size-4" /> Logs
+            </Button>
+            <Button variant="outline" @click="openDiagnostics">
+              <Stethoscope class="size-4" /> Diagnostics
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     </div>
+
+    <Modal
+      v-model:open="logsOpen"
+      title="Logs"
+      size="full"
+      @update:open="(o: boolean) => { if (!o) stopLogPolling(); }"
+    >
+      <div class="flex h-full flex-col gap-3">
+        <!-- Tabs + actions -->
+        <div class="flex shrink-0 items-center justify-between gap-2">
+          <div class="flex gap-1">
+            <Button
+              :variant="activeTab === 'gui' ? 'default' : 'outline'"
+              size="sm"
+              @click="activeTab = 'gui'"
+            >
+              GUI
+            </Button>
+            <Button
+              :variant="activeTab === 'daemon' ? 'default' : 'outline'"
+              size="sm"
+              @click="activeTab = 'daemon'"
+            >
+              Daemon
+            </Button>
+          </div>
+          <div class="flex gap-1">
+            <Button variant="outline" size="sm" @click="fetchLogs">Refresh</Button>
+            <Button variant="outline" size="sm" @click="copyActive">Copy</Button>
+          </div>
+        </div>
+        <p v-if="activePath" class="shrink-0 truncate font-mono text-xs text-muted-foreground">
+          {{ activePath }}
+        </p>
+        <pre
+          class="min-h-0 flex-1 overflow-auto rounded-md bg-muted p-3 text-xs leading-relaxed"
+        >{{ activeLines.length ? activeLines.join("\n") : "No log entries yet." }}</pre>
+      </div>
+
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close">Close</Button>
+      </template>
+    </Modal>
+
+    <Modal v-model:open="diagOpen" title="Diagnostics" size="full">
+      <div class="flex h-full flex-col gap-3">
+        <div class="flex shrink-0 items-center justify-between gap-2">
+          <p class="text-xs text-muted-foreground">
+            A snapshot of paths, service configuration, and recent errors.
+          </p>
+          <Button variant="outline" size="sm" :disabled="diagLoading" @click="copyDiagnostics">
+            Copy
+          </Button>
+        </div>
+        <pre
+          class="min-h-0 flex-1 overflow-auto rounded-md bg-muted p-3 text-xs leading-relaxed"
+        >{{ diagLoading ? "Gathering…" : diagText || "No diagnostics available." }}</pre>
+      </div>
+
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close">Close</Button>
+      </template>
+    </Modal>
   </div>
 </template>

--- a/apps/yerd-gui/src/views/AboutView.vue
+++ b/apps/yerd-gui/src/views/AboutView.vue
@@ -67,6 +67,13 @@ const lastCheckedAgo = computed(() => {
 // cached prefetch can't clobber fresher state when it resolves later.
 let liveUpdateFlow = false;
 
+// Monotonic guard for overlapping live checks. The channel Select stays enabled
+// while a check is in flight (only `!running` disables it), so a second channel
+// change / check can start before the first resolves. Each check captures the
+// current seq before awaiting and only commits if it's still the latest, so an
+// older response that resolves last can't overwrite newer state out of order.
+let checkSeq = 0;
+
 // Pre-fill the section from the daemon's persisted last-check result (no network)
 // so the channel + status + "last checked" show immediately on load.
 async function loadCachedUpdate(): Promise<void> {
@@ -85,8 +92,10 @@ async function loadCachedUpdate(): Promise<void> {
 async function runUpdateCheck(notify = false): Promise<void> {
   liveUpdateFlow = true;
   checkingUpdates.value = true;
+  const seq = ++checkSeq;
   try {
     const s = await checkUpdates();
+    if (seq !== checkSeq) return; // a newer check superseded this one
     updateStatus.value = s;
     updateChannel.value = s.channel;
     if (!notify) return;
@@ -105,9 +114,12 @@ async function runUpdateCheck(notify = false): Promise<void> {
       toast.success("Up to date", "You're on the latest version.");
     }
   } catch (e) {
+    if (seq !== checkSeq) return; // superseded; stay quiet, the latest owns the UI
     if (notify) toast.error("Couldn't check for updates", (e as IpcError).message);
   } finally {
-    checkingUpdates.value = false;
+    // Only the latest in-flight check clears the spinner; an older one resolving
+    // first must leave it spinning until the newer check finishes.
+    if (seq === checkSeq) checkingUpdates.value = false;
   }
 }
 

--- a/apps/yerd-gui/src/views/AboutView.vue
+++ b/apps/yerd-gui/src/views/AboutView.vue
@@ -63,11 +63,16 @@ const lastCheckedAgo = computed(() => {
   return at ? humaniseAgo(at) : null;
 });
 
+// Set once the user triggers a live check or changes the channel, so the slower
+// cached prefetch can't clobber fresher state when it resolves later.
+let liveUpdateFlow = false;
+
 // Pre-fill the section from the daemon's persisted last-check result (no network)
 // so the channel + status + "last checked" show immediately on load.
 async function loadCachedUpdate(): Promise<void> {
   try {
     const s = await cachedUpdateStatus();
+    if (liveUpdateFlow) return; // a newer check / channel change already won the race
     updateStatus.value = s;
     updateChannel.value = s.channel;
   } catch {
@@ -78,6 +83,7 @@ async function loadCachedUpdate(): Promise<void> {
 // Notify only on an explicit "Check now" (notify=true). A check triggered any
 // other way (channel change) updates the shown status silently.
 async function runUpdateCheck(notify = false): Promise<void> {
+  liveUpdateFlow = true;
   checkingUpdates.value = true;
   try {
     const s = await checkUpdates();
@@ -120,6 +126,7 @@ async function onUpdateNow(): Promise<void> {
 
 // Persist the channel on change, then re-check so the shown status reflects it.
 async function onUpdateChannelChange(value: UpdateChannel): Promise<void> {
+  liveUpdateFlow = true;
   const previous = updateChannel.value;
   updateChannel.value = value; // optimistic
   try {
@@ -164,11 +171,13 @@ const activePath = computed(() =>
   activeTab.value === "gui" ? logs.value?.guiPath : logs.value?.daemonPath,
 );
 
-async function fetchLogs(): Promise<void> {
+async function fetchLogs(silent = false): Promise<void> {
   try {
     logs.value = await getGuiLogs();
   } catch (e) {
-    toast.error("Couldn't read logs", (e as IpcError).message);
+    // The 2s poll passes silent=true so a transient read failure doesn't spam a
+    // toast every tick; only the initial/manual load surfaces the error.
+    if (!silent) toast.error("Couldn't read logs", (e as IpcError).message);
   }
 }
 
@@ -177,7 +186,7 @@ function openLogs(): void {
   void fetchLogs();
   // Light polling while open so a live daemon-start trail streams in.
   stopLogPolling();
-  logsTimer = setInterval(() => void fetchLogs(), 2000);
+  logsTimer = setInterval(() => void fetchLogs(true), 2000);
 }
 
 function stopLogPolling(): void {
@@ -309,14 +318,21 @@ async function copyDiagnostics(): Promise<void> {
 
           <div class="flex items-center justify-between gap-4">
             <div class="min-w-0 text-sm">
-              <template v-if="updateStatus && updateStatus.checked_at_epoch">
+              <template
+                v-if="
+                  updateStatus &&
+                  (updateStatus.checked_at_epoch || updateStatus.latest_stable || updateStatus.latest_edge)
+                "
+              >
                 <p class="font-medium">{{ updateSummary }}</p>
                 <p class="text-xs text-muted-foreground">
                   Current {{ updateStatus.current }} · stable
                   {{ updateStatus.latest_stable ?? "-" }} · edge
                   {{ updateStatus.latest_edge ?? "-" }}
                 </p>
-                <p class="text-xs text-muted-foreground">Last checked {{ lastCheckedAgo }}.</p>
+                <p v-if="lastCheckedAgo" class="text-xs text-muted-foreground">
+                  Last checked {{ lastCheckedAgo }}.
+                </p>
               </template>
               <p v-else class="text-xs text-muted-foreground">
                 {{ running ? "Not checked yet." : "Start the daemon to check for updates." }}
@@ -398,7 +414,7 @@ async function copyDiagnostics(): Promise<void> {
             </Button>
           </div>
           <div class="flex gap-1">
-            <Button variant="outline" size="sm" @click="fetchLogs">Refresh</Button>
+            <Button variant="outline" size="sm" @click="fetchLogs()">Refresh</Button>
             <Button variant="outline" size="sm" @click="copyActive">Copy</Button>
           </div>
         </div>

--- a/apps/yerd-gui/src/views/DoctorView.vue
+++ b/apps/yerd-gui/src/views/DoctorView.vue
@@ -36,7 +36,7 @@ const sevVariant: Record<Severity, "success" | "warning" | "destructive"> = {
   fail: "destructive",
 };
 
-// Human labels — the wire uses bare enum tokens (ok/warn/fail) that read as
+// Human labels - the wire uses bare enum tokens (ok/warn/fail) that read as
 // unfinished in the UI.
 const sevLabel: Record<Severity, string> = {
   ok: "Healthy",

--- a/apps/yerd-gui/src/views/DoctorView.vue
+++ b/apps/yerd-gui/src/views/DoctorView.vue
@@ -72,9 +72,13 @@ async function confirmRestartDaemon(close: () => void): Promise<void> {
   close();
   try {
     await restartDaemon();
+    // The daemon replies before it re-execs, so a resolved call means the
+    // restart was accepted; the connection drop is handled by the status poll.
     toast.info("Restarting daemon…", "It returns in a few seconds.");
   } catch (e) {
-    toast.info("Restarting daemon…", (e as IpcError).message);
+    // Reaching here is a genuine failure (the reply arrives ahead of the drop),
+    // so don't imply the restart started.
+    toast.error("Couldn't restart the daemon", (e as IpcError).message);
   } finally {
     busy.value = null;
   }
@@ -194,13 +198,13 @@ onMounted(() => void loadDiagnoses());
               <Spinner v-if="daemonStarting" class="size-4" />
               <Play v-else class="size-4" /> {{ daemonStartLabel ?? "Start" }}
             </Button>
-            <Button v-else variant="outline" :disabled="busy === 'daemon'" @click="onStop">
+            <Button v-else variant="outline" :disabled="busy !== null" @click="onStop">
               <Spinner v-if="busy === 'daemon'" class="size-4" />
               <Square v-else class="size-4" /> Stop
             </Button>
             <Button
               variant="outline"
-              :disabled="!running || busy === 'restart:daemon'"
+              :disabled="!running || busy !== null"
               @click="openRestartDaemon"
             >
               <Spinner v-if="busy === 'restart:daemon'" class="size-4" />

--- a/apps/yerd-gui/src/views/DoctorView.vue
+++ b/apps/yerd-gui/src/views/DoctorView.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { CheckCircle2, Copy, RefreshCw, Wrench } from "lucide-vue-next";
-import { computed, onMounted, ref } from "vue";
+import { CheckCircle2, Copy, Info, Play, RefreshCw, RotateCw, Square, Wrench } from "lucide-vue-next";
+import { computed, nextTick, onMounted, ref } from "vue";
 
+import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import EnvironmentCard from "@/components/EnvironmentCard.vue";
 import PageHeader from "@/components/PageHeader.vue";
+import StatusPill from "@/components/StatusPill.vue";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
@@ -11,14 +13,72 @@ import CardContent from "@/components/ui/CardContent.vue";
 import CardDescription from "@/components/ui/CardDescription.vue";
 import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
+import Modal from "@/components/ui/Modal.vue";
 import Spinner from "@/components/ui/Spinner.vue";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useDaemon } from "@/composables/useDaemon";
+import { useDaemonStart } from "@/composables/useDaemonStart";
 import { useToast } from "@/composables/useToast";
-import { diagnose, doctorFix, IpcError } from "@/ipc/client";
+import { diagnose, doctorFix, IpcError, restartDaemon, stopDaemon } from "@/ipc/client";
 import type { Diagnosis, Severity } from "@/ipc/types";
 
 const toast = useToast();
-const { refresh: refreshStatus } = useDaemon();
+const { connected, report, refresh: refreshStatus } = useDaemon();
+
+// ── daemon lifecycle (moved here from Settings) ──
+const {
+  starting: daemonStarting,
+  activeLabel: daemonStartLabel,
+  diagnostics: startDiagnostics,
+  start: startDaemonFlow,
+} = useDaemonStart();
+const busy = ref<string | null>(null);
+const running = computed(() => connected.value === true);
+const daemonPid = computed(() => report.value?.daemon_pid ?? null);
+
+async function onStart(): Promise<void> {
+  // Spinner + on-failure diagnostics are owned by the composable; it keeps
+  // spinning until the daemon connects (watch) or surfaces the panel.
+  await startDaemonFlow({ nudge: true });
+  await refreshStatus();
+}
+
+async function onStop(): Promise<void> {
+  busy.value = "daemon";
+  try {
+    await stopDaemon();
+    toast.success("Stopping daemon…");
+  } catch (e) {
+    toast.error("Couldn't stop the daemon", (e as IpcError).message);
+  } finally {
+    busy.value = null;
+    await refreshStatus();
+  }
+}
+
+const restartDaemonOpen = ref(false);
+function openRestartDaemon(): void {
+  void nextTick(() => {
+    restartDaemonOpen.value = true;
+  });
+}
+async function confirmRestartDaemon(close: () => void): Promise<void> {
+  busy.value = "restart:daemon";
+  close();
+  try {
+    await restartDaemon();
+    toast.info("Restarting daemon…", "It returns in a few seconds.");
+  } catch (e) {
+    toast.info("Restarting daemon…", (e as IpcError).message);
+  } finally {
+    busy.value = null;
+  }
+}
 
 const diagnoses = ref<Diagnosis[]>([]);
 const diagLoading = ref(true);
@@ -100,6 +160,56 @@ onMounted(() => void loadDiagnoses());
     <PageHeader title="Doctor" subtitle="Health checks and safe one-click fixes" />
 
     <div class="min-h-0 flex-1 space-y-6 overflow-y-auto p-6">
+      <!-- Daemon control -->
+      <Card>
+        <CardHeader class="flex-row items-center justify-between space-y-0">
+          <div class="flex items-center gap-1.5">
+            <CardTitle>Daemon</CardTitle>
+            <TooltipProvider v-if="running && daemonPid" :delay-duration="0">
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <span class="inline-flex cursor-help text-muted-foreground">
+                    <Info class="size-3.5" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">running as pid {{ daemonPid }}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <StatusPill
+            :tone="running ? 'ok' : 'bad'"
+            :label="running ? 'Running' : 'Stopped'"
+          />
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <p class="text-sm text-muted-foreground">
+            <code>yerdd</code> is the background service that supervises PHP-FPM,
+            serves your <code>.test</code> sites over HTTP/HTTPS, answers DNS, and
+            runs databases. It runs unprivileged - this app is just a client.
+          </p>
+          <!-- Why a start attempt failed (only when the daemon is down). -->
+          <DaemonDiagnosticsPanel v-if="startDiagnostics && !running" :diagnostics="startDiagnostics" />
+          <div class="flex justify-end gap-2">
+            <Button v-if="!running" :disabled="daemonStarting" @click="onStart">
+              <Spinner v-if="daemonStarting" class="size-4" />
+              <Play v-else class="size-4" /> {{ daemonStartLabel ?? "Start" }}
+            </Button>
+            <Button v-else variant="outline" :disabled="busy === 'daemon'" @click="onStop">
+              <Spinner v-if="busy === 'daemon'" class="size-4" />
+              <Square v-else class="size-4" /> Stop
+            </Button>
+            <Button
+              variant="outline"
+              :disabled="!running || busy === 'restart:daemon'"
+              @click="openRestartDaemon"
+            >
+              <Spinner v-if="busy === 'restart:daemon'" class="size-4" />
+              <RotateCw v-else class="size-4" /> Restart
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader class="flex-row items-center justify-between space-y-0">
           <div class="space-y-1.5">
@@ -176,5 +286,17 @@ onMounted(() => void loadDiagnoses());
            reflects the new state without a manual re-check. -->
       <EnvironmentCard @elevated="loadDiagnoses()" />
     </div>
+
+    <Modal v-model:open="restartDaemonOpen" title="Restart daemon">
+      <p class="text-sm text-muted-foreground">
+        This briefly stops all <strong class="text-foreground">.test</strong> sites,
+        DNS, and this connection while the daemon restarts. It returns in a few
+        seconds.
+      </p>
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close">Cancel</Button>
+        <Button @click="confirmRestartDaemon(close)">Restart</Button>
+      </template>
+    </Modal>
   </div>
 </template>

--- a/apps/yerd-gui/src/views/DumpsWindowView.vue
+++ b/apps/yerd-gui/src/views/DumpsWindowView.vue
@@ -62,7 +62,7 @@ function tabCount(tab: (typeof TABS)[number]): number {
 async function poll(): Promise<void> {
   const r = await listDumps(cursor);
   // Drop deleted rows AND anything below the server's min_live_id (evicted or
-  // cleared) — so reconciliation never depends on the bounded removed-ids log,
+  // cleared) - so reconciliation never depends on the bounded removed-ids log,
   // and the client array can't outgrow the server buffer.
   const removed = new Set(r.removed_ids);
   events.value = events.value.filter((e) => e.id >= r.min_live_id && !removed.has(e.id));

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -69,6 +69,7 @@ const { connected, report, refresh: refreshStatus } = useDaemon();
 // blind toast.
 const {
   starting: daemonStarting,
+  activeLabel: daemonStartLabel,
   diagnostics: startDiagnostics,
   start: startDaemonFlow,
 } = useDaemonStart();
@@ -77,13 +78,13 @@ const { pref, setTheme } = useTheme();
 
 const busy = ref<string | null>(null);
 const autostart = ref<AutostartState | null>(null);
-// Host platform — drives macOS-specific daemon copy (on macOS the daemon runs
+// Host platform - drives macOS-specific daemon copy (on macOS the daemon runs
 // as a background login item registered via SMAppService; see below).
 const platform = ref("");
 const isMac = computed(() => platform.value === "macos");
 // macOS-only: whether the bundled `yerd` CLI is symlinked onto PATH.
 const cli = ref<CliPathStatus | null>(null);
-// Dump-capture status (separate IPC from the report) — feeds the subsystem list.
+// Dump-capture status (separate IPC from the report) - feeds the subsystem list.
 const dumps = ref<DumpsStatusResponse | null>(null);
 
 const themeOptions = [
@@ -304,7 +305,7 @@ async function openApproval(): Promise<void> {
 // Run a check (no override → uses the saved channel). Mirror the saved channel
 // the daemon reports back into the selector so it stays the single source of
 // truth.
-// `notify` is true only for the explicit "Check now" button — a check triggered
+// `notify` is true only for the explicit "Check now" button - a check triggered
 // any other way (channel change) updates the shown status silently, so opening
 // Settings never pops an unsolicited toast.
 async function runUpdateCheck(notify = false): Promise<void> {
@@ -320,10 +321,10 @@ async function runUpdateCheck(notify = false): Promise<void> {
       toast.info("Up to date", "You're on a pre-release ahead of stable.");
     } else if (status.source === "cached") {
       // The daemon couldn't reach the update server and served its last cached
-      // result — don't claim "latest version" off possibly-stale data.
+      // result - don't claim "latest version" off possibly-stale data.
       toast.info(
         "Couldn't reach the update server",
-        "Showing the last cached result — you may be offline.",
+        "Showing the last cached result - you may be offline.",
       );
     } else {
       toast.success("Up to date", "You're on the latest version.");
@@ -371,7 +372,7 @@ onMounted(() => {
     loadDumps();
     void loadFallbackPorts();
   }
-  // No auto update-check on open — it only runs when the user clicks "Check now".
+  // No auto update-check on open - it only runs when the user clicks "Check now".
 });
 
 // Refresh the dump-capture row whenever the daemon comes up (and clear it when
@@ -446,7 +447,7 @@ async function loadFallbackPorts(): Promise<void> {
     fbHttpSaved.value = fbHttp.value;
     fbHttpsSaved.value = fbHttps.value;
   } catch {
-    // Daemon down / older daemon — clear so a later transient fetch failure
+    // Daemon down / older daemon - clear so a later transient fetch failure
     // can't leave stale ports shown (or re-savable) under the "running" card.
     fbHttp.value = "";
     fbHttps.value = "";
@@ -577,7 +578,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
           </div>
           <Button v-if="!running" :disabled="daemonStarting" @click="onStart">
             <Spinner v-if="daemonStarting" class="size-4" />
-            <Play v-else class="size-4" /> Start
+            <Play v-else class="size-4" /> {{ daemonStartLabel ?? "Start" }}
           </Button>
           <Button v-else variant="outline" :disabled="busy === 'daemon'" @click="onStop">
             <Spinner v-if="busy === 'daemon'" class="size-4" />
@@ -650,7 +651,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
           <CardTitle>Web ports</CardTitle>
           <CardDescription>
             The rootless ports Yerd serves on when 80/443 need elevation. Must be
-            {{ MIN_PORT }}+ — a privileged port like 80/443 would itself need
+            {{ MIN_PORT }}+ - a privileged port like 80/443 would itself need
             elevation, which the fallback exists to avoid.
           </CardDescription>
         </CardHeader>
@@ -665,7 +666,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
               It couldn't bind ports {{ report.web_unbound.http }}/{{
                 report.web_unbound.https
               }}
-              — they're in use by another process. Pick free ports below and save.
+              - they're in use by another process. Pick free ports below and save.
             </p>
           </div>
           <!-- Elevated: editing would break the pinned redirect. -->
@@ -771,7 +772,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
         </CardContent>
       </Card>
 
-      <!-- Terminal CLI (macOS) — Linux exposes `yerd` on PATH via the .deb. -->
+      <!-- Terminal CLI (macOS) - Linux exposes `yerd` on PATH via the .deb. -->
       <Card v-if="isMac">
         <CardHeader>
           <CardTitle>Terminal CLI</CardTitle>
@@ -913,7 +914,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
       <p class="text-sm text-muted-foreground">
         Saving sets the rootless ports to
         <strong class="text-foreground font-mono">{{ fbHttp }}/{{ fbHttps }}</strong>
-        and restarts the daemon — this briefly stops all
+        and restarts the daemon - this briefly stops all
         <strong class="text-foreground">.test</strong> sites, DNS, and this
         connection. It returns in a few seconds.
       </p>

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -1,17 +1,7 @@
 <script setup lang="ts">
-import {
-  Download,
-  Info,
-  Play,
-  RefreshCw,
-  RotateCw,
-  Square,
-} from "lucide-vue-next";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 
-import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import PageHeader from "@/components/PageHeader.vue";
-import StatusPill, { type Tone } from "@/components/StatusPill.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import CardContent from "@/components/ui/CardContent.vue";
@@ -23,19 +13,10 @@ import Modal from "@/components/ui/Modal.vue";
 import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import Switch from "@/components/ui/Switch.vue";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useDaemon } from "@/composables/useDaemon";
-import { useDaemonStart } from "@/composables/useDaemonStart";
 import { MIN_PORT, MAX_PORT, useFallbackPorts } from "@/composables/useFallbackPorts";
 import { useToast } from "@/composables/useToast";
 import {
-  applyUpdate,
-  checkUpdates,
   cliPathStatus,
   daemonInfo,
   dumpsStatus,
@@ -45,34 +26,14 @@ import {
   IpcError,
   openLoginItems,
   removeCliFromPath,
-  restartDaemon,
   setAutostartDaemon,
   setAutostartGui,
   setAutostartGuiMinimized,
-  setUpdateChannel,
-  stopDaemon,
 } from "@/ipc/client";
-import type {
-  AutostartState,
-  CliPathStatus,
-  DumpsStatusResponse,
-  StatusReport,
-  UpdateChannel,
-  UpdateStatusResponse,
-} from "@/ipc/types";
+import type { AutostartState, CliPathStatus } from "@/ipc/types";
 import { useTheme, type ThemePref } from "@/lib/theme";
-import { humaniseBytes, humaniseUptime } from "@/lib/utils";
 
 const { connected, report, refresh: refreshStatus } = useDaemon();
-// Surfaces the same failure diagnostics here as onboarding / the down-hero, so a
-// start attempt from Settings (a screen shown while the daemon is down) isn't a
-// blind toast.
-const {
-  starting: daemonStarting,
-  activeLabel: daemonStartLabel,
-  diagnostics: startDiagnostics,
-  start: startDaemonFlow,
-} = useDaemonStart();
 const toast = useToast();
 const { pref, setTheme } = useTheme();
 
@@ -84,8 +45,6 @@ const platform = ref("");
 const isMac = computed(() => platform.value === "macos");
 // macOS-only: whether the bundled `yerd` CLI is symlinked onto PATH.
 const cli = ref<CliPathStatus | null>(null);
-// Dump-capture status (separate IPC from the report) - feeds the subsystem list.
-const dumps = ref<DumpsStatusResponse | null>(null);
 
 const themeOptions = [
   { value: "system", label: "System" },
@@ -93,171 +52,7 @@ const themeOptions = [
   { value: "dark", label: "Dark" },
 ] as const;
 
-// ── self-update ──
-const channelOptions = [
-  { value: "stable", label: "Stable" },
-  { value: "edge", label: "Edge (pre-release)" },
-] as const;
-const updateChannel = ref<UpdateChannel>("stable");
-const updateStatus = ref<UpdateStatusResponse | null>(null);
-const checkingUpdates = ref(false);
-const applyingUpdate = ref(false);
-
-const updateSummary = computed(() => {
-  const s = updateStatus.value;
-  if (!s) return "";
-  if (s.available && s.target) return `Update available: ${s.target}`;
-  if (s.ahead_of_stable) return "Up to date (on a pre-release ahead of stable)";
-  return "Up to date";
-});
-
 const running = computed(() => connected.value === true);
-const daemonStatus = computed(() => {
-  if (!running.value) return "Stopped";
-  const pid = report.value?.daemon_pid;
-  return pid ? `Running · pid ${pid}` : "Running";
-});
-
-// ── subsystem table (daemon + the in-process DNS/proxy listeners; no FPM) ──
-interface Row {
-  key: string;
-  name: string;
-  tone: Tone;
-  state: string;
-  info: string;
-  child?: boolean; // indented under the daemon (runs inside its process)
-  menu?: boolean; // the daemon row gets the Restart action
-}
-
-const PRIVILEGED_PORT_CEILING = 1024;
-
-function portRow(
-  key: string,
-  name: string,
-  r: StatusReport,
-  which: "http" | "https",
-): Row {
-  const ps = r[which];
-  // Degraded: the daemon bound no web ports at all, so there's nothing serving.
-  if (r.web_unbound) {
-    return {
-      key,
-      name,
-      tone: "bad",
-      state: "not serving",
-      info: `couldn't bind the rootless port (tried :${ps.requested === ps.bound ? ps.requested : r.web_unbound[which]})`,
-      child: true,
-    };
-  }
-  const privileged = ps.requested < PRIVILEGED_PORT_CEILING;
-  const redirected = r.port_redirect === true;
-  const viaRedirect = privileged && ps.fell_back && redirected;
-  const problem = privileged && ps.fell_back && !redirected;
-
-  let detail: string;
-  if (!ps.fell_back) {
-    detail = "privileged port";
-  } else if (viaRedirect) {
-    detail = `:${ps.requested} via pf redirect → :${ps.bound}`;
-  } else {
-    detail = `rootless fallback from :${ps.requested}`;
-  }
-
-  return {
-    key,
-    name,
-    tone: problem ? "warn" : "ok",
-    state: viaRedirect ? `:${ps.requested}` : `:${ps.bound}`,
-    info: detail,
-    child: true,
-  };
-}
-
-function mailRow(r: StatusReport): Row | null {
-  const m = r.mail;
-  if (!m) return null; // daemon predates the mail subsystem
-  let tone: Tone;
-  let state: string;
-  let info: string;
-  if (!m.enabled) {
-    tone = "muted";
-    state = "disabled";
-    info = "enable it on the Mail page";
-  } else if (m.listening) {
-    tone = "ok";
-    state = `:${m.port}`;
-    info = `SMTP on 127.0.0.1:${m.port} · ${m.count} captured`;
-  } else {
-    tone = "warn";
-    state = `:${m.port}`;
-    info = `port :${m.port} unavailable`;
-  }
-  return { key: "mail", name: "Mail capture", tone, state, info, child: true };
-}
-
-// The dump-capture loopback server is a daemon subsystem like mail/DNS, but its
-// state lives in a separate IPC (dumps_status), fetched alongside the report.
-function dumpsRow(d: DumpsStatusResponse | null): Row | null {
-  if (!d) return null; // daemon predates the dumps subsystem / fetch failed
-  let tone: Tone;
-  let state: string;
-  let info: string;
-  if (!d.enabled) {
-    tone = "muted";
-    state = "disabled";
-    info = "enable capture on the Dumps page";
-  } else if (d.running) {
-    tone = "ok";
-    state = `:${d.port}`;
-    info = `dump server on 127.0.0.1:${d.port}`;
-  } else {
-    tone = "warn";
-    state = `:${d.port}`;
-    info = `port :${d.port} unavailable`;
-  }
-  return { key: "dumps", name: "Dump capture", tone, state, info, child: true };
-}
-
-const rows = computed<Row[]>(() => {
-  const r = report.value;
-  if (!r) return [];
-  const base: Row[] = [
-    {
-      key: "daemon",
-      name: "Daemon (yerdd)",
-      tone: "ok",
-      state: "running",
-      info: `pid ${r.daemon_pid} · up ${humaniseUptime(r.uptime_secs)}${
-        r.daemon_rss_bytes != null ? ` · ${humaniseBytes(r.daemon_rss_bytes)} RSS` : ""
-      }`,
-      menu: true,
-    },
-    r.dns_unbound != null
-      ? {
-          key: "dns",
-          name: "DNS resolver",
-          tone: "bad" as Tone,
-          state: "not resolving",
-          info: `couldn't bind port :${r.dns_unbound}`,
-          child: true,
-        }
-      : {
-          key: "dns",
-          name: "DNS resolver",
-          tone: "ok" as Tone,
-          state: "listening",
-          info: `bound on ${r.dns_addr}`,
-          child: true,
-        },
-    portRow("proxy-http", "Proxy (HTTP)", r, "http"),
-    portRow("proxy-https", "Proxy (HTTPS)", r, "https"),
-  ];
-  const mail = mailRow(r);
-  if (mail) base.push(mail);
-  const dump = dumpsRow(dumps.value);
-  if (dump) base.push(dump);
-  return base;
-});
 
 // ── data loads ──
 async function loadAutostart(): Promise<void> {
@@ -265,15 +60,6 @@ async function loadAutostart(): Promise<void> {
     autostart.value = await getAutostart();
   } catch (e) {
     toast.error("Couldn't load startup settings", (e as IpcError).message);
-  }
-}
-
-/** Dump-capture status is a separate IPC; a failure just hides the row. */
-async function loadDumps(): Promise<void> {
-  try {
-    dumps.value = await dumpsStatus();
-  } catch {
-    dumps.value = null;
   }
 }
 
@@ -310,67 +96,6 @@ async function openApproval(): Promise<void> {
   }
 }
 
-// ── self-update ──
-// Run a check (no override → uses the saved channel). Mirror the saved channel
-// the daemon reports back into the selector so it stays the single source of
-// truth.
-// `notify` is true only for the explicit "Check now" button - a check triggered
-// any other way (channel change) updates the shown status silently, so opening
-// Settings never pops an unsolicited toast.
-async function runUpdateCheck(notify = false): Promise<void> {
-  checkingUpdates.value = true;
-  try {
-    const status = await checkUpdates();
-    updateStatus.value = status;
-    updateChannel.value = status.channel;
-    if (!notify) return;
-    if (status.available && status.target) {
-      toast.success("Update available", `Version ${status.target} can be installed.`);
-    } else if (status.ahead_of_stable) {
-      toast.info("Up to date", "You're on a pre-release ahead of stable.");
-    } else if (status.source === "cached") {
-      // The daemon couldn't reach the update server and served its last cached
-      // result - don't claim "latest version" off possibly-stale data.
-      toast.info(
-        "Couldn't reach the update server",
-        "Showing the last cached result - you may be offline.",
-      );
-    } else {
-      toast.success("Up to date", "You're on the latest version.");
-    }
-  } catch (e) {
-    if (notify) toast.error("Couldn't check for updates", (e as IpcError).message);
-  } finally {
-    checkingUpdates.value = false;
-  }
-}
-
-// Download + verify + apply. The app quits during the swap and the applier
-// relaunches it, so `applyUpdate` usually never returns; a thrown error means
-// staging failed (offline, verification, or a non-writable /Applications).
-async function onUpdateNow(): Promise<void> {
-  applyingUpdate.value = true;
-  try {
-    await applyUpdate(updateChannel.value);
-  } catch (e) {
-    applyingUpdate.value = false;
-    toast.error("Couldn't apply the update", (e as IpcError).message);
-  }
-}
-
-// Persist the channel on change, then re-check so the shown status reflects it.
-async function onUpdateChannelChange(value: UpdateChannel): Promise<void> {
-  const previous = updateChannel.value;
-  updateChannel.value = value; // optimistic
-  try {
-    await setUpdateChannel(value);
-    await runUpdateCheck();
-  } catch (e) {
-    updateChannel.value = previous; // revert on failure
-    toast.error("Couldn't change the update channel", (e as IpcError).message);
-  }
-}
-
 onMounted(() => {
   loadAutostart();
   hostPlatform()
@@ -378,65 +103,14 @@ onMounted(() => {
     .catch(() => {});
   loadCli();
   if (running.value) {
-    loadDumps();
     void loadApplicationPorts();
   }
-  // No auto update-check on open - it only runs when the user clicks "Check now".
 });
 
-// Refresh the dump-capture row whenever the daemon comes up (and clear it when
-// it goes away), so the subsystem list doesn't show stale dump state.
+// Reload the editable port values whenever the daemon comes up.
 watch(running, (up) => {
-  if (up) {
-    loadDumps();
-    void loadApplicationPorts();
-  } else {
-    dumps.value = null;
-    updateStatus.value = null;
-  }
+  if (up) void loadApplicationPorts();
 });
-
-// ── daemon lifecycle ──
-async function onStart(): Promise<void> {
-  // Spinner + on-failure diagnostics are owned by the composable; it keeps
-  // spinning until the daemon connects (watch) or surfaces the panel.
-  await startDaemonFlow({ nudge: true });
-  // Refresh the approval banners (a fresh registration may now be pending).
-  await loadAutostart();
-}
-
-async function onStop(): Promise<void> {
-  busy.value = "daemon";
-  try {
-    await stopDaemon();
-    toast.success("Stopping daemon…");
-  } catch (e) {
-    toast.error("Couldn't stop the daemon", (e as IpcError).message);
-  } finally {
-    busy.value = null;
-    await refreshStatus();
-  }
-}
-
-// ── daemon restart (confirm modal) ──
-const restartDaemonOpen = ref(false);
-function openRestartDaemon(): void {
-  void nextTick(() => {
-    restartDaemonOpen.value = true;
-  });
-}
-async function confirmRestartDaemon(close: () => void): Promise<void> {
-  busy.value = "restart:daemon";
-  close();
-  try {
-    await restartDaemon();
-    toast.info("Restarting daemon…", "It returns in a few seconds.");
-  } catch (e) {
-    toast.info("Restarting daemon…", (e as IpcError).message);
-  } finally {
-    busy.value = null;
-  }
-}
 
 // ── application ports (HTTP/HTTPS fallback, DNS, mail, dumps) ──
 const { applyAndRestart, validate: validateFallbackPorts, validateLoopback } =
@@ -635,7 +309,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
 
 <template>
   <div class="flex h-full flex-col">
-    <PageHeader title="Settings" subtitle="Daemon, startup, and appearance" />
+    <PageHeader title="Settings" subtitle="Updates, ports, startup, and appearance" />
 
     <div class="flex-1 space-y-4 overflow-y-auto p-6">
       <!-- macOS: registered via SMAppService but awaiting Login-Items approval. -->
@@ -671,82 +345,6 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
           Open Login Items
         </Button>
       </div>
-
-      <!-- Daemon + subsystems -->
-      <Card>
-        <CardHeader class="flex-row items-center justify-between space-y-0">
-          <div class="space-y-1.5">
-            <CardTitle>Daemon</CardTitle>
-            <CardDescription>{{ daemonStatus }}</CardDescription>
-          </div>
-          <Button v-if="!running" :disabled="daemonStarting" @click="onStart">
-            <Spinner v-if="daemonStarting" class="size-4" />
-            <Play v-else class="size-4" /> {{ daemonStartLabel ?? "Start" }}
-          </Button>
-          <Button v-else variant="outline" :disabled="busy === 'daemon'" @click="onStop">
-            <Spinner v-if="busy === 'daemon'" class="size-4" />
-            <Square v-else class="size-4" /> Stop
-          </Button>
-        </CardHeader>
-        <!-- Why a start attempt failed (only when the daemon is down). -->
-        <CardContent v-if="startDiagnostics && !running">
-          <DaemonDiagnosticsPanel :diagnostics="startDiagnostics" />
-        </CardContent>
-        <CardContent v-if="report">
-          <TooltipProvider :delay-duration="0">
-            <div class="text-sm">
-              <div
-                v-for="row in rows"
-                :key="row.key"
-                class="flex items-center gap-3 py-1.5"
-              >
-                <div
-                  class="flex min-w-0 flex-1 items-center gap-1.5"
-                  :class="row.child ? 'pl-3' : ''"
-                >
-                  <span
-                    v-if="row.child"
-                    class="select-none text-muted-foreground/50"
-                    aria-hidden="true"
-                  >
-                    ↳
-                  </span>
-                  <span :class="row.child ? 'text-muted-foreground' : 'font-medium'">
-                    {{ row.name }}
-                  </span>
-                  <Tooltip v-if="row.info">
-                    <TooltipTrigger as-child>
-                      <span class="inline-flex cursor-help text-muted-foreground">
-                        <Info class="size-3.5" />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">{{ row.info }}</TooltipContent>
-                  </Tooltip>
-                </div>
-                <StatusPill :tone="row.tone" :label="row.state" />
-                <div class="flex w-9 shrink-0 justify-end">
-                  <template v-if="row.menu">
-                    <Spinner v-if="busy === 'restart:daemon'" class="size-4" />
-                    <Tooltip v-else>
-                      <TooltipTrigger as-child>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          aria-label="Restart daemon"
-                          @click="openRestartDaemon"
-                        >
-                          <RotateCw class="size-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top">Restart daemon</TooltipContent>
-                    </Tooltip>
-                  </template>
-                </div>
-              </div>
-            </div>
-          </TooltipProvider>
-        </CardContent>
-      </Card>
 
       <!-- Application ports (HTTP/HTTPS fallback, DNS, mail, dumps) -->
       <Card v-if="running">
@@ -988,90 +586,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
         </CardContent>
       </Card>
 
-      <!-- Updates -->
-      <Card>
-        <CardHeader>
-          <CardTitle>Updates</CardTitle>
-          <CardDescription>
-            Keep Yerd up to date. Choose a release channel and check for new
-            versions.
-          </CardDescription>
-        </CardHeader>
-        <CardContent class="space-y-4">
-          <div class="flex items-center justify-between gap-4">
-            <div>
-              <p class="text-sm font-medium">Release channel</p>
-              <p class="text-xs text-muted-foreground">
-                Stable tracks final releases; Edge opts in to pre-releases and
-                release candidates.
-              </p>
-            </div>
-            <Select
-              :model-value="updateChannel"
-              :options="channelOptions"
-              aria-label="Update channel"
-              :disabled="!running"
-              @update:model-value="(v: UpdateChannel) => onUpdateChannelChange(v)"
-            />
-          </div>
-
-          <div class="flex items-center justify-between gap-4 border-t pt-4">
-            <div class="min-w-0 text-sm">
-              <template v-if="updateStatus">
-                <p class="font-medium">{{ updateSummary }}</p>
-                <p class="text-xs text-muted-foreground">
-                  Current {{ updateStatus.current }} · stable
-                  {{ updateStatus.latest_stable ?? "-" }} · edge
-                  {{ updateStatus.latest_edge ?? "-" }}
-                  <span v-if="updateStatus.source === 'cached'">
-                    · offline (last known)
-                  </span>
-                </p>
-              </template>
-              <p v-else class="text-xs text-muted-foreground">
-                {{ running ? "Not checked yet." : "Start the daemon to check for updates." }}
-              </p>
-            </div>
-            <Button variant="outline" :disabled="!running || checkingUpdates" @click="runUpdateCheck(true)">
-              <Spinner v-if="checkingUpdates" class="size-4" />
-              <RefreshCw v-else class="size-4" />
-              Check now
-            </Button>
-          </div>
-
-          <div
-            v-if="updateStatus?.available"
-            class="flex items-center justify-between gap-4 rounded-lg border border-success/40 bg-success/10 p-3"
-          >
-            <p class="text-sm">
-              <template v-if="applyingUpdate">
-                Updating to <strong>{{ updateStatus.target }}</strong> - Yerd will restart…
-              </template>
-              <template v-else>
-                Yerd <strong>{{ updateStatus.target }}</strong> is available.
-              </template>
-            </p>
-            <Button :disabled="!running || applyingUpdate" @click="onUpdateNow">
-              <Spinner v-if="applyingUpdate" class="size-4" />
-              <Download v-else class="size-4" />
-              {{ applyingUpdate ? "Updating…" : "Update" }}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
     </div>
-
-    <Modal v-model:open="restartDaemonOpen" title="Restart daemon">
-      <p class="text-sm text-muted-foreground">
-        This briefly stops all <strong class="text-foreground">.test</strong> sites,
-        DNS, and this connection while the daemon restarts. It returns in a few
-        seconds.
-      </p>
-      <template #footer="{ close }">
-        <Button variant="ghost" @click="close">Cancel</Button>
-        <Button @click="confirmRestartDaemon(close)">Restart</Button>
-      </template>
-    </Modal>
 
     <Modal v-model:open="applicationPortsOpen" title="Change application ports?">
       <p class="text-sm text-muted-foreground">

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -309,7 +309,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
 
 <template>
   <div class="flex h-full flex-col">
-    <PageHeader title="Settings" subtitle="Updates, ports, startup, and appearance" />
+    <PageHeader title="Settings" subtitle="Ports, startup, and appearance" />
 
     <div class="flex-1 space-y-4 overflow-y-auto p-6">
       <!-- macOS: registered via SMAppService but awaiting Login-Items approval. -->

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -203,7 +203,9 @@ const webPortsChanged = computed(
 );
 const applicationPortsChanged = computed(
   () =>
-    webPortsChanged.value ||
+    // While elevated the web ports are pinned and never submitted, so a stale
+    // web delta must not flip Save on (or get snapshotted as if applied).
+    (!portsElevated.value && webPortsChanged.value) ||
     dnsPort.value !== dnsPortSaved.value ||
     mailPort.value !== mailPortSaved.value ||
     dumpsPort.value !== dumpsPortSaved.value,
@@ -252,9 +254,13 @@ async function confirmApplicationPorts(close: () => void): Promise<void> {
 
     const res = await applyAndRestart(changes);
     if (res.ok) {
-      // Re-snapshot the saved values so the form is no longer "changed".
-      fbHttpSaved.value = fbHttp.value;
-      fbHttpsSaved.value = fbHttps.value;
+      // Re-snapshot the saved values so the form is no longer "changed". Only
+      // re-snapshot web ports when they were actually submitted, so a pinned
+      // (elevated) edit isn't silently recorded as applied.
+      if (changes.web) {
+        fbHttpSaved.value = fbHttp.value;
+        fbHttpsSaved.value = fbHttps.value;
+      }
       dnsPortSaved.value = dnsPort.value;
       mailPortSaved.value = mailPort.value;
       dumpsPortSaved.value = dumpsPort.value;

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -232,14 +232,23 @@ const rows = computed<Row[]>(() => {
       }`,
       menu: true,
     },
-    {
-      key: "dns",
-      name: "DNS resolver",
-      tone: "ok",
-      state: "listening",
-      info: `bound on ${r.dns_addr}`,
-      child: true,
-    },
+    r.dns_unbound != null
+      ? {
+          key: "dns",
+          name: "DNS resolver",
+          tone: "bad" as Tone,
+          state: "not resolving",
+          info: `couldn't bind port :${r.dns_unbound}`,
+          child: true,
+        }
+      : {
+          key: "dns",
+          name: "DNS resolver",
+          tone: "ok" as Tone,
+          state: "listening",
+          info: `bound on ${r.dns_addr}`,
+          child: true,
+        },
     portRow("proxy-http", "Proxy (HTTP)", r, "http"),
     portRow("proxy-https", "Proxy (HTTPS)", r, "https"),
   ];
@@ -370,7 +379,7 @@ onMounted(() => {
   loadCli();
   if (running.value) {
     loadDumps();
-    void loadFallbackPorts();
+    void loadApplicationPorts();
   }
   // No auto update-check on open - it only runs when the user clicks "Check now".
 });
@@ -380,7 +389,7 @@ onMounted(() => {
 watch(running, (up) => {
   if (up) {
     loadDumps();
-    void loadFallbackPorts();
+    void loadApplicationPorts();
   } else {
     dumps.value = null;
     updateStatus.value = null;
@@ -429,61 +438,155 @@ async function confirmRestartDaemon(close: () => void): Promise<void> {
   }
 }
 
-// ── rootless fallback ports ──
-const { saveAndRestart: saveFallbackPorts, validate: validateFallbackPorts } =
+// ── application ports (HTTP/HTTPS fallback, DNS, mail, dumps) ──
+const { applyAndRestart, validate: validateFallbackPorts, validateLoopback } =
   useFallbackPorts();
 const fbHttp = ref("");
 const fbHttps = ref("");
+const dnsPort = ref("");
+const mailPort = ref("");
+const dumpsPort = ref("");
 // The values last loaded from / saved to the daemon, to detect a real change.
 const fbHttpSaved = ref("");
 const fbHttpsSaved = ref("");
-const fallbackPortsOpen = ref(false);
+const dnsPortSaved = ref("");
+const mailPortSaved = ref("");
+const dumpsPortSaved = ref("");
+const applicationPortsOpen = ref(false);
 
-async function loadFallbackPorts(): Promise<void> {
+/** Extract the port from a `host:port` socket address (e.g. `127.0.0.1:1053`). */
+function portFromAddr(addr: string | undefined): number {
+  if (!addr) return 0;
+  const port = Number(addr.slice(addr.lastIndexOf(":") + 1));
+  return Number.isInteger(port) ? port : 0;
+}
+
+async function loadApplicationPorts(): Promise<void> {
+  // HTTP/HTTPS fallback + DNS come from `daemonInfo`; dumps from its own status
+  // call; mail from the live status report.
   try {
     const info = await daemonInfo();
-    fbHttp.value = info.fallback_http != null ? String(info.fallback_http) : "";
-    fbHttps.value = info.fallback_https != null ? String(info.fallback_https) : "";
-    fbHttpSaved.value = fbHttp.value;
-    fbHttpsSaved.value = fbHttps.value;
+    fbHttp.value = info.fallback_http ? String(info.fallback_http) : "";
+    fbHttps.value = info.fallback_https ? String(info.fallback_https) : "";
+    // Prefer the configured `dns_port`; fall back to the *bound* DNS address
+    // (always present, incl. on an older daemon that omits `dns_port`) so the
+    // field shows a real value rather than relying on the placeholder.
+    const dp = info.dns_port || portFromAddr(report.value?.dns_addr);
+    dnsPort.value = dp ? String(dp) : "";
   } catch {
     // Daemon down / older daemon - clear so a later transient fetch failure
     // can't leave stale ports shown (or re-savable) under the "running" card.
     fbHttp.value = "";
     fbHttps.value = "";
-    fbHttpSaved.value = "";
-    fbHttpsSaved.value = "";
+    dnsPort.value = "";
   }
+  try {
+    const d = await dumpsStatus();
+    dumpsPort.value = d.port ? String(d.port) : "";
+  } catch {
+    dumpsPort.value = "";
+  }
+  const mp = report.value?.mail?.port;
+  mailPort.value = mp ? String(mp) : "";
+  fbHttpSaved.value = fbHttp.value;
+  fbHttpsSaved.value = fbHttps.value;
+  dnsPortSaved.value = dnsPort.value;
+  mailPortSaved.value = mailPort.value;
+  dumpsPortSaved.value = dumpsPort.value;
 }
 
-// macOS pf redirect is pinned to the current ports, so block edits until the
-// user un-elevates. Only fires on macOS (Linux reports null).
-const portsElevated = computed(() => report.value?.port_redirect === true);
-const fallbackPortsChanged = computed(
-  () => fbHttp.value !== fbHttpSaved.value || fbHttps.value !== fbHttpsSaved.value,
+// The mail port lives in the status report, which can lag the first paint by one
+// poll. Fill it once it arrives, but only while the field is still untouched.
+watch(
+  () => report.value?.mail?.port,
+  (p) => {
+    if (p != null && mailPort.value === "" && mailPortSaved.value === "") {
+      mailPort.value = String(p);
+      mailPortSaved.value = String(p);
+    }
+  },
 );
 
-function openFallbackPorts(): void {
-  const err = validateFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
-  if (err) {
-    toast.error("Invalid ports", err);
-    return;
+// Same for DNS against an older daemon that omits `dns_port` from `daemonInfo`:
+// backfill from the bound `dns_addr` once the report arrives, while untouched.
+watch(
+  () => report.value?.dns_addr,
+  (addr) => {
+    const p = portFromAddr(addr);
+    if (p && dnsPort.value === "" && dnsPortSaved.value === "") {
+      dnsPort.value = String(p);
+      dnsPortSaved.value = String(p);
+    }
+  },
+);
+
+// macOS pf redirect is pinned to the current HTTP/HTTPS ports, so block edits to
+// those until the user un-elevates. Only fires on macOS (Linux reports null).
+// DNS/mail/dumps are unaffected and stay editable.
+const portsElevated = computed(() => report.value?.port_redirect === true);
+const webPortsChanged = computed(
+  () => fbHttp.value !== fbHttpSaved.value || fbHttps.value !== fbHttpsSaved.value,
+);
+const applicationPortsChanged = computed(
+  () =>
+    webPortsChanged.value ||
+    dnsPort.value !== dnsPortSaved.value ||
+    mailPort.value !== mailPortSaved.value ||
+    dumpsPort.value !== dumpsPortSaved.value,
+);
+
+function openApplicationPorts(): void {
+  // Pre-validate only the fields that changed (and are editable), so the confirm
+  // modal never opens on input the daemon would reject anyway.
+  if (!portsElevated.value && webPortsChanged.value) {
+    const err = validateFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+    if (err) {
+      toast.error("Invalid ports", err);
+      return;
+    }
+  }
+  for (const [label, ref_, saved] of [
+    ["DNS", dnsPort, dnsPortSaved],
+    ["mail", mailPort, mailPortSaved],
+    ["dumps", dumpsPort, dumpsPortSaved],
+  ] as const) {
+    if (ref_.value !== saved.value) {
+      const err = validateLoopback(label, Number(ref_.value));
+      if (err) {
+        toast.error("Invalid ports", err);
+        return;
+      }
+    }
   }
   void nextTick(() => {
-    fallbackPortsOpen.value = true;
+    applicationPortsOpen.value = true;
   });
 }
 
-async function confirmFallbackPorts(close: () => void): Promise<void> {
+async function confirmApplicationPorts(close: () => void): Promise<void> {
   close();
-  busy.value = "fallback-ports";
+  busy.value = "application-ports";
   try {
-    const res = await saveFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+    const changes: Parameters<typeof applyAndRestart>[0] = {};
+    // Omit HTTP/HTTPS while elevated (the redirect pins them) or unchanged.
+    if (!portsElevated.value && webPortsChanged.value) {
+      changes.web = { http: Number(fbHttp.value), https: Number(fbHttps.value) };
+    }
+    if (dnsPort.value !== dnsPortSaved.value) changes.dns = Number(dnsPort.value);
+    if (mailPort.value !== mailPortSaved.value) changes.mail = Number(mailPort.value);
+    if (dumpsPort.value !== dumpsPortSaved.value) changes.dumps = Number(dumpsPort.value);
+
+    const res = await applyAndRestart(changes);
     if (res.ok) {
+      // Re-snapshot the saved values so the form is no longer "changed".
       fbHttpSaved.value = fbHttp.value;
       fbHttpsSaved.value = fbHttps.value;
-      toast.success("Ports updated", `Yerd is now serving on ${fbHttp.value}/${fbHttps.value}.`);
+      dnsPortSaved.value = dnsPort.value;
+      mailPortSaved.value = mailPort.value;
+      dumpsPortSaved.value = dumpsPort.value;
+      toast.success("Ports updated", "Yerd restarted with the new ports.");
     } else {
+      // Leave the user's edits in place so they can adjust and retry.
       toast.error("Couldn't apply the new ports", res.message ?? "The daemon is still degraded.");
     }
   } finally {
@@ -645,18 +748,18 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
         </CardContent>
       </Card>
 
-      <!-- Web ports (rootless fallback) -->
+      <!-- Application ports (HTTP/HTTPS fallback, DNS, mail, dumps) -->
       <Card v-if="running">
         <CardHeader>
-          <CardTitle>Web ports</CardTitle>
+          <CardTitle>Application Ports</CardTitle>
           <CardDescription>
-            The rootless ports Yerd serves on when 80/443 need elevation. Must be
-            {{ MIN_PORT }}+ - a privileged port like 80/443 would itself need
-            elevation, which the fallback exists to avoid.
+            The loopback ports Yerd's services listen on. HTTP/HTTPS are the
+            rootless ports used when 80/443 need elevation (must be
+            {{ MIN_PORT }}+). Saving any change restarts the daemon.
           </CardDescription>
         </CardHeader>
-        <CardContent class="space-y-3">
-          <!-- Degraded: nothing bound. -->
+        <CardContent class="space-y-4">
+          <!-- Degraded: no web ports bound. -->
           <div
             v-if="report?.web_unbound"
             class="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm"
@@ -666,52 +769,112 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
               It couldn't bind ports {{ report.web_unbound.http }}/{{
                 report.web_unbound.https
               }}
-              - they're in use by another process. Pick free ports below and save.
+              - they're in use by another process. Pick free HTTP/HTTPS ports
+              below and save.
             </p>
           </div>
-          <!-- Elevated: editing would break the pinned redirect. -->
+          <!-- Degraded: DNS port not bound. -->
+          <div
+            v-if="report?.dns_unbound != null"
+            class="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm"
+          >
+            <p class="font-medium">Yerd can't resolve .test domains</p>
+            <p class="mt-1 text-muted-foreground">
+              It couldn't bind DNS port {{ report.dns_unbound }} - it's in use by
+              another process. Pick a free DNS port below and save. You may need
+              to re-run Trust afterwards so the system points at the new port.
+            </p>
+          </div>
+          <!-- Elevated: editing HTTP/HTTPS would break the pinned redirect. -->
           <p v-if="portsElevated" class="text-xs text-muted-foreground">
-            Ports are elevated, so the rootless ports are pinned to the active
-            redirect. Un-elevate ports (Doctor) before changing them, then
-            re-elevate.
+            HTTP/HTTPS ports are elevated, so they're pinned to the active
+            redirect. Un-elevate ports (Doctor) before changing them. DNS, mail
+            and dumps ports can still be changed.
           </p>
-          <div class="flex flex-wrap items-end gap-4">
+          <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
             <div class="space-y-1">
-              <label for="fb-http" class="text-xs font-medium text-muted-foreground">HTTP</label>
+              <label for="ap-http" class="text-xs font-medium text-muted-foreground">HTTP</label>
               <Input
-                id="fb-http"
+                id="ap-http"
                 v-model="fbHttp"
                 type="number"
                 inputmode="numeric"
                 :min="MIN_PORT"
                 :max="MAX_PORT"
-                :disabled="portsElevated || busy === 'fallback-ports'"
+                :disabled="portsElevated || busy === 'application-ports'"
                 aria-label="Rootless HTTP port"
-                class="w-28 font-mono"
+                class="w-full font-mono"
                 placeholder="8080"
               />
             </div>
             <div class="space-y-1">
-              <label for="fb-https" class="text-xs font-medium text-muted-foreground">HTTPS</label>
+              <label for="ap-https" class="text-xs font-medium text-muted-foreground">HTTPS</label>
               <Input
-                id="fb-https"
+                id="ap-https"
                 v-model="fbHttps"
                 type="number"
                 inputmode="numeric"
                 :min="MIN_PORT"
                 :max="MAX_PORT"
-                :disabled="portsElevated || busy === 'fallback-ports'"
+                :disabled="portsElevated || busy === 'application-ports'"
                 aria-label="Rootless HTTPS port"
-                class="w-28 font-mono"
+                class="w-full font-mono"
                 placeholder="8443"
               />
             </div>
+            <div class="space-y-1">
+              <label for="ap-dns" class="text-xs font-medium text-muted-foreground">DNS</label>
+              <Input
+                id="ap-dns"
+                v-model="dnsPort"
+                type="number"
+                inputmode="numeric"
+                min="1"
+                :max="MAX_PORT"
+                :disabled="busy === 'application-ports'"
+                aria-label="DNS responder port"
+                class="w-full font-mono"
+                placeholder="1053"
+              />
+            </div>
+            <div class="space-y-1">
+              <label for="ap-mail" class="text-xs font-medium text-muted-foreground">Mail (SMTP)</label>
+              <Input
+                id="ap-mail"
+                v-model="mailPort"
+                type="number"
+                inputmode="numeric"
+                min="1"
+                :max="MAX_PORT"
+                :disabled="busy === 'application-ports'"
+                aria-label="Mail server port"
+                class="w-full font-mono"
+                placeholder="2525"
+              />
+            </div>
+            <div class="space-y-1">
+              <label for="ap-dumps" class="text-xs font-medium text-muted-foreground">Dumps</label>
+              <Input
+                id="ap-dumps"
+                v-model="dumpsPort"
+                type="number"
+                inputmode="numeric"
+                min="1"
+                :max="MAX_PORT"
+                :disabled="busy === 'application-ports'"
+                aria-label="Dump server port"
+                class="w-full font-mono"
+                placeholder="2304"
+              />
+            </div>
+          </div>
+          <div class="flex justify-end">
             <Button
               size="sm"
-              :disabled="!fallbackPortsChanged || portsElevated || busy === 'fallback-ports'"
-              @click="openFallbackPorts"
+              :disabled="!applicationPortsChanged || busy === 'application-ports'"
+              @click="openApplicationPorts"
             >
-              <Spinner v-if="busy === 'fallback-ports'" class="size-4" />
+              <Spinner v-if="busy === 'application-ports'" class="size-4" />
               Save &amp; restart
             </Button>
           </div>
@@ -910,17 +1073,15 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
       </template>
     </Modal>
 
-    <Modal v-model:open="fallbackPortsOpen" title="Change web ports?">
+    <Modal v-model:open="applicationPortsOpen" title="Change application ports?">
       <p class="text-sm text-muted-foreground">
-        Saving sets the rootless ports to
-        <strong class="text-foreground font-mono">{{ fbHttp }}/{{ fbHttps }}</strong>
-        and restarts the daemon - this briefly stops all
-        <strong class="text-foreground">.test</strong> sites, DNS, and this
-        connection. It returns in a few seconds.
+        Saving applies your port changes and restarts the daemon - this briefly
+        stops all <strong class="text-foreground">.test</strong> sites, DNS, PHP
+        pools, and this connection. It returns in a few seconds.
       </p>
       <template #footer="{ close }">
         <Button variant="ghost" @click="close">Cancel</Button>
-        <Button @click="confirmFallbackPorts(close)">Save &amp; restart</Button>
+        <Button @click="confirmApplicationPorts(close)">Save &amp; restart</Button>
       </template>
     </Modal>
   </div>

--- a/apps/yerd-gui/src/views/LaravelDumpsView.vue
+++ b/apps/yerd-gui/src/views/LaravelDumpsView.vue
@@ -127,7 +127,7 @@ async function openViewer(): Promise<void> {
                 Change it in Settings ▸ Application Ports.
               </p>
             </div>
-            <span class="font-mono text-sm">{{ status?.port ?? 2304 }}</span>
+            <span class="font-mono text-sm">{{ status?.port ?? "—" }}</span>
           </div>
 
           <div class="flex justify-end border-t pt-4">

--- a/apps/yerd-gui/src/views/LaravelDumpsView.vue
+++ b/apps/yerd-gui/src/views/LaravelDumpsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ExternalLink } from "lucide-vue-next";
-import { computed, ref, watch } from "vue";
+import { computed } from "vue";
 
 import PageHeader from "@/components/PageHeader.vue";
 import StatusPill from "@/components/StatusPill.vue";
@@ -11,7 +11,6 @@ import CardContent from "@/components/ui/CardContent.vue";
 import CardDescription from "@/components/ui/CardDescription.vue";
 import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
-import Input from "@/components/ui/Input.vue";
 import Switch from "@/components/ui/Switch.vue";
 import { usePoll } from "@/composables/usePoll";
 import { useToast } from "@/composables/useToast";
@@ -20,7 +19,6 @@ import {
   IpcError,
   setDumpFeature,
   setDumpsEnabled,
-  setDumpsPort,
   showDumpsWindow,
 } from "@/ipc/client";
 import type { DumpsStatusResponse } from "@/ipc/types";
@@ -43,39 +41,8 @@ const running = computed(() => status.value?.running ?? false);
 const enabled = computed(() => status.value?.enabled ?? false);
 const extensions = computed(() => status.value?.extensions ?? []);
 
-// Port draft, synced from the daemon until the user edits it.
-const portDraft = ref("");
-let portDirty = false;
-watch(
-  status,
-  (s) => {
-    if (s && !portDirty) portDraft.value = String(s.port);
-  },
-  { immediate: true },
-);
-function onPortInput(v: string): void {
-  portDraft.value = v;
-  portDirty = true;
-}
-const portChanged = computed(
-  () => status.value !== null && portDraft.value !== String(status.value.port),
-);
-
-async function savePort(): Promise<void> {
-  const port = Number.parseInt(portDraft.value, 10);
-  if (!Number.isInteger(port) || port < 1 || port > 65535) {
-    toast.error("Invalid port", "Enter a number between 1 and 65535.");
-    return;
-  }
-  try {
-    await setDumpsPort(port);
-    portDirty = false;
-    await refresh();
-    toast.success("Dump server port updated");
-  } catch (e) {
-    toast.error("Couldn't set port", (e as IpcError).message);
-  }
-}
+// The dump server *port* is now edited centrally on Settings ▸ Application Ports;
+// this page shows it read-only via `status.port`.
 
 async function toggleEnabled(next: boolean): Promise<void> {
   try {
@@ -152,26 +119,15 @@ async function openViewer(): Promise<void> {
             />
           </div>
 
-          <!-- Port -->
+          <!-- Port (read-only; edited centrally on Settings ▸ Application Ports) -->
           <div class="flex items-center justify-between gap-4">
             <div>
               <p class="text-sm font-medium">Dump server port</p>
               <p class="text-xs text-muted-foreground">
-                The port the dump server listens on (default 2304).
+                Change it in Settings ▸ Application Ports.
               </p>
             </div>
-            <div class="flex items-center gap-2">
-              <Input
-                :model-value="portDraft"
-                type="number"
-                inputmode="numeric"
-                min="1"
-                max="65535"
-                class="w-28 font-mono"
-                @update:model-value="onPortInput"
-              />
-              <Button size="sm" :disabled="!portChanged" @click="savePort">Save</Button>
-            </div>
+            <span class="font-mono text-sm">{{ status?.port ?? 2304 }}</span>
           </div>
 
           <div class="flex justify-end border-t pt-4">

--- a/apps/yerd-gui/src/views/MailView.vue
+++ b/apps/yerd-gui/src/views/MailView.vue
@@ -15,13 +15,7 @@ import Input from "@/components/ui/Input.vue";
 import Switch from "@/components/ui/Switch.vue";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
-import {
-  IpcError,
-  openInBrowser,
-  setMailEnabled,
-  setMailPort,
-  showMailsWindow,
-} from "@/ipc/client";
+import { IpcError, openInBrowser, setMailEnabled, showMailsWindow } from "@/ipc/client";
 
 const DOCS_URL = "https://yerd.dev/guide/features";
 
@@ -31,27 +25,18 @@ const { report, refresh } = useDaemon();
 // Live mail status comes from the shared 4s status poll (no extra loop).
 const mail = computed(() => report.value?.mail ?? null);
 
-// Local editable copies of the config values, seeded from the live status and
-// re-seeded whenever it changes (unless the user is mid-edit).
-const portInput = ref("");
+// Local editable copy of the enable toggle, seeded from the live status. The
+// mail *port* is now edited centrally on the Settings ▸ Application Ports page.
 const enabled = ref(false);
 const busy = ref(false);
-let dirtyPort = false;
 
 watch(
   mail,
   (m) => {
     if (!m) return;
     enabled.value = m.enabled;
-    if (!dirtyPort) portInput.value = String(m.port);
   },
   { immediate: true },
-);
-
-// Save is enabled only once the draft differs from the live port (mirrors the
-// Dumps page).
-const portChanged = computed(
-  () => mail.value != null && portInput.value !== String(mail.value.port),
 );
 
 const statusTone = computed<Tone>(() => {
@@ -79,25 +64,6 @@ async function onToggleEnabled(next: boolean): Promise<void> {
     await refresh();
   } catch (e) {
     toast.error("Couldn't update mail capture", (e as IpcError).message);
-  } finally {
-    busy.value = false;
-  }
-}
-
-async function onSavePort(): Promise<void> {
-  const port = Number(portInput.value);
-  if (!Number.isInteger(port) || port < 1 || port > 65535) {
-    toast.error("Invalid port", "Enter a number between 1 and 65535.");
-    return;
-  }
-  busy.value = true;
-  try {
-    await setMailPort(port);
-    dirtyPort = false;
-    toast.success("Mail port saved", "Takes effect after the daemon restarts.");
-    await refresh();
-  } catch (e) {
-    toast.error("Couldn't save the mail port", (e as IpcError).message);
   } finally {
     busy.value = false;
   }
@@ -192,29 +158,15 @@ async function copyEnv(): Promise<void> {
             />
           </div>
 
-          <!-- Port -->
+          <!-- Port (read-only; edited centrally on Settings ▸ Application Ports) -->
           <div class="flex items-center justify-between gap-4">
             <div>
               <p class="text-sm font-medium">Mail server port</p>
               <p class="text-xs text-muted-foreground">
-                The port the mail server listens on (default 2525).
+                Change it in Settings ▸ Application Ports.
               </p>
             </div>
-            <div class="flex items-center gap-2">
-              <Input
-                id="mail-port"
-                v-model="portInput"
-                type="number"
-                inputmode="numeric"
-                min="1"
-                max="65535"
-                aria-label="Mail server port"
-                class="w-28 font-mono"
-                placeholder="2525"
-                @input="dirtyPort = true"
-              />
-              <Button size="sm" :disabled="!portChanged || busy" @click="onSavePort">Save</Button>
-            </div>
+            <span class="font-mono text-sm">{{ mailPort }}</span>
           </div>
 
           <!-- Actions -->

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -40,8 +40,8 @@ const selectedApp = ref<string>("");
 
 const list = computed<MailSummary[]>(() => mails.value ?? []);
 
-/** The "application" an email belongs to: its From display name, or — when the
- *  From has no name — the bare email address. */
+/** The "application" an email belongs to: its From display name, or - when the
+ *  From has no name - the bare email address. */
 function applicationOf(from: string): string {
   const named = from.match(/^\s*(.*?)\s*<([^>]+)>\s*$/);
   if (named) {

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -31,7 +31,7 @@ import { humaniseUptime } from "@/lib/utils";
 
 // The home/dashboard. It reads the shared daemon report (no poller of its own)
 // and shows the shared daemon-down hero, so it stays useful when the socket is
-// gone — the same surface that celebrates "serving N sites" becomes the start button.
+// gone - the same surface that celebrates "serving N sites" becomes the start button.
 const { report, connected } = useDaemon();
 const { relaunch } = useOnboarding();
 
@@ -91,7 +91,7 @@ const securedCount = computed(() =>
 
 const SITE_CHIP_LIMIT = 14;
 const sitePreview = computed(() => {
-  // Secured first, then alphabetical — a stable, scannable order.
+  // Secured first, then alphabetical - a stable, scannable order.
   return [...sites.value]
     .sort((a, b) => Number(b.secure) - Number(a.secure) || a.name.localeCompare(b.name))
     .slice(0, SITE_CHIP_LIMIT);
@@ -207,7 +207,7 @@ const emptyEnvironment = computed(
 
     <div class="flex-1 space-y-4 overflow-y-auto p-6">
       <!-- Version conflict: this GUI is OLDER than the registered daemon. Shown
-           above every branch — it's independent of daemon reachability. -->
+           above every branch - it's independent of daemon reachability. -->
       <div
         v-if="versionConflict"
         class="flex items-start gap-3 rounded-md border border-warning/40 bg-warning/10 p-4"
@@ -218,7 +218,7 @@ const emptyEnvironment = computed(
           <p class="mt-1 text-sm text-muted-foreground">
             The background daemon is registered at version
             <span class="font-mono">{{ versionConflict }}</span
-            >, newer than this app. Yerd won't reconfigure or downgrade it — update
+            >, newer than this app. Yerd won't reconfigure or downgrade it - update
             Yerd to {{ versionConflict }} or newer.
           </p>
         </div>
@@ -245,7 +245,7 @@ const emptyEnvironment = computed(
             <p class="mt-1 text-sm text-muted-foreground">
               It couldn't bind its web ports ({{ r.web_unbound.http }}/{{
                 r.web_unbound.https
-              }}) — they're in use by another process. Change Yerd's ports to free
+              }}) - they're in use by another process. Change Yerd's ports to free
               ones to start serving.
             </p>
           </div>
@@ -277,7 +277,7 @@ const emptyEnvironment = computed(
         </div>
 
         <Card class="relative overflow-hidden">
-          <!-- A soft brand wash — the only place indigo gets a hero surface. -->
+          <!-- A soft brand wash - the only place indigo gets a hero surface. -->
           <div
             class="pointer-events-none absolute -right-20 -top-20 size-56 rounded-full bg-brand/5 blur-2xl"
             aria-hidden="true"

--- a/apps/yerd-gui/src/views/ServicesView.vue
+++ b/apps/yerd-gui/src/views/ServicesView.vue
@@ -132,7 +132,7 @@ async function doRestart(s: ServiceStatus): Promise<void> {
 
 // ── version modal (shared by "Install" and "Change version") ──
 // A service holds one installed version; both flows pick from the versions you
-// don't currently have, so the option list is identical — only the action,
+// don't currently have, so the option list is identical - only the action,
 // titles, and empty-state copy differ by mode.
 const installOpen = ref(false);
 const installLoading = ref(false);

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -8,7 +8,7 @@ import {
   FolderPlus,
   Rocket,
 } from "lucide-vue-next";
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
 import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
@@ -26,7 +26,10 @@ import { useOnboarding } from "@/composables/useOnboarding";
 import { useToast } from "@/composables/useToast";
 import {
   availablePhp,
+  cliPathStatus,
   getAutostart,
+  hostPlatform,
+  installCliToPath,
   installPhp,
   IpcError,
   openLoginItems,
@@ -36,7 +39,7 @@ import {
   setAutostartGui,
   setAutostartGuiMinimized,
 } from "@/ipc/client";
-import type { AutostartState, PhpVersion } from "@/ipc/types";
+import type { AutostartState, CliPathStatus, PhpVersion } from "@/ipc/types";
 
 // A first-run guided setup, shown only on a never-set-up machine (see
 // useOnboarding). Step 1 (start the daemon) is required; PHP, parking a folder,
@@ -68,22 +71,30 @@ const {
 } = useDaemonStart();
 const daemonUp = computed(() => connected.value === true);
 
-// ── degraded web ports (shown in step 1 when the daemon came up but couldn't
-// bind its web ports) ──
-const { saveAndRestart: saveFallbackPorts, validate: validateFallbackPorts } =
+// ── degraded ports (shown in step 1 when the daemon came up but couldn't bind
+// its web ports and/or its DNS port) ──
+const { applyAndRestart, validate: validateFallbackPorts, validateLoopback } =
   useFallbackPorts();
 const fbHttp = ref("");
 const fbHttps = ref("");
+const dnsPort = ref("");
 const fallbackBusy = ref(false);
 const fallbackError = ref<string | null>(null);
 const fallbackSkipped = ref(false);
-// Show the fix panel only once the daemon is up AND reports it bound no web
-// ports, and the user hasn't skipped. Seed the inputs from the ports it tried.
+const webUnbound = computed(() => report.value?.web_unbound ?? null);
+// `dns_unbound` carries the configured DNS port that failed to bind - exactly
+// the value the user wants to change, so seed the input from it.
+const dnsUnbound = computed(() => report.value?.dns_unbound ?? null);
+// Show the fix panel once the daemon is up AND reports a degraded web and/or DNS
+// port, and the user hasn't skipped. Seed the inputs from the ports it tried.
 const showPortFix = computed(
-  () => daemonUp.value && report.value?.web_unbound != null && !fallbackSkipped.value,
+  () =>
+    daemonUp.value &&
+    (webUnbound.value != null || dnsUnbound.value != null) &&
+    !fallbackSkipped.value,
 );
 watch(
-  () => report.value?.web_unbound,
+  webUnbound,
   (u) => {
     if (u && !fbHttp.value) {
       fbHttp.value = String(u.http);
@@ -92,20 +103,39 @@ watch(
   },
   { immediate: true },
 );
+watch(
+  dnsUnbound,
+  (p) => {
+    if (p != null && !dnsPort.value) dnsPort.value = String(p);
+  },
+  { immediate: true },
+);
 
 async function savePortFix(): Promise<void> {
   fallbackError.value = null;
-  const err = validateFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
-  if (err) {
-    fallbackError.value = err;
-    return;
+  const changes: Parameters<typeof applyAndRestart>[0] = {};
+  if (webUnbound.value != null) {
+    const err = validateFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+    if (err) {
+      fallbackError.value = err;
+      return;
+    }
+    changes.web = { http: Number(fbHttp.value), https: Number(fbHttps.value) };
+  }
+  if (dnsUnbound.value != null) {
+    const err = validateLoopback("DNS", Number(dnsPort.value));
+    if (err) {
+      fallbackError.value = err;
+      return;
+    }
+    changes.dns = Number(dnsPort.value);
   }
   fallbackBusy.value = true;
   try {
-    const res = await saveFallbackPorts(Number(fbHttp.value), Number(fbHttps.value));
+    const res = await applyAndRestart(changes);
     if (res.ok) {
-      toast.success("Yerd is serving", `On ports ${fbHttp.value}/${fbHttps.value}.`);
-      // `report.web_unbound` is now null, so the panel hides on its own.
+      toast.success("Yerd is ready", "It restarted with the new ports.");
+      // The `*_unbound` fields are now null, so the panel hides on its own.
     } else {
       fallbackError.value = res.message ?? "The daemon is still degraded.";
     }
@@ -235,6 +265,45 @@ async function doInstallPhp(): Promise<void> {
   }
 }
 
+// ── step 2: install yerd on PATH (macOS only; Linux already ships it on PATH
+// via the .deb, so the button is hidden there - see `isMac`). Optional and
+// recommended; it never blocks "Next". ──
+const platform = ref("");
+const isMac = computed(() => platform.value === "macos");
+const cli = ref<CliPathStatus | null>(null);
+const cliBusy = ref(false);
+
+async function loadCliStatus(): Promise<void> {
+  if (!isMac.value) return;
+  try {
+    cli.value = await cliPathStatus();
+  } catch {
+    cli.value = null;
+  }
+}
+
+async function installCli(): Promise<void> {
+  cliBusy.value = true;
+  try {
+    await installCliToPath();
+    await loadCliStatus();
+    toast.success("yerd is on your PATH", "Run `yerd` in a new terminal window.");
+  } catch (e) {
+    toast.error("Couldn't install the yerd CLI", (e as IpcError).message);
+  } finally {
+    cliBusy.value = false;
+  }
+}
+
+onMounted(() => {
+  hostPlatform()
+    .then((p) => {
+      platform.value = p;
+      void loadCliStatus();
+    })
+    .catch(() => {});
+});
+
 // ── step 3: park a folder ──
 const parking = ref(false);
 const parkedDir = ref<string | null>(null);
@@ -360,23 +429,29 @@ function onBack(): void {
             <!-- Why the daemon didn't come up (hints + log/service details). -->
             <DaemonDiagnosticsPanel v-if="diagnostics" :diagnostics="diagnostics" />
 
-            <!-- Degraded: the daemon is up but couldn't bind its web ports. Let
-                 the user pick free ports (skippable). Stays visible across its own
-                 restart via `fallbackBusy` so the action below doesn't flash. -->
+            <!-- Degraded: the daemon is up but couldn't bind its web and/or DNS
+                 ports. Let the user pick free ports (skippable). Stays visible
+                 across its own restart via `fallbackBusy` so the action below
+                 doesn't flash. -->
             <div
               v-if="showPortFix || fallbackBusy"
               class="space-y-3 rounded-md border border-warning/40 bg-warning/10 p-3 text-sm"
             >
               <div>
-                <p class="font-medium">Yerd started, but isn't serving yet</p>
-                <p class="mt-1 text-muted-foreground">
+                <p class="font-medium">Yerd started, but isn't fully ready yet</p>
+                <p v-if="webUnbound != null" class="mt-1 text-muted-foreground">
                   It couldn't bind its web ports - they're in use by another
                   program. Pick free ports ({{ MIN_PORT }} or higher, so they don't
                   need elevation) and Yerd will serve on those.
                 </p>
+                <p v-if="dnsUnbound != null" class="mt-1 text-muted-foreground">
+                  It couldn't bind its DNS port {{ dnsUnbound }} - it's in use by
+                  another program, so <strong class="text-foreground">.test</strong>
+                  names won't resolve. Pick a free DNS port and restart.
+                </p>
               </div>
               <div class="flex flex-wrap items-end gap-3">
-                <div class="space-y-1">
+                <div v-if="webUnbound != null" class="space-y-1">
                   <label for="ob-fb-http" class="text-xs font-medium text-muted-foreground">
                     HTTP
                   </label>
@@ -393,7 +468,7 @@ function onBack(): void {
                     placeholder="8080"
                   />
                 </div>
-                <div class="space-y-1">
+                <div v-if="webUnbound != null" class="space-y-1">
                   <label for="ob-fb-https" class="text-xs font-medium text-muted-foreground">
                     HTTPS
                   </label>
@@ -408,6 +483,23 @@ function onBack(): void {
                     aria-label="Rootless HTTPS port"
                     class="w-24 font-mono"
                     placeholder="8443"
+                  />
+                </div>
+                <div v-if="dnsUnbound != null" class="space-y-1">
+                  <label for="ob-dns" class="text-xs font-medium text-muted-foreground">
+                    DNS
+                  </label>
+                  <Input
+                    id="ob-dns"
+                    v-model="dnsPort"
+                    type="number"
+                    inputmode="numeric"
+                    min="1"
+                    :max="MAX_PORT"
+                    :disabled="fallbackBusy"
+                    aria-label="DNS responder port"
+                    class="w-24 font-mono"
+                    placeholder="1053"
                   />
                 </div>
                 <Button size="sm" :disabled="fallbackBusy" @click="savePortFix">
@@ -486,6 +578,40 @@ function onBack(): void {
               No installable versions were found. You can add one later from the
               PHP page.
             </p>
+
+            <!-- Optional (recommended): put the `yerd` CLI on PATH. macOS only -
+                 Linux already ships it via the .deb. Never blocks Continue. -->
+            <div
+              v-if="isMac"
+              class="flex items-center justify-between gap-4 rounded-md border bg-muted/30 p-3"
+            >
+              <div>
+                <p class="text-sm font-medium">
+                  Install <code>yerd</code> on your PATH
+                  <span class="text-muted-foreground">(recommended)</span>
+                </p>
+                <p class="text-xs text-muted-foreground">
+                  {{
+                    cli?.installed
+                      ? "Installed - run `yerd` in a new terminal window."
+                      : "Symlinks the bundled CLI so you can run `yerd` in your terminal."
+                  }}
+                </p>
+              </div>
+              <Button
+                v-if="!cli?.installed"
+                variant="outline"
+                size="sm"
+                :disabled="cliBusy"
+                @click="installCli"
+              >
+                <Spinner v-if="cliBusy" class="size-4" />
+                Install
+              </Button>
+              <div v-else class="flex items-center gap-1 text-sm font-medium text-success">
+                <Check class="size-4" /> Installed
+              </div>
+            </div>
           </section>
 
           <!-- 3. Park a folder -->

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -61,6 +61,7 @@ const step = ref(1);
 // its login-item ordering via `beforeProbe` (see installDaemon).
 const {
   starting: daemonStarting,
+  activeLabel: daemonStartLabel,
   pendingApproval,
   diagnostics,
   start: startDaemonFlow,
@@ -131,7 +132,7 @@ async function installDaemon(): Promise<void> {
         /* non-fatal */
       }
       // Onboarding default: run the daemon AND the app at login, app minimized to
-      // the tray. Best-effort/idempotent — users change all three in Settings; a
+      // the tray. Best-effort/idempotent - users change all three in Settings; a
       // missing service manager just skips the daemon toggle.
       await enableLoginDefaults(autostart?.daemonSupported ?? false);
       // Re-read AFTER enabling: the GUI login item is only registered now, so its
@@ -186,7 +187,7 @@ function onOpenLoginItems(): void {
 }
 
 // (Spinner/diagnostics auto-clear on connect is handled inside useDaemonStart.)
-// No auto-advance — the user clicks Continue (enabled once `daemonUp`).
+// No auto-advance - the user clicks Continue (enabled once `daemonUp`).
 
 // ── step 2: PHP ──
 const phpLoading = ref(false);
@@ -207,7 +208,7 @@ async function loadAvailablePhp(): Promise<void> {
     // Preselect the latest (daemon returns ascending → last is newest).
     const opts = phpOptions.value;
     selectedPhp.value = opts[opts.length - 1]?.value ?? "";
-    // Something already installed (e.g. revisiting) — reflect it.
+    // Something already installed (e.g. revisiting) - reflect it.
     if (r.installed.length) {
       installedPhp.value = r.installed[r.installed.length - 1] ?? null;
     }
@@ -369,7 +370,7 @@ function onBack(): void {
               <div>
                 <p class="font-medium">Yerd started, but isn't serving yet</p>
                 <p class="mt-1 text-muted-foreground">
-                  It couldn't bind its web ports — they're in use by another
+                  It couldn't bind its web ports - they're in use by another
                   program. Pick free ports ({{ MIN_PORT }} or higher, so they don't
                   need elevation) and Yerd will serve on those.
                 </p>
@@ -442,7 +443,7 @@ function onBack(): void {
               <Button v-else :disabled="daemonStarting" @click="installDaemon">
                 <Spinner v-if="daemonStarting" class="size-4" />
                 <Download v-else class="size-4" />
-                Install &amp; start daemon
+                {{ daemonStartLabel ?? "Install & start daemon" }}
               </Button>
             </div>
           </section>

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -482,6 +482,8 @@ pub fn render(resp: &Response, json: bool) -> Rendered {
             target,
             ahead_of_stable,
             source,
+            // The CLI `yerd update` output doesn't surface "last checked"; ignore.
+            checked_at_epoch: _,
         } => Rendered::ok(format_update_status(
             current,
             latest_stable.as_deref(),
@@ -1388,6 +1390,7 @@ mod tests {
             target: Some("2.0.5".into()),
             ahead_of_stable: false,
             source: UpdateSource::Live,
+            checked_at_epoch: None,
         };
         let out = render(&resp, false).stdout;
         // Every row present, both channel latests shown, plus status + source.
@@ -1415,6 +1418,7 @@ mod tests {
             target: None,
             ahead_of_stable: true,
             source: UpdateSource::Cached,
+            checked_at_epoch: None,
         };
         let out = render(&resp, false).stdout;
         assert!(out.contains("ahead of stable"), "{out}");

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -777,7 +777,16 @@ fn format_status(r: &StatusReport) -> String {
             "ports     conflict: another process is using 80/443 (run `yerd doctor`)"
         );
     }
-    let _ = writeln!(s, "dns       {}", r.dns_addr);
+    if let Some(port) = r.dns_unbound {
+        // Degraded: `dns_addr` holds the *wanted* address, so printing it would
+        // read as healthy. Surface the real state instead.
+        let _ = writeln!(
+            s,
+            "dns       not resolving — couldn't bind port {port} (run `yerd doctor`)"
+        );
+    } else {
+        let _ = writeln!(s, "dns       {}", r.dns_addr);
+    }
     let _ = writeln!(
         s,
         "ca        trusted: {}  ({})",
@@ -1625,6 +1634,7 @@ mod tests {
             services: vec![],
             mail: None,
             web_unbound: None,
+            dns_unbound: None,
             boot_id: None,
         }
     }
@@ -1671,6 +1681,19 @@ mod tests {
         assert!(out.contains("not serving — couldn't bind 8443"), "{out}");
         // The misleading "→ 0" fallback rendering must NOT appear.
         assert!(!out.contains("→ 0"), "{out}");
+    }
+
+    #[test]
+    fn status_degraded_dns_shows_not_resolving() {
+        let mut r = sample_report();
+        r.dns_unbound = Some(1053);
+        let out = format_status(&r);
+        assert!(
+            out.contains("not resolving — couldn't bind port 1053"),
+            "{out}"
+        );
+        // The healthy "dns       127.0.0.1:1053" line must NOT appear.
+        assert!(!out.contains("dns       127.0.0.1:1053"), "{out}");
     }
 
     #[test]

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -2126,6 +2126,52 @@ Subject: Captured\r\n\r\nhi\r\n";
     }
 
     #[tokio::test]
+    async fn dispatch_set_dns_port_rejects_zero_and_persists_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+
+        // A zero port is rejected explicitly by the handler (mapped to Internal),
+        // even though config `validate()` permits `0` as the ephemeral sentinel.
+        match dispatch(Request::SetDnsPort { port: 0 }, &state).await {
+            Response::Error { code, .. } => assert!(matches!(code, ErrorCode::Internal)),
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        // A valid port is persisted through both in-memory state and to disk.
+        assert!(matches!(
+            dispatch(Request::SetDnsPort { port: 5354 }, &state).await,
+            Response::Ok
+        ));
+        assert_eq!(state.config.lock().await.dns_port, 5354);
+        let reloaded = yerd_config::Config::load(&state.config_path).unwrap();
+        assert_eq!(reloaded.dns_port, 5354);
+    }
+
+    #[tokio::test]
+    async fn dispatch_cached_update_status_uncached_reports_running_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+
+        // Nothing was ever persisted, so the cached path reports the running
+        // version with no remote figures, no pending update, and no timestamp.
+        match dispatch(Request::CachedUpdateStatus, &state).await {
+            Response::UpdateStatus {
+                source,
+                available,
+                target,
+                checked_at_epoch,
+                ..
+            } => {
+                assert!(matches!(source, yerd_ipc::UpdateSource::Cached));
+                assert!(!available);
+                assert!(target.is_none());
+                assert!(checked_at_epoch.is_none());
+            }
+            other => panic!("expected UpdateStatus, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn dispatch_status_reports_runtime_facts() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -129,6 +129,7 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
                 https_port: state.https.bound,
                 fallback_http: cfg.ports.fallback_http,
                 fallback_https: cfg.ports.fallback_https,
+                dns_port: cfg.dns_port,
             }
         }
         Request::Park { .. }
@@ -259,6 +260,7 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         },
         Request::SetMailPort { port } => set_mail_port(port, state).await,
         Request::SetFallbackPorts { http, https } => set_fallback_ports(http, https, state).await,
+        Request::SetDnsPort { port } => set_dns_port(port, state).await,
         Request::SetMailEnabled { enabled } => set_mail_enabled(enabled, state).await,
         Request::ListTools => Response::Tools {
             tools: list_tools_with_external(state).await,
@@ -555,6 +557,7 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
             count: state.mail_store.count().await,
         }),
         web_unbound: state.web_unbound,
+        dns_unbound: state.dns_unbound,
         boot_id: Some(state.boot_id),
     }
 }
@@ -1185,6 +1188,33 @@ async fn set_fallback_ports(http: u16, https: u16, state: &DaemonState) -> Respo
     Response::Ok
 }
 
+/// Set the embedded DNS responder port (`dns_port`). Persisted to config; takes
+/// effect on the next daemon restart (the client triggers it). A zero port is
+/// rejected explicitly here — unlike the web/mail/dumps ports, `dns_port == 0` is
+/// a *valid* "ephemeral" value for in-process tests, so `validate()` permits it;
+/// for a user-facing change a zero port (which the OS resolver could never target)
+/// is meaningless.
+async fn set_dns_port(port: u16, state: &DaemonState) -> Response {
+    if port == 0 {
+        return Response::Error {
+            code: yerd_ipc::ErrorCode::Internal,
+            message: "DNS port must be non-zero".to_owned(),
+        };
+    }
+    let mut cfg_guard = state.config.lock().await;
+    let mut new = cfg_guard.clone();
+    new.dns_port = port;
+    if let Err(e) = new.validate() {
+        return internal(format!("config validation failed: {e}"));
+    }
+    if let Err(e) = new.save(&state.config_path) {
+        return internal(format!("config save failed: {e}"));
+    }
+    *cfg_guard = new;
+    tracing::info!(port, "set DNS port (effective on next restart)");
+    Response::Ok
+}
+
 /// Enable or disable mail capture. Persisted to config; takes effect on the next
 /// daemon start/restart.
 async fn set_mail_enabled(enabled: bool, state: &DaemonState) -> Response {
@@ -1572,6 +1602,7 @@ mod tests {
                 fell_back: true,
             },
             web_unbound: None,
+            dns_unbound: None,
             boot_id: 1,
             started_at: std::time::Instant::now(),
             shutdown_tx: tokio::sync::watch::channel(false).0,
@@ -2074,6 +2105,7 @@ Subject: Captured\r\n\r\nhi\r\n";
                 https_port,
                 fallback_http,
                 fallback_https,
+                dns_port,
             } => {
                 assert_eq!(dns_addr, state.dns_addr);
                 assert_eq!(tld, "test");
@@ -2085,6 +2117,7 @@ Subject: Captured\r\n\r\nhi\r\n";
                 assert_eq!(https_port, state.https.bound);
                 assert_eq!(fallback_http, 8080);
                 assert_eq!(fallback_https, 8443);
+                assert_eq!(dns_port, state.config.lock().await.dns_port);
             }
             other => panic!("expected Info, got {other:?}"),
         }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -271,6 +271,7 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
             let dl = crate::php_install::ReqwestDownloader::new();
             crate::self_update::check_update(channel, state, &dl).await
         }
+        Request::CachedUpdateStatus => crate::self_update::cached_update_status(state).await,
         Request::SetUpdateChannel { channel } => {
             crate::self_update::set_update_channel(channel, state).await
         }
@@ -1585,6 +1586,7 @@ mod tests {
             ca_fingerprint: yerd_platform::CaFingerprint::new([0u8; 32]),
             php_updates: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             yerd_update: tokio::sync::RwLock::new(Vec::new()),
+            update_snapshot: tokio::sync::RwLock::new(None),
             php_manager,
             service_manager: std::sync::Arc::new(Mutex::new(crate::services::new_manager(
                 dirs_in(tmp),

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -92,18 +92,25 @@ async fn run_until_shutdown(
     shutdown_rx: watch::Receiver<bool>,
 ) -> Result<Outcome, DaemonError> {
     // DNS task. The socket pair was bound during `bring_up`, so the daemon
-    // owns it here — we just consume it into the serve loop.
-    let dns_handle = {
-        let bound = daemon.dns_bound;
+    // owns it here — we just consume it into the serve loop. Skipped entirely
+    // when the daemon came up degraded (DNS port couldn't bind) — IPC/proxy
+    // still run so the GUI/CLI can connect and the user can fix the port.
+    // Mirrors the optional proxy/mail tasks below.
+    let dns_handle = if let Some(bound) = daemon.dns_bound {
         let responder = yerd_dns::Responder::new(daemon.dns_tld.clone());
         let mut rx = shutdown_rx.clone();
-        tokio::spawn(async move {
+        Some(tokio::spawn(async move {
             bound
                 .serve(responder, async move {
                     let _ = rx.changed().await;
                 })
                 .await
-        })
+        }))
+    } else {
+        tracing::warn!(
+            "DNS responder disabled (degraded): dns_port couldn't bind — .test names won't resolve until the port is fixed and the daemon restarts"
+        );
+        None
     };
 
     // Proxy task. Skipped entirely when the daemon came up degraded (no web
@@ -243,7 +250,9 @@ async fn run_until_shutdown(
 
     // Now the subsystems are winding down (they watch the same channel); cap
     // each join so a stuck task can't hang the exit/restart.
-    let _ = tokio::time::timeout(Duration::from_secs(10), dns_handle).await;
+    if let Some(dns_handle) = dns_handle {
+        let _ = tokio::time::timeout(Duration::from_secs(10), dns_handle).await;
+    }
     if let Some(proxy_handle) = proxy_handle {
         let _ = tokio::time::timeout(Duration::from_secs(10), proxy_handle).await;
     }

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -241,22 +241,29 @@ fn snapshot_from(decision: &yerd_update::UpdateDecision, checked_at: u64) -> Upd
     }
 }
 
-/// Build an `UpdateStatus` reply from a persisted snapshot.
-fn response_from_snapshot(snap: &UpdateSnapshot, source: UpdateSource) -> Response {
-    // Reconcile against the *currently running* version. If the snapshot was
-    // recorded for a different version (e.g. the daemon self-updated since it was
-    // written, and we're now serving it offline before a fresh poll), its
-    // decision fields can't be trusted — they'd claim a phantom update *to* the
-    // version we may already be running. Present the real running version with no
-    // pending update; the `latest_*` figures + timestamp still describe the last
-    // remote check. The next successful live check overwrites all of this.
+/// Build an `UpdateStatus` reply from a persisted snapshot, reconciled against
+/// the `effective` channel the caller is answering for.
+fn response_from_snapshot(
+    snap: &UpdateSnapshot,
+    effective: yerd_ipc::Channel,
+    source: UpdateSource,
+) -> Response {
+    // Reconcile against the *currently running* version and the *effective*
+    // channel. If the snapshot was recorded for a different version (e.g. the
+    // daemon self-updated since it was written) or a different channel (the user
+    // switched channels since the last poll), its `available`/`target`/
+    // `ahead_of_stable` decision fields can't be trusted — they'd describe a
+    // resolution that no longer applies. Present the live channel with no pending
+    // update; the `latest_*` figures + timestamp are channel-independent raw
+    // observations and still describe the last remote check. The next successful
+    // live check overwrites all of this.
     let running = current_version().to_string();
-    let drifted = snap.current != running;
+    let drifted = snap.current != running || snap.channel != effective;
     Response::UpdateStatus {
         current: running,
         latest_stable: snap.latest_stable.clone(),
         latest_edge: snap.latest_edge.clone(),
-        channel: snap.channel,
+        channel: effective,
         available: !drifted && snap.available,
         target: if drifted { None } else { snap.target.clone() },
         ahead_of_stable: !drifted && snap.ahead_of_stable,
@@ -276,7 +283,8 @@ async fn store_snapshot(state: &DaemonState, snap: UpdateSnapshot) {
 /// checked, report the running version with no remote figures.
 pub async fn cached_update_status(state: &DaemonState) -> Response {
     if let Some(snap) = state.update_snapshot.read().await.clone() {
-        return response_from_snapshot(&snap, UpdateSource::Cached);
+        let effective = to_ipc(configured_channel(state).await);
+        return response_from_snapshot(&snap, effective, UpdateSource::Cached);
     }
     Response::UpdateStatus {
         current: current_version().to_string(),
@@ -332,10 +340,11 @@ pub async fn check_update(
         *state.yerd_update.write().await = releases;
         let snap = snapshot_from(&decision, now_epoch());
         store_snapshot(state, snap.clone()).await;
-        response_from_snapshot(&snap, UpdateSource::Live)
+        response_from_snapshot(&snap, to_ipc(channel), UpdateSource::Live)
     } else if let Some(snap) = state.update_snapshot.read().await.clone() {
-        // Offline: serve the last persisted result (carries its real timestamp).
-        response_from_snapshot(&snap, UpdateSource::Cached)
+        // Offline: serve the last persisted result (carries its real timestamp),
+        // reconciled against the channel this check is answering for.
+        response_from_snapshot(&snap, to_ipc(channel), UpdateSource::Cached)
     } else {
         // Never persisted a snapshot: derive from whatever is in the in-memory
         // release cache, with no timestamp.
@@ -549,7 +558,9 @@ mod tests {
             target: Some("9.9.9".into()),
             ahead_of_stable: true,
         };
-        match response_from_snapshot(&snap, UpdateSource::Cached) {
+        // Answer for the *same* channel the snapshot used, so the only drift
+        // under test is the running version.
+        match response_from_snapshot(&snap, yerd_ipc::Channel::Stable, UpdateSource::Cached) {
             Response::UpdateStatus {
                 current,
                 available,
@@ -582,12 +593,50 @@ mod tests {
             target: Some("99.0.0".into()),
             ahead_of_stable: false,
         };
-        match response_from_snapshot(&snap, UpdateSource::Cached) {
+        match response_from_snapshot(&snap, yerd_ipc::Channel::Stable, UpdateSource::Cached) {
             Response::UpdateStatus {
                 available, target, ..
             } => {
                 assert!(available);
                 assert_eq!(target.as_deref(), Some("99.0.0"));
+            }
+            other => panic!("expected UpdateStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snapshot_response_suppresses_stale_decision_after_channel_switch() {
+        // A snapshot recorded on one channel must not advertise that channel's
+        // resolution after the user switches channels. The reported channel is
+        // the effective one; available/target/ahead are cleared because they were
+        // resolved for the old channel. The channel-independent `latest_*` figures
+        // and timestamp survive.
+        let snap = UpdateSnapshot {
+            checked_at: 1_719_445_200,
+            current: current_version().to_string(), // version matches: only channel drifts
+            latest_stable: Some("2.0.5".into()),
+            latest_edge: Some("2.1.0-rc.1".into()),
+            channel: yerd_ipc::Channel::Stable,
+            available: true,
+            target: Some("2.1.0-rc.1".into()),
+            ahead_of_stable: true,
+        };
+        match response_from_snapshot(&snap, yerd_ipc::Channel::Edge, UpdateSource::Cached) {
+            Response::UpdateStatus {
+                channel,
+                available,
+                target,
+                ahead_of_stable,
+                latest_edge,
+                checked_at_epoch,
+                ..
+            } => {
+                assert_eq!(channel, yerd_ipc::Channel::Edge);
+                assert!(!available);
+                assert_eq!(target, None);
+                assert!(!ahead_of_stable);
+                assert_eq!(latest_edge.as_deref(), Some("2.1.0-rc.1"));
+                assert_eq!(checked_at_epoch, Some(1_719_445_200));
             }
             other => panic!("expected UpdateStatus, got {other:?}"),
         }

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -243,14 +243,23 @@ fn snapshot_from(decision: &yerd_update::UpdateDecision, checked_at: u64) -> Upd
 
 /// Build an `UpdateStatus` reply from a persisted snapshot.
 fn response_from_snapshot(snap: &UpdateSnapshot, source: UpdateSource) -> Response {
+    // Reconcile against the *currently running* version. If the snapshot was
+    // recorded for a different version (e.g. the daemon self-updated since it was
+    // written, and we're now serving it offline before a fresh poll), its
+    // decision fields can't be trusted — they'd claim a phantom update *to* the
+    // version we may already be running. Present the real running version with no
+    // pending update; the `latest_*` figures + timestamp still describe the last
+    // remote check. The next successful live check overwrites all of this.
+    let running = current_version().to_string();
+    let drifted = snap.current != running;
     Response::UpdateStatus {
-        current: snap.current.clone(),
+        current: running,
         latest_stable: snap.latest_stable.clone(),
         latest_edge: snap.latest_edge.clone(),
         channel: snap.channel,
-        available: snap.available,
-        target: snap.target.clone(),
-        ahead_of_stable: snap.ahead_of_stable,
+        available: !drifted && snap.available,
+        target: if drifted { None } else { snap.target.clone() },
+        ahead_of_stable: !drifted && snap.ahead_of_stable,
         source,
         checked_at_epoch: Some(snap.checked_at),
     }
@@ -519,6 +528,66 @@ mod tests {
                 assert!(!ahead_of_stable);
                 assert_eq!(source, UpdateSource::Live);
                 assert_eq!(checked_at_epoch, Some(1_719_445_200));
+            }
+            other => panic!("expected UpdateStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snapshot_response_suppresses_stale_decision_after_version_drift() {
+        // A snapshot recorded for a *different* running version (e.g. before a
+        // self-update) must not advertise a phantom update against the version we
+        // now run. `current` is reported as the running version; available/target
+        // are cleared. The remote `latest_*` and timestamp survive.
+        let snap = UpdateSnapshot {
+            checked_at: 1_719_445_200,
+            current: "0.0.1".into(), // deliberately != the running version
+            latest_stable: Some("2.0.5".into()),
+            latest_edge: Some("2.1.0-rc.1".into()),
+            channel: yerd_ipc::Channel::Stable,
+            available: true,
+            target: Some("9.9.9".into()),
+            ahead_of_stable: true,
+        };
+        match response_from_snapshot(&snap, UpdateSource::Cached) {
+            Response::UpdateStatus {
+                current,
+                available,
+                target,
+                ahead_of_stable,
+                latest_stable,
+                checked_at_epoch,
+                ..
+            } => {
+                assert_eq!(current, current_version().to_string());
+                assert!(!available);
+                assert_eq!(target, None);
+                assert!(!ahead_of_stable);
+                assert_eq!(latest_stable.as_deref(), Some("2.0.5"));
+                assert_eq!(checked_at_epoch, Some(1_719_445_200));
+            }
+            other => panic!("expected UpdateStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snapshot_response_preserves_decision_when_version_matches() {
+        let snap = UpdateSnapshot {
+            checked_at: 1_719_445_200,
+            current: current_version().to_string(),
+            latest_stable: Some("99.0.0".into()),
+            latest_edge: Some("99.0.0".into()),
+            channel: yerd_ipc::Channel::Stable,
+            available: true,
+            target: Some("99.0.0".into()),
+            ahead_of_stable: false,
+        };
+        match response_from_snapshot(&snap, UpdateSource::Cached) {
+            Response::UpdateStatus {
+                available, target, ..
+            } => {
+                assert!(available);
+                assert_eq!(target.as_deref(), Some("99.0.0"));
             }
             other => panic!("expected UpdateStatus, got {other:?}"),
         }

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 
 use yerd_ipc::{Response, StagedArtifact, UpdateSource};
 use yerd_php::Downloader;
+use yerd_platform::PlatformDirs;
 use yerd_update::{
     select_asset, select_target, verify_minisign, verify_sha256, ArtifactKind, Asset, Channel,
     Platform, ReleaseMeta,
@@ -147,8 +148,12 @@ fn to_ipc(c: Channel) -> yerd_ipc::Channel {
     }
 }
 
-/// Build the `UpdateStatus` reply from a decision + freshness.
-fn status_response(decision: &yerd_update::UpdateDecision, source: UpdateSource) -> Response {
+/// Build the `UpdateStatus` reply from a decision + freshness + timestamp.
+fn status_response(
+    decision: &yerd_update::UpdateDecision,
+    source: UpdateSource,
+    checked_at_epoch: Option<u64>,
+) -> Response {
     Response::UpdateStatus {
         current: decision.current.to_string(),
         latest_stable: decision.latest_stable.as_ref().map(ToString::to_string),
@@ -158,6 +163,122 @@ fn status_response(decision: &yerd_update::UpdateDecision, source: UpdateSource)
         target: decision.target.as_ref().map(ToString::to_string),
         ahead_of_stable: decision.ahead_of_stable,
         source,
+        checked_at_epoch,
+    }
+}
+
+/// A durable snapshot of the last successful update check, persisted to
+/// `{state}/update-check.json` so the UI can pre-fill the Updates section on load
+/// (and across daemon restarts / while offline) and show a "last checked …"
+/// time. Mirrors the [`Response::UpdateStatus`] display fields plus the
+/// timestamp. Lives in the daemon's *cache*, not `yerd.toml` — it is regenerable.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UpdateSnapshot {
+    /// Unix epoch (seconds) when the check completed.
+    pub checked_at: u64,
+    /// The running Yerd version at check time.
+    pub current: String,
+    /// Highest stable version seen, if any.
+    pub latest_stable: Option<String>,
+    /// Highest edge (pre-release-inclusive) version seen, if any.
+    pub latest_edge: Option<String>,
+    /// Channel the decision resolved against.
+    pub channel: yerd_ipc::Channel,
+    /// Whether a newer version was available on `channel`.
+    pub available: bool,
+    /// The version `channel` would update to, if newer.
+    pub target: Option<String>,
+    /// True when the running version was a pre-release ahead of latest stable.
+    pub ahead_of_stable: bool,
+}
+
+/// Current wall-clock as Unix epoch seconds (`0` if the clock is before the
+/// epoch, which never happens in practice).
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+fn snapshot_path(dirs: &PlatformDirs) -> std::path::PathBuf {
+    dirs.state.join("update-check.json")
+}
+
+/// Read the persisted snapshot, if present and parseable. Best-effort: any I/O
+/// or decode error yields `None` (treated as "never checked").
+pub fn load_snapshot(dirs: &PlatformDirs) -> Option<UpdateSnapshot> {
+    let bytes = std::fs::read(snapshot_path(dirs)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Write the snapshot to disk. Best-effort: a failure is logged at `debug` and
+/// otherwise ignored (the in-memory copy still serves this session).
+fn persist_snapshot(dirs: &PlatformDirs, snap: &UpdateSnapshot) {
+    let path = snapshot_path(dirs);
+    let write = || -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_vec_pretty(snap).map_err(std::io::Error::other)?;
+        std::fs::write(&path, json)
+    };
+    if let Err(e) = write() {
+        tracing::debug!(error = %e, path = %path.display(), "could not persist update-check cache");
+    }
+}
+
+/// Build a snapshot from a fresh decision, stamped at `checked_at`.
+fn snapshot_from(decision: &yerd_update::UpdateDecision, checked_at: u64) -> UpdateSnapshot {
+    UpdateSnapshot {
+        checked_at,
+        current: decision.current.to_string(),
+        latest_stable: decision.latest_stable.as_ref().map(ToString::to_string),
+        latest_edge: decision.latest_edge.as_ref().map(ToString::to_string),
+        channel: to_ipc(decision.channel),
+        available: decision.available,
+        target: decision.target.as_ref().map(ToString::to_string),
+        ahead_of_stable: decision.ahead_of_stable,
+    }
+}
+
+/// Build an `UpdateStatus` reply from a persisted snapshot.
+fn response_from_snapshot(snap: &UpdateSnapshot, source: UpdateSource) -> Response {
+    Response::UpdateStatus {
+        current: snap.current.clone(),
+        latest_stable: snap.latest_stable.clone(),
+        latest_edge: snap.latest_edge.clone(),
+        channel: snap.channel,
+        available: snap.available,
+        target: snap.target.clone(),
+        ahead_of_stable: snap.ahead_of_stable,
+        source,
+        checked_at_epoch: Some(snap.checked_at),
+    }
+}
+
+/// Persist a fresh snapshot to disk and store it in `state` for this session.
+async fn store_snapshot(state: &DaemonState, snap: UpdateSnapshot) {
+    persist_snapshot(&state.dirs, &snap);
+    *state.update_snapshot.write().await = Some(snap);
+}
+
+/// `CachedUpdateStatus` handler: return the last persisted result without any
+/// network access (for pre-filling the UI on load). When nothing was ever
+/// checked, report the running version with no remote figures.
+pub async fn cached_update_status(state: &DaemonState) -> Response {
+    if let Some(snap) = state.update_snapshot.read().await.clone() {
+        return response_from_snapshot(&snap, UpdateSource::Cached);
+    }
+    Response::UpdateStatus {
+        current: current_version().to_string(),
+        latest_stable: None,
+        latest_edge: None,
+        channel: to_ipc(configured_channel(state).await),
+        available: false,
+        target: None,
+        ahead_of_stable: false,
+        source: UpdateSource::Cached,
+        checked_at_epoch: None,
     }
 }
 
@@ -179,6 +300,8 @@ pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader) {
             "a newer Yerd version is available (run `yerd update`)"
         );
     }
+    // Persist the outcome so the UI can pre-fill on load and show "last checked".
+    store_snapshot(state, snapshot_from(&decision, now_epoch())).await;
     *state.yerd_update.write().await = releases;
 }
 
@@ -198,11 +321,18 @@ pub async fn check_update(
     if let Some(releases) = fetch_releases(dl).await {
         let decision = select_target(&releases, channel, &current);
         *state.yerd_update.write().await = releases;
-        status_response(&decision, UpdateSource::Live)
+        let snap = snapshot_from(&decision, now_epoch());
+        store_snapshot(state, snap.clone()).await;
+        response_from_snapshot(&snap, UpdateSource::Live)
+    } else if let Some(snap) = state.update_snapshot.read().await.clone() {
+        // Offline: serve the last persisted result (carries its real timestamp).
+        response_from_snapshot(&snap, UpdateSource::Cached)
     } else {
+        // Never persisted a snapshot: derive from whatever is in the in-memory
+        // release cache, with no timestamp.
         let cache = state.yerd_update.read().await;
         let decision = select_target(&cache, channel, &current);
-        status_response(&decision, UpdateSource::Cached)
+        status_response(&decision, UpdateSource::Cached, None)
     }
 }
 
@@ -368,7 +498,7 @@ mod tests {
             available: true,
             ahead_of_stable: false,
         };
-        match status_response(&decision, UpdateSource::Live) {
+        match status_response(&decision, UpdateSource::Live, Some(1_719_445_200)) {
             Response::UpdateStatus {
                 current,
                 latest_stable,
@@ -378,6 +508,7 @@ mod tests {
                 target,
                 ahead_of_stable,
                 source,
+                checked_at_epoch,
             } => {
                 assert_eq!(current, "2.0.0");
                 assert_eq!(latest_stable.as_deref(), Some("2.0.5"));
@@ -387,6 +518,7 @@ mod tests {
                 assert_eq!(target.as_deref(), Some("2.0.5"));
                 assert!(!ahead_of_stable);
                 assert_eq!(source, UpdateSource::Live);
+                assert_eq!(checked_at_epoch, Some(1_719_445_200));
             }
             other => panic!("expected UpdateStatus, got {other:?}"),
         }

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -63,10 +63,13 @@ pub struct Daemon {
     /// IPC listener (Unix socket on Unix, named pipe on Windows).
     pub ipc_listener: IpcListener,
     /// Bound DNS sockets (UDP+TCP), owned by the daemon and consumed when the
-    /// DNS task is spawned.
-    pub dns_bound: yerd_dns::Bound,
-    /// Actual DNS bind address, read back from the kernel after the ephemeral
-    /// bind. The resolver installer (post-MVP) wires `.test → this port`.
+    /// DNS task is spawned. `None` when the DNS port couldn't bind — the daemon
+    /// then runs degraded (no name resolution) rather than aborting, mirroring
+    /// the `http_listener`/`https_listener` web degrade.
+    pub dns_bound: Option<yerd_dns::Bound>,
+    /// Actual DNS bind address, read back from the kernel after the bind. When
+    /// the DNS port couldn't bind this stays the *wanted* address (so the
+    /// resolver-install probe still has a target to report against).
     pub dns_addr: SocketAddr,
     /// Bound mail-capture SMTP listener, when capture is enabled and the port was
     /// free. `None` = disabled, or the bind failed (non-fatal). Consumed when the
@@ -234,16 +237,28 @@ pub async fn bring_up_with_dirs(
 
     // Bind DNS up front (like the HTTP/HTTPS listeners) so the daemon owns the
     // sockets. Uses the fixed configured port (see `DNS_IP`) so an installed
-    // resolver config keeps pointing at us across restarts.
-    let dns_want = SocketAddr::new(DNS_IP, config.dns_port);
-    let dns_bound = yerd_dns::Bound::bind(dns_want).await.inspect_err(|_e| {
-        tracing::error!(
-            dns = %dns_want,
-            "failed to bind DNS responder; another process may hold dns_port — change `dns_port` in yerd.toml or free the port"
-        );
-    })?;
-    let dns_addr = dns_bound.local_addr();
-    tracing::info!(dns = %dns_addr, "DNS responder bound");
+    // resolver config keeps pointing at us across restarts. A bind failure is
+    // **non-fatal** (mirrors the web-port degrade): the daemon comes up without
+    // name resolution so the GUI/CLI can connect and the user can change
+    // `dns_port` or free the port. Capture `config.dns_port` here, before
+    // `config` is moved into `DaemonState` below.
+    let cfg_dns = config.dns_port;
+    let dns_want = SocketAddr::new(DNS_IP, cfg_dns);
+    let (dns_bound, dns_addr, dns_unbound) = match yerd_dns::Bound::bind(dns_want).await {
+        Ok(bound) => {
+            let addr = bound.local_addr();
+            tracing::info!(dns = %addr, "DNS responder bound");
+            (Some(bound), addr, None)
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                dns = %dns_want,
+                "could not bind DNS responder; name resolution disabled — free dns_port or change it in Settings, then restart"
+            );
+            (None, dns_want, Some(cfg_dns))
+        }
+    };
 
     // Mail-capture store + (optional, non-fatal) SMTP listener. The store always
     // exists so already-captured mail stays listable even when capture is off; a
@@ -301,6 +316,7 @@ pub async fn bring_up_with_dirs(
             fell_back: bound_https != cfg_https,
         },
         web_unbound,
+        dns_unbound,
         boot_id: rand_boot_id(),
         started_at: std::time::Instant::now(),
         // The shutdown broadcast lives in state so the IPC `RestartDaemon`
@@ -385,7 +401,19 @@ fn load_or_default_config(cfg_path: &std::path::Path) -> Result<yerd_config::Con
             );
             Ok(yerd_config::Config::default())
         }
-        Err(e) => Err(DaemonError::from(e)),
+        Err(e) => {
+            // Log the exact parse/validation error (with its path) to the cache
+            // log before bubbling up — the tracing subscriber is installed in
+            // `main` before `run`, so this lands in the rolling daemon log, not
+            // just stderr. Otherwise an invalid config under launchd/systemd
+            // would exit (78) with no on-disk record of *why*.
+            tracing::error!(
+                config = %cfg_path.display(),
+                error = %e,
+                "invalid config file — refusing to start"
+            );
+            Err(DaemonError::from(e))
+        }
     }
 }
 

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -299,6 +299,7 @@ pub async fn bring_up_with_dirs(
         ca_fingerprint,
         php_updates: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         yerd_update: tokio::sync::RwLock::new(Vec::new()),
+        update_snapshot: tokio::sync::RwLock::new(crate::self_update::load_snapshot(&dirs)),
         php_manager: php_manager.clone(),
         service_manager,
         mail_store,

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -86,6 +86,10 @@ pub struct DaemonState {
     /// ports — it runs degraded (no proxy). Carries the fallback ports it failed
     /// on, surfaced in `Status` (`web_unbound`) so the UI/doctor can name them.
     pub web_unbound: Option<yerd_ipc::UnboundWeb>,
+    /// Set when the daemon could not bind its DNS responder port — it runs
+    /// degraded (no name resolution). Carries the configured `dns_port` it failed
+    /// on, surfaced in `Status` (`dns_unbound`) so the UI/doctor can name it.
+    pub dns_unbound: Option<u16>,
     /// Per-process id (see `StatusReport::boot_id`) clients use to detect a
     /// completed restart across the pid-preserving re-exec.
     pub boot_id: u64,

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -64,6 +64,11 @@ pub struct DaemonState {
     /// until the first successful fetch. Populated by the periodic checker /
     /// `CheckUpdate` and served (no network) when a live fetch fails.
     pub yerd_update: RwLock<Vec<yerd_update::ReleaseMeta>>,
+    /// The last persisted self-update result (loaded from `{state}/update-check.json`
+    /// at boot, refreshed on every successful poll / `CheckUpdate`). Served by
+    /// `CachedUpdateStatus` so the UI can pre-fill the Updates section on load and
+    /// show a "last checked …" time without a network round-trip.
+    pub update_snapshot: RwLock<Option<crate::self_update::UpdateSnapshot>>,
     /// The FPM pool supervisor, shared with the proxy backend resolver and the
     /// update task. `yerd status` / `yerd doctor` read live pool state from it.
     pub php_manager: Arc<Mutex<DaemonPhpManager>>,

--- a/bin/yerdd/tests/lifecycle.rs
+++ b/bin/yerdd/tests/lifecycle.rs
@@ -274,7 +274,9 @@ mod tests {
         // DNS now binds ephemerally (`127.0.0.1:0`), so it no longer collides
         // with the host's mDNS responder on 5353 — drive it like production.
         let dns_handle = {
-            let bound = daemon.dns_bound;
+            // The test daemon always binds DNS (ephemeral `127.0.0.1:0`), so the
+            // soft-fail `Option` is always `Some` here.
+            let bound = daemon.dns_bound.expect("test daemon binds its DNS sockets");
             let responder = yerd_dns::Responder::new(daemon.dns_tld.clone());
             let mut rx = shutdown_rx.clone();
             tokio::spawn(async move {

--- a/bin/yerdd/tests/lifecycle.rs
+++ b/bin/yerdd/tests/lifecycle.rs
@@ -41,6 +41,12 @@ mod tests {
         let mut cfg = yerd_config::Config::default();
         cfg.ports.http = 0;
         cfg.ports.https = 0;
+        // Ephemeral DNS too: the default `dns_port` (1053) is a fixed port that
+        // can be busy (a concurrent test, a stray binder), in which case the
+        // soft-fail `bring_up_with_dirs` returns `dns_bound: None` and the
+        // `drive_subsystems` setup below would panic. `0` binds `127.0.0.1:0`,
+        // which the OS always satisfies, so `dns_bound` is reliably `Some`.
+        cfg.dns_port = 0;
         cfg
     }
 

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -411,6 +411,10 @@ fn validate_ports(c: &Config) -> Result<(), ConfigError> {
     if c.dumps.port == 0 {
         return Err(ve(ValidateErrorReason::DumpsPortZero));
     }
+    // NB: `dns_port == 0` is intentionally NOT rejected here — `0` means
+    // "ephemeral" and must survive a parse round-trip (see
+    // `toml_byte_shape::dns_port_zero_round_trips`). The user-facing guard against
+    // a zero DNS port lives in the daemon's `set_dns_port` IPC handler.
     Ok(())
 }
 

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -259,6 +259,23 @@ pub fn is_auto_fixable(code: DiagnosisCode) -> bool {
 /// means 80/443 are in fact reachable — also suppressing the fallback warning.
 fn port_findings(report: &StatusReport) -> Vec<Diagnosis> {
     let mut out = Vec::new();
+    // DNS is independent of the web ports, so check it first — it must surface
+    // even when `web_unbound` triggers the early return below. A bind failure is
+    // a `Warn`, not a `Fail`: the daemon still runs, and on a fresh setup the OS
+    // resolver may not be installed yet (in which case `ResolverNotInstalled`
+    // already covers "names won't resolve").
+    if let Some(dns_port) = report.dns_unbound {
+        out.push(warn(
+            DiagnosisCode::DnsPortUnbound,
+            "Yerd's DNS port is busy",
+            format!(
+                "Yerd couldn't bind its DNS port ({dns_port}) — another process holds it — so \
+                 *.test names won't resolve through Yerd until it's freed or changed."
+            ),
+            "Free that port, or change Yerd's DNS port in Settings (Yerd ▸ General), then restart. \
+             If you changed the port, re-run Trust so the OS resolver points at the new one.",
+        ));
+    }
     let foreign_listener = report.foreign_web_listener == Some(true);
     if foreign_listener {
         out.push(warn(
@@ -390,6 +407,7 @@ mod tests {
             services: vec![],
             mail: None,
             web_unbound: None,
+            dns_unbound: None,
             boot_id: None,
         }
     }
@@ -464,6 +482,36 @@ mod tests {
         assert!(!cs.contains(&DiagnosisCode::PortFallback));
         // It's a hard failure, so the report is not "all good".
         assert!(!cs.contains(&DiagnosisCode::AllGood));
+    }
+
+    #[test]
+    fn dns_unbound_warns_independently_of_web() {
+        let mut r = healthy();
+        r.dns_unbound = Some(1053);
+        let ds = diagnose(&r, None);
+        let cs = codes(&ds);
+        assert!(cs.contains(&DiagnosisCode::DnsPortUnbound));
+        assert!(!cs.contains(&DiagnosisCode::AllGood));
+        // It's a warning (daemon still runs), not a hard fail.
+        let dns = ds
+            .iter()
+            .find(|d| d.code == DiagnosisCode::DnsPortUnbound)
+            .expect("dns finding present");
+        assert_eq!(dns.severity, Severity::Warn);
+    }
+
+    #[test]
+    fn dns_unbound_surfaces_even_when_web_unbound() {
+        let mut r = healthy();
+        r.dns_unbound = Some(1053);
+        r.web_unbound = Some(yerd_ipc::UnboundWeb {
+            http: 8080,
+            https: 8443,
+        });
+        let cs = codes(&diagnose(&r, None));
+        // The web early-return must not swallow the DNS finding.
+        assert!(cs.contains(&DiagnosisCode::DnsPortUnbound));
+        assert!(cs.contains(&DiagnosisCode::WebPortsUnbound));
     }
 
     #[test]

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -384,6 +384,12 @@ pub enum Request {
         /// persisted `update_channel`.
         channel: Option<crate::Channel>,
     },
+    /// Return the **last persisted** self-update result without any network
+    /// access — used to pre-fill the UI on load. Returns
+    /// [`super::Response::UpdateStatus`] with `source = Cached` and
+    /// `checked_at_epoch` set (or, if never checked, the running version with
+    /// `checked_at_epoch = None`).
+    CachedUpdateStatus,
     /// Persist the self-update channel preference. Returns
     /// [`super::Response::Ok`].
     SetUpdateChannel {
@@ -486,6 +492,7 @@ mod variant_name_pinning {
             Request::JobStatus { .. } => {}
             Request::JobCancel { .. } => {}
             Request::CheckUpdate { .. } => {}
+            Request::CachedUpdateStatus => {}
             Request::SetUpdateChannel { .. } => {}
             Request::StageUpdate { .. } => {}
         }
@@ -654,6 +661,7 @@ mod variant_name_pinning {
         pin(Request::CheckUpdate {
             channel: Some(crate::Channel::Edge),
         });
+        pin(Request::CachedUpdateStatus);
         pin(Request::SetUpdateChannel {
             channel: crate::Channel::Stable,
         });

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -319,6 +319,13 @@ pub enum Request {
         /// New rootless HTTPS port (`>= 1024`).
         https: u16,
     },
+    /// Set the embedded DNS responder port (`dns_port`). Must be non-zero. Takes
+    /// effect on the next daemon restart (no implicit hot rebind). Changing it may
+    /// require re-running the OS-resolver install so it points at the new port.
+    SetDnsPort {
+        /// The new loopback DNS port (must be non-zero).
+        port: u16,
+    },
     /// Enable or disable the mail-capture server. Takes effect on the next
     /// daemon start/restart.
     SetMailEnabled {
@@ -469,6 +476,7 @@ mod variant_name_pinning {
             Request::DeleteMails { .. } => {}
             Request::SetMailPort { .. } => {}
             Request::SetFallbackPorts { .. } => {}
+            Request::SetDnsPort { .. } => {}
             Request::SetMailEnabled { .. } => {}
             Request::ListTools => {}
             Request::InstallTool { .. } => {}

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -80,6 +80,13 @@ pub enum Response {
         /// The configured rootless HTTPS fallback port (e.g. 8443).
         #[serde(default)]
         fallback_https: u16,
+        /// The configured DNS responder port (`dns_port`, e.g. 1053) — what
+        /// Settings edits. Distinct from `dns_addr`, which is the *bound* address
+        /// (and stays the wanted addr when the DNS port couldn't bind).
+        /// `#[serde(default)]` keeps older daemons (which omit it) decodable;
+        /// defaults to 0.
+        #[serde(default)]
+        dns_port: u16,
     },
     /// Reply to [`crate::Request::ListPhp`] / `CheckPhpUpdates` / `UpdatePhp`.
     PhpVersions {
@@ -368,6 +375,7 @@ mod variant_name_pinning {
             https_port: 8443,
             fallback_http: 8080,
             fallback_https: 8443,
+            dns_port: 1053,
         });
         pin_response(Response::PhpVersions {
             installed: vec![PhpVersion::new(8, 5)],
@@ -413,6 +421,7 @@ mod variant_name_pinning {
                 services: vec![],
                 mail: None,
                 web_unbound: None,
+                dns_unbound: None,
                 boot_id: None,
             }),
         });

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -250,6 +250,12 @@ pub enum Response {
         ahead_of_stable: bool,
         /// Whether these figures are from a live fetch or a cached fallback.
         source: crate::UpdateSource,
+        /// Unix epoch (seconds) when this result was obtained, for a "last
+        /// checked …" display. `None` when never checked (or an older daemon that
+        /// predates the field). `#[serde(default, skip_serializing_if)]` keeps the
+        /// wire additive.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        checked_at_epoch: Option<u64>,
     },
     /// Reply to [`crate::Request::StageUpdate`] — the verified update artifact
     /// has been downloaded to `path`. The applier installs it.
@@ -515,6 +521,7 @@ mod variant_name_pinning {
             target: None,
             ahead_of_stable: true,
             source: crate::UpdateSource::Live,
+            checked_at_epoch: Some(1_719_445_200),
         });
         pin_response(Response::Staged {
             path: "/x/Yerd.app.tar.gz".into(),

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -105,6 +105,14 @@ pub struct StatusReport {
     /// skip_serializing_if)]` keeps the wire additive.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub web_unbound: Option<UnboundWeb>,
+    /// Set when the daemon could not bind its DNS responder port (the configured
+    /// `dns_port`): it runs degraded (HTTP/HTTPS/IPC up, but `*.test` names won't
+    /// resolve through Yerd) rather than aborting. Carries the configured port it
+    /// failed on so the UI/doctor can name it. `None`/absent on a healthy daemon;
+    /// `#[serde(default, skip_serializing_if)]` keeps the wire additive. Mirrors
+    /// [`StatusReport::web_unbound`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_unbound: Option<u16>,
     /// A random id the daemon generates once per process at startup. Clients use
     /// a *change* in this value to detect that a restart actually completed (the
     /// re-exec preserves the PID and `uptime_secs` has only one-second
@@ -392,6 +400,10 @@ pub enum DiagnosisCode {
     WebPortsUnbound,
     /// A non-Yerd process is listening on a privileged web port (80/443).
     ForeignWebListener,
+    /// The daemon could not bind its DNS responder port, so `*.test` names won't
+    /// resolve through Yerd until the port is freed or changed. See
+    /// [`StatusReport::dns_unbound`].
+    DnsPortUnbound,
     /// The local CA is not trusted in the system store.
     CaNotTrusted,
     /// The OS resolver does not route `*.<tld>` to Yerd.

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -94,6 +94,7 @@ fn encode_then_decode_response_roundtrip() {
         https_port: 8443,
         fallback_http: 8080,
         fallback_https: 8443,
+        dns_port: 1053,
     });
     assert_response_roundtrips(Response::PhpVersions {
         installed: vec![PhpVersion::new(8, 3), PhpVersion::new(8, 5)],
@@ -180,6 +181,7 @@ fn encode_then_decode_response_roundtrip() {
                 http: 8080,
                 https: 8443,
             }),
+            dns_unbound: Some(1053),
             boot_id: Some(42),
         }),
     });

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -75,6 +75,7 @@ fn encode_then_decode_request_roundtrip() {
         channel: Some(yerd_ipc::Channel::Edge),
     });
     assert_request_roundtrips(Request::CheckUpdate { channel: None });
+    assert_request_roundtrips(Request::CachedUpdateStatus);
     assert_request_roundtrips(Request::SetUpdateChannel {
         channel: yerd_ipc::Channel::Stable,
     });
@@ -219,6 +220,7 @@ fn encode_then_decode_response_roundtrip() {
         target: Some("2.0.2-rc.3".into()),
         ahead_of_stable: false,
         source: yerd_ipc::UpdateSource::Cached,
+        checked_at_epoch: Some(1_719_445_200),
     });
 }
 

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -1671,6 +1671,14 @@ fn request_check_update_byte_shape() {
 }
 
 #[test]
+fn request_cached_update_status_byte_shape() {
+    let r = Request::CachedUpdateStatus;
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(s, r#"{"type":"cached_update_status"}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
 fn request_set_update_channel_byte_shape() {
     let r = Request::SetUpdateChannel {
         channel: Channel::Stable,
@@ -1731,9 +1739,31 @@ fn response_update_status_byte_shape() {
         target: None,
         ahead_of_stable: true,
         source: UpdateSource::Live,
+        // `None` + skip_serializing_if → omitted, so the byte shape is unchanged
+        // from before the field existed (older clients decode it fine).
+        checked_at_epoch: None,
     };
     let s = serde_json::to_string(&r).unwrap();
     let expected = r#"{"type":"update_status","current":"2.0.2-rc.3","latest_stable":"2.0.1","latest_edge":"2.0.2-rc.3","channel":"stable","available":false,"target":null,"ahead_of_stable":true,"source":"live"}"#;
     assert_eq!(s, expected);
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+
+    // When set, `checked_at_epoch` serialises after `source` as a bare integer.
+    let with_ts = Response::UpdateStatus {
+        current: "2.0.2-rc.3".into(),
+        latest_stable: Some("2.0.1".into()),
+        latest_edge: Some("2.0.2-rc.3".into()),
+        channel: Channel::Stable,
+        available: false,
+        target: None,
+        ahead_of_stable: true,
+        source: UpdateSource::Cached,
+        checked_at_epoch: Some(1_719_445_200),
+    };
+    let s = serde_json::to_string(&with_ts).unwrap();
+    assert!(
+        s.contains(r#""source":"cached","checked_at_epoch":1719445200"#),
+        "{s}"
+    );
+    assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), with_ts);
 }

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -380,10 +380,11 @@ fn response_info_byte_shape() {
         https_port: 8443,
         fallback_http: 8080,
         fallback_https: 8443,
+        dns_port: 1053,
     };
     let s = serde_json::to_string(&r).unwrap();
     let expected = format!(
-        r#"{{"type":"info","dns_addr":"127.0.0.1:1053","tld":"test","ca_path":"/home/u/.local/share/yerd/ca.cert.pem","ca_fingerprint":"{}","http_port":8080,"https_port":8443,"fallback_http":8080,"fallback_https":8443}}"#,
+        r#"{{"type":"info","dns_addr":"127.0.0.1:1053","tld":"test","ca_path":"/home/u/.local/share/yerd/ca.cert.pem","ca_fingerprint":"{}","http_port":8080,"https_port":8443,"fallback_http":8080,"fallback_https":8443,"dns_port":1053}}"#,
         "ab".repeat(32)
     );
     assert_eq!(s, expected);
@@ -403,6 +404,7 @@ fn response_info_byte_shape() {
             https_port: 0,
             fallback_http: 0,
             fallback_https: 0,
+            dns_port: 0,
             ..
         }
     ));
@@ -577,6 +579,9 @@ fn response_status_byte_shape() {
             mail: None,
             // Likewise omitted when `None`, keeping the byte shape unchanged.
             web_unbound: None,
+            // Omitted when `None` (skip_serializing_if), so the byte shape is
+            // unchanged from before the dns_unbound field existed.
+            dns_unbound: None,
             boot_id: None,
         }),
     };
@@ -679,6 +684,7 @@ fn sample_status_report() -> StatusReport {
         services: vec![],
         mail: None,
         web_unbound: None,
+        dns_unbound: None,
         boot_id: None,
     }
 }
@@ -794,6 +800,7 @@ fn diagnosis_code_each_variant_byte_shape() {
             DiagnosisCode::ForeignWebListener,
             r#""foreign_web_listener""#,
         ),
+        (DiagnosisCode::DnsPortUnbound, r#""dns_port_unbound""#),
         (DiagnosisCode::CaNotTrusted, r#""ca_not_trusted""#),
         (
             DiagnosisCode::ResolverNotInstalled,
@@ -1336,6 +1343,14 @@ fn request_set_fallback_ports_byte_shape() {
 }
 
 #[test]
+fn request_set_dns_port_byte_shape() {
+    let r = Request::SetDnsPort { port: 1053 };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(s, r#"{"type":"set_dns_port","port":1053}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
 fn request_set_mail_enabled_byte_shape() {
     let r = Request::SetMailEnabled { enabled: true };
     let s = serde_json::to_string(&r).unwrap();
@@ -1432,6 +1447,24 @@ fn status_mail_appears_only_when_some() {
         s.contains(r#""mail":{"enabled":true,"port":2525,"listening":true,"count":3}"#),
         "{s}"
     );
+    let back: StatusReport = serde_json::from_str(&s).unwrap();
+    assert_eq!(back, report);
+}
+
+#[test]
+fn status_dns_unbound_appears_only_when_some() {
+    // `None` → omitted (additive: byte shape unchanged from before the field
+    // existed). `Some` → present as a bare integer.
+    let mut report = sample_status_report();
+    let s = serde_json::to_string(&report).unwrap();
+    assert!(
+        !s.contains("dns_unbound"),
+        "empty dns_unbound must be omitted: {s}"
+    );
+
+    report.dns_unbound = Some(1053);
+    let s = serde_json::to_string(&report).unwrap();
+    assert!(s.contains(r#""dns_unbound":1053"#), "{s}");
     let back: StatusReport = serde_json::from_str(&s).unwrap();
     assert_eq!(back, report);
 }

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,6 +8,13 @@ non-ongoing places: installing the system `.deb` (standard for any package),
 and a single, optional, **one-time** setup step. Day-to-day use never touches
 root.
 
+::: info Release status — Release Candidate
+Yerd is currently shipping **Release Candidate** builds, available from the
+[releases page](https://github.com/forjedio/yerd/releases). We're tracking a
+**stable v2.0.2** release on **8 July 2026**. The RCs are ready for everyday use —
+if you hit anything, please [report a bug on GitHub](https://github.com/forjedio/yerd/issues).
+:::
+
 ::: tip Coming from Herd, Valet, or Lerd?
 Already running another local PHP environment? They claim the same OS hooks Yerd
 needs - ports **80/443**, the `*.test` **resolver**, and a trusted local **CA** -
@@ -33,7 +40,9 @@ Silicon (arm64) only.
 
 Yerd is a **single desktop app** - the daemon, the `yerd` CLI, and the privileged
 helper are all embedded in it (nothing is downloaded at runtime). Grab the latest
-build from the [releases page](https://github.com/forjedio/yerd/releases):
+**Release Candidate** build from the
+[releases page](https://github.com/forjedio/yerd/releases) (stable **v2.0.2** is
+tracked for **8 July 2026**):
 
 | Platform | Download | Install |
 |---|---|---|


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cached self-update status (with “last checked” time) and release-channel updates.
  * Introduced per-session GUI logging with Logs and Diagnostics modals, plus a unified “Application Ports” editor (web/DNS/mail/dumps) with save-and-restart.
  * Improved daemon start UX with phase-based button labels and richer start/repair flow; added first-class daemon lifecycle controls to Doctor.
  * Added DNS port configuration from the GUI.
* **Bug Fixes**
  * DNS bind failures now run in degraded mode, with DNS unbound surfaced in status and diagnostics.
* **Documentation**
  * Updated installation/getting-started to reflect Release Candidate shipping and tracked stable v2.0.2 release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->