### PR TITLE
[Feat] Arch linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,19 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+      # The Arch package builds the daemon with `--features yerdd/pacman`, which
+      # default `--workspace` never exercises — so lint + test that path too
+      # (the `PkgFormat::Pacman` selection arm + the cfg-gated stage_update
+      # fixtures). Linux-only: it's where the Arch package ships, and the arm64
+      # leg also covers the aarch64 selection arm. Mirrors the release `arch`
+      # job's build flag so a feature-gated break fails on push, not at tag time.
+      - name: Clippy + test (pacman feature)
+        if: runner.os == 'Linux'
+        run: |
+          cargo clippy -p yerdd -p yerd-update --features yerdd/pacman \
+            --all-targets -- -D warnings
+          cargo test -p yerdd -p yerd-update --features yerdd/pacman
+
   # Frontend unit/component tests + production build (type-check via vue-tsc).
   frontend:
     name: frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,12 +365,99 @@ jobs:
             apps/yerd-gui/src-tauri/target/release/bundle/**/*.dmg
             apps/yerd-gui/src-tauri/target/release/bundle/updater/*.app.tar.gz
 
+  # Build the native Arch package (.pkg.tar.zst). Tauri has no pacman bundler, so
+  # we compile the binaries + GUI from source in an Arch container and assemble
+  # the package via packaging/arch/PKGBUILD. x86_64 only for v1. The daemon is
+  # built with the `pacman` self-update feature; the gate below proves it took.
+  arch:
+    name: arch (x86_64)
+    needs: check
+    runs-on: ubuntu-22.04
+    container: archlinux:base-devel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        # `namcap` and `desktop-file-utils` are separate `extra` packages (not in
+        # base-devel); the assert step needs them. libayatana-appindicator/librsvg
+        # are dlopen'd by the GUI at runtime (see PKGBUILD depends).
+        run: |
+          pacman -Syu --noconfirm --needed \
+            rust cargo nodejs npm git \
+            webkit2gtk-4.1 gtk3 libayatana-appindicator librsvg libcap \
+            namcap desktop-file-utils
+
+      - name: Build the Arch package
+        run: |
+          set -euo pipefail
+          # makepkg refuses to run as root; build as an unprivileged user that owns
+          # the checkout (actions/checkout runs as root inside the container).
+          useradd -m builder
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory '*'
+          # pkgver forbids '-'; a prerelease tag carries `-rc.N`. Strip leading `v`,
+          # then `-` → `_`. The release asset name is derived from the tag later, so
+          # this sanitisation only affects the in-package version string.
+          RAWVER="${GITHUB_REF_NAME#v}"
+          YERD_PKGVER="${RAWVER//-/_}"
+          echo "YERD_PKGVER=$YERD_PKGVER" >> "$GITHUB_ENV"
+          # Build from the in-tree checkout (PKGBUILD has no source=()).
+          sudo -u builder env \
+            YERD_PKGVER="$YERD_PKGVER" \
+            YERD_SRCROOT="$GITHUB_WORKSPACE" \
+            PKGEXT=".pkg.tar.zst" \
+            bash -c 'cd "$YERD_SRCROOT/packaging/arch" && makepkg -f --noconfirm'
+          pkg=$(find "$GITHUB_WORKSPACE/packaging/arch" -maxdepth 1 -name '*.pkg.tar.zst' | head -n1)
+          [ -n "$pkg" ] || { echo "::error::no .pkg.tar.zst produced"; exit 1; }
+          echo "PKG=$pkg" >> "$GITHUB_ENV"
+
+      - name: Assert package contents + lint + pkg-format
+        run: |
+          set -euo pipefail
+          list=$(bsdtar tf "$PKG")
+          # All four binaries embedded under /usr/bin (matches the .deb layout).
+          for b in yerd yerdd yerd-helper yerd-gui; do
+            printf '%s\n' "$list" | grep -Eq "^usr/bin/$b\$" \
+              || { echo "::error::Arch package missing /usr/bin/$b"; exit 1; }
+          done
+          printf '%s\n' "$list" | grep -q '^\.INSTALL$' \
+            || { echo "::error::Arch package has no .INSTALL scriptlet (setcap)"; exit 1; }
+          printf '%s\n' "$list" | grep -q '^usr/share/applications/yerd-gui\.desktop$' \
+            || { echo "::error::Arch package has no .desktop"; exit 1; }
+          printf '%s\n' "$list" | grep -q '^usr/share/licenses/yerd/LICENSE$' \
+            || { echo "::error::Arch package has no license"; exit 1; }
+          # Validate the desktop file; run namcap (informational).
+          tmp=$(mktemp -d)
+          bsdtar -xf "$PKG" -C "$tmp" usr/share/applications/yerd-gui.desktop
+          desktop-file-validate "$tmp/usr/share/applications/yerd-gui.desktop"
+          namcap "$PKG" || true
+          # Pkg-format gate: the SHIPPED daemon must self-update via pacman, else a
+          # forgotten `--features` flag would ship a `.deb`-format updater here.
+          fmt=$("$GITHUB_WORKSPACE/target/release/yerdd" --pkg-format)
+          [ "$fmt" = "pacman" ] \
+            || { echo "::error::yerdd --pkg-format=$fmt (expected pacman); the pacman feature did not take"; exit 1; }
+          echo "Arch package OK: $PKG (pkg-format=$fmt)"
+
+      - name: Stage with a Yerd_* name for the publish renamer
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/arch-out"
+          # `Yerd_*` + `x86_64` + `.pkg.tar.zst` so the publish rename loop relabels
+          # it to Yerd_Linux_x86_64_v<ver>.pkg.tar.zst.
+          cp "$PKG" "$GITHUB_WORKSPACE/arch-out/Yerd_${YERD_PKGVER}_x86_64.pkg.tar.zst"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: arch-x86_64
+          if-no-files-found: error
+          path: arch-out/*.pkg.tar.zst
+
   # The ONLY job that touches the release. Assemble everything, create it as a
   # hidden draft with all files + checksums attached, then flip it public —
   # so nobody can ever see a release missing its artifacts.
   publish:
     name: publish
-    needs: [gui]
+    needs: [gui, arch]
     runs-on: ubuntu-22.04
     # Checkout is needed so the trust-anchor gate can read the embedded
     # UPDATE_PUBLIC_KEY from source at the tagged commit. GH_REPO is kept explicit
@@ -400,22 +487,26 @@ jobs:
         run: |
           set -euo pipefail
           find . -mindepth 2 -type f \
-            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' \) -exec mv -t . {} +
+            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' \) \
+            -exec mv -t . {} +
           # Drop the now-redundant nested dirs so `dist/*` is files-only.
           find . -mindepth 1 -type d -exec rm -rf {} +
           # Human-friendly release asset names:
           #   Yerd_<OS>_<Arch>_v<version>.<ext>   (e.g. Yerd_MacOS_AppleSilicon_v2-0-2-rc-3.dmg)
           # Tauri emits Yerd_<ver>_<arch>.{dmg,deb}; the .app.tar.gz is already
-          # Yerd_MacOS_AppleSilicon.app.tar.gz. We relabel OS+arch and dash the
-          # version (dots → dashes) so the Releases page reads cleanly.
+          # Yerd_MacOS_AppleSilicon.app.tar.gz; the arch job emits
+          # Yerd_<ver>_x86_64.pkg.tar.zst. We relabel OS+arch and dash the version
+          # (dots → dashes) so the Releases page reads cleanly.
           ver="v$(printf '%s' "${GITHUB_REF_NAME#v}" | tr '.' '-')"
           for f in Yerd_* yerd-gui_* yerd_*; do
             [ -e "$f" ] || continue
-            # Compound extension first (`.app.tar.gz` would otherwise become `gz`).
+            # Compound extensions first (`.app.tar.gz`/`.pkg.tar.zst` would
+            # otherwise collapse to `gz`/`zst`).
             case "$f" in
-              *.app.tar.gz) ext="app.tar.gz"; os="MacOS" ;;
-              *.dmg)        ext="dmg";        os="MacOS" ;;
-              *.deb)        ext="deb";        os="Linux" ;;
+              *.app.tar.gz)  ext="app.tar.gz";  os="MacOS" ;;
+              *.pkg.tar.zst) ext="pkg.tar.zst"; os="Linux" ;;
+              *.dmg)         ext="dmg";         os="MacOS" ;;
+              *.deb)         ext="deb";         os="Linux" ;;
               *) continue ;;
             esac
             case "$f" in
@@ -456,7 +547,7 @@ jobs:
           trap 'rm -f "$RUNNER_TEMP/minisign.key"' EXIT
           umask 077; printf '%s\n' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/minisign.key"
           shopt -s nullglob
-          for f in *.app.tar.gz *.deb; do
+          for f in *.app.tar.gz *.deb *.pkg.tar.zst; do
             minisign -S -H -s "$RUNNER_TEMP/minisign.key" -m "$f" -x "$f.sig"
             echo "signed $f -> $f.sig"
           done
@@ -479,7 +570,7 @@ jobs:
             exit 1
           fi
           shopt -s nullglob
-          for f in *.app.tar.gz *.deb; do
+          for f in *.app.tar.gz *.deb *.pkg.tar.zst; do
             minisign -V -H -P "$KEY" -m "$f" -x "$f.sig" \
               || { echo "::error::embedded UPDATE_PUBLIC_KEY does not verify $f.sig (key/secret mismatch)"; exit 1; }
             echo "verified $f against embedded key"
@@ -489,7 +580,7 @@ jobs:
         working-directory: dist
         run: |
           find . -maxdepth 1 -type f \
-            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' \) \
+            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' \) \
             -printf '%P\n' | sort | xargs -r sha256sum > SHA256SUMS
           echo "Artifacts:" && cat SHA256SUMS
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,12 @@ jobs:
         run: |
           set -euo pipefail
           cargo build --release -p yerd -p yerdd -p yerd-helper
+          # Symmetric guard to the arch job: the bundled daemon MUST be deb-format
+          # (the `pacman` self-update feature must never leak into the .deb/macOS
+          # build, or a .deb daemon would try `pacman -U` on Debian).
+          fmt=$(./target/release/yerdd --pkg-format)
+          [ "$fmt" = "deb" ] \
+            || { echo "::error::bundle yerdd --pkg-format=$fmt (expected deb); the pacman feature leaked into the GUI bundle build"; exit 1; }
           mkdir -p apps/yerd-gui/src-tauri/binaries
           # Native build per runner — the triple suffix is only Tauri's sidecar
           # naming, so it must match the arch cargo actually produced.
@@ -375,6 +381,11 @@ jobs:
     runs-on: ubuntu-22.04
     container: archlinux:base-devel
     steps:
+      # `git` isn't in base-devel; install it BEFORE checkout so actions/checkout
+      # does a real clone instead of the slower, rate-limited REST-tarball fallback.
+      - name: Install git (for a real checkout)
+        run: pacman -Sy --noconfirm git
+
       - uses: actions/checkout@v4
 
       - name: Install build deps
@@ -394,12 +405,12 @@ jobs:
           # the checkout (actions/checkout runs as root inside the container).
           useradd -m builder
           chown -R builder:builder "$GITHUB_WORKSPACE"
-          git config --global --add safe.directory '*'
-          # pkgver forbids '-'; a prerelease tag carries `-rc.N`. Strip leading `v`,
-          # then `-` → `_`. The release asset name is derived from the tag later, so
+          # pkgver may only contain [A-Za-z0-9._]; a tag can carry `-rc.N` (and in
+          # principle `+build`). Strip leading `v`, then map every other illegal
+          # char to `_`. The release asset name is derived from the tag later, so
           # this sanitisation only affects the in-package version string.
           RAWVER="${GITHUB_REF_NAME#v}"
-          YERD_PKGVER="${RAWVER//-/_}"
+          YERD_PKGVER=$(printf '%s' "$RAWVER" | tr -c 'A-Za-z0-9._' '_')
           echo "YERD_PKGVER=$YERD_PKGVER" >> "$GITHUB_ENV"
           # Build from the in-tree checkout (PKGBUILD has no source=()).
           sudo -u builder env \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,7 +386,12 @@ jobs:
       - name: Install git (for a real checkout)
         run: pacman -Sy --noconfirm git
 
+      # `persist-credentials: false` so the GitHub token isn't left in
+      # .git/config — the workspace is chowned to the unprivileged `builder` user
+      # for makepkg, and the build needs no authenticated git operations.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install build deps
         # `namcap` and `desktop-file-utils` are separate `extra` packages (not in
@@ -437,16 +442,17 @@ jobs:
             || { echo "::error::Arch package has no .desktop"; exit 1; }
           printf '%s\n' "$list" | grep -q '^usr/share/licenses/yerd/LICENSE$' \
             || { echo "::error::Arch package has no license"; exit 1; }
-          # Validate the desktop file; run namcap (informational).
+          # Extract the .desktop and the packaged daemon for validation.
           tmp=$(mktemp -d)
-          bsdtar -xf "$PKG" -C "$tmp" usr/share/applications/yerd-gui.desktop
+          bsdtar -xf "$PKG" -C "$tmp" usr/share/applications/yerd-gui.desktop usr/bin/yerdd
           desktop-file-validate "$tmp/usr/share/applications/yerd-gui.desktop"
           namcap "$PKG" || true
-          # Pkg-format gate: the SHIPPED daemon must self-update via pacman, else a
-          # forgotten `--features` flag would ship a `.deb`-format updater here.
-          fmt=$("$GITHUB_WORKSPACE/target/release/yerdd" --pkg-format)
+          # Pkg-format gate: run the daemon FROM THE PACKAGE (not the build tree) so a
+          # packaging-path mistake can't pass. The shipped daemon must self-update via
+          # pacman, else a forgotten `--features` flag would ship a `.deb`-format updater.
+          fmt=$("$tmp/usr/bin/yerdd" --pkg-format)
           [ "$fmt" = "pacman" ] \
-            || { echo "::error::yerdd --pkg-format=$fmt (expected pacman); the pacman feature did not take"; exit 1; }
+            || { echo "::error::packaged yerdd --pkg-format=$fmt (expected pacman); the pacman feature did not take"; exit 1; }
           echo "Arch package OK: $PKG (pkg-format=$fmt)"
 
       - name: Stage with a Yerd_* name for the publish renamer

--- a/README.md
+++ b/README.md
@@ -107,8 +107,14 @@ runtime). Grab the latest **Release Candidate** build from the
 | Platform | Download | Install |
 |---|---|---|
 | macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` | open, drag to Applications |
-| Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
-| Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Arch (x86-64) | `Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` | `sudo pacman -U ./Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` |
+
+> **Arch note.** If you have a leftover `/usr/bin/yerd` from the old v1 (Go)
+> project, remove it first — pacman refuses to install over a file it doesn't
+> own. Run `pacman -Syu` before installing/upgrading so the WebKit/GTK libraries
+> the app links match (it's built against current Arch packages).
 
 On first launch the app **starts its bundled daemon** - so on macOS setup is
 essentially drag-and-drop. It then walks you through a **one-time**
@@ -117,8 +123,9 @@ Everything after runs as your user - never as root.
 
 ### Terminal CLI
 
-The `yerd` command ships with the app: on **Linux** the `.deb` puts it on your
-`PATH`; on **macOS** open *Settings → Terminal CLI → Install*. Then the one-time
+The `yerd` command ships with the app: on **Linux** the `.deb`/`.pkg.tar.zst`
+puts it on your `PATH`; on **macOS** open *Settings → Terminal CLI → Install*.
+Then the one-time
 setup is available from the terminal too:
 
 ```bash

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -182,7 +182,9 @@ pub async fn set_update_channel(channel: String) -> Result<Response, GuiError> {
 ///
 /// On macOS this needs `/Applications/Yerd.app` to be user-writable (the common
 /// admin case); elevated self-update is a follow-up. On Linux the applier uses
-/// `pkexec dpkg -i`, which prompts via the desktop polkit agent.
+/// `pkexec dpkg -i` (`.deb`) or `pkexec pacman -U` (`.pkg.tar.zst`), which prompt
+/// via the desktop polkit agent. The `kind_str` mapping below must stay in sync
+/// with the `YERD_APPLY_KIND` parser in `bin/yerd/src/apply.rs`.
 #[tauri::command]
 pub async fn apply_update(app: tauri::AppHandle, channel: Option<String>) -> Result<(), GuiError> {
     let channel = channel.as_deref().map(parse_channel).transpose()?;
@@ -192,14 +194,15 @@ pub async fn apply_update(app: tauri::AppHandle, channel: Option<String>) -> Res
     };
     let yerd = crate::daemon::resolve_binary("yerd")
         .ok_or_else(|| GuiError::internal("could not locate the bundled yerd binary"))?;
-    // `StagedArtifact` is `#[non_exhaustive]`, so a wildcard arm is required; the
-    // explicit Pacman arm is what stops an Arch update falling through to the
-    // macOS installer (`"app_tar_gz"`). Keep these in sync with the applier's
-    // `YERD_APPLY_KIND` parser in `bin/yerd/src/apply.rs`.
     let kind_str = match kind {
+        yerd_ipc::StagedArtifact::AppTarGz => "app_tar_gz",
         yerd_ipc::StagedArtifact::Deb => "deb",
         yerd_ipc::StagedArtifact::Pacman => "pacman",
-        _ => "app_tar_gz",
+        _ => {
+            return Err(GuiError::internal(
+                "unknown staged artifact kind from the daemon",
+            ))
+        }
     };
     spawn_applier(&yerd, &path, kind_str)?;
     app.exit(0);

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -192,8 +192,13 @@ pub async fn apply_update(app: tauri::AppHandle, channel: Option<String>) -> Res
     };
     let yerd = crate::daemon::resolve_binary("yerd")
         .ok_or_else(|| GuiError::internal("could not locate the bundled yerd binary"))?;
+    // `StagedArtifact` is `#[non_exhaustive]`, so a wildcard arm is required; the
+    // explicit Pacman arm is what stops an Arch update falling through to the
+    // macOS installer (`"app_tar_gz"`). Keep these in sync with the applier's
+    // `YERD_APPLY_KIND` parser in `bin/yerd/src/apply.rs`.
     let kind_str = match kind {
         yerd_ipc::StagedArtifact::Deb => "deb",
+        yerd_ipc::StagedArtifact::Pacman => "pacman",
         _ => "app_tar_gz",
     };
     spawn_applier(&yerd, &path, kind_str)?;

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -529,8 +529,8 @@ export interface DaemonDiagnostics {
 
 /**
  * Whether the bundled `yerd` CLI is symlinked onto PATH (macOS host command
- * `cli_path_status`). On Linux the `.deb` already puts `yerd` on PATH, so the
- * control is hidden there.
+ * `cli_path_status`). On Linux the package (`.deb`/`.pkg.tar.zst`) already puts
+ * `yerd` on PATH, so the control is hidden there.
  */
 export interface CliPathStatus {
   installed: boolean;

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -539,7 +539,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
         </CardContent>
       </Card>
 
-      <!-- Terminal CLI (macOS) - Linux exposes `yerd` on PATH via the .deb. -->
+      <!-- Terminal CLI (macOS) - Linux exposes `yerd` on PATH via the package (.deb/.pkg.tar.zst). -->
       <Card v-if="isMac">
         <CardHeader>
           <CardTitle>Terminal CLI</CardTitle>

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -270,9 +270,9 @@ async function doInstallPhp(): Promise<void> {
   }
 }
 
-// ── step 2: install yerd on PATH (macOS only; Linux already ships it on PATH
-// via the .deb, so the button is hidden there - see `isMac`). Optional and
-// recommended; it never blocks "Next". ──
+// ── step 2: install yerd on PATH (macOS only; the Linux package (.deb/.pkg.tar.zst)
+// already ships it on PATH, so the button is hidden there - see `isMac`). Optional
+// and recommended; it never blocks "Next". ──
 const platform = ref("");
 const isMac = computed(() => platform.value === "macos");
 const cli = ref<CliPathStatus | null>(null);
@@ -591,7 +591,7 @@ function onBack(): void {
             </p>
 
             <!-- Optional (recommended): put the `yerd` CLI on PATH. macOS only -
-                 Linux already ships it via the .deb. Never blocks Continue. -->
+                 the Linux package (.deb/.pkg.tar.zst) already ships it. Never blocks Continue. -->
             <div
               v-if="isMac"
               class="flex items-center justify-between gap-4 rounded-md border bg-muted/30 p-3"

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -518,10 +518,11 @@ fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
         } else {
             // Prefer stderr; fall back to stdout (pacman writes some diagnostics there).
             let stderr = String::from_utf8_lossy(&out.stderr);
-            let mut detail = stderr.trim().to_owned();
-            if detail.is_empty() {
-                detail = String::from_utf8_lossy(&out.stdout).trim().to_owned();
-            }
+            let detail = if stderr.trim().is_empty() {
+                String::from_utf8_lossy(&out.stdout).trim().to_owned()
+            } else {
+                stderr.trim().to_owned()
+            };
             if detail.is_empty() {
                 Err("pacman failed to install the new package".to_owned())
             } else {

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -475,8 +475,16 @@ fn apply_linux_pacman(staged: &Path, relaunch_gui: bool) -> Result<(), String> {
 /// Elevated installer (runs as root via the `pkexec` re-exec). Mirror of
 /// [`elevated_install_deb`] for the Arch package: reads + verifies the staged
 /// `.pkg.tar.zst` **once**, copies the verified bytes into a root-owned 0700 dir,
-/// and `pacman -U`s that copy — closing the verify→re-read TOCTOU on the
+/// and `pacman -U`s that copy - closing the verify→re-read TOCTOU on the
 /// user-writable staged path. The package's `.install` scriptlet reapplies setcap.
+///
+/// `pacman -U` installs the file regardless of version (so an edge-to-stable
+/// downgrade works, like `dpkg -i`); `--noconfirm` because the re-exec is
+/// non-interactive. It is a partial upgrade, so on a host behind on `pacman -Syu`
+/// a newer library soname can make it abort; pacman's output (stderr, then stdout)
+/// is surfaced in the error so db-lock / unresolved-dep / `SigLevel` failures are
+/// legible rather than a generic "failed". The copy keeps a `.pkg.tar.zst` suffix
+/// for clarity; the package name itself comes from the embedded `.PKGINFO`.
 #[cfg(target_os = "linux")]
 fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
     use std::os::unix::fs::{DirBuilderExt as _, PermissionsExt as _};
@@ -495,18 +503,10 @@ fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
         .mode(0o700)
         .create(&dir)
         .map_err(|e| format!("creating secure install dir: {e}"))?;
-    // Keep a recognizable `.pkg.tar.zst` suffix on the root-owned copy (clarity;
-    // the package name itself comes from the embedded `.PKGINFO`, not the filename).
     let pkg = dir.join("update.pkg.tar.zst");
     let install = (|| -> Result<(), String> {
         std::fs::write(&pkg, &bytes).map_err(|e| format!("writing verified .pkg.tar.zst: {e}"))?;
         let _ = std::fs::set_permissions(&pkg, std::fs::Permissions::from_mode(0o600));
-        // `pacman -U` installs the given file regardless of version (so an
-        // edge→stable downgrade works, like `dpkg -i`); `--noconfirm` for the
-        // non-interactive re-exec. Capture output so db-lock / unresolved-dep /
-        // SigLevel failures are legible rather than a generic "failed". (`pacman -U`
-        // is a partial upgrade: if the host is behind on `pacman -Syu`, a newer
-        // library soname can make it abort — surfaced here.)
         let out = Command::new("pacman")
             .arg("-U")
             .arg("--noconfirm")
@@ -516,7 +516,6 @@ fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
         if out.status.success() {
             Ok(())
         } else {
-            // Prefer stderr; fall back to stdout (pacman writes some diagnostics there).
             let stderr = String::from_utf8_lossy(&out.stderr);
             let detail = if stderr.trim().is_empty() {
                 String::from_utf8_lossy(&out.stdout).trim().to_owned()

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -45,7 +45,7 @@ use yerd_update::{verify_minisign, UPDATE_PUBLIC_KEY};
 pub const APPLY_ENV: &str = "YERD_APPLY_UPDATE";
 /// Env var carrying the staged artifact path.
 pub const APPLY_PATH_ENV: &str = "YERD_APPLY_PATH";
-/// Env var carrying the artifact kind (`"deb"` / anything else = app tarball).
+/// Env var carrying the artifact kind: `"deb"`, `"pacman"`, or `"app_tar_gz"`.
 pub const APPLY_KIND_ENV: &str = "YERD_APPLY_KIND";
 /// Env var: `"1"` to relaunch the GUI after the install.
 pub const APPLY_RELAUNCH_GUI_ENV: &str = "YERD_APPLY_RELAUNCH_GUI";
@@ -53,6 +53,10 @@ pub const APPLY_RELAUNCH_GUI_ENV: &str = "YERD_APPLY_RELAUNCH_GUI";
 /// environment, so the staged path is passed positionally. Internal; not a clap
 /// subcommand, so it never appears in help/completions.
 pub const INSTALL_DEB_ARG: &str = "__yerd-install-deb";
+
+/// argv sentinel for the elevated Arch pacman-install re-exec. Mirrors
+/// [`INSTALL_DEB_ARG`] for the `.pkg.tar.zst` install path.
+pub const INSTALL_PACMAN_ARG: &str = "__yerd-install-pacman";
 
 /// If invoked as the elevated deb installer (`yerd __yerd-install-deb <path>`),
 /// run it and return the exit code; otherwise `None` (normal dispatch proceeds).
@@ -68,6 +72,22 @@ pub fn run_install_deb_from_args() -> Option<ExitCode> {
         return Some(ExitCode::from(2));
     };
     Some(install_deb_entry(Path::new(&path)))
+}
+
+/// If invoked as the elevated pacman installer (`yerd __yerd-install-pacman
+/// <path>`), run it and return the exit code; otherwise `None`. The pacman
+/// counterpart of [`run_install_deb_from_args`].
+#[must_use]
+pub fn run_install_pacman_from_args() -> Option<ExitCode> {
+    let mut args = std::env::args_os().skip(1);
+    if args.next()?.to_str() != Some(INSTALL_PACMAN_ARG) {
+        return None;
+    }
+    let Some(path) = args.next() else {
+        eprintln!("yerd: {INSTALL_PACMAN_ARG} requires a path");
+        return Some(ExitCode::from(2));
+    };
+    Some(install_pacman_entry(Path::new(&path)))
 }
 
 /// Run the elevated deb install (Linux). The cfg split lives in a helper with a
@@ -89,6 +109,24 @@ fn install_deb_entry(_path: &Path) -> ExitCode {
     ExitCode::from(1)
 }
 
+/// Run the elevated pacman install (Linux). Mirror of [`install_deb_entry`].
+#[cfg(target_os = "linux")]
+fn install_pacman_entry(path: &Path) -> ExitCode {
+    match elevated_install_pacman(path) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("yerd: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn install_pacman_entry(_path: &Path) -> ExitCode {
+    eprintln!("yerd: elevated pacman install is Linux-only");
+    ExitCode::from(1)
+}
+
 /// If invoked in applier mode (the [`APPLY_ENV`] var is set), run the apply and
 /// return its exit code; otherwise `None` (normal CLI dispatch proceeds). All
 /// inputs travel via env vars so nothing leaks into the argv-driven help.
@@ -101,10 +139,11 @@ pub fn run_from_env() -> Option<ExitCode> {
     };
     let kind = match std::env::var(APPLY_KIND_ENV).as_deref() {
         Ok("deb") => StagedArtifact::Deb,
+        Ok("pacman") => StagedArtifact::Pacman,
         Ok("app_tar_gz") => StagedArtifact::AppTarGz,
         other => {
             eprintln!(
-                "yerd: invalid {APPLY_KIND_ENV}={other:?} (expected \"deb\" or \"app_tar_gz\")"
+                "yerd: invalid {APPLY_KIND_ENV}={other:?} (expected \"deb\", \"pacman\" or \"app_tar_gz\")"
             );
             return Some(ExitCode::from(2));
         }
@@ -125,6 +164,7 @@ pub fn run(staged: &Path, kind: StagedArtifact, relaunch_gui: bool) -> ExitCode 
     let result = match kind {
         StagedArtifact::AppTarGz => apply_macos(staged, relaunch_gui),
         StagedArtifact::Deb => apply_linux(staged, relaunch_gui),
+        StagedArtifact::Pacman => apply_linux_pacman(staged, relaunch_gui),
         _ => Err("unknown staged artifact kind from the daemon".to_owned()),
     };
     match result {
@@ -411,6 +451,84 @@ fn elevated_install_deb(staged: &Path) -> Result<(), String> {
     install
 }
 
+// ── Linux (Arch): reinstall the .pkg.tar.zst ─────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn apply_linux_pacman(staged: &Path, relaunch_gui: bool) -> Result<(), String> {
+    if nix::unistd::geteuid().is_root() {
+        return elevated_install_pacman(staged);
+    }
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let status = Command::new("pkexec")
+        .arg(&exe)
+        .arg(INSTALL_PACMAN_ARG)
+        .arg(staged)
+        .status()
+        .map_err(|e| format!("spawning pkexec: {e}"))?;
+    if !status.success() {
+        return Err("privileged install (pkexec) failed or was cancelled".to_owned());
+    }
+    restart_services(relaunch_gui);
+    Ok(())
+}
+
+/// Elevated installer (runs as root via the `pkexec` re-exec). Mirror of
+/// [`elevated_install_deb`] for the Arch package: reads + verifies the staged
+/// `.pkg.tar.zst` **once**, copies the verified bytes into a root-owned 0700 dir,
+/// and `pacman -U`s that copy — closing the verify→re-read TOCTOU on the
+/// user-writable staged path. The package's `.install` scriptlet reapplies setcap.
+#[cfg(target_os = "linux")]
+fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
+    use std::os::unix::fs::{DirBuilderExt as _, PermissionsExt as _};
+
+    if !nix::unistd::geteuid().is_root() {
+        return Err("the elevated installer must run as root".to_owned());
+    }
+    let bytes = std::fs::read(staged).map_err(|e| format!("reading staged .pkg.tar.zst: {e}"))?;
+    let sig_path = sibling_sig(staged);
+    let sig = std::fs::read_to_string(&sig_path)
+        .map_err(|e| format!("reading signature {}: {e}", sig_path.display()))?;
+    verify_minisign(UPDATE_PUBLIC_KEY, &sig, &bytes).map_err(|e| e.to_string())?;
+
+    let dir = std::env::temp_dir().join(format!("yerd-update-{}", unique_suffix()));
+    std::fs::DirBuilder::new()
+        .mode(0o700)
+        .create(&dir)
+        .map_err(|e| format!("creating secure install dir: {e}"))?;
+    // pacman infers the package name from the filename, so keep the `.pkg.tar.zst`
+    // suffix on the root-owned copy.
+    let pkg = dir.join("update.pkg.tar.zst");
+    let install = (|| -> Result<(), String> {
+        std::fs::write(&pkg, &bytes).map_err(|e| format!("writing verified .pkg.tar.zst: {e}"))?;
+        let _ = std::fs::set_permissions(&pkg, std::fs::Permissions::from_mode(0o600));
+        // `pacman -U` installs the given file regardless of version (so an
+        // edge→stable downgrade works, like `dpkg -i`); `--noconfirm` for the
+        // non-interactive re-exec. Capture stderr so db-lock / unresolved-dep
+        // failures are legible rather than a generic "failed".
+        let out = Command::new("pacman")
+            .arg("-U")
+            .arg("--noconfirm")
+            .arg(&pkg)
+            .output()
+            .map_err(|e| format!("spawning pacman: {e}"))?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let detail = stderr.trim();
+            if detail.is_empty() {
+                Err("pacman failed to install the new package".to_owned())
+            } else {
+                Err(format!(
+                    "pacman failed to install the new package: {detail}"
+                ))
+            }
+        }
+    })();
+    let _ = std::fs::remove_dir_all(&dir);
+    install
+}
+
 #[cfg(target_os = "linux")]
 fn relaunch_gui_app() {
     use std::os::unix::process::CommandExt as _;
@@ -442,6 +560,11 @@ fn apply_macos(_staged: &Path, _relaunch_gui: bool) -> Result<(), String> {
 #[cfg(not(target_os = "linux"))]
 fn apply_linux(_staged: &Path, _relaunch_gui: bool) -> Result<(), String> {
     Err("a .deb package cannot be installed on this platform".to_owned())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn apply_linux_pacman(_staged: &Path, _relaunch_gui: bool) -> Result<(), String> {
+    Err("an Arch .pkg.tar.zst cannot be installed on this platform".to_owned())
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -495,16 +495,18 @@ fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
         .mode(0o700)
         .create(&dir)
         .map_err(|e| format!("creating secure install dir: {e}"))?;
-    // pacman infers the package name from the filename, so keep the `.pkg.tar.zst`
-    // suffix on the root-owned copy.
+    // Keep a recognizable `.pkg.tar.zst` suffix on the root-owned copy (clarity;
+    // the package name itself comes from the embedded `.PKGINFO`, not the filename).
     let pkg = dir.join("update.pkg.tar.zst");
     let install = (|| -> Result<(), String> {
         std::fs::write(&pkg, &bytes).map_err(|e| format!("writing verified .pkg.tar.zst: {e}"))?;
         let _ = std::fs::set_permissions(&pkg, std::fs::Permissions::from_mode(0o600));
         // `pacman -U` installs the given file regardless of version (so an
         // edge→stable downgrade works, like `dpkg -i`); `--noconfirm` for the
-        // non-interactive re-exec. Capture stderr so db-lock / unresolved-dep
-        // failures are legible rather than a generic "failed".
+        // non-interactive re-exec. Capture output so db-lock / unresolved-dep /
+        // SigLevel failures are legible rather than a generic "failed". (`pacman -U`
+        // is a partial upgrade: if the host is behind on `pacman -Syu`, a newer
+        // library soname can make it abort — surfaced here.)
         let out = Command::new("pacman")
             .arg("-U")
             .arg("--noconfirm")
@@ -514,8 +516,12 @@ fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
         if out.status.success() {
             Ok(())
         } else {
+            // Prefer stderr; fall back to stdout (pacman writes some diagnostics there).
             let stderr = String::from_utf8_lossy(&out.stderr);
-            let detail = stderr.trim();
+            let mut detail = stderr.trim().to_owned();
+            if detail.is_empty() {
+                detail = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+            }
             if detail.is_empty() {
                 Err("pacman failed to install the new package".to_owned())
             } else {

--- a/bin/yerd/src/main.rs
+++ b/bin/yerd/src/main.rs
@@ -26,6 +26,9 @@ fn main() -> ExitCode {
     if let Some(code) = yerd::apply::run_install_deb_from_args() {
         return code;
     }
+    if let Some(code) = yerd::apply::run_install_pacman_from_args() {
+        return code;
+    }
 
     let cli = Cli::parse();
     let runtime = match tokio::runtime::Builder::new_current_thread()

--- a/bin/yerdd/Cargo.toml
+++ b/bin/yerdd/Cargo.toml
@@ -7,6 +7,12 @@ license.workspace      = true
 publish.workspace      = true
 description            = "Yerd unprivileged daemon — wires every Phase-1 library together."
 
+[features]
+# Build the daemon for the Arch package: flips `yerd_update::PkgFormat::current()`
+# to `Pacman` so self-update selects the `.pkg.tar.zst` and installs via `pacman -U`.
+# Enabled ONLY by the Arch CI build (`--features yerdd/pacman`); default off → `.deb`.
+pacman = ["yerd-update/pacman"]
+
 [[bin]]
 name = "yerdd"
 path = "src/main.rs"

--- a/bin/yerdd/src/args.rs
+++ b/bin/yerdd/src/args.rs
@@ -6,6 +6,15 @@ use std::path::PathBuf;
 #[derive(clap::Parser, Debug)]
 #[command(name = "yerdd", version, about = "Yerd daemon")]
 pub struct Cli {
+    /// Print the build's self-update package format (`deb`/`pacman`) and exit.
+    ///
+    /// Hidden diagnostic: the release pipeline runs this on the freshly-built
+    /// Arch `yerdd` to assert it was compiled with the `pacman` feature, so a
+    /// forgotten `--features` flag fails the release instead of shipping a
+    /// `.deb`-format updater inside the `.pkg.tar.zst`. Handled in `main` before
+    /// the daemon starts.
+    #[arg(long, hide = true)]
+    pub pkg_format: bool,
     /// Subcommand to run; defaults to `Serve` with default args when omitted.
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -2814,9 +2814,6 @@ Subject: Captured\r\n\r\nhi\r\n";
         let mac = "Yerd_MacOS_AppleSilicon_v99-0-1.app.tar.gz";
         let deb = "Yerd_Linux_x86_64_v99-0-1.deb";
         let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
-        // A real release carries the `.pkg.tar.zst` alongside the `.deb`; include
-        // both so the fixture resolves whether this build's `PkgFormat` is Deb or
-        // Pacman (the `pacman` feature flips selection to the `.pkg.tar.zst`).
         let pkg = "Yerd_Linux_x86_64_v99-0-1.pkg.tar.zst";
         let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
         let releases = format!(
@@ -2849,8 +2846,6 @@ Subject: Captured\r\n\r\nhi\r\n";
                 let p = std::path::Path::new(&path);
                 assert!(p.exists(), "staged file should exist at {path}");
                 assert_eq!(std::fs::read(p).unwrap(), b"test");
-                // The selected artifact depends on BOTH the running platform and
-                // the build's `PkgFormat` (the `pacman` feature picks pacman).
                 let (expected_kind, expected_name) = match (
                     yerd_update::Platform::current(),
                     yerd_update::PkgFormat::current(),
@@ -2898,8 +2893,6 @@ Subject: Captured\r\n\r\nhi\r\n";
         let mac = "Yerd_MacOS_AppleSilicon_v99-0-1.app.tar.gz";
         let deb = "Yerd_Linux_x86_64_v99-0-1.deb";
         let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
-        // Include the pacman artifacts too, so the checksum-mismatch path is
-        // exercised regardless of this build's `PkgFormat`.
         let pkg = "Yerd_Linux_x86_64_v99-0-1.pkg.tar.zst";
         let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
         let releases = format!(

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -2814,6 +2814,11 @@ Subject: Captured\r\n\r\nhi\r\n";
         let mac = "Yerd_MacOS_AppleSilicon_v99-0-1.app.tar.gz";
         let deb = "Yerd_Linux_x86_64_v99-0-1.deb";
         let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
+        // A real release carries the `.pkg.tar.zst` alongside the `.deb`; include
+        // both so the fixture resolves whether this build's `PkgFormat` is Deb or
+        // Pacman (the `pacman` feature flips selection to the `.pkg.tar.zst`).
+        let pkg = "Yerd_Linux_x86_64_v99-0-1.pkg.tar.zst";
+        let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
         let releases = format!(
             r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
@@ -2822,11 +2827,15 @@ Subject: Captured\r\n\r\nhi\r\n";
                 {{"name":"{deb}.sig","browser_download_url":"https://h/{deb}.sig","size":1}},
                 {{"name":"{arm}","browser_download_url":"https://h/{arm}","size":4}},
                 {{"name":"{arm}.sig","browser_download_url":"https://h/{arm}.sig","size":1}},
+                {{"name":"{pkg}","browser_download_url":"https://h/{pkg}","size":4}},
+                {{"name":"{pkg}.sig","browser_download_url":"https://h/{pkg}.sig","size":1}},
+                {{"name":"{pkg_arm}","browser_download_url":"https://h/{pkg_arm}","size":4}},
+                {{"name":"{pkg_arm}.sig","browser_download_url":"https://h/{pkg_arm}.sig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
             ]}}]"#
         );
         let h = yerd_update::sha256_hex(b"test");
-        let sums = format!("{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n");
+        let sums = format!("{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n{h}  {pkg}\n{h}  {pkg_arm}\n");
         let dl = StageDl { releases, sums };
 
         let resp = crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await;
@@ -2840,25 +2849,34 @@ Subject: Captured\r\n\r\nhi\r\n";
                 let p = std::path::Path::new(&path);
                 assert!(p.exists(), "staged file should exist at {path}");
                 assert_eq!(std::fs::read(p).unwrap(), b"test");
-                let expected = if matches!(
+                // The selected artifact depends on BOTH the running platform and
+                // the build's `PkgFormat` (the `pacman` feature picks pacman).
+                let (expected_kind, expected_name) = match (
                     yerd_update::Platform::current(),
-                    yerd_update::Platform::LinuxX86_64 | yerd_update::Platform::LinuxAarch64
+                    yerd_update::PkgFormat::current(),
                 ) {
-                    yerd_ipc::StagedArtifact::Deb
-                } else {
-                    yerd_ipc::StagedArtifact::AppTarGz
+                    (yerd_update::Platform::MacOsAarch64, _) => {
+                        (yerd_ipc::StagedArtifact::AppTarGz, mac)
+                    }
+                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Deb) => {
+                        (yerd_ipc::StagedArtifact::Deb, deb)
+                    }
+                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Pacman) => {
+                        (yerd_ipc::StagedArtifact::Pacman, pkg)
+                    }
+                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Deb) => {
+                        (yerd_ipc::StagedArtifact::Deb, arm)
+                    }
+                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Pacman) => {
+                        (yerd_ipc::StagedArtifact::Pacman, pkg_arm)
+                    }
+                    (other, _) => panic!("unexpected platform for fixture: {other:?}"),
                 };
-                assert_eq!(kind, expected);
-                let expected_name = match yerd_update::Platform::current() {
-                    yerd_update::Platform::MacOsAarch64 => mac,
-                    yerd_update::Platform::LinuxX86_64 => deb,
-                    yerd_update::Platform::LinuxAarch64 => arm,
-                    other => panic!("unexpected platform for fixture: {other:?}"),
-                };
+                assert_eq!(kind, expected_kind);
                 assert_eq!(
                     p.file_name().and_then(|n| n.to_str()),
                     Some(expected_name),
-                    "staged basename should be the current platform's asset"
+                    "staged basename should be the current platform+format's asset"
                 );
             }
             other => panic!("expected Staged, got {other:?}"),
@@ -2880,6 +2898,10 @@ Subject: Captured\r\n\r\nhi\r\n";
         let mac = "Yerd_MacOS_AppleSilicon_v99-0-1.app.tar.gz";
         let deb = "Yerd_Linux_x86_64_v99-0-1.deb";
         let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
+        // Include the pacman artifacts too, so the checksum-mismatch path is
+        // exercised regardless of this build's `PkgFormat`.
+        let pkg = "Yerd_Linux_x86_64_v99-0-1.pkg.tar.zst";
+        let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
         let releases = format!(
             r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
@@ -2888,11 +2910,16 @@ Subject: Captured\r\n\r\nhi\r\n";
                 {{"name":"{deb}.sig","browser_download_url":"https://h/{deb}.sig","size":1}},
                 {{"name":"{arm}","browser_download_url":"https://h/{arm}","size":4}},
                 {{"name":"{arm}.sig","browser_download_url":"https://h/{arm}.sig","size":1}},
+                {{"name":"{pkg}","browser_download_url":"https://h/{pkg}","size":4}},
+                {{"name":"{pkg}.sig","browser_download_url":"https://h/{pkg}.sig","size":1}},
+                {{"name":"{pkg_arm}","browser_download_url":"https://h/{pkg_arm}","size":4}},
+                {{"name":"{pkg_arm}.sig","browser_download_url":"https://h/{pkg_arm}.sig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
             ]}}]"#
         );
         let bad = "0".repeat(64);
-        let sums = format!("{bad}  {mac}\n{bad}  {deb}\n{bad}  {arm}\n");
+        let sums =
+            format!("{bad}  {mac}\n{bad}  {deb}\n{bad}  {arm}\n{bad}  {pkg}\n{bad}  {pkg_arm}\n");
         let dl = StageDl { releases, sums };
         match crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await {
             Response::Error { .. } => {}
@@ -2901,7 +2928,9 @@ Subject: Captured\r\n\r\nhi\r\n";
         assert!(
             !state.dirs.cache.join("update").join(mac).exists()
                 && !state.dirs.cache.join("update").join(deb).exists()
-                && !state.dirs.cache.join("update").join(arm).exists(),
+                && !state.dirs.cache.join("update").join(arm).exists()
+                && !state.dirs.cache.join("update").join(pkg).exists()
+                && !state.dirs.cache.join("update").join(pkg_arm).exists(),
             "must not write an artifact when verification fails"
         );
     }

--- a/bin/yerdd/src/main.rs
+++ b/bin/yerdd/src/main.rs
@@ -12,6 +12,13 @@ use yerdd::{error, run, tracing_init, Outcome};
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    // Hidden diagnostic (release gate): print the build's self-update package
+    // format and exit before any daemon work. Reads `yerd_update::PkgFormat`,
+    // which the `pacman` feature flips — see `args::Cli::pkg_format`.
+    if cli.pkg_format {
+        println!("{}", pkg_format_str());
+        return ExitCode::SUCCESS;
+    }
     let Command::Serve(args) = cli
         .command
         .unwrap_or_else(|| Command::Serve(ServeArgs::default()));
@@ -49,6 +56,16 @@ fn main() -> ExitCode {
             tracing::error!(error = %e, "yerdd exiting with error");
             ExitCode::from(error::exit_code(&e))
         }
+    }
+}
+
+/// The build's self-update package format as a stable lowercase string
+/// (`"pacman"` when compiled with the `pacman` feature, else `"deb"`). Used by the
+/// hidden `--pkg-format` diagnostic the release pipeline asserts on.
+fn pkg_format_str() -> &'static str {
+    match yerd_update::PkgFormat::current() {
+        yerd_update::PkgFormat::Pacman => "pacman",
+        yerd_update::PkgFormat::Deb => "deb",
     }
 }
 

--- a/bin/yerdd/src/main.rs
+++ b/bin/yerdd/src/main.rs
@@ -12,9 +12,6 @@ use yerdd::{error, run, tracing_init, Outcome};
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
-    // Hidden diagnostic (release gate): print the build's self-update package
-    // format and exit before any daemon work. Reads `yerd_update::PkgFormat`,
-    // which the `pacman` feature flips — see `args::Cli::pkg_format`.
     if cli.pkg_format {
         println!("{}", pkg_format_str());
         return ExitCode::SUCCESS;

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -367,9 +367,6 @@ pub async fn stage_update(
     let Some(target_rel) = releases.iter().find(|r| r.version == target_ver) else {
         return internal("internal: resolved target release vanished".to_owned());
     };
-    // `PkgFormat::current()` is the build-time deb-vs-pacman tiebreak: a release
-    // carries both Linux artifacts and only the format this binary was packaged
-    // for is installable here (see `yerd_update::PkgFormat`).
     let sel = match select_asset(target_rel, Platform::current(), PkgFormat::current()) {
         Ok(s) => s,
         Err(e) => return internal(format!("no installable artifact: {e}")),

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -16,7 +16,7 @@ use yerd_php::Downloader;
 use yerd_platform::PlatformDirs;
 use yerd_update::{
     select_asset, select_target, verify_minisign, verify_sha256, ArtifactKind, Asset, Channel,
-    Platform, ReleaseMeta,
+    PkgFormat, Platform, ReleaseMeta,
 };
 
 use crate::ipc_server::internal;
@@ -367,7 +367,10 @@ pub async fn stage_update(
     let Some(target_rel) = releases.iter().find(|r| r.version == target_ver) else {
         return internal("internal: resolved target release vanished".to_owned());
     };
-    let sel = match select_asset(target_rel, Platform::current()) {
+    // `PkgFormat::current()` is the build-time deb-vs-pacman tiebreak: a release
+    // carries both Linux artifacts and only the format this binary was packaged
+    // for is installable here (see `yerd_update::PkgFormat`).
+    let sel = match select_asset(target_rel, Platform::current(), PkgFormat::current()) {
         Ok(s) => s,
         Err(e) => return internal(format!("no installable artifact: {e}")),
     };
@@ -412,6 +415,7 @@ pub async fn stage_update(
     let kind = match sel.kind {
         ArtifactKind::AppTarGz => StagedArtifact::AppTarGz,
         ArtifactKind::Deb => StagedArtifact::Deb,
+        ArtifactKind::Pacman => StagedArtifact::Pacman,
     };
     tracing::info!(version = %target_ver, path = %path.display(), "staged verified update artifact");
     Response::Staged {

--- a/crates/yerd-ipc/src/update.rs
+++ b/crates/yerd-ipc/src/update.rs
@@ -44,4 +44,6 @@ pub enum StagedArtifact {
     AppTarGz,
     /// Linux `.deb` - the applier reinstalls via `dpkg -i`.
     Deb,
+    /// Arch `.pkg.tar.zst` - the applier reinstalls via `pacman -U`.
+    Pacman,
 }

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -1681,6 +1681,14 @@ fn staged_artifact_each_variant_byte_shape() {
         serde_json::from_str::<StagedArtifact>(r#""deb""#).unwrap(),
         StagedArtifact::Deb
     );
+    assert_eq!(
+        serde_json::to_string(&StagedArtifact::Pacman).unwrap(),
+        r#""pacman""#
+    );
+    assert_eq!(
+        serde_json::from_str::<StagedArtifact>(r#""pacman""#).unwrap(),
+        StagedArtifact::Pacman
+    );
 }
 
 #[test]

--- a/crates/yerd-update/Cargo.toml
+++ b/crates/yerd-update/Cargo.toml
@@ -13,5 +13,12 @@ sha2            = { workspace = true }
 minisign-verify = { workspace = true }
 hex             = { workspace = true }
 
+[features]
+# Build-time package-format tiebreak. A release ships BOTH a `.deb` and a
+# `.pkg.tar.zst` for the same Linux arch; the running binary must pick the one
+# matching how it was installed. Enabling `pacman` (the Arch package build only)
+# flips `PkgFormat::current()` to `Pacman`. Default off → `Deb`. See `PkgFormat`.
+pacman = []
+
 [lints]
 workspace = true

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -69,6 +69,41 @@ pub enum ArtifactKind {
     AppTarGz,
     /// A Debian package (reinstalled via `dpkg -i`).
     Deb,
+    /// An Arch package (reinstalled via `pacman -U`).
+    Pacman,
+}
+
+/// The Linux package format a build self-updates with.
+///
+/// A release ships BOTH a `.deb` and a `.pkg.tar.zst` for the same arch, so a
+/// running Linux binary cannot tell which to install from [`Platform`] alone
+/// (that only knows OS + arch, not distro). Instead the format is fixed at build
+/// time: [`PkgFormat::current`] returns [`PkgFormat::Pacman`] when compiled with
+/// the `pacman` feature (the Arch package build) and [`PkgFormat::Deb`] otherwise.
+/// macOS selection ignores it. This is decoupled from `cfg!` in the type so
+/// selection stays testable for either format from any build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PkgFormat {
+    /// Debian `.deb` (installed via `dpkg -i`). The default build.
+    Deb,
+    /// Arch `.pkg.tar.zst` (installed via `pacman -U`).
+    Pacman,
+}
+
+impl PkgFormat {
+    /// The package format this binary was built for: [`PkgFormat::Pacman`] when
+    /// compiled with the `pacman` feature, else [`PkgFormat::Deb`].
+    #[must_use]
+    pub fn current() -> Self {
+        #[cfg(feature = "pacman")]
+        {
+            Self::Pacman
+        }
+        #[cfg(not(feature = "pacman"))]
+        {
+            Self::Deb
+        }
+    }
 }
 
 /// A fully-resolved download set for one platform: the artifact, its detached
@@ -110,22 +145,32 @@ impl std::fmt::Display for AssetError {
 
 impl std::error::Error for AssetError {}
 
-/// Pick the artifact + signature + checksums for `platform` from `release`.
+/// Pick the artifact + signature + checksums for `platform` + `format` from
+/// `release`.
 ///
 /// Selection is by filename convention (the names the release workflow emits):
 /// the macOS artifact ends `.app.tar.gz` and is arch-tagged; the Linux artifact
-/// ends `.deb` and is arch-tagged (`x86_64` or `arm64`); the signature is
-/// `<artifact>.sig`; the manifest is named `SHA256SUMS`. Intel macOS / unsupported
-/// platforms return [`AssetError::NoArtifactForPlatform`] rather than mis-selecting.
+/// ends `.deb` (Debian) or `.pkg.tar.zst` (Arch) per `format` and is arch-tagged
+/// (`x86_64` or `arm64`); the signature is `<artifact>.sig`; the manifest is named
+/// `SHA256SUMS`. `format` resolves the deb-vs-pacman ambiguity on Linux (a release
+/// carries both) and is ignored on macOS. Intel macOS / unsupported platforms
+/// return [`AssetError::NoArtifactForPlatform`] rather than mis-selecting.
 pub fn select_asset(
     release: &ReleaseMeta,
     platform: Platform,
+    format: PkgFormat,
 ) -> Result<ArtifactSelection<'_>, AssetError> {
-    let (kind, matches): (ArtifactKind, fn(&str) -> bool) = match platform {
-        Platform::MacOsAarch64 => (ArtifactKind::AppTarGz, is_macos_aarch64_artifact),
-        Platform::LinuxX86_64 => (ArtifactKind::Deb, is_linux_x86_64_artifact),
-        Platform::LinuxAarch64 => (ArtifactKind::Deb, is_linux_aarch64_artifact),
-        p @ (Platform::MacOsX86_64 | Platform::Unsupported) => {
+    let (kind, matches): (ArtifactKind, fn(&str) -> bool) = match (platform, format) {
+        (Platform::MacOsAarch64, _) => (ArtifactKind::AppTarGz, is_macos_aarch64_artifact),
+        (Platform::LinuxX86_64, PkgFormat::Deb) => (ArtifactKind::Deb, is_linux_x86_64_artifact),
+        (Platform::LinuxX86_64, PkgFormat::Pacman) => {
+            (ArtifactKind::Pacman, is_linux_x86_64_pacman)
+        }
+        (Platform::LinuxAarch64, PkgFormat::Deb) => (ArtifactKind::Deb, is_linux_aarch64_artifact),
+        (Platform::LinuxAarch64, PkgFormat::Pacman) => {
+            (ArtifactKind::Pacman, is_linux_aarch64_pacman)
+        }
+        (p @ (Platform::MacOsX86_64 | Platform::Unsupported), _) => {
             return Err(AssetError::NoArtifactForPlatform(p));
         }
     };
@@ -176,6 +221,22 @@ fn is_linux_x86_64_artifact(name: &str) -> bool {
 fn is_linux_aarch64_artifact(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     lower.ends_with(".deb") && (lower.contains("aarch64") || lower.contains("arm64"))
+}
+
+// The Arch package is named `Yerd_Linux_x86_64_*.pkg.tar.zst`. The `.zst` suffix is
+// disjoint from `.deb`, so deb and pacman matchers never collide on the same name.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn is_linux_x86_64_pacman(name: &str) -> bool {
+    name.ends_with(".pkg.tar.zst") && (name.contains("x86_64") || name.contains("amd64"))
+}
+
+// arm64 Arch is not built for v1 (no artifact is published), but the matcher is kept
+// symmetric with the .deb side and tested for disjointness. Case-insensitive for the
+// `Arm64`/`aarch64` token, mirroring `is_linux_aarch64_artifact`.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn is_linux_aarch64_pacman(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.ends_with(".pkg.tar.zst") && (lower.contains("aarch64") || lower.contains("arm64"))
 }
 
 /// Why verification failed.
@@ -298,11 +359,24 @@ mod tests {
             "Yerd_MacOS_AppleSilicon_v2-0-2.dmg",
             "SHA256SUMS",
         ]);
-        let sel = select_asset(&r, Platform::MacOsAarch64).unwrap();
+        let sel = select_asset(&r, Platform::MacOsAarch64, PkgFormat::Deb).unwrap();
         assert_eq!(sel.kind, ArtifactKind::AppTarGz);
         assert!(sel.artifact.name.ends_with(".app.tar.gz"));
         assert!(sel.signature.name.ends_with(".app.tar.gz.sig"));
         assert_eq!(sel.checksums.name, "SHA256SUMS");
+    }
+
+    #[test]
+    fn macos_selection_ignores_pkg_format() {
+        // A pacman-format build on macOS still picks the `.app.tar.gz`: `format`
+        // only disambiguates Linux.
+        let r = release_with(&[
+            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz",
+            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz.sig",
+            "SHA256SUMS",
+        ]);
+        let sel = select_asset(&r, Platform::MacOsAarch64, PkgFormat::Pacman).unwrap();
+        assert_eq!(sel.kind, ArtifactKind::AppTarGz);
     }
 
     #[test]
@@ -312,7 +386,7 @@ mod tests {
             "Yerd_Linux_x86_64_v2-0-2.deb.sig",
             "SHA256SUMS",
         ]);
-        let sel = select_asset(&r, Platform::LinuxX86_64).unwrap();
+        let sel = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb).unwrap();
         assert_eq!(sel.kind, ArtifactKind::Deb);
         assert!(sel.artifact.name.ends_with(".deb"));
     }
@@ -324,9 +398,41 @@ mod tests {
             "Yerd_Linux_Arm64_v2-0-2.deb.sig",
             "SHA256SUMS",
         ]);
-        let sel = select_asset(&r, Platform::LinuxAarch64).unwrap();
+        let sel = select_asset(&r, Platform::LinuxAarch64, PkgFormat::Deb).unwrap();
         assert_eq!(sel.kind, ArtifactKind::Deb);
         assert_eq!(sel.artifact.name, "Yerd_Linux_Arm64_v2-0-2.deb");
+    }
+
+    #[test]
+    fn selects_linux_x86_64_pacman() {
+        let r = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
+            "SHA256SUMS",
+        ]);
+        let sel = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Pacman).unwrap();
+        assert_eq!(sel.kind, ArtifactKind::Pacman);
+        assert!(sel.artifact.name.ends_with(".pkg.tar.zst"));
+        assert!(sel.signature.name.ends_with(".pkg.tar.zst.sig"));
+    }
+
+    #[test]
+    fn both_artifacts_present_resolves_per_format() {
+        // The real release carries BOTH the .deb and the .pkg.tar.zst for x86_64;
+        // the build-time format is the only tiebreak.
+        let r = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.deb",
+            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
+            "SHA256SUMS",
+        ]);
+        let deb = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb).unwrap();
+        assert_eq!(deb.kind, ArtifactKind::Deb);
+        assert!(deb.artifact.name.ends_with(".deb"));
+        let pac = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Pacman).unwrap();
+        assert_eq!(pac.kind, ArtifactKind::Pacman);
+        assert!(pac.artifact.name.ends_with(".pkg.tar.zst"));
     }
 
     #[test]
@@ -337,7 +443,7 @@ mod tests {
             "SHA256SUMS",
         ]);
         assert_eq!(
-            select_asset(&only_x86, Platform::LinuxAarch64),
+            select_asset(&only_x86, Platform::LinuxAarch64, PkgFormat::Deb),
             Err(AssetError::NoArtifactForPlatform(Platform::LinuxAarch64))
         );
         let only_arm = release_with(&[
@@ -346,7 +452,42 @@ mod tests {
             "SHA256SUMS",
         ]);
         assert_eq!(
-            select_asset(&only_arm, Platform::LinuxX86_64),
+            select_asset(&only_arm, Platform::LinuxX86_64, PkgFormat::Deb),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+    }
+
+    #[test]
+    fn pacman_matchers_are_disjoint_from_deb_and_across_arch() {
+        // A pacman-format build must never pick a `.deb`, and the x86_64/arm64
+        // pacman matchers must not cross-select.
+        let only_deb = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.deb",
+            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&only_deb, Platform::LinuxX86_64, PkgFormat::Pacman),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+        // A .deb build must never pick a `.pkg.tar.zst`.
+        let only_pac = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&only_pac, Platform::LinuxX86_64, PkgFormat::Deb),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+        // x86_64 pacman build must not pick an arm64 `.pkg.tar.zst`.
+        let only_arm_pac = release_with(&[
+            "Yerd_Linux_Arm64_v2-0-2.pkg.tar.zst",
+            "Yerd_Linux_Arm64_v2-0-2.pkg.tar.zst.sig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&only_arm_pac, Platform::LinuxX86_64, PkgFormat::Pacman),
             Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
         );
     }
@@ -355,7 +496,7 @@ mod tests {
     fn intel_macos_has_no_artifact() {
         let r = release_with(&["Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz", "SHA256SUMS"]);
         assert_eq!(
-            select_asset(&r, Platform::MacOsX86_64),
+            select_asset(&r, Platform::MacOsX86_64, PkgFormat::Deb),
             Err(AssetError::NoArtifactForPlatform(Platform::MacOsX86_64))
         );
     }
@@ -364,7 +505,7 @@ mod tests {
     fn missing_signature_is_an_error() {
         let r = release_with(&["Yerd_Linux_x86_64_v2-0-2.deb", "SHA256SUMS"]);
         assert!(matches!(
-            select_asset(&r, Platform::LinuxX86_64),
+            select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb),
             Err(AssetError::MissingSignature(_))
         ));
     }
@@ -376,7 +517,7 @@ mod tests {
             "Yerd_Linux_x86_64_v2-0-2.deb.sig",
         ]);
         assert_eq!(
-            select_asset(&r, Platform::LinuxX86_64),
+            select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb),
             Err(AssetError::MissingChecksums)
         );
     }

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -368,8 +368,6 @@ mod tests {
 
     #[test]
     fn macos_selection_ignores_pkg_format() {
-        // A pacman-format build on macOS still picks the `.app.tar.gz`: `format`
-        // only disambiguates Linux.
         let r = release_with(&[
             "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz",
             "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz.sig",
@@ -418,8 +416,6 @@ mod tests {
 
     #[test]
     fn both_artifacts_present_resolves_per_format() {
-        // The real release carries BOTH the .deb and the .pkg.tar.zst for x86_64;
-        // the build-time format is the only tiebreak.
         let r = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
             "Yerd_Linux_x86_64_v2-0-2.deb.sig",
@@ -459,8 +455,6 @@ mod tests {
 
     #[test]
     fn pacman_matchers_are_disjoint_from_deb_and_across_arch() {
-        // A pacman-format build must never pick a `.deb`, and the x86_64/arm64
-        // pacman matchers must not cross-select.
         let only_deb = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
             "Yerd_Linux_x86_64_v2-0-2.deb.sig",
@@ -470,7 +464,6 @@ mod tests {
             select_asset(&only_deb, Platform::LinuxX86_64, PkgFormat::Pacman),
             Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
         );
-        // A .deb build must never pick a `.pkg.tar.zst`.
         let only_pac = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
             "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
@@ -480,7 +473,6 @@ mod tests {
             select_asset(&only_pac, Platform::LinuxX86_64, PkgFormat::Deb),
             Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
         );
-        // x86_64 pacman build must not pick an arm64 `.pkg.tar.zst`.
         let only_arm_pac = release_with(&[
             "Yerd_Linux_Arm64_v2-0-2.pkg.tar.zst",
             "Yerd_Linux_Arm64_v2-0-2.pkg.tar.zst.sig",

--- a/crates/yerd-update/src/lib.rs
+++ b/crates/yerd-update/src/lib.rs
@@ -19,7 +19,7 @@ use semver::Version;
 mod artifact;
 pub use artifact::{
     select_asset, sha256_for, sha256_hex, verify_minisign, verify_sha256, ArtifactKind,
-    ArtifactSelection, AssetError, Platform, VerifyError, UPDATE_PUBLIC_KEY,
+    ArtifactSelection, AssetError, PkgFormat, Platform, VerifyError, UPDATE_PUBLIC_KEY,
 };
 
 /// Self-update release channel.

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -447,10 +447,19 @@ job in [`release.yml`](https://github.com/forjedio/yerd/blob/main/.github/workfl
 runs an `archlinux:base-devel` container, compiles the frontend + all four
 binaries from source, and assembles the package with
 [`packaging/arch/PKGBUILD`](https://github.com/forjedio/yerd/blob/main/packaging/arch).
-Unlike the `.deb`, the Arch package installs the four binaries as real files in
-`/usr/bin` (matching the upstream `.deb`'s current layout), and a `.install`
-scriptlet `setcap`s `/usr/bin/yerdd` on install/upgrade so the daemon can bind
-ports 80/443.
+The package installs the four binaries as real files in `/usr/bin` — the three
+driven binaries (`yerd`/`yerdd`/`yerd-helper`) land at the same paths as the
+upstream `.deb`, so the daemon's sibling-binary lookup is identical (the GUI binary
+is `/usr/bin/yerd-gui`). A `.install` scriptlet `setcap`s `/usr/bin/yerdd` on
+install/upgrade so the daemon can bind ports 80/443.
+
+In-app `yerd update` on Arch runs `pacman -U` on the downloaded, minisign-verified
+`.pkg.tar.zst` — a **partial upgrade**: if the host is behind on `pacman -Syu`, a
+newer library soname can make it abort (Yerd surfaces pacman's message), so Arch
+users should keep their system current. It also requires the default
+`LocalFileSigLevel = Optional` in `pacman.conf` — the package is not pacman-signed
+(Yerd verifies it itself with the embedded update key), so a hardened
+`LocalFileSigLevel = Required` rejects the local install.
 
 **The `pacman` feature / `PkgFormat` tiebreak.** A release carries *both* a `.deb`
 and a `.pkg.tar.zst` for x86-64, so a running Linux binary can't tell which to

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -432,7 +432,9 @@ cargo xtask version-check v2.0.2 # release gate: assert a tag matches the manife
 The shipped artifacts are the **GUI bundle** (`.dmg` on macOS, `.deb` on Linux),
 built by Tauri with the three binaries (`yerd`/`yerdd`/`yerd-helper`) embedded via
 `externalBin` (per-platform overlays in `apps/yerd-gui/src-tauri/`), **plus a native
-Arch package** (`.pkg.tar.zst`, x86-64). There is no standalone CLI tarball/`.deb`.
+Arch package** (`.pkg.tar.zst`, x86-64). The CLI and daemon are never shipped on
+their own - there is no CLI-only artifact (tarball or `.deb`) separate from the GUI
+bundle and the Arch package.
 
 `bump` keeps three files in sync - `Cargo.toml`,
 `apps/yerd-gui/src-tauri/tauri.conf.json`, and `apps/yerd-gui/package.json` - so

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -429,16 +429,41 @@ cargo xtask bump 2.0.2           # set the version across the three manifests
 cargo xtask version-check v2.0.2 # release gate: assert a tag matches the manifests
 ```
 
-The shipped artifact is the **GUI bundle** (`.dmg` on macOS, `.deb` on Linux),
+The shipped artifacts are the **GUI bundle** (`.dmg` on macOS, `.deb` on Linux),
 built by Tauri with the three binaries (`yerd`/`yerdd`/`yerd-helper`) embedded via
-`externalBin` (per-platform overlays in `apps/yerd-gui/src-tauri/`). There is no
-standalone CLI tarball/`.deb`.
+`externalBin` (per-platform overlays in `apps/yerd-gui/src-tauri/`), **plus a native
+Arch package** (`.pkg.tar.zst`, x86-64). There is no standalone CLI tarball/`.deb`.
 
 `bump` keeps three files in sync - `Cargo.toml`,
 `apps/yerd-gui/src-tauri/tauri.conf.json`, and `apps/yerd-gui/package.json` - so
 the CLI/daemon and the GUI never disagree on version. The release pipeline runs
 `version-check` to fail fast on a mismatched tag. See
 [Build Automation (xtask)](./xtask) for the full breakdown.
+
+### The Arch package (`.pkg.tar.zst`)
+
+Tauri has no pacman bundler, so the Arch package is built separately: the `arch`
+job in [`release.yml`](https://github.com/forjedio/yerd/blob/main/.github/workflows/release.yml)
+runs an `archlinux:base-devel` container, compiles the frontend + all four
+binaries from source, and assembles the package with
+[`packaging/arch/PKGBUILD`](https://github.com/forjedio/yerd/blob/main/packaging/arch).
+Unlike the `.deb`, the Arch package installs the four binaries as real files in
+`/usr/bin` (matching the upstream `.deb`'s current layout), and a `.install`
+scriptlet `setcap`s `/usr/bin/yerdd` on install/upgrade so the daemon can bind
+ports 80/443.
+
+**The `pacman` feature / `PkgFormat` tiebreak.** A release carries *both* a `.deb`
+and a `.pkg.tar.zst` for x86-64, so a running Linux binary can't tell which to
+self-update from `Platform` (OS + arch) alone. The format is fixed at **build
+time**: `yerd_update::PkgFormat::current()` returns `Pacman` only when compiled
+with the `pacman` Cargo feature. The `arch` job builds the daemon with
+`--features yerdd/pacman` (→ `yerd-update/pacman`), so its `yerdd` selects the
+`.pkg.tar.zst` and the applier installs it via `pacman -U`; every other build
+defaults to `Deb`/`dpkg -i`. **This only works because the Arch package is built
+in a separate job (its own cargo invocation/target dir)** — within one cargo
+build, the feature would unify across the whole graph. The release gate proves
+the flag took by running the freshly-built `yerdd --pkg-format` and asserting it
+prints `pacman`. arm64 Arch is not built for v1.
 
 ### macOS code signing & notarisation
 

--- a/docs/developer/gui.md
+++ b/docs/developer/gui.md
@@ -228,7 +228,12 @@ baked into the artifact: the `postinst` script grants
 re-applies it on every upgrade, since dpkg wipes file capabilities) — falling
 back to ports 8080/8443 if `setcap` is missing or the filesystem can't hold
 caps. There's no AppImage target because its ephemeral mount can't host a
-`postinst` step, so the daemon's `setcap` can't be persisted that way.
+`postinst` step, so the daemon's `setcap` can't be persisted that way. The native
+Arch package (`.pkg.tar.zst`) is **not** a Tauri bundle target (Tauri has no
+pacman bundler) — it's built separately from
+[`packaging/arch/PKGBUILD`](https://github.com/forjedio/yerd/blob/main/packaging/arch)
+in the release workflow's `arch` job, with a `.install` scriptlet doing the same
+`setcap`. See [Packaging and releasing](./building#the-arch-package-pkg-tar-zst).
 
 ::: info Three windows, one bundle
 The app is no longer single-window. `tauri.conf.json` declares **three** windows,

--- a/docs/developer/xtask.md
+++ b/docs/developer/xtask.md
@@ -43,7 +43,7 @@ pub enum Command {
 ```
 
 ::: info Scope
-`xtask` only keeps **versions in sync**. It does *not* build any artifacts - the shipped product is the **GUI bundle** (`.dmg` on macOS, `.deb` on Linux), built by Tauri in the release pipeline with the three binaries (`yerd`/`yerdd`/`yerd-helper`) embedded via `externalBin` (per-platform overlays in `apps/yerd-gui/src-tauri/`). There is no standalone CLI tarball/`.deb`. `xtask` also doesn't download or cache PHP - PHP builds are fetched at runtime by the daemon (see [yerd-php](./crates/yerd-php)). Cross-platform release artifacts and checksums are assembled by the GitHub Actions workflows.
+`xtask` only keeps **versions in sync**. It does *not* build any artifacts - the shipped products are the **GUI bundle** (`.dmg` on macOS, `.deb` on Linux), built by Tauri in the release pipeline with the three binaries (`yerd`/`yerdd`/`yerd-helper`) embedded via `externalBin` (per-platform overlays in `apps/yerd-gui/src-tauri/`), plus a native **Arch package** (`.pkg.tar.zst`, x86-64) built from `packaging/arch/PKGBUILD` in the workflow's `arch` job. There is no standalone CLI tarball/`.deb`. `xtask` also doesn't download or cache PHP - PHP builds are fetched at runtime by the daemon (see [yerd-php](./crates/yerd-php)). Cross-platform release artifacts and checksums are assembled by the GitHub Actions workflows.
 :::
 
 ## Module map

--- a/docs/guide/daemon.md
+++ b/docs/guide/daemon.md
@@ -98,7 +98,7 @@ loginctl enable-linger "$USER"
 :::
 
 ::: info Binding 80/443 unprivileged
-On the `.deb` install, the post-install step grants `yerdd` the `cap_net_bind_service` capability so the unprivileged daemon can bind 80/443, and re-applies it on every upgrade (dpkg replaces the binary, wiping file capabilities). Without the capability, the daemon falls back to `8080`/`8443` and `yerd doctor` tells you. See [Elevation & Privileges](./elevation).
+On a Linux package install (the `.deb`'s post-install, or the Arch package's `.install` scriptlet), the step grants `yerdd` the `cap_net_bind_service` capability so the unprivileged daemon can bind 80/443, and re-applies it on every upgrade (the package manager replaces the binary, wiping file capabilities). Without the capability, the daemon falls back to `8080`/`8443` and `yerd doctor` tells you. See [Elevation & Privileges](./elevation).
 :::
 
 ### macOS

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -11,13 +11,14 @@ The app is the **only** artifact, with the daemon + CLI + helper embedded:
 | Platform | Artifact | Install |
 |---|---|---|
 | macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` | Open the DMG, drag Yerd to Applications |
-| Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
-| Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Arch (x86-64) | `Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` | `sudo pacman -U ./Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` |
 
 The macOS DMG targets Apple Silicon (`aarch64`) only; Intel (x86-64) Macs are not supported at this time. There's no Windows bundle yet: the daemon's named-pipe address isn't client-derivable.
 
 ::: tip The GUI sets up the backend for you
-The GUI is a client of the [daemon](./daemon), and the daemon (`yerdd`), the `yerd` CLI, and `yerd-helper` are all **bundled inside the app** - nothing is downloaded at runtime. On first launch the app simply **starts its bundled daemon**, then lands you on the Overview dashboard. On macOS that makes setup essentially **drag-and-drop**: drag Yerd to Applications, launch it, done. On macOS the daemon registers as a background **SMAppService** login item (shown as "Yerd" in System Settings → Login Items); on Linux the `.deb` puts `yerd` on your `PATH` and grants the daemon its privileged-port capability.
+The GUI is a client of the [daemon](./daemon), and the daemon (`yerdd`), the `yerd` CLI, and `yerd-helper` are all **bundled inside the app** - nothing is downloaded at runtime. On first launch the app simply **starts its bundled daemon**, then lands you on the Overview dashboard. On macOS that makes setup essentially **drag-and-drop**: drag Yerd to Applications, launch it, done. On macOS the daemon registers as a background **SMAppService** login item (shown as "Yerd" in System Settings → Login Items); on Linux the package (`.deb`/`.pkg.tar.zst`) puts `yerd` on your `PATH` and grants the daemon its privileged-port capability.
 :::
 
 ## Tray-first by design

--- a/docs/guide/elevation.md
+++ b/docs/guide/elevation.md
@@ -94,7 +94,7 @@ The platforms diverge most here.
 - **Linux:** grants `cap_net_bind_service=+ep` on the `yerdd` binary (`setcap`). The unprivileged daemon can then bind 80/443 directly. Restart the daemon (as your user) for it to take effect.
 
   ::: warning setcap is reset by upgrades
-  The capability lives on the binary file, so replacing that file (a package upgrade) clears it. The `.deb` re-applies it on every upgrade; other install methods need `sudo yerd elevate ports` again after upgrading. There's no clean reverse, so `sudo yerd unelevate ports` only prints the manual command (`sudo setcap -r <path-to-yerdd>`).
+  The capability lives on the binary file, so replacing that file (a package upgrade) clears it. The Linux packages re-apply it on every upgrade (the `.deb`'s post-install and the Arch package's `.install` scriptlet); other install methods need `sudo yerd elevate ports` again after upgrading. There's no clean reverse, so `sudo yerd unelevate ports` only prints the manual command (`sudo setcap -r <path-to-yerdd>`).
   :::
 
 - **macOS:** no `setcap`. The helper installs a `pf` redirect (`rdr`) mapping `80 -> http_port` and `443 -> https_port`, the rootless ports the daemon already bound. The daemon keeps its high ports; pf forwards the privileged ones. A `LaunchDaemon` re-applies the redirect at boot. It's live immediately (no restart) and fully reversible via `sudo yerd unelevate ports`.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -104,7 +104,7 @@ yerd doctor fix    # auto-repair the safe ones
 
 ## Desktop app
 
-A Tauri v2 tray app (Vue 3 + TypeScript) ships as a single bundle: `.dmg` on macOS, `.deb` on Linux. It's the recommended way to run Yerd, surfacing the same data and actions as the CLI in a native tray UI.
+A Tauri v2 tray app (Vue 3 + TypeScript) ships as a single bundle: `.dmg` on macOS, `.deb` on Linux (plus a native Arch `.pkg.tar.zst` for x86-64). It's the recommended way to run Yerd, surfacing the same data and actions as the CLI in a native tray UI.
 
 ::: tip The app sets up the backend for you
 The daemon, the `yerd` CLI, and `yerd-helper` are all **bundled inside the app** (Apple Silicon macOS · Linux x86-64 and arm64). On first launch it starts the daemon - no separate CLI install needed.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -287,7 +287,7 @@ all happen for you on first launch - drag Yerd to Applications (macOS), open it,
 and you land ready to add a site. The terminal path, start to finish:
 
 ```sh
-# Install the app (.dmg on macOS, .deb on Linux) from the releases page. The app
+# Install the app (.dmg on macOS, .deb/.pkg.tar.zst on Linux) from the releases page. The app
 # starts the daemon for you; to run it from a terminal instead:
 yerdd serve &                           # start the bundled daemon directly
 sudo yerd elevate                       # one-time: trust CA, resolver, ports

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,7 +25,8 @@ so they can't both own them at once. **Stop the other tool first**, then follow
 
 ::: info Supported platforms
 Yerd ships a single desktop app for **macOS** (Apple Silicon) and **Linux**
-(x86-64 and arm64, Debian/Ubuntu `.deb`). The daemon, the `yerd` CLI, and the privileged
+(Debian/Ubuntu `.deb` for x86-64 and arm64, plus an Arch `.pkg.tar.zst` for
+x86-64). The daemon, the `yerd` CLI, and the privileged
 helper are all bundled inside it — there is nothing else to install. PHP itself is
 **not** bundled - Yerd downloads prebuilt static PHP builds on demand when you run
 `yerd install php`, so the install stays tiny and fast.
@@ -47,8 +48,15 @@ tracked for **8 July 2026**):
 | Platform | Download | Install |
 |---|---|---|
 | macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` | open, drag Yerd to Applications |
-| Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
-| Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Arch (x86-64) | `Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` | `sudo pacman -U ./Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` |
+
+::: tip Arch Linux
+Remove any leftover `/usr/bin/yerd` from the old v1 (Go) project first — pacman
+won't install over a file it doesn't own — and `pacman -Syu` before installing so
+the bundled GUI's WebKit/GTK libraries match your system.
+:::
 
 On first launch the app greets you with a short [onboarding journey](./welcome-journey)
 that starts the bundled daemon, installs a PHP version, parks your projects, and
@@ -60,9 +68,10 @@ and follow the steps.
 <ThemedImage light="/images/overview-light.png" dark="/images/overview-dark.png" alt="The Yerd desktop app, landed on the Overview dashboard" />
 
 ::: tip How the daemon binds 80/443
-On Linux the `.deb`'s post-install grants `yerdd` the `cap_net_bind_service`
-capability (via `setcap`) so the **unprivileged** daemon can bind ports 80/443,
-and re-applies it on every upgrade. On macOS the one-time elevate installs a `pf`
+On Linux the package's post-install (the `.deb` postinst / the Arch `.install`
+scriptlet) grants `yerdd` the `cap_net_bind_service` capability (via `setcap`) so
+the **unprivileged** daemon can bind ports 80/443, and re-applies it on every
+upgrade. On macOS the one-time elevate installs a `pf`
 redirect. If neither is in place, Yerd falls back to `8080`/`8443` automatically -
 and `yerd doctor` tells you.
 :::
@@ -71,7 +80,7 @@ and `yerd doctor` tells you.
 
 The `yerd` command comes with the app:
 
-- **Linux:** the `.deb` puts `yerd` on your `PATH` automatically.
+- **Linux:** the `.deb`/`.pkg.tar.zst` puts `yerd` on your `PATH` automatically.
 - **macOS:** open **Settings → Terminal CLI** and click **Install** - it links the
   bundled `yerd` onto your `PATH` (via `yerd path`).
 

--- a/docs/guide/upgrading-from-v1.md
+++ b/docs/guide/upgrading-from-v1.md
@@ -19,7 +19,7 @@ Yerd v2 (`forjedio/yerd`) is a ground-up Rust rewrite. Different binaries, a dif
 So v2 installs small and fast (no compiler needed for PHP), doesn't ask for your password every time you touch a site, and behaves the same across operating systems.
 
 ::: info Rootless by design
-`sudo` appears in only two places: installing the system package (normal for any `.deb`), and the one-time `sudo yerd elevate`. After that, day-to-day use never touches root. See [Elevation & Privileges](./elevation).
+`sudo` appears in only two places: installing the system package (normal for any `.deb`/`.pkg.tar.zst`), and the one-time `sudo yerd elevate`. After that, day-to-day use never touches root. See [Elevation & Privileges](./elevation).
 :::
 
 ## What does not carry over
@@ -47,8 +47,9 @@ After removing v1, reboot or flush DNS so the OS forgets v1's resolver before v2
 See [Getting Started](./getting-started) for platform-specific instructions. The short version: download the Yerd app from the [releases page](https://github.com/forjedio/yerd/releases/latest) -
 
 | macOS (Apple Silicon) | `Yerd_MacOS_AppleSilicon_v<ver>.dmg` |
-| Linux (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` |
-| Linux (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` |
+| Linux · Debian/Ubuntu (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` |
+| Linux · Arch (x86-64) | `Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` |
 
 The daemon (`yerdd`), the `yerd` CLI, and `yerd-helper` are all bundled inside the app; first launch starts the daemon. PHP is not bundled; you install versions in a later step.
 

--- a/docs/reference/cli/uninstall.md
+++ b/docs/reference/cli/uninstall.md
@@ -27,7 +27,7 @@ It removes, in order:
 2. **The daemon** — stops and disables the per-user service (systemd `--user` / launchd) and reaps the running `yerdd` (which in turn stops its PHP-FPM pools and any managed services).
 3. **The PATH entry** — removes the yerd block from your shell startup files (the same block [`yerd path`](./tooling) manages).
 4. **Config, data, and cache** — the `yerd.toml` config, installed PHP versions, dev tools, downloads, the local CA, and the runtime socket directory.
-5. **The binaries** — `yerd`, `yerdd`, and `yerd-helper`. A `.deb` install is left for `sudo apt purge yerd` instead (yerd never `rm`s package-managed files).
+5. **The binaries** — `yerd`, `yerdd`, and `yerd-helper`. A package install is left for your package manager instead (`sudo apt purge yerd` on Debian/Ubuntu, `sudo pacman -R yerd` on Arch) — yerd never `rm`s package-managed files.
 
 When something can't be removed automatically, it's listed at the end as a leftover to handle manually.
 
@@ -48,7 +48,7 @@ You'll be asked to confirm before anything is removed. Pass `--yes` (`-y`) to sk
 
 ## Platform support
 
-Full uninstall is supported on **macOS** and **Linux**. The desktop app itself (the `.app` / `.deb`) is removed the usual way for your platform — drag to Trash on macOS, or `sudo apt purge yerd` on Linux.
+Full uninstall is supported on **macOS** and **Linux**. The desktop app itself (the `.app` / `.deb` / `.pkg.tar.zst`) is removed the usual way for your platform — drag to Trash on macOS, or `sudo apt purge yerd` (Debian/Ubuntu) / `sudo pacman -R yerd` (Arch) on Linux.
 
 ## See also
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -41,8 +41,9 @@ build() {
 package() {
   cd "${YERD_SRCROOT:?YERD_SRCROOT must point at the workspace checkout root}"
 
-  # All four binaries as real files in /usr/bin (matches the upstream .deb so the
-  # GUI's trusted_yerd()/resolve_binary sibling lookup is identical).
+  # All four binaries as real files in /usr/bin. The three driven binaries
+  # (yerd/yerdd/yerd-helper) land at the same paths as the upstream .deb, so the
+  # GUI's trusted_yerd()/resolve_binary sibling lookup is identical.
   install -Dm755 target/release/yerd        "$pkgdir/usr/bin/yerd"
   install -Dm755 target/release/yerdd       "$pkgdir/usr/bin/yerdd"
   install -Dm755 target/release/yerd-helper "$pkgdir/usr/bin/yerd-helper"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Yerd <yerd@forjed.io>
+#
+# Native Arch package for Yerd: the Tauri GUI plus the three binaries (yerd CLI,
+# yerdd daemon, yerd-helper) that the GUI drives. Mirrors the layout of the
+# upstream .deb (all four binaries in /usr/bin), so the daemon's sibling-binary
+# lookup behaves identically. The daemon is built with the `pacman` feature so
+# in-app `yerd update` self-updates via `pacman -U` (not `dpkg -i`).
+#
+# Built in CI from the in-tree checkout (no source=()/AUR fetch in v1). The
+# release workflow exports YERD_SRCROOT (the workspace root) and YERD_PKGVER (the
+# release version with any `-` replaced by `_`, since makepkg forbids `-` in
+# pkgver) before invoking makepkg.
+pkgname=yerd
+pkgver="${YERD_PKGVER:-0.0.0}"
+pkgrel=1
+pkgdesc="Local PHP development environment — daemon, CLI, and desktop app"
+arch=('x86_64')
+url="https://github.com/forjedio/yerd"
+license=('MIT')
+# Runtime deps. webkit2gtk-4.1/gtk3/librsvg/libayatana-appindicator back the Tauri
+# GUI; libayatana-appindicator + librsvg are dlopen'd (not ELF-NEEDED) so namcap
+# can't infer them — list explicitly. cairo/pango/gdk-pixbuf2/glib2 come in via
+# gtk3. libcap provides setcap, used by the install scriptlet (namcap will report
+# it "not needed" — a false positive, it is not ELF-linked).
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'librsvg' 'libcap')
+makedepends=('rust' 'cargo' 'nodejs' 'npm')
+options=('!strip' '!debug')
+install="yerd.install"
+
+build() {
+  cd "${YERD_SRCROOT:?YERD_SRCROOT must point at the workspace checkout root}"
+  # The GUI embeds the built frontend (frontendDist=../dist) at compile time, so
+  # build the web assets BEFORE cargo.
+  ( cd apps/yerd-gui && npm ci && npm run build )
+  # Build the daemon with the pacman self-update format (`yerdd/pacman` →
+  # `yerd-update/pacman`) plus the CLI, helper, and GUI binaries.
+  cargo build --release --locked --features yerdd/pacman \
+    -p yerd -p yerdd -p yerd-helper -p yerd-gui
+}
+
+package() {
+  cd "${YERD_SRCROOT:?YERD_SRCROOT must point at the workspace checkout root}"
+
+  # All four binaries as real files in /usr/bin (matches the upstream .deb so the
+  # GUI's trusted_yerd()/resolve_binary sibling lookup is identical).
+  install -Dm755 target/release/yerd        "$pkgdir/usr/bin/yerd"
+  install -Dm755 target/release/yerdd       "$pkgdir/usr/bin/yerdd"
+  install -Dm755 target/release/yerd-helper "$pkgdir/usr/bin/yerd-helper"
+  install -Dm755 target/release/yerd-gui    "$pkgdir/usr/bin/yerd-gui"
+
+  # Desktop entry + hicolor icons, named after the GUI binary (its runtime
+  # WM_CLASS is `yerd-gui`) so the dock binds the window to the launcher.
+  install -Dm644 packaging/arch/yerd-gui.desktop \
+    "$pkgdir/usr/share/applications/yerd-gui.desktop"
+  install -Dm644 apps/yerd-gui/src-tauri/icons/32x32.png \
+    "$pkgdir/usr/share/icons/hicolor/32x32/apps/yerd-gui.png"
+  install -Dm644 apps/yerd-gui/src-tauri/icons/64x64.png \
+    "$pkgdir/usr/share/icons/hicolor/64x64/apps/yerd-gui.png"
+  install -Dm644 apps/yerd-gui/src-tauri/icons/128x128.png \
+    "$pkgdir/usr/share/icons/hicolor/128x128/apps/yerd-gui.png"
+  # 256px source is the @2x variant (there is no 256x256.png).
+  install -Dm644 apps/yerd-gui/src-tauri/icons/128x128@2x.png \
+    "$pkgdir/usr/share/icons/hicolor/256x256/apps/yerd-gui.png"
+
+  install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/arch/yerd-gui.desktop
+++ b/packaging/arch/yerd-gui.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=Yerd
+GenericName=PHP development environment
+Comment=Local PHP development environment
+Exec=yerd-gui
+Icon=yerd-gui
+Terminal=false
+Categories=Development;Utility;
+# Must equal the window's runtime WM_CLASS so the dock binds it to this launcher;
+# the GUI sets prgname "yerd-gui" (apps/yerd-gui/src-tauri/src/main.rs).
+StartupWMClass=yerd-gui
+StartupNotify=true

--- a/packaging/arch/yerd.install
+++ b/packaging/arch/yerd.install
@@ -1,0 +1,18 @@
+# Yerd pacman install scriptlet.
+#
+# Grant the daemon permission to bind privileged ports (80/443). pacman replaces
+# the binary on upgrade and drops its file capabilities, so reapply on both
+# install and upgrade. Best-effort: on overlayfs/NFS/noxattr mounts that can't
+# hold file capabilities, setcap fails and the daemon falls back to 8080/8443.
+# Capabilities can't be baked into the package (fakeroot can't grant them), so
+# the scriptlet is the right place. The /usr/bin symlinks and desktop/icon cache
+# are pacman-tracked / handled by pacman hooks, so nothing else is needed here.
+
+post_install() {
+  setcap 'cap_net_bind_service=+ep' /usr/bin/yerdd 2>/dev/null \
+    || echo "yerd: setcap failed; the daemon will use ports 8080/8443" >&2
+}
+
+post_upgrade() {
+  post_install "$@"
+}


### PR DESCRIPTION
## What does this PR do?

Adds a native Arch Linux deployable (.pkg.tar.zst) alongside the existing .deb/.dmg, with full in-app self-update parity, plus updates documentation for the new install method. 

## Related issues

Closes #53 

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arch Linux package releases (`.pkg.tar.zst` via pacman) alongside existing Linux bundles.
  * Extended self-updates and the GUI installer flow to handle pacman-based upgrades.

* **Bug Fixes**
  * Updated release publishing checks (signing, key verification, checksums, and staging validation) to include Arch artifacts.
  * Improved pacman install error reporting and root elevation behavior for smoother upgrades.

* **Documentation**
  * Updated installation, upgrading, desktop, daemon/elevation, and uninstall guides with Arch-specific instructions.

* **Tests / CI**
  * Added CI and wire/update test coverage for the Arch/pacman artifact and apply flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->