### PR TITLE
[Feat] In-app keyboard shortcuts: command palette, view navigation, and contextual actions

### DIFF
--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -160,19 +160,27 @@ fn main() {
             logging::get_diagnostics,
         ])
         .setup(setup_app)
-        // Cmd+W on a borderless/transparent window: AppKit's performClose: no-ops
-        // (no closable style mask), so the custom close-window menu item routes
-        // here and calls close(), hitting the CloseRequested handler below.
+        // Cmd+W and Cmd+M on a borderless/transparent window: AppKit's
+        // performClose: / performMiniaturize: no-op (no closable/miniaturizable
+        // style mask), so the custom menu items route here and call the Tauri
+        // APIs directly. close() hits the CloseRequested handler below; minimize()
+        // works the same as the titlebar control.
         .on_menu_event(|app, event| {
-            if event.id.as_ref() == "close-window" {
-                // get_focused_window is behind Tauri's unstable feature; find the
-                // focused window among the managed webview windows instead.
-                if let Some(win) = app
-                    .webview_windows()
-                    .into_values()
-                    .find(|w| w.is_focused().unwrap_or(false))
-                {
-                    let _ = win.close();
+            // get_focused_window is behind Tauri's unstable feature; find the
+            // focused window among the managed webview windows instead.
+            let focused = app
+                .webview_windows()
+                .into_values()
+                .find(|w| w.is_focused().unwrap_or(false));
+            if let Some(win) = focused {
+                match event.id.as_ref() {
+                    "close-window" => {
+                        let _ = win.close();
+                    }
+                    "minimize-window" => {
+                        let _ = win.minimize();
+                    }
+                    _ => {}
                 }
             }
         })
@@ -230,8 +238,17 @@ fn build_app_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         ..Default::default()
     };
 
-    // Custom Cmd+W item (handled in on_menu_event), used in both File and Window.
+    // Custom Cmd+W / Cmd+M items (handled in on_menu_event): the predefined
+    // Close/Minimize no-op on our borderless windows, so these route to the Tauri
+    // close()/minimize() APIs instead.
     let close = MenuItem::with_id(app, "close-window", "Close", true, Some("CmdOrCtrl+W"))?;
+    let minimize = MenuItem::with_id(
+        app,
+        "minimize-window",
+        "Minimize",
+        true,
+        Some("CmdOrCtrl+M"),
+    )?;
 
     let app_menu = Submenu::with_items(
         app,
@@ -274,7 +291,7 @@ fn build_app_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         "Window",
         true,
         &[
-            &PredefinedMenuItem::minimize(app, None)?,
+            &minimize,
             &PredefinedMenuItem::maximize(app, None)?,
             &PredefinedMenuItem::separator(app)?,
             &close,

--- a/apps/yerd-gui/src/App.vue
+++ b/apps/yerd-gui/src/App.vue
@@ -26,8 +26,6 @@ const windowLabel = getCurrentWindow().label;
 const isDumpsWindow = windowLabel === "dumps";
 const isMailsWindow = windowLabel === "mails";
 
-// The standalone viewer windows render bare (no AppShell), so they install their
-// own scoped shortcut dispatcher here. The main window's lives in AppShell.
 if (isDumpsWindow) useShortcuts("dumps");
 else if (isMailsWindow) useShortcuts("mails");
 

--- a/apps/yerd-gui/src/App.vue
+++ b/apps/yerd-gui/src/App.vue
@@ -13,6 +13,7 @@ import Spinner from "@/components/ui/Spinner.vue";
 import { useDaemon } from "@/composables/useDaemon";
 import { useOnboarding } from "@/composables/useOnboarding";
 import { useToast } from "@/composables/useToast";
+import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import { IpcError, startDaemon } from "@/ipc/client";
 
 // The auxiliary "dumps" and "mails" windows render standalone viewers with no app
@@ -24,6 +25,11 @@ import { IpcError, startDaemon } from "@/ipc/client";
 const windowLabel = getCurrentWindow().label;
 const isDumpsWindow = windowLabel === "dumps";
 const isMailsWindow = windowLabel === "mails";
+
+// The standalone viewer windows render bare (no AppShell), so they install their
+// own scoped shortcut dispatcher here. The main window's lives in AppShell.
+if (isDumpsWindow) useShortcuts("dumps");
+else if (isMailsWindow) useShortcuts("mails");
 
 // Start the single shared daemon poller for the app's lifetime.
 const { start, stop, refresh } = useDaemon();

--- a/apps/yerd-gui/src/components/AppShell.vue
+++ b/apps/yerd-gui/src/components/AppShell.vue
@@ -10,10 +10,13 @@ import SideNav from "@/components/SideNav.vue";
 import TitleBar from "@/components/TitleBar.vue";
 import { useDaemon } from "@/composables/useDaemon";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
+import { useSiteCommands } from "@/lib/shortcuts/useSiteCommands";
 
 const route = useRoute();
 const { unreachable } = useDaemon();
 const { paletteOpen, cheatSheetOpen, commands, run } = useShortcuts("main");
+const siteCommands = useSiteCommands(paletteOpen);
+const paletteCommands = computed(() => [...commands, ...siteCommands.value]);
 
 // Only three views work without a live daemon: Overview (owns its own
 // daemon-down hero + start affordance), Settings/General (can start/install it),
@@ -69,7 +72,7 @@ const pageSubtitle = computed(() =>
 
     <CommandPalette
       v-model:open="paletteOpen"
-      :commands="commands"
+      :commands="paletteCommands"
       :run="run"
     />
     <ShortcutsCheatSheet v-model:open="cheatSheetOpen" :commands="commands" />

--- a/apps/yerd-gui/src/components/AppShell.vue
+++ b/apps/yerd-gui/src/components/AppShell.vue
@@ -2,14 +2,18 @@
 import { computed } from "vue";
 import { useRoute } from "vue-router";
 
+import CommandPalette from "@/components/CommandPalette.vue";
 import DaemonDownHero from "@/components/DaemonDownHero.vue";
 import PageHeader from "@/components/PageHeader.vue";
+import ShortcutsCheatSheet from "@/components/ShortcutsCheatSheet.vue";
 import SideNav from "@/components/SideNav.vue";
 import TitleBar from "@/components/TitleBar.vue";
 import { useDaemon } from "@/composables/useDaemon";
+import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 
 const route = useRoute();
 const { unreachable } = useDaemon();
+const { paletteOpen, cheatSheetOpen, commands, run } = useShortcuts("main");
 
 // Only three views work without a live daemon: Overview (owns its own
 // daemon-down hero + start affordance), Settings/General (can start/install it),
@@ -62,5 +66,12 @@ const pageSubtitle = computed(() =>
         <RouterView v-else />
       </main>
     </div>
+
+    <CommandPalette
+      v-model:open="paletteOpen"
+      :commands="commands"
+      :run="run"
+    />
+    <ShortcutsCheatSheet v-model:open="cheatSheetOpen" :commands="commands" />
   </div>
 </template>

--- a/apps/yerd-gui/src/components/CommandPalette.spec.ts
+++ b/apps/yerd-gui/src/components/CommandPalette.spec.ts
@@ -2,53 +2,71 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 import CommandPalette from "./CommandPalette.vue";
+import type { Chord } from "@/lib/shortcuts/chord";
 import type { Command } from "@/lib/shortcuts/registry";
 
-function cmd(id: string, title: string): Command {
-  return {
-    id,
-    title,
-    group: "Go to",
-    chord: { mod: true, key: "k" },
-    scopes: ["main"],
-    inPalette: true,
-    run: () => {},
-  };
+function cmd(id: string, title: string, group: string, chord?: Chord): Command {
+  return { id, title, group, chord, scopes: ["main"], inPalette: true, run: () => {} };
 }
 
-const COMMANDS = [cmd("nav:/sites", "Go to Sites"), cmd("nav:/php", "Go to PHP")];
+const STATIC = [
+  cmd("nav:/sites", "Go to Sites", "Go to", { mod: true, code: "Digit3" }),
+  cmd("settings", "Open Settings", "General", { mod: true, key: "," }),
+];
+const SITE = [
+  cmd("site-open:zeta", "Open zeta.test", "zeta.test"),
+  cmd("site-secure:zeta", "Secure zeta.test", "zeta.test"),
+];
+// flat order: known groups first (Go to, General), then site groups descending.
+const FLAT = [...STATIC, ...SITE];
 
-function mountPalette(run = vi.fn()) {
+function mountPalette(commands = FLAT, run = vi.fn()) {
   const wrapper = mount(CommandPalette, {
-    props: { open: true, commands: COMMANDS, run },
+    props: { open: true, commands, run },
     global: { stubs: { teleport: true } },
   });
   return { wrapper, run };
 }
 
 describe("CommandPalette", () => {
-  it("lists palette commands and filters by query", async () => {
+  it("renders grouped sections with headers", () => {
     const { wrapper } = mountPalette();
-    expect(wrapper.findAll("li")).toHaveLength(2);
+    const text = wrapper.text();
+    expect(text).toContain("Go to");
+    expect(text).toContain("zeta.test");
+    expect(wrapper.findAll("li")).toHaveLength(4);
+  });
 
-    await wrapper.find("input").setValue("php");
+  it("filters across groups by query", async () => {
+    const { wrapper } = mountPalette();
+    await wrapper.find("input").setValue("zeta");
     const items = wrapper.findAll("li");
-    expect(items).toHaveLength(1);
-    expect(items[0]?.text()).toContain("Go to PHP");
+    expect(items).toHaveLength(2);
+    expect(wrapper.text()).toContain("zeta.test");
+    expect(wrapper.text()).not.toContain("Go to Sites");
   });
 
-  it("runs the selected command on Enter and closes", async () => {
+  it("runs the first flat command on Enter", async () => {
     const { wrapper, run } = mountPalette();
     await wrapper.find("input").trigger("keydown", { key: "Enter" });
-    expect(run).toHaveBeenCalledWith(COMMANDS[0]);
-    expect(wrapper.emitted("update:open")?.[0]).toEqual([false]);
+    expect(run).toHaveBeenCalledWith(STATIC[0]);
   });
 
-  it("moves the selection with the arrow keys", async () => {
+  it("traverses across groups with the arrow keys", async () => {
     const { wrapper, run } = mountPalette();
+    const input = wrapper.find("input");
+    await input.trigger("keydown", { key: "ArrowDown" });
+    await input.trigger("keydown", { key: "ArrowDown" });
+    await input.trigger("keydown", { key: "Enter" });
+    expect(run).toHaveBeenCalledWith(SITE[0]);
+  });
+
+  it("resets the selection when the command list grows asynchronously", async () => {
+    const { wrapper, run } = mountPalette(STATIC);
     await wrapper.find("input").trigger("keydown", { key: "ArrowDown" });
+    await wrapper.setProps({ commands: FLAT });
     await wrapper.find("input").trigger("keydown", { key: "Enter" });
-    expect(run).toHaveBeenCalledWith(COMMANDS[1]);
+    expect(run).toHaveBeenCalledWith(STATIC[0]);
   });
 
   it("closes on Escape without running", async () => {
@@ -56,11 +74,5 @@ describe("CommandPalette", () => {
     await wrapper.find("input").trigger("keydown", { key: "Escape" });
     expect(run).not.toHaveBeenCalled();
     expect(wrapper.emitted("update:open")?.[0]).toEqual([false]);
-  });
-
-  it("shows an empty state when nothing matches", async () => {
-    const { wrapper } = mountPalette();
-    await wrapper.find("input").setValue("zzz");
-    expect(wrapper.text()).toContain("No matching commands");
   });
 });

--- a/apps/yerd-gui/src/components/CommandPalette.spec.ts
+++ b/apps/yerd-gui/src/components/CommandPalette.spec.ts
@@ -1,0 +1,66 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import CommandPalette from "./CommandPalette.vue";
+import type { Command } from "@/lib/shortcuts/registry";
+
+function cmd(id: string, title: string): Command {
+  return {
+    id,
+    title,
+    group: "Go to",
+    chord: { mod: true, key: "k" },
+    scopes: ["main"],
+    inPalette: true,
+    run: () => {},
+  };
+}
+
+const COMMANDS = [cmd("nav:/sites", "Go to Sites"), cmd("nav:/php", "Go to PHP")];
+
+function mountPalette(run = vi.fn()) {
+  const wrapper = mount(CommandPalette, {
+    props: { open: true, commands: COMMANDS, run },
+    global: { stubs: { teleport: true } },
+  });
+  return { wrapper, run };
+}
+
+describe("CommandPalette", () => {
+  it("lists palette commands and filters by query", async () => {
+    const { wrapper } = mountPalette();
+    expect(wrapper.findAll("li")).toHaveLength(2);
+
+    await wrapper.find("input").setValue("php");
+    const items = wrapper.findAll("li");
+    expect(items).toHaveLength(1);
+    expect(items[0]?.text()).toContain("Go to PHP");
+  });
+
+  it("runs the selected command on Enter and closes", async () => {
+    const { wrapper, run } = mountPalette();
+    await wrapper.find("input").trigger("keydown", { key: "Enter" });
+    expect(run).toHaveBeenCalledWith(COMMANDS[0]);
+    expect(wrapper.emitted("update:open")?.[0]).toEqual([false]);
+  });
+
+  it("moves the selection with the arrow keys", async () => {
+    const { wrapper, run } = mountPalette();
+    await wrapper.find("input").trigger("keydown", { key: "ArrowDown" });
+    await wrapper.find("input").trigger("keydown", { key: "Enter" });
+    expect(run).toHaveBeenCalledWith(COMMANDS[1]);
+  });
+
+  it("closes on Escape without running", async () => {
+    const { wrapper, run } = mountPalette();
+    await wrapper.find("input").trigger("keydown", { key: "Escape" });
+    expect(run).not.toHaveBeenCalled();
+    expect(wrapper.emitted("update:open")?.[0]).toEqual([false]);
+  });
+
+  it("shows an empty state when nothing matches", async () => {
+    const { wrapper } = mountPalette();
+    await wrapper.find("input").setValue("zzz");
+    expect(wrapper.text()).toContain("No matching commands");
+  });
+});

--- a/apps/yerd-gui/src/components/CommandPalette.vue
+++ b/apps/yerd-gui/src/components/CommandPalette.vue
@@ -17,13 +17,33 @@ const selected = ref(0);
 const input = ref<HTMLInputElement | null>(null);
 const mac = isMac();
 
-const listed = computed(() => props.commands.filter((c) => c.inPalette));
+// Known groups render first in this order; everything else (the per-site groups)
+// follows, sorted by name descending.
+const KNOWN_GROUPS = ["Go to", "General", "Actions", "Sites"];
 
-const filtered = computed(() => {
+const groups = computed(() => {
   const q = query.value.trim().toLowerCase();
-  if (!q) return listed.value;
-  return listed.value.filter((c) => c.title.toLowerCase().includes(q));
+  const items = props.commands.filter(
+    (c) => c.inPalette && (!q || c.title.toLowerCase().includes(q)),
+  );
+  const by = new Map<string, Command[]>();
+  for (const c of items) {
+    const list = by.get(c.group) ?? [];
+    list.push(c);
+    by.set(c.group, list);
+  }
+  const known = KNOWN_GROUPS.filter((g) => by.has(g));
+  const sites = [...by.keys()]
+    .filter((g) => !KNOWN_GROUPS.includes(g))
+    .sort()
+    .reverse();
+  return [...known, ...sites].map((title) => ({
+    title,
+    items: by.get(title) ?? [],
+  }));
 });
+
+const flat = computed(() => groups.value.flatMap((g) => g.items));
 
 watch(
   () => props.open,
@@ -35,7 +55,7 @@ watch(
   },
 );
 
-watch(filtered, () => {
+watch(flat, () => {
   selected.value = 0;
 });
 
@@ -50,7 +70,7 @@ function choose(cmd: Command | undefined): void {
 }
 
 function move(delta: number): void {
-  const n = filtered.value.length;
+  const n = flat.value.length;
   if (n === 0) return;
   selected.value = (selected.value + delta + n) % n;
 }
@@ -67,7 +87,7 @@ function onKey(e: KeyboardEvent): void {
     move(-1);
   } else if (e.key === "Enter") {
     e.preventDefault();
-    choose(filtered.value[selected.value]);
+    choose(flat.value[selected.value]);
   }
 }
 </script>
@@ -93,33 +113,42 @@ function onKey(e: KeyboardEvent): void {
           class="w-full shrink-0 border-b bg-transparent px-4 py-3 text-sm outline-none placeholder:text-muted-foreground"
           @keydown="onKey"
         />
-        <ul class="min-h-0 flex-1 overflow-auto p-1">
-          <li
-            v-for="(cmd, i) in filtered"
-            :key="cmd.id"
-            :class="
-              i === selected
-                ? 'flex cursor-pointer items-center justify-between rounded-md bg-muted px-3 py-2 text-sm'
-                : 'flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm'
-            "
-            @click="choose(cmd)"
-            @mousemove="selected = i"
-          >
-            <span>{{ cmd.title }}</span>
-            <span
-              v-if="cmd.chord"
-              class="ml-4 shrink-0 text-xs text-muted-foreground"
+        <div class="min-h-0 flex-1 overflow-auto p-1">
+          <template v-for="group in groups" :key="group.title">
+            <p
+              class="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70"
             >
-              {{ formatChord(cmd.chord, mac) }}
-            </span>
-          </li>
-          <li
-            v-if="filtered.length === 0"
+              {{ group.title }}
+            </p>
+            <ul>
+              <li
+                v-for="cmd in group.items"
+                :key="cmd.id"
+                :class="
+                  cmd === flat[selected]
+                    ? 'flex cursor-pointer items-center justify-between rounded-md bg-muted px-3 py-2 text-sm'
+                    : 'flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm'
+                "
+                @click="choose(cmd)"
+                @mousemove="selected = flat.indexOf(cmd)"
+              >
+                <span>{{ cmd.title }}</span>
+                <span
+                  v-if="cmd.chord"
+                  class="ml-4 shrink-0 text-xs text-muted-foreground"
+                >
+                  {{ formatChord(cmd.chord, mac) }}
+                </span>
+              </li>
+            </ul>
+          </template>
+          <p
+            v-if="flat.length === 0"
             class="px-3 py-2 text-sm text-muted-foreground"
           >
             No matching commands
-          </li>
-        </ul>
+          </p>
+        </div>
       </div>
     </div>
   </Teleport>

--- a/apps/yerd-gui/src/components/CommandPalette.vue
+++ b/apps/yerd-gui/src/components/CommandPalette.vue
@@ -78,7 +78,7 @@ function onKey(e: KeyboardEvent): void {
       v-if="open"
       class="fixed inset-0 z-50 flex items-start justify-center p-4 pt-[12vh]"
     >
-      <div class="absolute inset-0 bg-black/50 animate-fade-in" @click="close" />
+      <div class="absolute inset-0 bg-black/50 rounded-[10px] animate-fade-in" @click="close" />
       <div
         role="dialog"
         aria-modal="true"
@@ -106,7 +106,10 @@ function onKey(e: KeyboardEvent): void {
             @mousemove="selected = i"
           >
             <span>{{ cmd.title }}</span>
-            <span class="ml-4 shrink-0 text-xs text-muted-foreground">
+            <span
+              v-if="cmd.chord"
+              class="ml-4 shrink-0 text-xs text-muted-foreground"
+            >
               {{ formatChord(cmd.chord, mac) }}
             </span>
           </li>

--- a/apps/yerd-gui/src/components/CommandPalette.vue
+++ b/apps/yerd-gui/src/components/CommandPalette.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+
+import { formatChord } from "@/lib/shortcuts/format";
+import { isMac } from "@/lib/shortcuts/platform";
+import type { Command } from "@/lib/shortcuts/registry";
+
+const props = defineProps<{
+  open: boolean;
+  commands: Command[];
+  run: (cmd: Command) => void;
+}>();
+const emit = defineEmits<{ "update:open": [boolean] }>();
+
+const query = ref("");
+const selected = ref(0);
+const input = ref<HTMLInputElement | null>(null);
+const mac = isMac();
+
+const listed = computed(() => props.commands.filter((c) => c.inPalette));
+
+const filtered = computed(() => {
+  const q = query.value.trim().toLowerCase();
+  if (!q) return listed.value;
+  return listed.value.filter((c) => c.title.toLowerCase().includes(q));
+});
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (!isOpen) return;
+    query.value = "";
+    selected.value = 0;
+    void nextTick(() => input.value?.focus());
+  },
+);
+
+watch(filtered, () => {
+  selected.value = 0;
+});
+
+function close(): void {
+  emit("update:open", false);
+}
+
+function choose(cmd: Command | undefined): void {
+  if (!cmd) return;
+  close();
+  props.run(cmd);
+}
+
+function move(delta: number): void {
+  const n = filtered.value.length;
+  if (n === 0) return;
+  selected.value = (selected.value + delta + n) % n;
+}
+
+function onKey(e: KeyboardEvent): void {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    close();
+  } else if (e.key === "ArrowDown") {
+    e.preventDefault();
+    move(1);
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    move(-1);
+  } else if (e.key === "Enter") {
+    e.preventDefault();
+    choose(filtered.value[selected.value]);
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-start justify-center p-4 pt-[12vh]"
+    >
+      <div class="absolute inset-0 bg-black/50 animate-fade-in" @click="close" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        class="relative z-10 flex max-h-[70vh] w-full max-w-lg flex-col overflow-hidden rounded-lg border bg-background shadow-lg animate-fade-in"
+      >
+        <input
+          ref="input"
+          v-model="query"
+          type="text"
+          placeholder="Type a command or page…"
+          class="w-full shrink-0 border-b bg-transparent px-4 py-3 text-sm outline-none placeholder:text-muted-foreground"
+          @keydown="onKey"
+        />
+        <ul class="min-h-0 flex-1 overflow-auto p-1">
+          <li
+            v-for="(cmd, i) in filtered"
+            :key="cmd.id"
+            :class="
+              i === selected
+                ? 'flex cursor-pointer items-center justify-between rounded-md bg-muted px-3 py-2 text-sm'
+                : 'flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm'
+            "
+            @click="choose(cmd)"
+            @mousemove="selected = i"
+          >
+            <span>{{ cmd.title }}</span>
+            <span class="ml-4 shrink-0 text-xs text-muted-foreground">
+              {{ formatChord(cmd.chord, mac) }}
+            </span>
+          </li>
+          <li
+            v-if="filtered.length === 0"
+            class="px-3 py-2 text-sm text-muted-foreground"
+          >
+            No matching commands
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/apps/yerd-gui/src/components/ShortcutsCheatSheet.vue
+++ b/apps/yerd-gui/src/components/ShortcutsCheatSheet.vue
@@ -2,9 +2,10 @@
 import { computed } from "vue";
 
 import Modal from "@/components/ui/Modal.vue";
+import type { Chord } from "@/lib/shortcuts/chord";
 import { formatChord } from "@/lib/shortcuts/format";
 import { isMac } from "@/lib/shortcuts/platform";
-import type { Command } from "@/lib/shortcuts/registry";
+import { nativeShortcuts, type Command } from "@/lib/shortcuts/registry";
 
 const props = defineProps<{ open: boolean; commands: Command[] }>();
 defineEmits<{ "update:open": [boolean] }>();
@@ -13,12 +14,16 @@ const mac = isMac();
 const GROUP_ORDER = ["Go to", "General", "Actions", "View", "Window"];
 
 const groups = computed(() => {
-  const by = new Map<string, Command[]>();
+  const by = new Map<string, { title: string; chord: Chord }[]>();
+  const add = (group: string, title: string, chord: Chord): void => {
+    const list = by.get(group) ?? [];
+    list.push({ title, chord });
+    by.set(group, list);
+  };
   for (const cmd of props.commands) {
-    const list = by.get(cmd.group) ?? [];
-    list.push(cmd);
-    by.set(cmd.group, list);
+    if (cmd.chord) add(cmd.group, cmd.title, cmd.chord);
   }
+  for (const n of nativeShortcuts(mac)) add(n.group, n.title, n.chord);
   return GROUP_ORDER.filter((g) => by.has(g)).map((title) => ({
     title,
     items: by.get(title) ?? [],
@@ -43,7 +48,7 @@ const groups = computed(() => {
         <ul class="flex flex-col gap-1">
           <li
             v-for="cmd in group.items"
-            :key="cmd.id"
+            :key="cmd.title"
             class="flex items-center justify-between gap-4 text-sm"
           >
             <span>{{ cmd.title }}</span>

--- a/apps/yerd-gui/src/components/ShortcutsCheatSheet.vue
+++ b/apps/yerd-gui/src/components/ShortcutsCheatSheet.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import Modal from "@/components/ui/Modal.vue";
+import { formatChord } from "@/lib/shortcuts/format";
+import { isMac } from "@/lib/shortcuts/platform";
+import type { Command } from "@/lib/shortcuts/registry";
+
+const props = defineProps<{ open: boolean; commands: Command[] }>();
+defineEmits<{ "update:open": [boolean] }>();
+
+const mac = isMac();
+const GROUP_ORDER = ["Go to", "General", "Actions", "View", "Window"];
+
+const groups = computed(() => {
+  const by = new Map<string, Command[]>();
+  for (const cmd of props.commands) {
+    const list = by.get(cmd.group) ?? [];
+    list.push(cmd);
+    by.set(cmd.group, list);
+  }
+  return GROUP_ORDER.filter((g) => by.has(g)).map((title) => ({
+    title,
+    items: by.get(title) ?? [],
+  }));
+});
+</script>
+
+<template>
+  <Modal
+    title="Keyboard shortcuts"
+    size="lg"
+    :open="open"
+    @update:open="$emit('update:open', $event)"
+  >
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <section v-for="group in groups" :key="group.title">
+        <h3
+          class="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70"
+        >
+          {{ group.title }}
+        </h3>
+        <ul class="flex flex-col gap-1">
+          <li
+            v-for="cmd in group.items"
+            :key="cmd.id"
+            class="flex items-center justify-between gap-4 text-sm"
+          >
+            <span>{{ cmd.title }}</span>
+            <kbd
+              class="shrink-0 rounded border bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
+            >
+              {{ formatChord(cmd.chord, mac) }}
+            </kbd>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </Modal>
+</template>

--- a/apps/yerd-gui/src/components/ShortcutsCheatSheet.vue
+++ b/apps/yerd-gui/src/components/ShortcutsCheatSheet.vue
@@ -11,14 +11,20 @@ const props = defineProps<{ open: boolean; commands: Command[] }>();
 defineEmits<{ "update:open": [boolean] }>();
 
 const mac = isMac();
-const GROUP_ORDER = ["Go to", "General", "Actions", "View", "Window"];
+const GROUP_ORDER = ["Go to", "General", "Actions", "View"];
+
+// In the cheat-sheet the Sites and Window shortcuts live under General.
+function displayGroup(group: string): string {
+  return group === "Sites" || group === "Window" ? "General" : group;
+}
 
 const groups = computed(() => {
   const by = new Map<string, { title: string; chord: Chord }[]>();
   const add = (group: string, title: string, chord: Chord): void => {
-    const list = by.get(group) ?? [];
+    const key = displayGroup(group);
+    const list = by.get(key) ?? [];
     list.push({ title, chord });
-    by.set(group, list);
+    by.set(key, list);
   };
   for (const cmd of props.commands) {
     if (cmd.chord) add(cmd.group, cmd.title, cmd.chord);

--- a/apps/yerd-gui/src/components/ui/Input.spec.ts
+++ b/apps/yerd-gui/src/components/ui/Input.spec.ts
@@ -1,0 +1,13 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import Input from "./Input.vue";
+
+describe("Input", () => {
+  it("exposes focus() that moves focus to the inner field (for ⌘F)", () => {
+    const wrapper = mount(Input, { attachTo: document.body });
+    (wrapper.vm as unknown as { focus: () => void }).focus();
+    expect(document.activeElement).toBe(wrapper.find("input").element);
+    wrapper.unmount();
+  });
+});

--- a/apps/yerd-gui/src/components/ui/Input.vue
+++ b/apps/yerd-gui/src/components/ui/Input.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ref } from "vue";
+
 import { cn } from "@/lib/utils";
 
 defineProps<{
@@ -8,10 +10,16 @@ defineProps<{
   disabled?: boolean;
 }>();
 defineEmits<{ "update:modelValue": [string] }>();
+
+const el = ref<HTMLInputElement | null>(null);
+
+// Exposed so callers (e.g. the ⌘F shortcut) can move focus to the field.
+defineExpose({ focus: () => el.value?.focus() });
 </script>
 
 <template>
   <input
+    ref="el"
     :type="type ?? 'text'"
     :value="modelValue"
     :placeholder="placeholder"

--- a/apps/yerd-gui/src/components/ui/Input.vue
+++ b/apps/yerd-gui/src/components/ui/Input.vue
@@ -13,7 +13,6 @@ defineEmits<{ "update:modelValue": [string] }>();
 
 const el = ref<HTMLInputElement | null>(null);
 
-// Exposed so callers (e.g. the ⌘F shortcut) can move focus to the field.
 defineExpose({ focus: () => el.value?.focus() });
 </script>
 

--- a/apps/yerd-gui/src/components/ui/Modal.vue
+++ b/apps/yerd-gui/src/components/ui/Modal.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { X } from "lucide-vue-next";
-import { watch } from "vue";
+import { useId, watch } from "vue";
 
 import { cn } from "@/lib/utils";
+
+const titleId = useId();
 
 const props = withDefaults(
   defineProps<{
@@ -46,6 +48,7 @@ watch(
       <div
         role="dialog"
         aria-modal="true"
+        :aria-labelledby="titleId"
         :class="
           cn(
             'relative z-10 flex max-h-[90vh] w-full flex-col rounded-lg border bg-background p-6 shadow-lg animate-fade-in',
@@ -56,7 +59,7 @@ watch(
         "
       >
         <div class="flex shrink-0 items-start justify-between gap-4">
-          <h2 class="text-lg font-semibold">{{ title }}</h2>
+          <h2 :id="titleId" class="text-lg font-semibold">{{ title }}</h2>
           <button
             type="button"
             aria-label="Close"

--- a/apps/yerd-gui/src/components/ui/Modal.vue
+++ b/apps/yerd-gui/src/components/ui/Modal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { X } from "lucide-vue-next";
 import { watch } from "vue";
 
 import { cn } from "@/lib/utils";
@@ -39,7 +40,7 @@ watch(
       class="fixed inset-0 z-50 flex items-center justify-center p-4"
     >
       <div
-        class="absolute inset-0 bg-black/50 animate-fade-in"
+        class="absolute inset-0 bg-black/50 rounded-[10px] animate-fade-in"
         @click="close"
       />
       <div
@@ -54,7 +55,17 @@ watch(
           )
         "
       >
-        <h2 class="shrink-0 text-lg font-semibold">{{ title }}</h2>
+        <div class="flex shrink-0 items-start justify-between gap-4">
+          <h2 class="text-lg font-semibold">{{ title }}</h2>
+          <button
+            type="button"
+            aria-label="Close"
+            class="-mr-1 -mt-1 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            @click="close"
+          >
+            <X class="size-5" />
+          </button>
+        </div>
         <div class="mt-4 min-h-0 flex-1 overflow-auto">
           <slot />
         </div>

--- a/apps/yerd-gui/src/lib/desktop.ts
+++ b/apps/yerd-gui/src/lib/desktop.ts
@@ -33,9 +33,11 @@ function hardenWithin(root: ParentNode): void {
 }
 
 /**
- * Disable macOS autocorrect/autocapitalize/spellcheck on all form fields. The
- * attributes are set at element creation (before focus) via a MutationObserver,
- * since WKWebView may latch the correction state when a field is focused.
+ * Disable browser text assistance (autocorrect/autocapitalize/spellcheck) on all
+ * form fields. Harmless no-ops off WebKit, so it runs on every platform; it
+ * chiefly matters on macOS WKWebView, which may latch the correction state when a
+ * field is focused, so the attributes are set at element creation (before focus)
+ * via a MutationObserver.
  */
 function disableTextAssist(): void {
   hardenWithin(document);

--- a/apps/yerd-gui/src/lib/desktop.ts
+++ b/apps/yerd-gui/src/lib/desktop.ts
@@ -5,6 +5,8 @@
  *  - Suppresses the web context menu everywhere except editable fields (so
  *    inputs keep cut/copy/paste).
  *  - Cancels ghost-dragging of images/links.
+ *  - Turns off native text assistance (autocorrect, autocapitalize,
+ *    spellcheck) on every form field, current and future.
  *
  * Text-selection is handled in CSS (style.css) so it stays declarative.
  */
@@ -18,6 +20,36 @@ export function isEditable(el: EventTarget | null): boolean {
 }
 
 const ZOOM_KEYS = new Set(["+", "-", "=", "0"]);
+
+/** Strip WKWebView's text substitution off a single field. */
+function harden(el: Element): void {
+  el.setAttribute("autocorrect", "off");
+  el.setAttribute("autocapitalize", "off");
+  el.setAttribute("spellcheck", "false");
+}
+
+function hardenWithin(root: ParentNode): void {
+  root.querySelectorAll("input, textarea").forEach(harden);
+}
+
+/**
+ * Disable macOS autocorrect/autocapitalize/spellcheck on all form fields. The
+ * attributes are set at element creation (before focus) via a MutationObserver,
+ * since WKWebView may latch the correction state when a field is focused.
+ */
+function disableTextAssist(): void {
+  hardenWithin(document);
+  const observer = new MutationObserver((records) => {
+    for (const rec of records) {
+      rec.addedNodes.forEach((node) => {
+        if (!(node instanceof Element)) return;
+        if (node.matches("input, textarea")) harden(node);
+        hardenWithin(node);
+      });
+    }
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+}
 
 export function initDesktopChrome(): void {
   // Ctrl/Cmd + wheel zoom.
@@ -52,4 +84,6 @@ export function initDesktopChrome(): void {
   globalThis.addEventListener("dragstart", (e) => {
     if (!isEditable(e.target)) e.preventDefault();
   });
+
+  disableTextAssist();
 }

--- a/apps/yerd-gui/src/lib/desktop.ts
+++ b/apps/yerd-gui/src/lib/desktop.ts
@@ -9,7 +9,8 @@
  * Text-selection is handled in CSS (style.css) so it stays declarative.
  */
 
-function isEditable(el: EventTarget | null): boolean {
+/** True when the event target is a text field, so shortcuts can defer to typing. */
+export function isEditable(el: EventTarget | null): boolean {
   const node = el as HTMLElement | null;
   if (!node?.tagName) return false;
   const tag = node.tagName.toLowerCase();

--- a/apps/yerd-gui/src/lib/shortcuts/chord.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/chord.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { matchChord, type Chord } from "./chord";
+
+interface FakeKey {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  key?: string;
+  code?: string;
+}
+
+function ev(e: FakeKey): KeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    key: "",
+    code: "",
+    ...e,
+  } as KeyboardEvent;
+}
+
+const CMD_K: Chord = { mod: true, key: "k" };
+
+describe("matchChord - primary accelerator", () => {
+  it("resolves mod to Cmd on macOS and Ctrl on Linux", () => {
+    expect(matchChord(ev({ metaKey: true, key: "k" }), CMD_K, true)).toBe(true);
+    expect(matchChord(ev({ ctrlKey: true, key: "k" }), CMD_K, false)).toBe(true);
+  });
+
+  it("does not cross platforms: Ctrl+K is not ⌘K and vice-versa", () => {
+    expect(matchChord(ev({ ctrlKey: true, key: "k" }), CMD_K, true)).toBe(false);
+    expect(matchChord(ev({ metaKey: true, key: "k" }), CMD_K, false)).toBe(false);
+  });
+
+  it("rejects when the secondary modifier is also held", () => {
+    expect(
+      matchChord(ev({ metaKey: true, ctrlKey: true, key: "k" }), CMD_K, true),
+    ).toBe(false);
+  });
+
+  it("rejects a bare key with no modifier", () => {
+    expect(matchChord(ev({ key: "k" }), CMD_K, true)).toBe(false);
+  });
+});
+
+describe("matchChord - shift / alt are exact", () => {
+  const reverse: Chord = { mod: true, shift: true, key: "r" };
+  it("requires shift when specified", () => {
+    expect(
+      matchChord(ev({ metaKey: true, shiftKey: true, key: "r" }), reverse, true),
+    ).toBe(true);
+    expect(matchChord(ev({ metaKey: true, key: "r" }), reverse, true)).toBe(false);
+  });
+  it("rejects an unexpected shift", () => {
+    expect(
+      matchChord(ev({ metaKey: true, shiftKey: true, key: "k" }), CMD_K, true),
+    ).toBe(false);
+  });
+});
+
+describe("matchChord - code vs key", () => {
+  it("matches digits by physical code", () => {
+    const chord: Chord = { mod: true, code: "Digit1" };
+    expect(matchChord(ev({ metaKey: true, code: "Digit1" }), chord, true)).toBe(true);
+    expect(matchChord(ev({ metaKey: true, code: "Digit2" }), chord, true)).toBe(false);
+  });
+});
+
+describe("matchChord - literal Control (tab cycle)", () => {
+  const ctrlTab: Chord = { ctrl: true, code: "Tab" };
+  const ctrlShiftTab: Chord = { ctrl: true, shift: true, code: "Tab" };
+
+  it("is Control on both platforms, not Command", () => {
+    expect(matchChord(ev({ ctrlKey: true, code: "Tab" }), ctrlTab, true)).toBe(true);
+    expect(matchChord(ev({ ctrlKey: true, code: "Tab" }), ctrlTab, false)).toBe(true);
+    expect(matchChord(ev({ metaKey: true, code: "Tab" }), ctrlTab, true)).toBe(false);
+  });
+
+  it("distinguishes the shifted reverse", () => {
+    expect(
+      matchChord(ev({ ctrlKey: true, shiftKey: true, code: "Tab" }), ctrlShiftTab, true),
+    ).toBe(true);
+    expect(matchChord(ev({ ctrlKey: true, code: "Tab" }), ctrlShiftTab, true)).toBe(false);
+  });
+});

--- a/apps/yerd-gui/src/lib/shortcuts/chord.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/chord.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure key-chord matching - no DOM listeners, no globals, fully unit-testable.
+ *
+ * A `Chord` is the platform-independent description of a shortcut. `mod` is the
+ * primary accelerator: Command on macOS, Control on Linux (same letter, swapped
+ * modifier - the convention this app follows). `ctrl` is the *literal* Control
+ * key, used for the few chords that are Control on both platforms (e.g. the
+ * dumps-window tab cycle, since Cmd+Tab is the macOS app switcher and can't be
+ * repurposed). `shift`/`alt` are literal.
+ *
+ * Match on `code` for layout-stable physical keys (digits, Tab) and on `key`
+ * for character keys (k, comma, slash) so the binding follows the printed glyph.
+ */
+export interface Chord {
+  /** Primary accelerator: Cmd on macOS, Ctrl on Linux. */
+  mod?: boolean;
+  /** Literal Control key (Control on both platforms). */
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  /** Character key, matched case-insensitively against `event.key`. */
+  key?: string;
+  /** Physical key, matched against `event.code` (e.g. "Digit1", "Tab"). */
+  code?: string;
+}
+
+/** Does this keyboard event satisfy `chord` on the given platform? */
+export function matchChord(e: KeyboardEvent, chord: Chord, isMac: boolean): boolean {
+  const requiredMeta = isMac ? !!chord.mod : false;
+  const requiredCtrl = isMac ? !!chord.ctrl : !!chord.mod || !!chord.ctrl;
+
+  if (e.metaKey !== requiredMeta) return false;
+  if (e.ctrlKey !== requiredCtrl) return false;
+  if (!!chord.shift !== e.shiftKey) return false;
+  if (!!chord.alt !== e.altKey) return false;
+
+  if (chord.code) return e.code === chord.code;
+  if (chord.key) return e.key.toLowerCase() === chord.key.toLowerCase();
+  return false;
+}

--- a/apps/yerd-gui/src/lib/shortcuts/format.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/format.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { formatChord } from "./format";
+
+describe("formatChord", () => {
+  it("renders the primary accelerator per platform", () => {
+    expect(formatChord({ mod: true, key: "k" }, true)).toBe("⌘K");
+    expect(formatChord({ mod: true, key: "k" }, false)).toBe("Ctrl+K");
+  });
+
+  it("orders modifiers and renders the shifted reverse", () => {
+    expect(formatChord({ mod: true, shift: true, key: "r" }, true)).toBe("⇧⌘R");
+    expect(formatChord({ mod: true, shift: true, key: "r" }, false)).toBe("Ctrl+Shift+R");
+  });
+
+  it("labels digit codes", () => {
+    expect(formatChord({ mod: true, code: "Digit1" }, true)).toBe("⌘1");
+    expect(formatChord({ mod: true, code: "Digit1" }, false)).toBe("Ctrl+1");
+  });
+
+  it("labels the tab-cycle chord (literal Control)", () => {
+    expect(formatChord({ ctrl: true, code: "Tab" }, true)).toBe("⌃⇥");
+    expect(formatChord({ ctrl: true, code: "Tab" }, false)).toBe("Ctrl+Tab");
+  });
+
+  it("keeps punctuation keys verbatim", () => {
+    expect(formatChord({ mod: true, key: "," }, true)).toBe("⌘,");
+    expect(formatChord({ mod: true, key: "/" }, false)).toBe("Ctrl+/");
+  });
+});

--- a/apps/yerd-gui/src/lib/shortcuts/format.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/format.ts
@@ -1,0 +1,49 @@
+/**
+ * Render a `Chord` as the label users see in the palette and cheat-sheet:
+ * macOS glyphs (⌃⌥⇧⌘, joined tight) versus the spelled-out Linux form
+ * ("Ctrl+Shift+K"). Order follows each platform's convention.
+ */
+import type { Chord } from "./chord";
+
+const KEY_LABELS: Record<string, string> = {
+  Digit1: "1",
+  Digit2: "2",
+  Digit3: "3",
+  Digit4: "4",
+  Digit5: "5",
+  Digit6: "6",
+  Digit7: "7",
+  Digit8: "8",
+  Digit9: "9",
+};
+
+function keyLabel(chord: Chord, isMac: boolean): string {
+  if (chord.code) {
+    if (chord.code === "Tab") return isMac ? "⇥" : "Tab";
+    const mapped = KEY_LABELS[chord.code];
+    if (mapped) return mapped;
+    return chord.code;
+  }
+  const key = chord.key ?? "";
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}
+
+/** Human-readable shortcut label for `chord`, formatted for the platform. */
+export function formatChord(chord: Chord, isMac: boolean): string {
+  const key = keyLabel(chord, isMac);
+  if (isMac) {
+    let out = "";
+    if (chord.ctrl) out += "⌃";
+    if (chord.alt) out += "⌥";
+    if (chord.shift) out += "⇧";
+    if (chord.mod) out += "⌘";
+    return out + key;
+  }
+  const parts: string[] = [];
+  if (chord.mod || chord.ctrl) parts.push("Ctrl");
+  if (chord.alt) parts.push("Alt");
+  if (chord.shift) parts.push("Shift");
+  parts.push(key);
+  return parts.join("+");
+}

--- a/apps/yerd-gui/src/lib/shortcuts/platform.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/platform.ts
@@ -1,0 +1,17 @@
+/**
+ * Platform detection for the shortcut layer. Kept out of `chord.ts` so that the
+ * matcher stays pure (the boolean is passed in), and cached because the platform
+ * doesn't change for the life of the webview.
+ */
+let cached: boolean | undefined;
+
+/** True on macOS, where the primary accelerator is Command rather than Control. */
+export function isMac(): boolean {
+  if (cached === undefined) {
+    const nav = globalThis.navigator;
+    const platform = nav?.platform ?? "";
+    const ua = nav?.userAgent ?? "";
+    cached = /mac/i.test(platform) || (/mac/i.test(ua) && !/iphone|ipad|ipod/i.test(ua));
+  }
+  return cached;
+}

--- a/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildCommands,
   commandsForScope,
+  nativeShortcuts,
   VIEW_TARGETS,
   type ShortcutCtx,
 } from "./registry";
@@ -12,10 +13,12 @@ function fakeCtx(view: ViewActions = {}): ShortcutCtx {
   return {
     push: vi.fn(),
     openPalette: vi.fn(),
-    openCheatSheet: vi.fn(),
+    toggleCheatSheet: vi.fn(),
     toggleTheme: vi.fn(),
     restartDaemon: vi.fn(),
     closeWindow: vi.fn(),
+    openMailWindow: vi.fn(),
+    openDumpsWindow: vi.fn(),
     view: () => view,
   };
 }
@@ -26,6 +29,22 @@ describe("VIEW_TARGETS", () => {
     expect(VIEW_TARGETS[0]?.path).toBe("/overview");
     expect(VIEW_TARGETS[VIEW_TARGETS.length - 1]?.path).toBe("/doctor");
     expect(VIEW_TARGETS.map((v) => v.path)).not.toContain("/about");
+  });
+});
+
+describe("nativeShortcuts", () => {
+  it("documents the macOS native window shortcuts", () => {
+    const mac = nativeShortcuts(true);
+    expect(mac.map((s) => s.title)).toEqual([
+      "Minimise window",
+      "Close window",
+      "Quit Yerd",
+    ]);
+    expect(mac.every((s) => s.group === "Window")).toBe(true);
+  });
+
+  it("returns nothing on Linux (no native menu)", () => {
+    expect(nativeShortcuts(false)).toEqual([]);
   });
 });
 
@@ -74,8 +93,12 @@ describe("command run wiring", () => {
 
   it("contextual commands no-op when the view registers no handler", () => {
     const ctx = fakeCtx({});
-    expect(() => all.find((c) => c.id === "find")?.run(ctx)).not.toThrow();
-    expect(() => all.find((c) => c.id === "new")?.run(ctx)).not.toThrow();
+    const find = all.find((c) => c.id === "find");
+    const create = all.find((c) => c.id === "new");
+    expect(find).toBeDefined();
+    expect(create).toBeDefined();
+    expect(() => find?.run(ctx)).not.toThrow();
+    expect(() => create?.run(ctx)).not.toThrow();
   });
 
   it("contextual commands call the active view handler", () => {
@@ -83,5 +106,18 @@ describe("command run wiring", () => {
     const ctx = fakeCtx({ create });
     all.find((c) => c.id === "new")?.run(ctx);
     expect(create).toHaveBeenCalledOnce();
+  });
+
+  it("opens the viewer windows via their chords", () => {
+    const mail = all.find((c) => c.id === "open-mail");
+    const dumps = all.find((c) => c.id === "open-dumps");
+    expect(mail?.chord).toEqual({ mod: true, shift: true, key: "m" });
+    expect(dumps?.chord).toEqual({ mod: true, shift: true, key: "d" });
+
+    const ctx = fakeCtx();
+    mail?.run(ctx);
+    dumps?.run(ctx);
+    expect(ctx.openMailWindow).toHaveBeenCalledOnce();
+    expect(ctx.openDumpsWindow).toHaveBeenCalledOnce();
   });
 });

--- a/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
@@ -51,13 +51,15 @@ describe("commandsForScope", () => {
     expect(dumps).not.toContain("new");
   });
 
-  it("drops Close/Quit on macOS (the native menu owns them)", () => {
+  it("drops the Linux-only Close on macOS (the native menu owns Cmd+W)", () => {
     const macMain = commandsForScope(all, "main", true).map((c) => c.id);
     expect(macMain).not.toContain("close-window");
-    expect(macMain).not.toContain("quit");
     const linuxMain = commandsForScope(all, "main", false).map((c) => c.id);
     expect(linuxMain).toContain("close-window");
-    expect(linuxMain).toContain("quit");
+  });
+
+  it("does not bind a Quit chord (tray app; macOS quits via native menu)", () => {
+    expect(all.some((c) => c.id === "quit")).toBe(false);
   });
 });
 

--- a/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildCommands,
+  commandsForScope,
+  VIEW_TARGETS,
+  type ShortcutCtx,
+} from "./registry";
+import type { ViewActions } from "./useViewActions";
+
+function fakeCtx(view: ViewActions = {}): ShortcutCtx {
+  return {
+    push: vi.fn(),
+    openPalette: vi.fn(),
+    openCheatSheet: vi.fn(),
+    toggleTheme: vi.fn(),
+    restartDaemon: vi.fn(),
+    closeWindow: vi.fn(),
+    view: () => view,
+  };
+}
+
+describe("VIEW_TARGETS", () => {
+  it("covers nine views in sidebar order, About excluded", () => {
+    expect(VIEW_TARGETS).toHaveLength(9);
+    expect(VIEW_TARGETS[0]?.path).toBe("/overview");
+    expect(VIEW_TARGETS[VIEW_TARGETS.length - 1]?.path).toBe("/doctor");
+    expect(VIEW_TARGETS.map((v) => v.path)).not.toContain("/about");
+  });
+});
+
+describe("commandsForScope", () => {
+  const all = buildCommands();
+
+  it("surfaces ⌘1…⌘9 navigation only in the main window", () => {
+    const main = commandsForScope(all, "main", false).filter((c) =>
+      c.id.startsWith("nav:"),
+    );
+    expect(main).toHaveLength(9);
+    expect(commandsForScope(all, "dumps", false).some((c) => c.id.startsWith("nav:"))).toBe(
+      false,
+    );
+  });
+
+  it("gives the dumps window its tab-cycle and find/refresh, not navigation", () => {
+    const dumps = commandsForScope(all, "dumps", false).map((c) => c.id);
+    expect(dumps).toContain("dumps-next-tab");
+    expect(dumps).toContain("dumps-prev-tab");
+    expect(dumps).toContain("find");
+    expect(dumps).toContain("refresh");
+    expect(dumps).not.toContain("new");
+  });
+
+  it("drops Close/Quit on macOS (the native menu owns them)", () => {
+    const macMain = commandsForScope(all, "main", true).map((c) => c.id);
+    expect(macMain).not.toContain("close-window");
+    expect(macMain).not.toContain("quit");
+    const linuxMain = commandsForScope(all, "main", false).map((c) => c.id);
+    expect(linuxMain).toContain("close-window");
+    expect(linuxMain).toContain("quit");
+  });
+});
+
+describe("command run wiring", () => {
+  const all = buildCommands();
+
+  it("navigates to the matching path", () => {
+    const ctx = fakeCtx();
+    all.find((c) => c.id === "nav:/sites")?.run(ctx);
+    expect(ctx.push).toHaveBeenCalledWith("/sites");
+  });
+
+  it("contextual commands no-op when the view registers no handler", () => {
+    const ctx = fakeCtx({});
+    expect(() => all.find((c) => c.id === "find")?.run(ctx)).not.toThrow();
+    expect(() => all.find((c) => c.id === "new")?.run(ctx)).not.toThrow();
+  });
+
+  it("contextual commands call the active view handler", () => {
+    const create = vi.fn();
+    const ctx = fakeCtx({ create });
+    all.find((c) => c.id === "new")?.run(ctx);
+    expect(create).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.test.ts
@@ -19,6 +19,8 @@ function fakeCtx(view: ViewActions = {}): ShortcutCtx {
     closeWindow: vi.fn(),
     openMailWindow: vi.fn(),
     openDumpsWindow: vi.fn(),
+    openLinkSite: vi.fn(),
+    parkFolder: vi.fn(),
     view: () => view,
   };
 }
@@ -106,6 +108,22 @@ describe("command run wiring", () => {
     const ctx = fakeCtx({ create });
     all.find((c) => c.id === "new")?.run(ctx);
     expect(create).toHaveBeenCalledOnce();
+  });
+
+  it("Link Site / Park Folder route to the Sites dialogs via their chords", () => {
+    const link = all.find((c) => c.id === "link-site");
+    const park = all.find((c) => c.id === "park-folder");
+    expect(link?.group).toBe("Sites");
+    expect(park?.group).toBe("Sites");
+    expect(link?.chord).toEqual({ mod: true, shift: true, key: "n" });
+    expect(park?.chord).toEqual({ mod: true, shift: true, key: "p" });
+    expect(link?.inPalette).toBe(true);
+
+    const ctx = fakeCtx();
+    link?.run(ctx);
+    park?.run(ctx);
+    expect(ctx.openLinkSite).toHaveBeenCalledOnce();
+    expect(ctx.parkFolder).toHaveBeenCalledOnce();
   });
 
   it("opens the viewer windows via their chords", () => {

--- a/apps/yerd-gui/src/lib/shortcuts/registry.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.ts
@@ -24,10 +24,14 @@ export interface ShortcutCtx {
   /** Navigate the main window's router. */
   push: (path: string) => void;
   openPalette: () => void;
-  openCheatSheet: () => void;
+  toggleCheatSheet: () => void;
   toggleTheme: () => void;
   restartDaemon: () => void;
   closeWindow: () => void;
+  /** Open the standalone Mail viewer window. */
+  openMailWindow: () => void;
+  /** Open the standalone Dumps viewer window. */
+  openDumpsWindow: () => void;
   /** Live contextual handlers for the currently mounted view. */
   view: () => ViewActions;
 }
@@ -36,7 +40,8 @@ export interface Command {
   id: string;
   title: string;
   group: string;
-  chord: Chord;
+  /** The key chord, when bound. Palette-only actions (e.g. Open Mail) omit it. */
+  chord?: Chord;
   scopes: WindowScope[];
   /** Skipped on macOS (the native menu provides it there). */
   linuxOnly?: boolean;
@@ -86,7 +91,7 @@ export function buildCommands(): Command[] {
       chord: { mod: true, key: "/" },
       scopes: ["main"],
       inPalette: true,
-      run: (ctx) => ctx.openCheatSheet(),
+      run: (ctx) => ctx.toggleCheatSheet(),
     },
     {
       id: "settings",
@@ -114,6 +119,24 @@ export function buildCommands(): Command[] {
       scopes: ALL,
       inPalette: true,
       run: (ctx) => ctx.toggleTheme(),
+    },
+    {
+      id: "open-mail",
+      title: "Open Mail viewer",
+      group: "Actions",
+      chord: { mod: true, shift: true, key: "m" },
+      scopes: ["main"],
+      inPalette: true,
+      run: (ctx) => ctx.openMailWindow(),
+    },
+    {
+      id: "open-dumps",
+      title: "Open Dumps viewer",
+      group: "Actions",
+      chord: { mod: true, shift: true, key: "d" },
+      scopes: ["main"],
+      inPalette: true,
+      run: (ctx) => ctx.openDumpsWindow(),
     },
     {
       id: "find",
@@ -167,6 +190,26 @@ export function buildCommands(): Command[] {
   ];
 
   return [...nav, ...rest];
+}
+
+/**
+ * OS-provided shortcuts shown in the cheat-sheet for discoverability but handled
+ * by the native macOS menu, not the JS dispatcher. Linux has no native app menu,
+ * so it returns nothing (its Ctrl+W close is a real dispatched command).
+ */
+export interface NativeShortcut {
+  title: string;
+  chord: Chord;
+  group: string;
+}
+
+export function nativeShortcuts(isMac: boolean): NativeShortcut[] {
+  if (!isMac) return [];
+  return [
+    { title: "Minimise window", chord: { mod: true, key: "m" }, group: "Window" },
+    { title: "Close window", chord: { mod: true, key: "w" }, group: "Window" },
+    { title: "Quit Yerd", chord: { mod: true, key: "q" }, group: "Window" },
+  ];
 }
 
 /** Commands active in `scope` on this platform (drops macOS-native duplicates). */

--- a/apps/yerd-gui/src/lib/shortcuts/registry.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.ts
@@ -1,0 +1,186 @@
+/**
+ * The command catalog: the single source of truth for the keyboard dispatcher,
+ * the command palette, and the cheat-sheet. Commands reference only the injected
+ * `ShortcutCtx`, never app singletons directly, so the registry stays free of
+ * Tauri/IPC imports and is unit-testable with a fake context.
+ *
+ * `scopes` lists the windows a command is active in ("main" is the app shell;
+ * "dumps"/"mails" are the standalone viewer windows). `linuxOnly` commands are
+ * skipped on macOS, where the native app menu already owns them (Close/Quit).
+ */
+import type { Chord } from "./chord";
+import type { ViewActions } from "./useViewActions";
+
+export type WindowScope = "main" | "dumps" | "mails";
+
+const ALL: WindowScope[] = ["main", "dumps", "mails"];
+
+/** Everything a command needs to act, injected by the dispatcher. */
+export interface ShortcutCtx {
+  /** Navigate the main window's router. */
+  push: (path: string) => void;
+  openPalette: () => void;
+  openCheatSheet: () => void;
+  toggleTheme: () => void;
+  restartDaemon: () => void;
+  closeWindow: () => void;
+  /** Live contextual handlers for the currently mounted view. */
+  view: () => ViewActions;
+}
+
+export interface Command {
+  id: string;
+  title: string;
+  group: string;
+  chord: Chord;
+  scopes: WindowScope[];
+  /** Skipped on macOS (the native menu provides it there). */
+  linuxOnly?: boolean;
+  /** Listed in the command palette (navigation + global actions). */
+  inPalette?: boolean;
+  run: (ctx: ShortcutCtx) => void;
+}
+
+/** Main-window views reachable by ⌘1…⌘9, in sidebar order (About omitted). */
+export const VIEW_TARGETS: { path: string; title: string }[] = [
+  { path: "/overview", title: "Overview" },
+  { path: "/php", title: "PHP" },
+  { path: "/sites", title: "Sites" },
+  { path: "/tooling", title: "Tooling" },
+  { path: "/services", title: "Services" },
+  { path: "/mail", title: "Mail" },
+  { path: "/dumps", title: "Dumps" },
+  { path: "/general", title: "Settings" },
+  { path: "/doctor", title: "Doctor" },
+];
+
+/** Build the full command catalog. Pure: no side effects until a `run` fires. */
+export function buildCommands(): Command[] {
+  const nav: Command[] = VIEW_TARGETS.map((v, i) => ({
+    id: `nav:${v.path}`,
+    title: `Go to ${v.title}`,
+    group: "Go to",
+    chord: { mod: true, code: `Digit${i + 1}` },
+    scopes: ["main"],
+    inPalette: true,
+    run: (ctx) => ctx.push(v.path),
+  }));
+
+  const rest: Command[] = [
+    {
+      id: "palette",
+      title: "Command palette",
+      group: "General",
+      chord: { mod: true, key: "k" },
+      scopes: ["main"],
+      run: (ctx) => ctx.openPalette(),
+    },
+    {
+      id: "cheatsheet",
+      title: "Keyboard shortcuts",
+      group: "General",
+      chord: { mod: true, key: "/" },
+      scopes: ["main"],
+      inPalette: true,
+      run: (ctx) => ctx.openCheatSheet(),
+    },
+    {
+      id: "settings",
+      title: "Open Settings",
+      group: "General",
+      chord: { mod: true, key: "," },
+      scopes: ["main"],
+      inPalette: true,
+      run: (ctx) => ctx.push("/general"),
+    },
+    {
+      id: "restart-daemon",
+      title: "Restart daemon",
+      group: "Actions",
+      chord: { mod: true, shift: true, key: "r" },
+      scopes: ["main"],
+      inPalette: true,
+      run: (ctx) => ctx.restartDaemon(),
+    },
+    {
+      id: "toggle-theme",
+      title: "Toggle light / dark theme",
+      group: "Actions",
+      chord: { mod: true, shift: true, key: "l" },
+      scopes: ALL,
+      inPalette: true,
+      run: (ctx) => ctx.toggleTheme(),
+    },
+    {
+      id: "find",
+      title: "Find in view",
+      group: "Actions",
+      chord: { mod: true, key: "f" },
+      scopes: ["main", "dumps"],
+      run: (ctx) => ctx.view().find?.(),
+    },
+    {
+      id: "new",
+      title: "New / Add",
+      group: "Actions",
+      chord: { mod: true, key: "n" },
+      scopes: ["main"],
+      run: (ctx) => ctx.view().create?.(),
+    },
+    {
+      id: "refresh",
+      title: "Refresh view",
+      group: "Actions",
+      chord: { mod: true, key: "r" },
+      scopes: ALL,
+      run: (ctx) => ctx.view().refresh?.(),
+    },
+    {
+      id: "dumps-prev-tab",
+      title: "Previous tab",
+      group: "View",
+      chord: { ctrl: true, shift: true, code: "Tab" },
+      scopes: ["dumps"],
+      run: (ctx) => ctx.view().prevTab?.(),
+    },
+    {
+      id: "dumps-next-tab",
+      title: "Next tab",
+      group: "View",
+      chord: { ctrl: true, code: "Tab" },
+      scopes: ["dumps"],
+      run: (ctx) => ctx.view().nextTab?.(),
+    },
+    {
+      id: "close-window",
+      title: "Close window",
+      group: "Window",
+      chord: { mod: true, key: "w" },
+      scopes: ALL,
+      linuxOnly: true,
+      run: (ctx) => ctx.closeWindow(),
+    },
+    {
+      id: "quit",
+      title: "Quit",
+      group: "Window",
+      chord: { mod: true, key: "q" },
+      scopes: ["main"],
+      linuxOnly: true,
+      run: (ctx) => ctx.closeWindow(),
+    },
+  ];
+
+  return [...nav, ...rest];
+}
+
+/** Commands active in `scope` on this platform (drops macOS-native duplicates). */
+export function commandsForScope(
+  commands: Command[],
+  scope: WindowScope,
+  isMac: boolean,
+): Command[] {
+  return commands.filter(
+    (c) => c.scopes.includes(scope) && !(c.linuxOnly && isMac),
+  );
+}

--- a/apps/yerd-gui/src/lib/shortcuts/registry.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.ts
@@ -36,7 +36,7 @@ export interface ShortcutCtx {
   openLinkSite: () => void;
   /** Go to the Sites page and open the Park-folder picker. */
   parkFolder: () => void;
-  /** Live contextual handlers for the currently mounted view. */
+  /** Live contextual handlers for the active view. */
   view: () => ViewActions;
 }
 
@@ -44,7 +44,7 @@ export interface Command {
   id: string;
   title: string;
   group: string;
-  /** The key chord, when bound. Palette-only actions (e.g. Open Mail) omit it. */
+  /** The key chord, when bound. Some palette entries have none, e.g. the dynamic per-site commands. */
   chord?: Chord;
   scopes: WindowScope[];
   /** Skipped on macOS (the native menu provides it there). */

--- a/apps/yerd-gui/src/lib/shortcuts/registry.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.ts
@@ -32,6 +32,10 @@ export interface ShortcutCtx {
   openMailWindow: () => void;
   /** Open the standalone Dumps viewer window. */
   openDumpsWindow: () => void;
+  /** Go to the Sites page and open the Link-site dialog. */
+  openLinkSite: () => void;
+  /** Go to the Sites page and open the Park-folder picker. */
+  parkFolder: () => void;
   /** Live contextual handlers for the currently mounted view. */
   view: () => ViewActions;
 }
@@ -139,6 +143,24 @@ export function buildCommands(): Command[] {
       run: (ctx) => ctx.openDumpsWindow(),
     },
     {
+      id: "link-site",
+      title: "Link Site",
+      group: "Sites",
+      chord: { mod: true, shift: true, key: "n" },
+      scopes: ["main"],
+      inPalette: true,
+      run: (ctx) => ctx.openLinkSite(),
+    },
+    {
+      id: "park-folder",
+      title: "Park Folder",
+      group: "Sites",
+      chord: { mod: true, shift: true, key: "p" },
+      scopes: ["main"],
+      inPalette: true,
+      run: (ctx) => ctx.parkFolder(),
+    },
+    {
       id: "find",
       title: "Find in view",
       group: "Actions",
@@ -203,6 +225,7 @@ export interface NativeShortcut {
   group: string;
 }
 
+/** The native macOS window shortcuts to display in the cheat-sheet (none on Linux). */
 export function nativeShortcuts(isMac: boolean): NativeShortcut[] {
   if (!isMac) return [];
   return [

--- a/apps/yerd-gui/src/lib/shortcuts/registry.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.ts
@@ -152,20 +152,16 @@ export function buildCommands(): Command[] {
       run: (ctx) => ctx.view().nextTab?.(),
     },
     {
+      // Linux only: macOS owns Cmd+W via the native menu. On Linux a window
+      // close hides to the tray (the daemon keeps running), matching the
+      // titlebar button. There is intentionally no "Quit" chord: the app is a
+      // tray app with no JS path to a true exit, and a Quit that merely hid
+      // would duplicate this. macOS keeps a real Cmd+Q via its native menu.
       id: "close-window",
       title: "Close window",
       group: "Window",
       chord: { mod: true, key: "w" },
       scopes: ALL,
-      linuxOnly: true,
-      run: (ctx) => ctx.closeWindow(),
-    },
-    {
-      id: "quit",
-      title: "Quit",
-      group: "Window",
-      chord: { mod: true, key: "q" },
-      scopes: ["main"],
       linuxOnly: true,
       run: (ctx) => ctx.closeWindow(),
     },

--- a/apps/yerd-gui/src/lib/shortcuts/registry.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/registry.ts
@@ -6,7 +6,11 @@
  *
  * `scopes` lists the windows a command is active in ("main" is the app shell;
  * "dumps"/"mails" are the standalone viewer windows). `linuxOnly` commands are
- * skipped on macOS, where the native app menu already owns them (Close/Quit).
+ * skipped on macOS, where the native app menu already owns them (e.g. Close).
+ *
+ * There is intentionally no Quit chord: closing the window hides it to the tray
+ * (the daemon keeps running), so a JS Quit would only duplicate Close. macOS
+ * keeps a real Cmd+Q via its native menu.
  */
 import type { Chord } from "./chord";
 import type { ViewActions } from "./useViewActions";
@@ -152,11 +156,6 @@ export function buildCommands(): Command[] {
       run: (ctx) => ctx.view().nextTab?.(),
     },
     {
-      // Linux only: macOS owns Cmd+W via the native menu. On Linux a window
-      // close hides to the tray (the daemon keeps running), matching the
-      // titlebar button. There is intentionally no "Quit" chord: the app is a
-      // tray app with no JS path to a true exit, and a Quit that merely hid
-      // would duplicate this. macOS keeps a real Cmd+Q via its native menu.
       id: "close-window",
       title: "Close window",
       group: "Window",

--- a/apps/yerd-gui/src/lib/shortcuts/siteCommands.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/siteCommands.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildSiteCommands, type SiteCommandHandlers } from "./useSiteCommands";
+import type { ShortcutCtx } from "./registry";
+import type { Site } from "@/ipc/types";
+
+function site(name: string, secure: boolean): Site {
+  return { name, document_root: `/srv/${name}`, php: "8.4", secure, kind: "linked" };
+}
+
+const noop: SiteCommandHandlers = { onOpen: vi.fn(), onToggleSecure: vi.fn() };
+const ctx = {} as ShortcutCtx;
+
+describe("buildSiteCommands", () => {
+  it("yields two commands per site, ordered by name descending", () => {
+    const cmds = buildSiteCommands([site("alpha", false), site("zeta", true)], "test", noop);
+    expect(cmds.map((c) => c.id)).toEqual([
+      "site-open:zeta",
+      "site-secure:zeta",
+      "site-open:alpha",
+      "site-secure:alpha",
+    ]);
+  });
+
+  it("labels open and secure/unsecure by state, grouped by domain, no chord", () => {
+    const [open, secure] = buildSiteCommands([site("alpha", false)], "test", noop);
+    expect(open.title).toBe("Open alpha.test");
+    expect(open.group).toBe("alpha.test");
+    expect(open.chord).toBeUndefined();
+    expect(open.inPalette).toBe(true);
+    expect(secure.title).toBe("Secure alpha.test");
+
+    const [, unsecure] = buildSiteCommands([site("beta", true)], "test", noop);
+    expect(unsecure.title).toBe("Unsecure beta.test");
+  });
+
+  it("uses the given tld in titles and groups", () => {
+    const [open] = buildSiteCommands([site("alpha", false)], "dev", noop);
+    expect(open.title).toBe("Open alpha.dev");
+    expect(open.group).toBe("alpha.dev");
+  });
+
+  it("delegates run to the injected handlers", () => {
+    const onOpen = vi.fn();
+    const onToggleSecure = vi.fn();
+    const s = site("alpha", false);
+    const [open, secure] = buildSiteCommands([s], "test", { onOpen, onToggleSecure });
+    open.run(ctx);
+    secure.run(ctx);
+    expect(onOpen).toHaveBeenCalledWith(s);
+    expect(onToggleSecure).toHaveBeenCalledWith(s);
+  });
+});

--- a/apps/yerd-gui/src/lib/shortcuts/sitesIntent.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/sitesIntent.ts
@@ -1,0 +1,13 @@
+/**
+ * A one-shot request to open a Sites-page dialog from elsewhere (the command
+ * palette / a shortcut). The Link/Park commands set this, then navigate to
+ * `/sites`; SitesView consumes and clears it on mount (or while already mounted).
+ *
+ * Module-level singleton, like `useViewActions` - and per-webview, so the
+ * standalone dumps/mails windows hold their own (always-null) copy.
+ */
+import { ref } from "vue";
+
+export type SitesIntent = "link" | "park";
+
+export const sitesIntent = ref<SitesIntent | null>(null);

--- a/apps/yerd-gui/src/lib/shortcuts/useShortcuts.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useShortcuts.ts
@@ -12,6 +12,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
 import { useRouter } from "vue-router";
 
+import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import { isEditable } from "@/lib/desktop";
 import { setTheme } from "@/lib/theme";
@@ -26,6 +27,7 @@ import {
   type ShortcutCtx,
   type WindowScope,
 } from "./registry";
+import { sitesIntent } from "./sitesIntent";
 import { getViewActions } from "./useViewActions";
 
 export interface UseShortcuts {
@@ -40,13 +42,20 @@ export interface UseShortcuts {
 export function useShortcuts(scope: WindowScope): UseShortcuts {
   const router = useRouter();
   const toast = useToast();
+  const { unreachable } = useDaemon();
   const paletteOpen = ref(false);
   const cheatSheetOpen = ref(false);
 
   const ctx: ShortcutCtx = {
     push: (path) => void router.push(path),
-    openPalette: () => (paletteOpen.value = true),
-    toggleCheatSheet: () => (cheatSheetOpen.value = !cheatSheetOpen.value),
+    openPalette: () => {
+      cheatSheetOpen.value = false;
+      paletteOpen.value = true;
+    },
+    toggleCheatSheet: () => {
+      paletteOpen.value = false;
+      cheatSheetOpen.value = !cheatSheetOpen.value;
+    },
     toggleTheme: () => {
       const dark = document.documentElement.classList.contains("dark");
       setTheme(dark ? "light" : "dark");
@@ -60,6 +69,14 @@ export function useShortcuts(scope: WindowScope): UseShortcuts {
       }
     },
     closeWindow: () => void getCurrentWindow().close(),
+    openLinkSite: () => {
+      if (!unreachable.value) sitesIntent.value = "link";
+      void router.push("/sites");
+    },
+    parkFolder: () => {
+      if (!unreachable.value) sitesIntent.value = "park";
+      void router.push("/sites");
+    },
     openMailWindow: async () => {
       try {
         await showMailsWindow();
@@ -82,6 +99,7 @@ export function useShortcuts(scope: WindowScope): UseShortcuts {
     () => {
       paletteOpen.value = false;
       cheatSheetOpen.value = false;
+      if (router.currentRoute.value.path !== "/sites") sitesIntent.value = null;
     },
   );
 

--- a/apps/yerd-gui/src/lib/shortcuts/useShortcuts.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useShortcuts.ts
@@ -1,0 +1,92 @@
+/**
+ * Installs the single window-level keydown dispatcher for a given window scope
+ * and wires the registry's injected context to the real app singletons (router,
+ * theme, daemon IPC, Tauri window). Returns the palette/cheat-sheet open refs so
+ * the app shell can render those overlays.
+ *
+ * The listener runs in the capture phase so it sees the chord before the
+ * webview's own handling; on a registry match it prevents default (e.g. stops a
+ * ⌘R page reload) and runs the command.
+ */
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { onMounted, onUnmounted, ref, type Ref } from "vue";
+import { useRouter } from "vue-router";
+
+import { useToast } from "@/composables/useToast";
+import { isEditable } from "@/lib/desktop";
+import { setTheme } from "@/lib/theme";
+import { IpcError, restartDaemon } from "@/ipc/client";
+
+import { matchChord } from "./chord";
+import { isMac } from "./platform";
+import {
+  buildCommands,
+  commandsForScope,
+  type Command,
+  type ShortcutCtx,
+  type WindowScope,
+} from "./registry";
+import { getViewActions } from "./useViewActions";
+
+export interface UseShortcuts {
+  paletteOpen: Ref<boolean>;
+  cheatSheetOpen: Ref<boolean>;
+  /** Commands active in this window, for the palette and cheat-sheet. */
+  commands: Command[];
+  /** Execute a command against the wired context. */
+  run: (cmd: Command) => void;
+}
+
+export function useShortcuts(scope: WindowScope): UseShortcuts {
+  const router = useRouter();
+  const toast = useToast();
+  const paletteOpen = ref(false);
+  const cheatSheetOpen = ref(false);
+
+  const ctx: ShortcutCtx = {
+    push: (path) => void router.push(path),
+    openPalette: () => (paletteOpen.value = true),
+    openCheatSheet: () => (cheatSheetOpen.value = true),
+    toggleTheme: () => {
+      const dark = document.documentElement.classList.contains("dark");
+      setTheme(dark ? "light" : "dark");
+    },
+    restartDaemon: async () => {
+      try {
+        await restartDaemon();
+        toast.success("Daemon restarted");
+      } catch (e) {
+        toast.error("Couldn't restart the daemon", (e as IpcError).message);
+      }
+    },
+    closeWindow: () => void getCurrentWindow().close(),
+    view: getViewActions,
+  };
+
+  const mac = isMac();
+  const commands = commandsForScope(buildCommands(), scope, mac);
+
+  function onKey(e: KeyboardEvent): void {
+    const editable = isEditable(e.target);
+    for (const cmd of commands) {
+      if (editable && !cmd.chord.mod && !cmd.chord.ctrl) continue;
+      if (!matchChord(e, cmd.chord, mac)) continue;
+      e.preventDefault();
+      e.stopPropagation();
+      cmd.run(ctx);
+      return;
+    }
+  }
+
+  onMounted(() => globalThis.addEventListener("keydown", onKey, { capture: true }));
+  onUnmounted(() =>
+    globalThis.removeEventListener("keydown", onKey, { capture: true }),
+  );
+
+  return {
+    paletteOpen,
+    cheatSheetOpen,
+    commands,
+    run: (cmd: Command) => cmd.run(ctx),
+  };
+}

--- a/apps/yerd-gui/src/lib/shortcuts/useShortcuts.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useShortcuts.ts
@@ -9,13 +9,13 @@
  * ⌘R page reload) and runs the command.
  */
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { onMounted, onUnmounted, ref, type Ref } from "vue";
+import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
 import { useRouter } from "vue-router";
 
 import { useToast } from "@/composables/useToast";
 import { isEditable } from "@/lib/desktop";
 import { setTheme } from "@/lib/theme";
-import { IpcError, restartDaemon } from "@/ipc/client";
+import { IpcError, restartDaemon, showDumpsWindow, showMailsWindow } from "@/ipc/client";
 
 import { matchChord } from "./chord";
 import { isMac } from "./platform";
@@ -46,7 +46,7 @@ export function useShortcuts(scope: WindowScope): UseShortcuts {
   const ctx: ShortcutCtx = {
     push: (path) => void router.push(path),
     openPalette: () => (paletteOpen.value = true),
-    openCheatSheet: () => (cheatSheetOpen.value = true),
+    toggleCheatSheet: () => (cheatSheetOpen.value = !cheatSheetOpen.value),
     toggleTheme: () => {
       const dark = document.documentElement.classList.contains("dark");
       setTheme(dark ? "light" : "dark");
@@ -60,15 +60,39 @@ export function useShortcuts(scope: WindowScope): UseShortcuts {
       }
     },
     closeWindow: () => void getCurrentWindow().close(),
+    openMailWindow: async () => {
+      try {
+        await showMailsWindow();
+      } catch (e) {
+        toast.error("Couldn't open the Mail viewer", (e as IpcError).message);
+      }
+    },
+    openDumpsWindow: async () => {
+      try {
+        await showDumpsWindow();
+      } catch (e) {
+        toast.error("Couldn't open the Dumps viewer", (e as IpcError).message);
+      }
+    },
     view: getViewActions,
   };
+
+  watch(
+    () => router.currentRoute.value.fullPath,
+    () => {
+      paletteOpen.value = false;
+      cheatSheetOpen.value = false;
+    },
+  );
 
   const mac = isMac();
   const commands = commandsForScope(buildCommands(), scope, mac);
 
   function onKey(e: KeyboardEvent): void {
+    if (paletteOpen.value) return;
     const editable = isEditable(e.target);
     for (const cmd of commands) {
+      if (!cmd.chord) continue;
       if (editable && !cmd.chord.mod && !cmd.chord.ctrl) continue;
       if (!matchChord(e, cmd.chord, mac)) continue;
       e.preventDefault();

--- a/apps/yerd-gui/src/lib/shortcuts/useSiteCommands.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useSiteCommands.ts
@@ -1,0 +1,98 @@
+/**
+ * Dynamic command-palette entries for the user's sites: per site an "Open
+ * {domain}" and a "Secure/Unsecure {domain}" action, grouped by domain and
+ * ordered by name descending. These carry no key chord and are appended after
+ * the static commands, so they sit at the bottom of the palette.
+ *
+ * The list is fetched lazily when the palette opens (sites aren't in the daemon
+ * report, only counts), and falls back to empty when the daemon is unreachable.
+ *
+ * The command list keys off the `tld` string rather than the whole report
+ * object: the daemon poll replaces the report by identity every few seconds, so
+ * depending on it directly would churn the list and reset the palette selection
+ * while it is open.
+ */
+import { computed, ref, watch, type Ref } from "vue";
+
+import { useDaemon } from "@/composables/useDaemon";
+import { useToast } from "@/composables/useToast";
+import {
+  IpcError,
+  listSites,
+  openInBrowser,
+  setSecure,
+} from "@/ipc/client";
+import { siteUrl } from "@/lib/siteUrl";
+import type { Site } from "@/ipc/types";
+import type { Command } from "./registry";
+
+export interface SiteCommandHandlers {
+  onOpen: (site: Site) => void;
+  onToggleSecure: (site: Site) => void;
+}
+
+/** Pure: build the per-site palette commands. Sorted by name descending. */
+export function buildSiteCommands(
+  sites: Site[],
+  tld: string,
+  handlers: SiteCommandHandlers,
+): Command[] {
+  const ordered = [...sites].sort((a, b) => b.name.localeCompare(a.name));
+  return ordered.flatMap((s): Command[] => {
+    const domain = `${s.name}.${tld}`;
+    return [
+      {
+        id: `site-open:${s.name}`,
+        title: `Open ${domain}`,
+        group: domain,
+        scopes: ["main"],
+        inPalette: true,
+        run: () => handlers.onOpen(s),
+      },
+      {
+        id: `site-secure:${s.name}`,
+        title: `${s.secure ? "Unsecure" : "Secure"} ${domain}`,
+        group: domain,
+        scopes: ["main"],
+        inPalette: true,
+        run: () => handlers.onToggleSecure(s),
+      },
+    ];
+  });
+}
+
+/** Live per-site palette commands; refetches each time the palette opens. */
+export function useSiteCommands(paletteOpen: Ref<boolean>): Ref<Command[]> {
+  const { report, refresh } = useDaemon();
+  const toast = useToast();
+  const sites = ref<Site[]>([]);
+
+  async function load(): Promise<void> {
+    try {
+      sites.value = await listSites();
+    } catch {
+      sites.value = [];
+    }
+  }
+
+  watch(paletteOpen, (open) => {
+    if (open) void load();
+  });
+
+  const handlers: SiteCommandHandlers = {
+    onOpen: (s) => void openInBrowser(siteUrl(s, report.value)),
+    onToggleSecure: async (s) => {
+      try {
+        await setSecure(s.name, !s.secure);
+        toast.success(`Updated ${s.name}`);
+        await refresh();
+        await load();
+      } catch (e) {
+        toast.error("Couldn't update site", (e as IpcError).message);
+      }
+    },
+  };
+
+  const tld = computed(() => report.value?.tld ?? "test");
+  return computed(() => buildSiteCommands(sites.value, tld.value, handlers));
+}

--- a/apps/yerd-gui/src/lib/shortcuts/useSiteCommands.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useSiteCommands.ts
@@ -68,6 +68,7 @@ export function useSiteCommands(paletteOpen: Ref<boolean>): Ref<Command[]> {
   const sites = ref<Site[]>([]);
 
   async function load(): Promise<void> {
+    sites.value = [];
     try {
       sites.value = await listSites();
     } catch {

--- a/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
@@ -28,4 +28,12 @@ describe("registerViewActions", () => {
     getViewActions().find?.();
     expect(bFind).toHaveBeenCalledOnce();
   });
+
+  it("a reused actions object is not wiped by a stale disposer", () => {
+    const shared = { find: vi.fn() };
+    const disposeA = registerViewActions(shared);
+    registerViewActions(shared); // same object, new active registration
+    disposeA();
+    expect(getViewActions().find).toBe(shared.find);
+  });
 });

--- a/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getViewActions, registerViewActions } from "./useViewActions";
 
 afterEach(() => {
-  // Leave the module-level registry empty between tests.
   registerViewActions({})();
 });
 
@@ -25,7 +24,7 @@ describe("registerViewActions", () => {
     const disposeA = registerViewActions({ find: vi.fn() });
     const bFind = vi.fn();
     registerViewActions({ find: bFind });
-    disposeA(); // A unmounts after B mounted - must be a no-op
+    disposeA();
     getViewActions().find?.();
     expect(bFind).toHaveBeenCalledOnce();
   });

--- a/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getViewActions, registerViewActions } from "./useViewActions";
+
+afterEach(() => {
+  // Leave the module-level registry empty between tests.
+  registerViewActions({})();
+});
+
+describe("registerViewActions", () => {
+  it("exposes the latest registration", () => {
+    const refresh = vi.fn();
+    registerViewActions({ refresh });
+    getViewActions().refresh?.();
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("disposer clears the handlers it registered", () => {
+    const dispose = registerViewActions({ refresh: vi.fn() });
+    dispose();
+    expect(getViewActions().refresh).toBeUndefined();
+  });
+
+  it("a stale disposer does not wipe a newer view's registration", () => {
+    const disposeA = registerViewActions({ find: vi.fn() });
+    const bFind = vi.fn();
+    registerViewActions({ find: bFind });
+    disposeA(); // A unmounts after B mounted - must be a no-op
+    getViewActions().find?.();
+    expect(bFind).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useViewActions.test.ts
@@ -32,7 +32,7 @@ describe("registerViewActions", () => {
   it("a reused actions object is not wiped by a stale disposer", () => {
     const shared = { find: vi.fn() };
     const disposeA = registerViewActions(shared);
-    registerViewActions(shared); // same object, new active registration
+    registerViewActions(shared);
     disposeA();
     expect(getViewActions().find).toBe(shared.find);
   });

--- a/apps/yerd-gui/src/lib/shortcuts/useViewActions.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useViewActions.ts
@@ -1,0 +1,41 @@
+/**
+ * Per-view contextual handlers for the shortcuts whose target depends on the
+ * active view: Find (⌘F), New (⌘N), Refresh (⌘R), and the dumps-window tab
+ * cycle. A view registers its handlers on mount and the returned disposer clears
+ * them on unmount; the dispatcher reads the live set when a chord fires.
+ *
+ * `register` returns a disposer that only clears if its own handlers are still
+ * the current ones, so a route change (new view mounts before the old unmounts)
+ * never wipes the incoming view's registration.
+ */
+import { shallowRef } from "vue";
+
+export interface ViewActions {
+  /** Focus this view's text-search field (⌘F). */
+  find?: () => void;
+  /** Trigger this view's primary create/add action (⌘N). */
+  create?: () => void;
+  /** Refetch this view's data (⌘R). */
+  refresh?: () => void;
+  /** Dumps window: select the previous category tab. */
+  prevTab?: () => void;
+  /** Dumps window: select the next category tab. */
+  nextTab?: () => void;
+}
+
+// shallowRef, not ref: a deep reactive proxy would break the identity check in
+// the disposer (current.value would be a proxy, never === the raw `actions`).
+const current = shallowRef<ViewActions>({});
+
+/** Register the active view's contextual handlers; returns a disposer. */
+export function registerViewActions(actions: ViewActions): () => void {
+  current.value = actions;
+  return () => {
+    if (current.value === actions) current.value = {};
+  };
+}
+
+/** The contextual handlers for the currently mounted view. */
+export function getViewActions(): ViewActions {
+  return current.value;
+}

--- a/apps/yerd-gui/src/lib/shortcuts/useViewActions.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useViewActions.ts
@@ -1,8 +1,9 @@
 /**
  * Per-view contextual handlers for the shortcuts whose target depends on the
  * active view: Find (⌘F), New (⌘N), Refresh (⌘R), and the dumps-window tab
- * cycle. A view registers its handlers on mount and the returned disposer clears
- * them on unmount; the dispatcher reads the live set when a chord fires.
+ * cycle. A view registers its handlers during setup and clears them via the
+ * returned disposer on unmount; the dispatcher reads the live set when a chord
+ * fires.
  *
  * `register` returns a disposer that clears state only if its registration is
  * still the active one (tracked by a per-call token), so a stale disposer from
@@ -40,7 +41,7 @@ export function registerViewActions(actions: ViewActions): () => void {
   };
 }
 
-/** The contextual handlers for the currently mounted view. */
+/** The contextual handlers for the active view. */
 export function getViewActions(): ViewActions {
   return current.value;
 }

--- a/apps/yerd-gui/src/lib/shortcuts/useViewActions.ts
+++ b/apps/yerd-gui/src/lib/shortcuts/useViewActions.ts
@@ -4,9 +4,9 @@
  * cycle. A view registers its handlers on mount and the returned disposer clears
  * them on unmount; the dispatcher reads the live set when a chord fires.
  *
- * `register` returns a disposer that only clears if its own handlers are still
- * the current ones, so a route change (new view mounts before the old unmounts)
- * never wipes the incoming view's registration.
+ * `register` returns a disposer that clears state only if its registration is
+ * still the active one (tracked by a per-call token), so a stale disposer from
+ * an unmounting view can't wipe a newer view's registration.
  */
 import { shallowRef } from "vue";
 
@@ -23,15 +23,20 @@ export interface ViewActions {
   nextTab?: () => void;
 }
 
-// shallowRef, not ref: a deep reactive proxy would break the identity check in
-// the disposer (current.value would be a proxy, never === the raw `actions`).
+// shallowRef: the handlers are invoked imperatively by the dispatcher, never
+// rendered, so deep reactivity would be wasted work.
 const current = shallowRef<ViewActions>({});
+// Monotonic registration id: a disposer clears state only while its own
+// registration is still the active one, so a stale disposer can't wipe a newer
+// view's registration even when the same actions object is reused.
+let activeToken = 0;
 
 /** Register the active view's contextual handlers; returns a disposer. */
 export function registerViewActions(actions: ViewActions): () => void {
+  const token = ++activeToken;
   current.value = actions;
   return () => {
-    if (current.value === actions) current.value = {};
+    if (token === activeToken) current.value = {};
   };
 }
 

--- a/apps/yerd-gui/src/views/DoctorView.vue
+++ b/apps/yerd-gui/src/views/DoctorView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { CheckCircle2, Copy, Info, Play, RefreshCw, RotateCw, Square, Wrench } from "lucide-vue-next";
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 
 import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import EnvironmentCard from "@/components/EnvironmentCard.vue";
@@ -21,6 +21,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useDaemonStart } from "@/composables/useDaemonStart";
 import { useToast } from "@/composables/useToast";
@@ -157,6 +158,7 @@ async function copyRemedy(text: string): Promise<void> {
 }
 
 onMounted(() => void loadDiagnoses());
+onUnmounted(registerViewActions({ refresh: () => void loadDiagnoses() }));
 </script>
 
 <template>

--- a/apps/yerd-gui/src/views/DumpsWindowView.vue
+++ b/apps/yerd-gui/src/views/DumpsWindowView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Antenna, Layers, Pin, PinOff, Search, Trash2 } from "lucide-vue-next";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import TitleBar from "@/components/TitleBar.vue";
 import Input from "@/components/ui/Input.vue";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useToast } from "@/composables/useToast";
 import { usePoll } from "@/composables/usePoll";
 import {
@@ -36,6 +37,7 @@ const persist = ref(false);
 const alwaysOnTop = ref(false);
 const activeTab = ref<DumpCategory | "all">("all");
 const search = ref("");
+const searchInput = ref<InstanceType<typeof Input> | null>(null);
 let cursor = 0;
 
 const TABS: { key: DumpCategory | "all"; label: string; countKey?: keyof DumpCounts }[] = [
@@ -335,6 +337,21 @@ onMounted(async () => {
   }
   await refresh();
 });
+
+function cycleTab(delta: number): void {
+  const i = TABS.findIndex((t) => t.key === activeTab.value);
+  const next = TABS[(i + delta + TABS.length) % TABS.length];
+  if (next) activeTab.value = next.key;
+}
+
+onUnmounted(
+  registerViewActions({
+    find: () => searchInput.value?.focus(),
+    refresh: () => void refresh(),
+    prevTab: () => cycleTab(-1),
+    nextTab: () => cycleTab(1),
+  }),
+);
 </script>
 
 <template>
@@ -396,7 +413,12 @@ onMounted(async () => {
           <Search
             class="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
           />
-          <Input v-model="search" placeholder="Filter…" class="pl-8" />
+          <Input
+            ref="searchInput"
+            v-model="search"
+            placeholder="Filter…"
+            class="pl-8"
+          />
         </div>
       </div>
 

--- a/apps/yerd-gui/src/views/LaravelDumpsView.vue
+++ b/apps/yerd-gui/src/views/LaravelDumpsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ExternalLink } from "lucide-vue-next";
-import { computed } from "vue";
+import { computed, onUnmounted } from "vue";
 
 import PageHeader from "@/components/PageHeader.vue";
 import StatusPill from "@/components/StatusPill.vue";
@@ -12,6 +12,7 @@ import CardDescription from "@/components/ui/CardDescription.vue";
 import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
 import Switch from "@/components/ui/Switch.vue";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { usePoll } from "@/composables/usePoll";
 import { useToast } from "@/composables/useToast";
 import {
@@ -25,6 +26,8 @@ import type { DumpsStatusResponse } from "@/ipc/types";
 
 const toast = useToast();
 const { data: status, refresh } = usePoll<DumpsStatusResponse>(dumpsStatus, 2500);
+
+onUnmounted(registerViewActions({ refresh: () => void refresh() }));
 
 const FEATURES: { key: string; label: string }[] = [
   { key: "dumps", label: "Dumps (dump / dd)" },

--- a/apps/yerd-gui/src/views/MailView.vue
+++ b/apps/yerd-gui/src/views/MailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Copy } from "lucide-vue-next";
-import { computed, ref, watch } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 
 import PageHeader from "@/components/PageHeader.vue";
 import StatusPill from "@/components/StatusPill.vue";
@@ -13,6 +13,7 @@ import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
 import Input from "@/components/ui/Input.vue";
 import Switch from "@/components/ui/Switch.vue";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import { IpcError, openInBrowser, setMailEnabled, showMailsWindow } from "@/ipc/client";
@@ -24,6 +25,8 @@ const { report, refresh } = useDaemon();
 
 // Live mail status comes from the shared 4s status poll (no extra loop).
 const mail = computed(() => report.value?.mail ?? null);
+
+onUnmounted(registerViewActions({ refresh: () => void refresh() }));
 
 // Local editable copy of the enable toggle, seeded from the live status. The
 // mail *port* is now edited centrally on the Settings ▸ Application Ports page.

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { Inbox, Trash2 } from "lucide-vue-next";
-import { computed, ref, watch } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
 import Modal from "@/components/ui/Modal.vue";
 import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { usePoll } from "@/composables/usePoll";
 import { useToast } from "@/composables/useToast";
 import { clearMails, deleteMails, getMail, IpcError, listMails } from "@/ipc/client";
@@ -24,6 +25,8 @@ const toast = useToast();
 
 // Live list of captured mail (newest first).
 const { data: mails, refresh } = usePoll<MailSummary[]>(listMails, 4000);
+
+onUnmounted(registerViewActions({ refresh: () => void refresh() }));
 
 const selectedId = ref<string | null>(null);
 const detail = ref<MailDetail | null>(null);

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -13,7 +13,7 @@ import {
   SquareCode,
 } from "lucide-vue-next";
 import type { Component } from "vue";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 
 import DaemonDownHero from "@/components/DaemonDownHero.vue";
@@ -22,6 +22,7 @@ import StatusPill, { type Tone } from "@/components/StatusPill.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import Spinner from "@/components/ui/Spinner.vue";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useOnboarding } from "@/composables/useOnboarding";
 import { daemonVersionConflict, listSites, openInBrowser } from "@/ipc/client";
@@ -73,6 +74,14 @@ watch(running, (up) => {
     sitesLoaded.value = false;
   }
 });
+
+onUnmounted(
+  registerViewActions({
+    refresh: () => {
+      if (running.value) loadSites();
+    },
+  }),
+);
 
 // Once the real list is in, drive every count from it so the headline and the
 // chips never disagree; fall back to the report's counts until then.

--- a/apps/yerd-gui/src/views/PhpView.vue
+++ b/apps/yerd-gui/src/views/PhpView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import {
   Download,
   Info,
@@ -36,6 +36,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import {
@@ -345,6 +346,13 @@ async function confirmInstall(close: () => void): Promise<void> {
 }
 
 onMounted(load);
+
+onUnmounted(
+  registerViewActions({
+    create: () => void openInstall(),
+    refresh: () => void load(),
+  }),
+);
 </script>
 
 <template>

--- a/apps/yerd-gui/src/views/ServicesView.vue
+++ b/apps/yerd-gui/src/views/ServicesView.vue
@@ -35,6 +35,7 @@ import Input from "@/components/ui/Input.vue";
 import Modal from "@/components/ui/Modal.vue";
 import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import {
@@ -489,6 +490,7 @@ async function copyConfig(): Promise<void> {
 
 onMounted(load);
 onUnmounted(stopLogPolling);
+onUnmounted(registerViewActions({ refresh: () => void load() }));
 </script>
 
 <template>

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import {
   ChevronDown,
   ExternalLink,
@@ -41,6 +41,7 @@ import Spinner from "@/components/ui/Spinner.vue";
 import Switch from "@/components/ui/Switch.vue";
 import { openTitle, siteUrl } from "@/lib/siteUrl";
 import { registerViewActions } from "@/lib/shortcuts/useViewActions";
+import { sitesIntent } from "@/lib/shortcuts/sitesIntent";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import {
@@ -307,6 +308,17 @@ onUnmounted(
     refresh: () => void load(),
   }),
 );
+
+function consumeIntent(): void {
+  const intent = sitesIntent.value;
+  if (!intent) return;
+  sitesIntent.value = null;
+  if (intent === "link") linkOpen.value = true;
+  else void onPark();
+}
+
+onMounted(consumeIntent);
+watch(sitesIntent, consumeIntent);
 </script>
 
 <template>

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import {
   ChevronDown,
   ExternalLink,
@@ -40,6 +40,7 @@ import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import Switch from "@/components/ui/Switch.vue";
 import { openTitle, siteUrl } from "@/lib/siteUrl";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import {
@@ -68,6 +69,7 @@ const loading = ref(true);
 const error = ref<string | null>(null);
 const rowBusy = ref<string | null>(null);
 const siteFilter = ref("");
+const filterInput = ref<InstanceType<typeof Input> | null>(null);
 
 const tld = computed(() => report.value?.tld ?? "test");
 const caTrusted = computed(() => report.value?.ca.trusted_system === true);
@@ -297,6 +299,14 @@ async function confirmUnlink(close: () => void): Promise<void> {
 }
 
 onMounted(load);
+
+onUnmounted(
+  registerViewActions({
+    create: openCreate,
+    find: () => filterInput.value?.focus(),
+    refresh: () => void load(),
+  }),
+);
 </script>
 
 <template>
@@ -381,6 +391,7 @@ onMounted(load);
               class="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
             />
             <Input
+              ref="filterInput"
               v-model="siteFilter"
               placeholder="Filter by domain…"
               aria-label="Filter sites by domain"

--- a/apps/yerd-gui/src/views/ToolingView.vue
+++ b/apps/yerd-gui/src/views/ToolingView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import { Download, RefreshCw, Trash2 } from "lucide-vue-next";
 
 import PageHeader from "@/components/PageHeader.vue";
@@ -12,6 +12,7 @@ import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
 import Modal from "@/components/ui/Modal.vue";
 import Spinner from "@/components/ui/Spinner.vue";
+import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
 import {
@@ -129,6 +130,7 @@ async function confirmUninstall(close: () => void): Promise<void> {
 }
 
 onMounted(load);
+onUnmounted(registerViewActions({ refresh: () => void load() }));
 </script>
 
 <template>

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -149,6 +149,8 @@ Shows the app, daemon, and negotiated IPC protocol versions, plus your local env
 
 The window is fully keyboard-driven. Shortcuts follow each platform's convention: where macOS uses **Cmd** (`⌘`), Linux uses **Ctrl** with the same letter. Two of them are all you need to remember - the **command palette** (`⌘K` / `Ctrl+K`) jumps to any page or runs any action by typing, and the **shortcuts** overlay (`⌘/` / `Ctrl+/`) lists everything below in the app itself.
 
+The command palette also lists your sites at the bottom (grouped by domain): **Open** a site in the browser, or **Secure / Unsecure** it (toggle HTTPS), without leaving the keyboard.
+
 | Action | macOS | Linux | What it does |
 |---|---|---|---|
 | Command palette | `⌘K` | `Ctrl+K` | Search-and-run overlay for every page and action |
@@ -162,6 +164,8 @@ The window is fully keyboard-driven. Shortcuts follow each platform's convention
 | Toggle theme | `⇧⌘L` | `Ctrl+Shift+L` | Switch light / dark (applies to every window) |
 | Open Mail viewer | `⇧⌘M` | `Ctrl+Shift+M` | Open the standalone Mail capture window |
 | Open Dumps viewer | `⇧⌘D` | `Ctrl+Shift+D` | Open the standalone Dumps telemetry window |
+| Link Site | `⇧⌘N` | `Ctrl+Shift+N` | Open the Link-site dialog on the Sites page |
+| Park Folder | `⇧⌘P` | `Ctrl+Shift+P` | Open the park-folder picker on the Sites page |
 | Cycle Dumps tabs | `⌃⇥` / `⌃⇧⇥` | `Ctrl+Tab` / `Ctrl+Shift+Tab` | Move between categories in the Dumps viewer |
 | Close window | `⌘W` | `Ctrl+W` | Hide the window to the tray |
 | Close dialog | `Esc` | `Esc` | Dismiss the open modal |

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -160,6 +160,8 @@ The window is fully keyboard-driven. Shortcuts follow each platform's convention
 | Refresh | `⌘R` | `Ctrl+R` | Re-fetch the current page's data |
 | Restart daemon | `⇧⌘R` | `Ctrl+Shift+R` | Restart `yerdd` |
 | Toggle theme | `⇧⌘L` | `Ctrl+Shift+L` | Switch light / dark (applies to every window) |
+| Open Mail viewer | `⇧⌘M` | `Ctrl+Shift+M` | Open the standalone Mail capture window |
+| Open Dumps viewer | `⇧⌘D` | `Ctrl+Shift+D` | Open the standalone Dumps telemetry window |
 | Cycle Dumps tabs | `⌃⇥` / `⌃⇧⇥` | `Ctrl+Tab` / `Ctrl+Shift+Tab` | Move between categories in the Dumps viewer |
 | Close window | `⌘W` | `Ctrl+W` | Hide the window to the tray |
 | Close dialog | `Esc` | `Esc` | Dismiss the open modal |

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -145,6 +145,31 @@ The Fix buttons run the audited `yerd elevate` helper under an OS prompt; the GU
 
 Shows the app, daemon, and negotiated IPC protocol versions, plus your local environment: the TLD (`.test`), the DNS responder address, and the local CA certificate path and fingerprint (both copyable, with reveal-in-finder). It also links to the project repository.
 
+## Keyboard shortcuts
+
+The window is fully keyboard-driven. Shortcuts follow each platform's convention: where macOS uses **Cmd** (`⌘`), Linux uses **Ctrl** with the same letter. Two of them are all you need to remember - the **command palette** (`⌘K` / `Ctrl+K`) jumps to any page or runs any action by typing, and the **shortcuts** overlay (`⌘/` / `Ctrl+/`) lists everything below in the app itself.
+
+| Action | macOS | Linux | What it does |
+|---|---|---|---|
+| Command palette | `⌘K` | `Ctrl+K` | Search-and-run overlay for every page and action |
+| Shortcuts | `⌘/` | `Ctrl+/` | Show this list inside the app |
+| Go to a page | `⌘1` … `⌘9` | `Ctrl+1` … `Ctrl+9` | Jump straight to a sidebar page (see order below) |
+| Settings | `⌘,` | `Ctrl+,` | Open the Settings page |
+| Find | `⌘F` | `Ctrl+F` | Focus the page's filter box (Sites, Dumps) |
+| New | `⌘N` | `Ctrl+N` | Start the page's primary action (Add site, Install PHP) |
+| Refresh | `⌘R` | `Ctrl+R` | Re-fetch the current page's data |
+| Restart daemon | `⇧⌘R` | `Ctrl+Shift+R` | Restart `yerdd` |
+| Toggle theme | `⇧⌘L` | `Ctrl+Shift+L` | Switch light / dark (applies to every window) |
+| Cycle Dumps tabs | `⌃⇥` / `⌃⇧⇥` | `Ctrl+Tab` / `Ctrl+Shift+Tab` | Move between categories in the Dumps viewer |
+| Close window | `⌘W` | `Ctrl+W` | Hide the window to the tray |
+| Close dialog | `Esc` | `Esc` | Dismiss the open modal |
+
+`⌘1`…`⌘9` follow the sidebar order: **1** Overview, **2** PHP, **3** Sites, **4** Tooling, **5** Services, **6** Mail, **7** Dumps, **8** Settings, **9** Doctor.
+
+::: info Quitting the app
+There's no Quit shortcut: closing the window (`⌘W` / `Ctrl+W`) hides it to the tray and leaves the daemon running, by design. Quit from the tray menu, or on macOS with the standard `⌘Q`.
+:::
+
 ## How it fits together
 
 ```mermaid


### PR DESCRIPTION
## What does this PR do?

Adds a platform-aware keyboard-shortcut layer to the GUI. A single capture-phase dispatcher per window resolves chords from one command registry - the same source of truth that feeds a new **command palette** (⌘K) and a **shortcuts cheat-sheet** (⌘/). Conventions follow the macOS HIG and GNOME HIG: `⌘` on macOS maps to `Ctrl` on Linux (same letter), `⇧⌘` for reverse/extended actions, and modals still close on `Esc`.

Pure logic (chord matching, formatting, the registry) is dependency-injected and unit-tested; side effects (router, theme, daemon IPC, Tauri window) live at the edge in the dispatcher.

## New shortcuts

| Action | macOS | Linux | What it does |
|---|---|---|---|
| Command palette | `⌘K` | `Ctrl+K` | Search-and-run overlay for any page or action |
| Keyboard shortcuts | `⌘/` | `Ctrl+/` | Toggle this cheat-sheet open/closed |
| Go to a page (1–9) | `⌘1`…`⌘9` | `Ctrl+1`…`Ctrl+9` | Jump to a sidebar page (1 Overview, 2 PHP, 3 Sites, 4 Tooling, 5 Services, 6 Mail, 7 Dumps, 8 Settings, 9 Doctor) |
| Settings | `⌘,` | `Ctrl+,` | Open the Settings page |
| Find | `⌘F` | `Ctrl+F` | Focus the page's filter box (Sites, Dumps) |
| New / Add | `⌘N` | `Ctrl+N` | Primary create action (Add site, Install PHP) |
| Refresh | `⌘R` | `Ctrl+R` | Re-fetch the current page's data |
| Restart daemon | `⇧⌘R` | `Ctrl+Shift+R` | Restart `yerdd` |
| Toggle theme | `⇧⌘L` | `Ctrl+Shift+L` | Switch light / dark (all windows) |
| Open Mail viewer | `⇧⌘M` | `Ctrl+Shift+M` | Open the standalone Mail capture window |
| Open Dumps viewer | `⇧⌘D` | `Ctrl+Shift+D` | Open the standalone Dumps telemetry window |
| Cycle Dumps tabs | `⌃⇥` / `⌃⇧⇥` | `Ctrl+Tab` / `Ctrl+Shift+Tab` | Move between categories in the Dumps viewer |
| Minimise window | `⌘M` | — | Minimise to the Dock (Linux: titlebar button) |
| Close window | `⌘W` | `Ctrl+W` | Hide the window to the tray |
| Quit Yerd | `⌘Q` | — | Quit the app (Linux: tray menu) |
| Close dialog | `Esc` | `Esc` | Dismiss the open modal/overlay |

`⌘F`/`⌘N` are wired only on views with an unambiguous primary action and no-op elsewhere. The standalone Dumps and Mails windows get a reduced set (theme, find, refresh, close, tab-cycle) with navigation/palette correctly scoped out.

## Related issues

Closes #26

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a command palette with keyboard search and execution, plus a keyboard shortcuts cheat sheet.
  * Enabled window- and view-aware shortcut actions (including find/refresh, Dumps tab cycling, and Sites open/secure actions).
  * Extended macOS behavior to support proper minimize handling, and improved modal close controls.
* **Bug Fixes**
  * Prevent shortcuts from triggering while typing in text fields; improved chord matching and keyboard navigation.
* **Documentation**
  * Expanded the desktop app guide with a full keyboard shortcuts reference.
* **Other**
  * Disabled macOS text assistance on form inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->