### PR TITLE
[Fix] Resolve libcurl issue with resolving .test locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
+
+[[package]]
 name = "ctor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +897,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1509,8 +1526,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1785,6 +1804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2348,6 +2385,18 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26541387415a1e829df5d532aad019fb11bc723e2b5bc99edefa4cf5bfad0de7"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.2.17",
+ "rpassword",
+ "scrypt",
+]
 
 [[package]]
 name = "minisign-verify"
@@ -2886,6 +2935,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pem"
@@ -3455,6 +3514,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,6 +3716,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "security-framework"
@@ -6261,6 +6361,7 @@ dependencies = [
  "fs4",
  "hex",
  "interprocess",
+ "minisign",
  "nix",
  "notify-debouncer-mini",
  "reqwest 0.12.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_test  = "1"
 toml        = "0.8"
 semver      = "1"
 minisign-verify = "0.2"
+minisign    = "0.7"
 tokio       = { version = "1", default-features = false, features = ["io-util"] }
 tempfile    = "=3.10.1"
 rcgen            = { version = "=0.13.2", default-features = false, features = ["pem", "crypto", "ring", "x509-parser"] }

--- a/bin/yerdd/Cargo.toml
+++ b/bin/yerdd/Cargo.toml
@@ -76,6 +76,7 @@ nix            = { workspace = true, features = ["user"] }
 [dev-dependencies]
 tempfile       = { workspace = true }
 serde_json     = { workspace = true }
+minisign       = { workspace = true }
 tokio          = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util", "sync", "time"] }
 
 [lints]

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -13,7 +13,6 @@ use yerd_ipc::{
     read_message, write_message, ErrorCode, FrameDecoder, IpcError, Request, Response,
     DEFAULT_MAX_FRAME,
 };
-use yerd_php::Downloader; // brings the `download` method into scope for `update_php`
 
 use crate::error::DaemonError;
 use crate::state::DaemonState;
@@ -136,7 +135,8 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         Request::SetDefaultPhp { version } => set_default_php(version, state).await,
         Request::CheckPhpUpdates => {
             let dl = crate::php_install::ReqwestDownloader::new();
-            crate::php_updates::poll_and_refresh(state, &dl).await;
+            crate::php_updates::poll_and_refresh(state, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY)
+                .await;
             php_versions_response(state).await
         }
         Request::UpdatePhp { version } => update_php(version, state).await,
@@ -329,12 +329,16 @@ async fn php_versions_response(state: &DaemonState) -> Response {
 /// (an empty parse result is a valid empty list).
 async fn available_php_response(state: &DaemonState) -> Response {
     let dl = crate::php_install::ReqwestDownloader::new();
-    available_php_with(state, &dl).await
+    available_php_with(state, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY).await
 }
 
 /// Injectable core of [`available_php_response`] (the downloader is a parameter
 /// so tests can feed a fixture listing without touching the network).
-async fn available_php_with(state: &DaemonState, dl: &dyn yerd_php::Downloader) -> Response {
+async fn available_php_with(
+    state: &DaemonState,
+    dl: &dyn yerd_php::Downloader,
+    public_key: &str,
+) -> Response {
     let (os, arch) = match yerd_php::current_os_arch() {
         Ok(p) => p,
         Err(e) => {
@@ -344,9 +348,9 @@ async fn available_php_with(state: &DaemonState, dl: &dyn yerd_php::Downloader) 
             }
         }
     };
-    let listing = match dl.download(&yerd_php::listing_url(os)).await {
-        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
-        Err(e) => return internal(format!("couldn't reach the PHP distribution: {e}")),
+    let listing = match crate::php_install::fetch_verified_listing(dl, public_key).await {
+        Ok(body) => body,
+        Err(e) => return internal(format!("couldn't reach the PHP listing: {e}")),
     };
     Response::AvailablePhp {
         available: yerd_php::available_minors(&listing, os, arch),
@@ -672,20 +676,37 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
         }
         None => crate::php_updates::installed_minors(state),
     };
-    let listing = match dl.download(&yerd_php::listing_url(os)).await {
-        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
-        Err(e) => return internal(format!("listing fetch failed: {e}")),
-    };
+    let listing =
+        match crate::php_install::fetch_verified_listing(&dl, yerd_update::PHP_LISTING_PUBLIC_KEY)
+            .await
+        {
+            Ok(body) => body,
+            Err(e) => return internal(format!("listing fetch/verify failed: {e}")),
+        };
     let _guard = state.php_mutate.lock().await;
     for minor in targets {
         let Some(installed) = crate::php_install::installed_patch(&state.dirs, minor) else {
             continue;
         };
+        let installed_rev = crate::php_install::installed_revision(&state.dirs, minor);
         let Ok(artifact) = yerd_php::resolve_from_listing(&listing, minor, os, arch) else {
             continue;
         };
-        if yerd_php::is_newer(&installed, &artifact.full_version) {
-            if let Err(e) = crate::php_install::install(minor, &state.dirs, &dl, None).await {
+        if yerd_php::is_newer_build(
+            &installed,
+            installed_rev,
+            &artifact.full_version,
+            artifact.revision,
+        ) {
+            if let Err(e) = crate::php_install::install(
+                minor,
+                &state.dirs,
+                &dl,
+                yerd_update::PHP_LISTING_PUBLIC_KEY,
+                None,
+            )
+            .await
+            {
                 tracing::error!(version = %minor, error = %e, "PHP update failed");
                 return Response::Error {
                     code: php_error_code(&e),
@@ -695,7 +716,7 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
             tracing::info!(version = %minor, from = %installed, to = %artifact.full_version, "updated PHP");
         }
     }
-    crate::php_updates::poll_and_refresh(state, &dl).await;
+    crate::php_updates::poll_and_refresh(state, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY).await;
     php_versions_response(state).await
 }
 
@@ -711,7 +732,15 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
 async fn install_php(version: yerd_core::PhpVersion, state: &DaemonState) -> Response {
     let dl = crate::php_install::ReqwestDownloader::new();
     let _guard = state.php_mutate.lock().await;
-    match crate::php_install::install(version, &state.dirs, &dl, None).await {
+    match crate::php_install::install(
+        version,
+        &state.dirs,
+        &dl,
+        yerd_update::PHP_LISTING_PUBLIC_KEY,
+        None,
+    )
+    .await
+    {
         Ok(()) => {
             finalize_php_install(version, state).await;
             Response::Ok
@@ -790,7 +819,7 @@ pub(crate) async fn install_php_streamed(
             }
         };
         let result = tokio::select! {
-            r = crate::php_install::install(version, &state.dirs, &dl, Some(&tx)) => Some(r),
+            r = crate::php_install::install(version, &state.dirs, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY, Some(&tx)) => Some(r),
             _ = cancel.changed() => None,
         };
 
@@ -2610,35 +2639,58 @@ Subject: Captured\r\n\r\nhi\r\n";
     async fn dispatch_list_php_surfaces_cached_update() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
-        fake_install_patch(&state.dirs, PhpVersion::new(8, 5), "8.5.6");
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
         state
             .php_updates
             .write()
             .await
-            .insert(PhpVersion::new(8, 5), "8.5.7".to_owned());
+            .insert(PhpVersion::new(8, 5), ("8.5.7".to_owned(), 1));
 
         match dispatch(Request::ListPhp, &state).await {
             Response::PhpVersions { updates, .. } => {
                 assert_eq!(updates.len(), 1);
                 assert_eq!(updates[0].version, PhpVersion::new(8, 5));
-                assert_eq!(updates[0].installed, "8.5.6");
-                assert_eq!(updates[0].latest, "8.5.7");
+                assert_eq!(updates[0].installed, "8.5.6-1");
+                assert_eq!(updates[0].latest, "8.5.7-1");
             }
             other => panic!("expected PhpVersions, got {other:?}"),
         }
     }
 
-    /// No cache entry (or not-newer) → no update annotation.
+    /// A legacy install (no `.yerd-revision`, so revision 0) is offered the
+    /// c-ares-cutover rebuild of the *same* patch - the auto-heal contract.
     #[tokio::test]
-    async fn dispatch_list_php_no_update_when_cache_not_newer() {
+    async fn dispatch_list_php_surfaces_revision_autoheal() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
-        fake_install_patch(&state.dirs, PhpVersion::new(8, 5), "8.5.6");
+        fake_install_patch(&state.dirs, PhpVersion::new(8, 5), "8.5.7");
         state
             .php_updates
             .write()
             .await
-            .insert(PhpVersion::new(8, 5), "8.5.6".to_owned());
+            .insert(PhpVersion::new(8, 5), ("8.5.7".to_owned(), 1));
+
+        match dispatch(Request::ListPhp, &state).await {
+            Response::PhpVersions { updates, .. } => {
+                assert_eq!(updates.len(), 1);
+                assert_eq!(updates[0].installed, "8.5.7");
+                assert_eq!(updates[0].latest, "8.5.7-1");
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+    }
+
+    /// Same build (patch + revision) → no update annotation.
+    #[tokio::test]
+    async fn dispatch_list_php_no_update_when_cache_not_newer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
+        state
+            .php_updates
+            .write()
+            .await
+            .insert(PhpVersion::new(8, 5), ("8.5.6".to_owned(), 1));
 
         match dispatch(Request::ListPhp, &state).await {
             Response::PhpVersions { updates, .. } => assert!(updates.is_empty()),
@@ -2663,14 +2715,28 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
     }
 
-    /// Fake downloader: directory URL (ends `/`) → the given listing; anything
-    /// else errors (the poll only fetches the listing).
-    struct ListingDl(String);
+    /// Fake downloader for the listing path: serves a signed `php.json` +
+    /// `php.json.minisig`; anything else errors (the poll/available paths only
+    /// fetch the manifest, not tarballs).
+    struct ListingDl {
+        manifest: String,
+        minisig: String,
+    }
+    impl ListingDl {
+        fn new(signed: &crate::test_support::SignedManifest) -> Self {
+            Self {
+                manifest: signed.manifest.clone(),
+                minisig: signed.minisig.clone(),
+            }
+        }
+    }
     #[async_trait::async_trait]
     impl yerd_php::Downloader for ListingDl {
         async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
-            if url.ends_with('/') {
-                Ok(self.0.clone().into_bytes())
+            if url.ends_with(".minisig") {
+                Ok(self.minisig.clone().into_bytes())
+            } else if url.ends_with("php.json") {
+                Ok(self.manifest.clone().into_bytes())
             } else {
                 Err(yerd_php::DownloadError::Transport {
                     url: url.to_owned(),
@@ -2678,6 +2744,37 @@ Subject: Captured\r\n\r\nhi\r\n";
                 })
             }
         }
+    }
+
+    /// Build + sign a `php.json` with the given `(php, minor, revision)` builds
+    /// for the host platform. Tarball shas are placeholders (`"00"`) - the poll /
+    /// available paths never download tarballs.
+    fn signed_listing(builds: &[(&str, &str, u32)]) -> crate::test_support::SignedManifest {
+        let (os, arch) = yerd_php::current_os_arch().unwrap();
+        let entries: Vec<String> = builds
+            .iter()
+            .map(|(php, minor, rev)| {
+                format!(
+                    r#"{{ "php": "{php}", "minor": "{minor}", "os": "{os}", "arch": "{arch}", "revision": {rev},
+                       "cli": {{ "file": "php-{php}-{rev}-cli-{os}-{arch}.tar.gz", "sha256": "00", "size": 1 }},
+                       "fpm": {{ "file": "php-{php}-{rev}-fpm-{os}-{arch}.tar.gz", "sha256": "00", "size": 1 }} }}"#,
+                    os = os.as_str(),
+                    arch = arch.as_str(),
+                )
+            })
+            .collect();
+        let manifest = format!("{{ \"schema\": 1, \"builds\": [{}] }}", entries.join(","));
+        crate::test_support::sign_manifest(&manifest)
+    }
+
+    /// Like `fake_install_patch` but also writes the `.yerd-revision` marker.
+    fn fake_install_build(dirs: &PlatformDirs, v: PhpVersion, full: &str, revision: u32) {
+        fake_install_patch(dirs, v, full);
+        let base = dirs
+            .data
+            .join("php")
+            .join(format!("php-{}.{}", v.major, v.minor));
+        std::fs::write(base.join(".yerd-revision"), revision.to_string()).unwrap();
     }
 
     struct FailingDl;
@@ -2695,11 +2792,11 @@ Subject: Captured\r\n\r\nhi\r\n";
     async fn poll_and_refresh_populates_cache_from_listing() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
-        fake_install_patch(&state.dirs, PhpVersion::new(8, 5), "8.5.6");
-        let (os, arch) = yerd_php::current_os_arch().unwrap();
-        let listing = format!("php-8.5.9-cli-{}-{}.tar.gz", os.as_str(), arch.as_str());
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
+        let signed = signed_listing(&[("8.5.9", "8.5", 1)]);
 
-        crate::php_updates::poll_and_refresh(&state, &ListingDl(listing)).await;
+        crate::php_updates::poll_and_refresh(&state, &ListingDl::new(&signed), &signed.public_key)
+            .await;
 
         assert_eq!(
             state
@@ -2707,8 +2804,8 @@ Subject: Captured\r\n\r\nhi\r\n";
                 .read()
                 .await
                 .get(&PhpVersion::new(8, 5))
-                .map(String::as_str),
-            Some("8.5.9")
+                .cloned(),
+            Some(("8.5.9".to_owned(), 1))
         );
     }
 
@@ -2716,14 +2813,19 @@ Subject: Captured\r\n\r\nhi\r\n";
     async fn poll_and_refresh_is_failure_tolerant() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
-        fake_install_patch(&state.dirs, PhpVersion::new(8, 5), "8.5.6");
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
         state
             .php_updates
             .write()
             .await
-            .insert(PhpVersion::new(8, 5), "8.5.6".to_owned());
+            .insert(PhpVersion::new(8, 5), ("8.5.6".to_owned(), 1));
 
-        crate::php_updates::poll_and_refresh(&state, &FailingDl).await;
+        crate::php_updates::poll_and_refresh(
+            &state,
+            &FailingDl,
+            yerd_update::PHP_LISTING_PUBLIC_KEY,
+        )
+        .await;
 
         assert_eq!(
             state
@@ -2731,8 +2833,8 @@ Subject: Captured\r\n\r\nhi\r\n";
                 .read()
                 .await
                 .get(&PhpVersion::new(8, 5))
-                .map(String::as_str),
-            Some("8.5.6")
+                .cloned(),
+            Some(("8.5.6".to_owned(), 1))
         );
     }
 
@@ -3005,14 +3107,9 @@ Subject: Captured\r\n\r\nhi\r\n";
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
         fake_install_patch(&state.dirs, PhpVersion::new(8, 5), "8.5.6");
-        let (os, arch) = yerd_php::current_os_arch().unwrap();
-        let listing = format!(
-            "php-8.3.20-cli-{os}-{arch}.tar.gz php-8.5.9-cli-{os}-{arch}.tar.gz",
-            os = os.as_str(),
-            arch = arch.as_str()
-        );
+        let signed = signed_listing(&[("8.3.20", "8.3", 1), ("8.5.9", "8.5", 1)]);
 
-        match available_php_with(&state, &ListingDl(listing)).await {
+        match available_php_with(&state, &ListingDl::new(&signed), &signed.public_key).await {
             Response::AvailablePhp {
                 available,
                 installed,
@@ -3032,7 +3129,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
 
-        match available_php_with(&state, &FailingDl).await {
+        match available_php_with(&state, &FailingDl, yerd_update::PHP_LISTING_PUBLIC_KEY).await {
             Response::Error { code, .. } => assert_eq!(code, ErrorCode::Internal),
             other => panic!("expected Error, got {other:?}"),
         }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -684,6 +684,7 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
             Err(e) => return internal(format!("listing fetch/verify failed: {e}")),
         };
     let _guard = state.php_mutate.lock().await;
+    let mut updated: Vec<yerd_core::PhpVersion> = Vec::new();
     for minor in targets {
         let Some(installed) = crate::php_install::installed_patch(&state.dirs, minor) else {
             continue;
@@ -714,10 +715,49 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
                 };
             }
             tracing::info!(version = %minor, from = %installed, to = %artifact.full_version, "updated PHP");
+            updated.push(minor);
         }
     }
+    restart_updated_pools(state, &updated).await;
     crate::php_updates::poll_and_refresh(state, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY).await;
     php_versions_response(state).await
+}
+
+/// Restart the FPM pool of each just-updated minor **that is currently active**,
+/// so a running pool re-execs the freshly-installed binary instead of the stale
+/// process. A pool that isn't started is left alone (the next request spawns it
+/// from the new binary), matching [`restart_all_php`]'s ondemand semantics.
+/// Per-pool failures are logged, not fatal - the update itself already
+/// succeeded. Runs under the caller's `php_mutate` guard.
+async fn restart_updated_pools(state: &DaemonState, updated: &[yerd_core::PhpVersion]) {
+    if updated.is_empty() {
+        return;
+    }
+    let mut mgr = state.php_manager.lock().await;
+    let active: std::collections::HashSet<yerd_core::PhpVersion> =
+        mgr.snapshots().into_iter().map(|s| s.version).collect();
+    for minor in pools_needing_restart(&active, updated) {
+        match mgr.restart(minor).await {
+            Ok(_) => tracing::info!(version = %minor, "restarted FPM pool after PHP update"),
+            Err(e) => {
+                tracing::warn!(version = %minor, error = %e, "failed to restart FPM pool after PHP update");
+            }
+        }
+    }
+}
+
+/// The just-updated minors whose pool is currently active, preserving `updated`
+/// order. Updated-but-inactive minors are excluded so an update never *starts* a
+/// pool the user had stopped - it only re-execs one already running.
+fn pools_needing_restart(
+    active: &std::collections::HashSet<yerd_core::PhpVersion>,
+    updated: &[yerd_core::PhpVersion],
+) -> Vec<yerd_core::PhpVersion> {
+    updated
+        .iter()
+        .copied()
+        .filter(|m| active.contains(m))
+        .collect()
 }
 
 /// `install php <ver>` - download + verify + unpack a prebuilt build. Runs the
@@ -3136,6 +3176,24 @@ Subject: Captured\r\n\r\nhi\r\n";
     }
 
     // ---------- pure helpers ----------
+
+    #[test]
+    fn pools_needing_restart_only_targets_active_updated_minors() {
+        let active: std::collections::HashSet<PhpVersion> =
+            [PhpVersion::new(8, 4), PhpVersion::new(8, 5)]
+                .into_iter()
+                .collect();
+        let updated = [
+            PhpVersion::new(8, 5), // active -> restart
+            PhpVersion::new(8, 3), // updated but not running -> skip
+        ];
+        assert_eq!(
+            pools_needing_restart(&active, &updated),
+            vec![PhpVersion::new(8, 5)]
+        );
+        assert!(pools_needing_restart(&active, &[]).is_empty());
+        assert!(pools_needing_restart(&std::collections::HashSet::new(), &updated).is_empty());
+    }
 
     #[test]
     fn map_pool_state_maps_both_variants() {

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -652,10 +652,12 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
 /// latest published build when newer; restart the updated pools; refresh the
 /// cache; return the new list.
 ///
-/// A resolve failure for a **targeted** update (`version: Some`) is surfaced as
-/// an error rather than a silent no-op; update-all skips an unresolvable minor.
-/// If a later minor's install fails, the minors that already updated are still
-/// finalised (pools restarted, cache refreshed) before the error is returned.
+/// Update-all skips only a minor that is genuinely absent from the manifest
+/// (`VersionUnavailable`); a manifest-wide fault (parse/schema/untrusted) and any
+/// failure for a **targeted** update (`version: Some`) are surfaced as an error
+/// rather than a silent no-op. If a later minor's install fails, the minors that
+/// already updated are still finalised (pools restarted, cache refreshed) before
+/// the error is returned.
 ///
 /// Holds `php_mutate` across the install loop so it can't race
 /// `install_php`/`install_php_streamed` over the same per-version staging dir.
@@ -692,7 +694,7 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
         };
     let _guard = state.php_mutate.lock().await;
     let mut updated: Vec<yerd_core::PhpVersion> = Vec::new();
-    let mut install_error: Option<yerd_php::PhpError> = None;
+    let mut pending_error: Option<yerd_php::PhpError> = None;
     for minor in targets {
         let Some(installed) = crate::php_install::installed_patch(&state.dirs, minor) else {
             continue;
@@ -700,13 +702,11 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
         let installed_rev = crate::php_install::installed_revision(&state.dirs, minor);
         let artifact = match yerd_php::resolve_from_listing(&listing, minor, os, arch) {
             Ok(a) => a,
-            Err(e) if version.is_some() => {
-                return Response::Error {
-                    code: php_error_code(&e),
-                    message: e.to_string(),
-                };
+            Err(yerd_php::PhpError::VersionUnavailable { .. }) if version.is_none() => continue,
+            Err(e) => {
+                pending_error = Some(e);
+                break;
             }
-            Err(_) => continue,
         };
         if yerd_php::is_newer_build(
             &installed,
@@ -724,7 +724,7 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
             .await
             {
                 tracing::error!(version = %minor, error = %e, "PHP update failed");
-                install_error = Some(e);
+                pending_error = Some(e);
                 break;
             }
             tracing::info!(version = %minor, from = %installed, to = %artifact.full_version, "updated PHP");
@@ -733,7 +733,7 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
     }
     restart_updated_pools(state, &updated).await;
     crate::php_updates::poll_and_refresh(state, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY).await;
-    if let Some(e) = install_error {
+    if let Some(e) = pending_error {
         return Response::Error {
             code: php_error_code(&e),
             message: e.to_string(),
@@ -3231,10 +3231,7 @@ Subject: Captured\r\n\r\nhi\r\n";
             [PhpVersion::new(8, 4), PhpVersion::new(8, 5)]
                 .into_iter()
                 .collect();
-        let updated = [
-            PhpVersion::new(8, 5), // active -> restart
-            PhpVersion::new(8, 3), // updated but not running -> skip
-        ];
+        let updated = [PhpVersion::new(8, 5), PhpVersion::new(8, 3)];
         assert_eq!(
             pools_needing_restart(&active, &updated),
             vec![PhpVersion::new(8, 5)]

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -323,10 +323,11 @@ async fn php_versions_response(state: &DaemonState) -> Response {
     }
 }
 
-/// `available php` - list the major.minor versions installable from the
-/// distribution, plus what's already installed (so clients hide or tag them).
-/// Fetches the listing on demand; only a fetch/transport failure is an error
-/// (an empty parse result is a valid empty list).
+/// `available php` - list the major.minor versions installable from the signed
+/// `php.json` manifest, plus what's already installed (so clients hide or tag
+/// them). Fetches + verifies the manifest on demand; a fetch/transport OR
+/// signature-verification failure is an error (an empty parse result is still a
+/// valid empty list).
 async fn available_php_response(state: &DaemonState) -> Response {
     let dl = crate::php_install::ReqwestDownloader::new();
     available_php_with(state, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY).await
@@ -350,7 +351,7 @@ async fn available_php_with(
     };
     let listing = match crate::php_install::fetch_verified_listing(dl, public_key).await {
         Ok(body) => body,
-        Err(e) => return internal(format!("couldn't reach the PHP listing: {e}")),
+        Err(e) => return internal(format!("couldn't load the PHP listing: {e}")),
     };
     Response::AvailablePhp {
         available: yerd_php::available_minors(&listing, os, arch),
@@ -648,7 +649,13 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
 }
 
 /// `update php [<ver>]` - upgrade the given minor (or all installed) to the
-/// latest published patch when newer; refresh the cache; return the new list.
+/// latest published build when newer; restart the updated pools; refresh the
+/// cache; return the new list.
+///
+/// A resolve failure for a **targeted** update (`version: Some`) is surfaced as
+/// an error rather than a silent no-op; update-all skips an unresolvable minor.
+/// If a later minor's install fails, the minors that already updated are still
+/// finalised (pools restarted, cache refreshed) before the error is returned.
 ///
 /// Holds `php_mutate` across the install loop so it can't race
 /// `install_php`/`install_php_streamed` over the same per-version staging dir.
@@ -685,13 +692,21 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
         };
     let _guard = state.php_mutate.lock().await;
     let mut updated: Vec<yerd_core::PhpVersion> = Vec::new();
+    let mut install_error: Option<yerd_php::PhpError> = None;
     for minor in targets {
         let Some(installed) = crate::php_install::installed_patch(&state.dirs, minor) else {
             continue;
         };
         let installed_rev = crate::php_install::installed_revision(&state.dirs, minor);
-        let Ok(artifact) = yerd_php::resolve_from_listing(&listing, minor, os, arch) else {
-            continue;
+        let artifact = match yerd_php::resolve_from_listing(&listing, minor, os, arch) {
+            Ok(a) => a,
+            Err(e) if version.is_some() => {
+                return Response::Error {
+                    code: php_error_code(&e),
+                    message: e.to_string(),
+                };
+            }
+            Err(_) => continue,
         };
         if yerd_php::is_newer_build(
             &installed,
@@ -709,10 +724,8 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
             .await
             {
                 tracing::error!(version = %minor, error = %e, "PHP update failed");
-                return Response::Error {
-                    code: php_error_code(&e),
-                    message: e.to_string(),
-                };
+                install_error = Some(e);
+                break;
             }
             tracing::info!(version = %minor, from = %installed, to = %artifact.full_version, "updated PHP");
             updated.push(minor);
@@ -720,6 +733,12 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
     }
     restart_updated_pools(state, &updated).await;
     crate::php_updates::poll_and_refresh(state, &dl, yerd_update::PHP_LISTING_PUBLIC_KEY).await;
+    if let Some(e) = install_error {
+        return Response::Error {
+            code: php_error_code(&e),
+            message: e.to_string(),
+        };
+    }
     php_versions_response(state).await
 }
 
@@ -2875,6 +2894,35 @@ Subject: Captured\r\n\r\nhi\r\n";
                 .get(&PhpVersion::new(8, 5))
                 .cloned(),
             Some(("8.5.6".to_owned(), 1))
+        );
+    }
+
+    /// A validly-signed but unknown-schema manifest must NOT wipe a good cache:
+    /// resolve fails schema-wide, so the poll aborts without overwriting.
+    #[tokio::test]
+    async fn poll_and_refresh_keeps_cache_on_unknown_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
+        state
+            .php_updates
+            .write()
+            .await
+            .insert(PhpVersion::new(8, 5), ("8.5.7".to_owned(), 1));
+        let signed = crate::test_support::sign_manifest(r#"{ "schema": 2, "builds": [] }"#);
+
+        crate::php_updates::poll_and_refresh(&state, &ListingDl::new(&signed), &signed.public_key)
+            .await;
+
+        assert_eq!(
+            state
+                .php_updates
+                .read()
+                .await
+                .get(&PhpVersion::new(8, 5))
+                .cloned(),
+            Some(("8.5.7".to_owned(), 1)),
+            "a bad-schema manifest must not clear the previously-cached update"
         );
     }
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -723,12 +723,12 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
     php_versions_response(state).await
 }
 
-/// Restart the FPM pool of each just-updated minor **that is currently active**,
-/// so a running pool re-execs the freshly-installed binary instead of the stale
-/// process. A pool that isn't started is left alone (the next request spawns it
-/// from the new binary), matching [`restart_all_php`]'s ondemand semantics.
-/// Per-pool failures are logged, not fatal - the update itself already
-/// succeeded. Runs under the caller's `php_mutate` guard.
+/// Restart the FPM pool of each just-updated minor that has a **started** pool
+/// (running or crashed/`Failed`), so it re-execs the freshly-installed binary
+/// instead of the stale process. A never-started / stopped ondemand pool is left
+/// alone (the next request spawns it from the new binary), matching
+/// [`restart_all_php`]'s semantics. Per-pool failures are logged, not fatal - the
+/// update itself already succeeded. Runs under the caller's `php_mutate` guard.
 async fn restart_updated_pools(state: &DaemonState, updated: &[yerd_core::PhpVersion]) {
     if updated.is_empty() {
         return;

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -37,6 +37,9 @@ pub mod tools;
 pub mod tracing_init;
 pub mod tunnel;
 
+#[cfg(test)]
+pub mod test_support;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
@@ -150,7 +153,12 @@ async fn run_until_shutdown(
             loop {
                 tokio::select! {
                     _ = tick.tick() => {
-                        crate::php_updates::poll_and_refresh(&state, &dl).await;
+                        crate::php_updates::poll_and_refresh(
+                            &state,
+                            &dl,
+                            yerd_update::PHP_LISTING_PUBLIC_KEY,
+                        )
+                        .await;
                         crate::self_update::poll_and_refresh(&state, &dl).await;
                     }
                     _ = rx.changed() => break,

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -828,6 +828,26 @@ mod tests {
 
     /// A validly-signed manifest that simply lacks the requested minor (only 8.4
     /// present) resolves to `VersionUnavailable`, not a trust error.
+    /// The fetch choke point rejects a manifest whose body was altered after
+    /// signing: the original signature no longer covers the served bytes, so
+    /// `fetch_verified_listing` returns `ListingUntrusted` before any resolve.
+    #[tokio::test]
+    async fn fetch_verified_listing_rejects_tampered_body() {
+        let cli = gzip_tar_single("php", b"CLI-BYTES", 0o755);
+        let fpm = gzip_tar_single("php-fpm", b"FPM-BYTES", 0o755);
+        let signed = signed_manifest_for("8.5.7", "8.5", 1, &cli, &fpm);
+        let dl = FakeDownloader {
+            manifest: signed.manifest.replace("8.5.7", "8.5.9"),
+            minisig: signed.minisig.clone(),
+            cli,
+            fpm,
+        };
+        let err = fetch_verified_listing(&dl, &signed.public_key)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PhpError::ListingUntrusted), "got {err:?}");
+    }
+
     #[tokio::test]
     async fn install_errors_when_version_not_published_and_writes_nothing() {
         let tmp = tempfile::tempdir().unwrap();

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -149,7 +149,9 @@ fn note(progress: Option<&ProgressTx>, msg: impl Into<String>) {
 /// (install, update poll, available-versions). The signature is **prehashed**
 /// (`minisign -H`); `verify_minisign` rejects legacy signatures. Mirrors
 /// `self_update::stage_update`, which likewise threads the public key so tests
-/// can sign a fixture manifest with their own key.
+/// can sign a fixture manifest with their own key. Returns the body via
+/// `from_utf8` (not lossily), so the parsed manifest is byte-for-byte what the
+/// signature covered - invalid UTF-8 is rejected as `ListingParse`.
 pub(crate) async fn fetch_verified_listing(
     dl: &dyn Downloader,
     public_key: &str,
@@ -161,7 +163,9 @@ pub(crate) async fn fetch_verified_listing(
         tracing::warn!(error = %e, "php.json signature verification failed");
         PhpError::ListingUntrusted
     })?;
-    Ok(String::from_utf8_lossy(&body).into_owned())
+    String::from_utf8(body).map_err(|e| PhpError::ListingParse {
+        detail: format!("listing body is not valid UTF-8: {e}"),
+    })
 }
 
 /// Install `version` (major.minor) into `dirs.data/php/php-<minor>/`.

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -3,9 +3,11 @@
 //!
 //! The `reqwest`-backed [`Downloader`] lives here (a binary) so `yerd-php`
 //! stays dependency-light. Version resolution + tar-member safety are pure
-//! helpers from `yerd_php::release`; this module is the I/O edge: fetch the
-//! listing → resolve → fetch tarballs → safe-extract the single binary →
-//! atomic install. Integrity is TLS-only (no sha pinning - per user decision).
+//! helpers from `yerd_php::release`; this module is the I/O edge: fetch +
+//! **verify** the signed `php.json` manifest → resolve → fetch tarballs →
+//! **SHA-256-verify** and safe-extract the single binary → atomic install.
+//! Integrity is anchored by the manifest's minisign signature (verified here)
+//! and each tarball's published SHA-256.
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -16,7 +18,8 @@ use async_trait::async_trait;
 
 use yerd_core::PhpVersion;
 use yerd_php::{
-    current_os_arch, is_safe_member, Artifact, BinaryKind, DownloadError, Downloader, PhpError,
+    current_os_arch, is_safe_member, listing_sig_url, listing_url, Artifact, BinaryKind,
+    DownloadError, Downloader, PhpError,
 };
 use yerd_platform::PlatformDirs;
 
@@ -139,13 +142,36 @@ fn note(progress: Option<&ProgressTx>, msg: impl Into<String>) {
     }
 }
 
+/// Download the signed `php.json` manifest and its detached minisign signature,
+/// verify the signature against `public_key`, and return the trusted JSON body.
+///
+/// This is the single choke point through which every PHP listing read passes
+/// (install, update poll, available-versions). The signature is **prehashed**
+/// (`minisign -H`); `verify_minisign` rejects legacy signatures. Mirrors
+/// `self_update::stage_update`, which likewise threads the public key so tests
+/// can sign a fixture manifest with their own key.
+pub(crate) async fn fetch_verified_listing(
+    dl: &dyn Downloader,
+    public_key: &str,
+) -> Result<String, PhpError> {
+    let body = dl.download(&listing_url()).await?;
+    let sig = dl.download(&listing_sig_url()).await?;
+    let sig = String::from_utf8_lossy(&sig);
+    yerd_update::verify_minisign(public_key, &sig, &body).map_err(|e| {
+        tracing::warn!(error = %e, "php.json signature verification failed");
+        PhpError::ListingUntrusted
+    })?;
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
 /// Install `version` (major.minor) into `dirs.data/php/php-<minor>/`.
 ///
-/// Resolves the latest patch from the distribution's live listing, downloads
-/// the CLI and FPM tarballs, safely extracts the single binary from each, and
-/// atomically swaps the result into place. Idempotent: reinstalling replaces
-/// the dir. **Integrity is TLS-only** - the distribution publishes no checksum
-/// sidecars and yerd does not pin hashes (deliberate; see `yerd_php::release`).
+/// Fetches + verifies the signed `php.json` manifest, resolves the single build
+/// for this platform, downloads the CLI and FPM tarballs, **verifies each
+/// tarball's SHA-256** against the manifest, safely extracts the single binary
+/// from each, and atomically swaps the result into place. Idempotent:
+/// reinstalling replaces the dir. `public_key` is the minisign key the manifest
+/// is verified against (prod passes [`yerd_update::PHP_LISTING_PUBLIC_KEY`]).
 ///
 /// When `progress` is set, coarse phase + byte-count updates are streamed to it
 /// (the GUI's streamed install polls these); pass `None` for the silent path.
@@ -153,14 +179,14 @@ pub async fn install(
     version: PhpVersion,
     dirs: &PlatformDirs,
     dl: &dyn Downloader,
+    public_key: &str,
     progress: Option<&ProgressTx>,
 ) -> Result<(), PhpError> {
     let (os, arch) = current_os_arch()?;
-    note(progress, format!("Resolving latest PHP {version}…"));
-    let listing = dl.download(&yerd_php::listing_url(os)).await?;
-    let listing = String::from_utf8_lossy(&listing);
+    note(progress, format!("Resolving PHP {version}…"));
+    let listing = fetch_verified_listing(dl, public_key).await?;
     let artifact = yerd_php::resolve_from_listing(&listing, version, os, arch)?;
-    tracing::info!(%version, patch = %artifact.full_version, "resolved PHP build; downloading");
+    tracing::info!(%version, patch = %artifact.full_version, revision = artifact.revision, "resolved PHP build; downloading");
     note(
         progress,
         format!("Found PHP {} — downloading…", artifact.full_version),
@@ -210,8 +236,14 @@ pub fn write_cli_ini(
     yerd_php::io::atomic_write::write(&dirs.data.join("php-cli.ini"), contents.as_bytes())
 }
 
-/// Filename of the installed-patch marker inside a per-version dir.
+/// Filename of the installed-patch marker inside a per-version dir. Kept
+/// byte-identical to older yerd (bare patch string) so a rolled-back client
+/// still parses it; the revision lives in a sibling [`REVISION_MARKER`].
 const VERSION_MARKER: &str = ".yerd-version";
+
+/// Filename of the installed-revision marker inside a per-version dir (the `-N`
+/// suffix). Absent for pre-cutover installs, which read as revision 0.
+const REVISION_MARKER: &str = ".yerd-revision";
 
 async fn stage(
     artifact: &Artifact,
@@ -222,6 +254,7 @@ async fn stage(
     fetch_and_extract(
         dl,
         &artifact.cli_url,
+        &artifact.cli_sha256,
         BinaryKind::Cli,
         staging,
         progress,
@@ -231,6 +264,7 @@ async fn stage(
     fetch_and_extract(
         dl,
         &artifact.fpm_url,
+        &artifact.fpm_sha256,
         BinaryKind::Fpm,
         staging,
         progress,
@@ -240,6 +274,11 @@ async fn stage(
     fs_ctx(std::fs::create_dir_all(staging), staging)?;
     let marker = staging.join(VERSION_MARKER);
     fs_ctx(std::fs::write(&marker, &artifact.full_version), &marker)?;
+    let rev_marker = staging.join(REVISION_MARKER);
+    fs_ctx(
+        std::fs::write(&rev_marker, artifact.revision.to_string()),
+        &rev_marker,
+    )?;
     Ok(())
 }
 
@@ -261,13 +300,33 @@ pub fn installed_patch(dirs: &PlatformDirs, minor: PhpVersion) -> Option<String>
     }
 }
 
-/// Download one PHP binary tarball and extract its single member into `staging`.
+/// The installed build revision of `minor` (reads the `.yerd-revision` marker).
+/// A missing/unparseable marker reads as `0` - a legacy install predating the
+/// c-ares cutover, which every `revision >= 1` manifest build then supersedes.
+#[must_use]
+pub fn installed_revision(dirs: &PlatformDirs, minor: PhpVersion) -> u32 {
+    let marker = dirs
+        .data
+        .join("php")
+        .join(format!("php-{}.{}", minor.major, minor.minor))
+        .join(REVISION_MARKER);
+    std::fs::read_to_string(marker)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Download one PHP binary tarball, verify its SHA-256 against the manifest, and
+/// extract its single member into `staging`.
 ///
 /// Streams with byte-progress when `progress` is attached, otherwise takes the
-/// silent path; a download error converts to `PhpError` via `#[from]`.
+/// silent path; a download error converts to `PhpError` via `#[from]`. The
+/// SHA-256 check happens on both paths (this is the single fetch site) - bytes
+/// that don't match `expected_sha256` are never extracted.
 async fn fetch_and_extract(
     dl: &dyn Downloader,
     url: &str,
+    expected_sha256: &str,
     kind: BinaryKind,
     staging: &Path,
     progress: Option<&ProgressTx>,
@@ -284,6 +343,12 @@ async fn fetch_and_extract(
         }
         None => dl.download(url).await?,
     };
+    if !yerd_update::sha256_hex(&bytes).eq_ignore_ascii_case(expected_sha256) {
+        tracing::warn!(%url, "PHP tarball sha256 mismatch");
+        return Err(PhpError::ShaMismatch {
+            file: url.to_owned(),
+        });
+    }
     let binary = extract_member(&bytes, kind, url)?;
 
     let mut target = staging.to_path_buf();
@@ -616,10 +681,12 @@ mod tests {
         }
     }
 
-    /// URL-keyed fake: the directory URL (ends `/`) → listing; `-cli-`/`-fpm-`
-    /// URLs → the respective tarball.
+    /// URL-keyed fake: `php.json.minisig` → signature; `php.json` → manifest;
+    /// `-cli-`/`-fpm-` → the respective tarball. Missing tarballs (empty) still
+    /// answer so a resolve-then-download path can run.
     struct FakeDownloader {
-        listing: String,
+        manifest: String,
+        minisig: String,
         cli: Vec<u8>,
         fpm: Vec<u8>,
     }
@@ -627,8 +694,10 @@ mod tests {
     #[async_trait]
     impl Downloader for FakeDownloader {
         async fn download(&self, url: &str) -> Result<Vec<u8>, DownloadError> {
-            if url.ends_with('/') {
-                Ok(self.listing.clone().into_bytes())
+            if url.ends_with(".minisig") {
+                Ok(self.minisig.clone().into_bytes())
+            } else if url.ends_with("php.json") {
+                Ok(self.manifest.clone().into_bytes())
             } else if url.contains("-cli-") {
                 Ok(self.cli.clone())
             } else if url.contains("-fpm-") {
@@ -642,25 +711,49 @@ mod tests {
         }
     }
 
+    /// Build a one-build `php.json` for the host platform whose `cli`/`fpm`
+    /// sha256 match the given tarball bytes, then sign it.
+    fn signed_manifest_for(
+        php: &str,
+        minor: &str,
+        revision: u32,
+        cli: &[u8],
+        fpm: &[u8],
+    ) -> crate::test_support::SignedManifest {
+        let (os, arch) = current_os_arch().unwrap();
+        let manifest = format!(
+            r#"{{ "schema": 1, "builds": [
+                {{ "php": "{php}", "minor": "{minor}", "os": "{os}", "arch": "{arch}", "revision": {revision},
+                   "cli": {{ "file": "php-{php}-{revision}-cli-{os}-{arch}.tar.gz", "sha256": "{cli_sha}", "size": {cli_len} }},
+                   "fpm": {{ "file": "php-{php}-{revision}-fpm-{os}-{arch}.tar.gz", "sha256": "{fpm_sha}", "size": {fpm_len} }} }}
+            ] }}"#,
+            os = os.as_str(),
+            arch = arch.as_str(),
+            cli_sha = yerd_update::sha256_hex(cli),
+            fpm_sha = yerd_update::sha256_hex(fpm),
+            cli_len = cli.len(),
+            fpm_len = fpm.len(),
+        );
+        crate::test_support::sign_manifest(&manifest)
+    }
+
+    const KEY: &str = yerd_update::PHP_LISTING_PUBLIC_KEY;
+
     #[tokio::test]
     async fn install_lays_down_both_binaries_executable() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
-        let (os, arch) = current_os_arch().unwrap();
-        let listing = format!(
-            "<a href=\"php-8.5.2-cli-{os}-{arch}.tar.gz\">x</a>\
-             <a href=\"php-8.5.6-cli-{os}-{arch}.tar.gz\">y</a>\
-             <a href=\"php-8.5.6-fpm-{os}-{arch}.tar.gz\">z</a>",
-            os = os.as_str(),
-            arch = arch.as_str()
-        );
+        let cli = gzip_tar_single("php", b"CLI-BYTES", 0o755);
+        let fpm = gzip_tar_single("php-fpm", b"FPM-BYTES", 0o755);
+        let signed = signed_manifest_for("8.5.7", "8.5", 1, &cli, &fpm);
         let dl = FakeDownloader {
-            listing,
-            cli: gzip_tar_single("php", b"CLI-BYTES", 0o755),
-            fpm: gzip_tar_single("php-fpm", b"FPM-BYTES", 0o755),
+            manifest: signed.manifest.clone(),
+            minisig: signed.minisig.clone(),
+            cli,
+            fpm,
         };
 
-        install(PhpVersion::new(8, 5), &dirs, &dl, None)
+        install(PhpVersion::new(8, 5), &dirs, &dl, &signed.public_key, None)
             .await
             .unwrap();
 
@@ -675,8 +768,9 @@ mod tests {
         );
         assert_eq!(
             installed_patch(&dirs, PhpVersion::new(8, 5)).as_deref(),
-            Some("8.5.6")
+            Some("8.5.7")
         );
+        assert_eq!(installed_revision(&dirs, PhpVersion::new(8, 5)), 1);
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -688,18 +782,66 @@ mod tests {
         }
     }
 
+    /// The manifest is signed over the correct shas, but the fake serves
+    /// different tarball bytes, so the post-download sha check must abort.
+    #[tokio::test]
+    async fn install_rejects_sha_mismatch_and_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let cli = gzip_tar_single("php", b"CLI-BYTES", 0o755);
+        let fpm = gzip_tar_single("php-fpm", b"FPM-BYTES", 0o755);
+        let signed = signed_manifest_for("8.5.7", "8.5", 1, &cli, &fpm);
+        let dl = FakeDownloader {
+            manifest: signed.manifest.clone(),
+            minisig: signed.minisig.clone(),
+            cli: gzip_tar_single("php", b"TAMPERED", 0o755),
+            fpm,
+        };
+        let err = install(PhpVersion::new(8, 5), &dirs, &dl, &signed.public_key, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PhpError::ShaMismatch { .. }), "got {err:?}");
+        assert!(!dirs.data.join("php").join("php-8.5").exists());
+    }
+
+    /// A manifest signed by a throwaway key fails when verified against the
+    /// production `PHP_LISTING_PUBLIC_KEY`, and nothing is installed.
+    #[tokio::test]
+    async fn install_rejects_untrusted_listing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let cli = gzip_tar_single("php", b"CLI-BYTES", 0o755);
+        let fpm = gzip_tar_single("php-fpm", b"FPM-BYTES", 0o755);
+        let signed = signed_manifest_for("8.5.7", "8.5", 1, &cli, &fpm);
+        let dl = FakeDownloader {
+            manifest: signed.manifest.clone(),
+            minisig: signed.minisig.clone(),
+            cli,
+            fpm,
+        };
+        let err = install(PhpVersion::new(8, 5), &dirs, &dl, KEY, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PhpError::ListingUntrusted), "got {err:?}");
+        assert!(!dirs.data.join("php").join("php-8.5").exists());
+    }
+
+    /// A validly-signed manifest that simply lacks the requested minor (only 8.4
+    /// present) resolves to `VersionUnavailable`, not a trust error.
     #[tokio::test]
     async fn install_errors_when_version_not_published_and_writes_nothing() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
-        let (os, arch) = current_os_arch().unwrap();
-        let listing = format!("php-8.4.21-cli-{}-{}.tar.gz", os.as_str(), arch.as_str());
+        let cli = gzip_tar_single("php", b"x", 0o755);
+        let fpm = gzip_tar_single("php-fpm", b"y", 0o755);
+        let signed = signed_manifest_for("8.4.21", "8.4", 1, &cli, &fpm);
         let dl = FakeDownloader {
-            listing,
-            cli: vec![],
-            fpm: vec![],
+            manifest: signed.manifest.clone(),
+            minisig: signed.minisig.clone(),
+            cli,
+            fpm,
         };
-        let err = install(PhpVersion::new(8, 5), &dirs, &dl, None)
+        let err = install(PhpVersion::new(8, 5), &dirs, &dl, &signed.public_key, None)
             .await
             .unwrap_err();
         assert!(

--- a/bin/yerdd/src/php_updates.rs
+++ b/bin/yerdd/src/php_updates.rs
@@ -1,19 +1,22 @@
 //! PHP update polling and the daemon's update cache.
 //!
 //! The cache (`DaemonState::php_updates`) maps each installed minor → the newest
-//! full patch seen at the last distribution poll. [`poll_and_refresh`] (network)
-//! repopulates it and logs available updates; [`cached_updates`] (no network)
-//! serves the annotations shown on `list php`.
+//! build `(patch, revision)` seen at the last manifest poll. [`poll_and_refresh`]
+//! (network) repopulates it and logs available updates; [`cached_updates`] (no
+//! network) serves the annotations shown on `list php`. The revision dimension
+//! is what surfaces a c-ares-cutover rebuild (`8.5.7-1`) as an update to an
+//! existing `8.5.7` install recorded as revision 0.
 
 use std::collections::HashMap;
 
 use yerd_core::PhpVersion;
 use yerd_ipc::PhpUpdate;
 use yerd_php::{
-    current_os_arch, discover_bundled, is_newer, listing_url, resolve_from_listing, Downloader,
+    current_os_arch, discover_bundled, display_build, is_newer_build, resolve_from_listing,
+    Downloader,
 };
 
-use crate::php_install::installed_patch;
+use crate::php_install::{fetch_verified_listing, installed_patch, installed_revision};
 use crate::state::DaemonState;
 
 /// Installed minors, from on-disk bundled discovery (keyed on the FPM binary).
@@ -25,10 +28,12 @@ pub(crate) fn installed_minors(state: &DaemonState) -> Vec<PhpVersion> {
         .collect()
 }
 
-/// Poll the distribution once, refresh `state.php_updates`, and log
-/// (notify-only) any installed minor with a newer patch. **Failure-tolerant**:
-/// network/platform errors are logged at `debug` and leave the cache untouched.
-pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader) {
+/// Poll the manifest once, refresh `state.php_updates`, and log (notify-only)
+/// any installed minor with a newer build. **Failure-tolerant**: network,
+/// signature, and platform errors are logged at `debug` and leave the cache
+/// untouched. `public_key` is the minisign key the manifest is verified against
+/// (prod passes [`yerd_update::PHP_LISTING_PUBLIC_KEY`]).
+pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader, public_key: &str) {
     let minors = installed_minors(state);
     if minors.is_empty() {
         return;
@@ -40,49 +45,58 @@ pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader) {
             return;
         }
     };
-    let listing = match dl.download(&listing_url(os)).await {
-        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+    let listing = match fetch_verified_listing(dl, public_key).await {
+        Ok(body) => body,
         Err(e) => {
-            tracing::debug!(error = %e, "php update poll skipped: listing fetch failed");
+            tracing::debug!(error = %e, "php update poll skipped: listing fetch/verify failed");
             return;
         }
     };
 
-    let mut latest: HashMap<PhpVersion, String> = HashMap::new();
+    let mut latest: HashMap<PhpVersion, (String, u32)> = HashMap::new();
     for minor in minors {
         let Ok(artifact) = resolve_from_listing(&listing, minor, os, arch) else {
             continue;
         };
         if let Some(installed) = installed_patch(&state.dirs, minor) {
-            if is_newer(&installed, &artifact.full_version) {
+            let installed_rev = installed_revision(&state.dirs, minor);
+            if is_newer_build(
+                &installed,
+                installed_rev,
+                &artifact.full_version,
+                artifact.revision,
+            ) {
                 tracing::info!(
                     version = %minor,
-                    installed = %installed,
-                    latest = %artifact.full_version,
-                    "a newer PHP patch is available (run `yerd update php`)"
+                    installed = %display_build(&installed, installed_rev),
+                    latest = %display_build(&artifact.full_version, artifact.revision),
+                    "a newer PHP build is available (run `yerd update php`)"
                 );
             }
         }
-        latest.insert(minor, artifact.full_version);
+        latest.insert(minor, (artifact.full_version, artifact.revision));
     }
     *state.php_updates.write().await = latest;
 }
 
 /// Available updates derived from the cache + installed markers (no network).
+/// Only minors whose cached build is strictly newer than the installed one are
+/// emitted; both sides are formatted as `<patch>-<revision>` for display.
 pub async fn cached_updates(state: &DaemonState) -> Vec<PhpUpdate> {
     let cache = state.php_updates.read().await;
     let mut out = Vec::new();
     for minor in installed_minors(state) {
-        let (Some(installed), Some(latest)) =
+        let (Some(installed), Some((latest_patch, latest_rev))) =
             (installed_patch(&state.dirs, minor), cache.get(&minor))
         else {
             continue;
         };
-        if is_newer(&installed, latest) {
+        let installed_rev = installed_revision(&state.dirs, minor);
+        if is_newer_build(&installed, installed_rev, latest_patch, *latest_rev) {
             out.push(PhpUpdate {
                 version: minor,
-                installed,
-                latest: latest.clone(),
+                installed: display_build(&installed, installed_rev),
+                latest: display_build(latest_patch, *latest_rev),
             });
         }
     }

--- a/bin/yerdd/src/php_updates.rs
+++ b/bin/yerdd/src/php_updates.rs
@@ -55,8 +55,13 @@ pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader, public_k
 
     let mut latest: HashMap<PhpVersion, (String, u32)> = HashMap::new();
     for minor in minors {
-        let Ok(artifact) = resolve_from_listing(&listing, minor, os, arch) else {
-            continue;
+        let artifact = match resolve_from_listing(&listing, minor, os, arch) {
+            Ok(a) => a,
+            Err(yerd_php::PhpError::VersionUnavailable { .. }) => continue,
+            Err(e) => {
+                tracing::debug!(error = %e, "php update poll aborted: manifest unusable, keeping cache");
+                return;
+            }
         };
         if let Some(installed) = installed_patch(&state.dirs, minor) {
             let installed_rev = installed_revision(&state.dirs, minor);

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -56,10 +56,10 @@ pub struct DaemonState {
     pub ca_path: PathBuf,
     /// SHA-256 fingerprint of the CA cert (reported by `DaemonInfo`).
     pub ca_fingerprint: CaFingerprint,
-    /// Update cache: installed minor → newest full patch known from the last
-    /// distribution poll. Populated by the periodic checker / `CheckPhpUpdates`
-    /// and served (no network) on `ListPhp`.
-    pub php_updates: RwLock<HashMap<PhpVersion, String>>,
+    /// Update cache: installed minor → newest build `(patch, revision)` known
+    /// from the last manifest poll. Populated by the periodic checker /
+    /// `CheckPhpUpdates` and served (no network) on `ListPhp`.
+    pub php_updates: RwLock<HashMap<PhpVersion, (String, u32)>>,
     /// Yerd self-update cache: the releases seen at the last GitHub poll. Empty
     /// until the first successful fetch. Populated by the periodic checker /
     /// `CheckUpdate` and served (no network) when a live fetch fails.

--- a/bin/yerdd/src/test_support.rs
+++ b/bin/yerdd/src/test_support.rs
@@ -1,0 +1,65 @@
+//! Test-only helpers shared across daemon unit tests.
+//!
+//! The signed-`php.json` fetch path (`php_install::fetch_verified_listing`)
+//! verifies a **prehashed** minisign signature, so tests that exercise install /
+//! update / available-versions need a validly-signed manifest. `minisign-verify`
+//! only verifies, so we generate a throwaway keypair and sign at runtime with
+//! the `minisign` crate (dev-dependency), handing the generated public key to
+//! the code under test.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+/// A `php.json` body plus its detached minisign signature and the public key it
+/// was signed with. Feed `public_key` to `fetch_verified_listing`, and serve
+/// `manifest` / `minisig` from a fake `Downloader`.
+pub struct SignedManifest {
+    /// Base64 public-key line accepted by `yerd_update::verify_minisign`.
+    pub public_key: String,
+    /// The `php.json` body.
+    pub manifest: String,
+    /// The detached `php.json.minisig` file contents.
+    pub minisig: String,
+}
+
+/// Sign `manifest` with a freshly generated keypair (prehashed, as yerd
+/// requires) and return it with its signature and public key. Panics on any
+/// crypto error - test-only.
+///
+/// Before returning, the signature is re-checked with the **production**
+/// `verify_minisign` so that if the signing crate ever stops producing a
+/// prehashed/non-legacy signature this fails loudly here, rather than turning
+/// every downstream test red for an opaque reason.
+#[must_use]
+pub fn sign_manifest(manifest: &str) -> SignedManifest {
+    let kp = minisign::KeyPair::generate_unencrypted_keypair().unwrap();
+    let sig_box = minisign::sign(
+        Some(&kp.pk),
+        &kp.sk,
+        std::io::Cursor::new(manifest.as_bytes()),
+        Some("test manifest"),
+        Some("yerd test"),
+    )
+    .unwrap();
+    let out = SignedManifest {
+        public_key: kp.pk.to_base64(),
+        manifest: manifest.to_owned(),
+        minisig: sig_box.into_string(),
+    };
+    yerd_update::verify_minisign(&out.public_key, &out.minisig, out.manifest.as_bytes())
+        .expect("freshly signed manifest must verify with the production verifier");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_production_verifier() {
+        let s = sign_manifest(r#"{"schema":1,"builds":[]}"#);
+        assert!(
+            yerd_update::verify_minisign(&s.public_key, &s.minisig, s.manifest.as_bytes()).is_ok()
+        );
+        assert!(yerd_update::verify_minisign(&s.public_key, &s.minisig, b"tampered").is_err());
+    }
+}

--- a/crates/yerd-php/src/error.rs
+++ b/crates/yerd-php/src/error.rs
@@ -107,11 +107,40 @@ pub enum PhpError {
     },
 
     /// No prebuilt build of the requested version is published for this
-    /// platform (discovered from the distribution's listing).
-    #[error("no prebuilt PHP {version} found for this platform at the distribution")]
+    /// platform (looked up in the `php.json` manifest).
+    #[error("no prebuilt PHP {version} found for this platform in the listing")]
     VersionUnavailable {
         /// The version that was requested.
         version: PhpVersion,
+    },
+
+    /// The `php.json` manifest body could not be parsed as JSON.
+    #[error("parse php.json listing: {detail}")]
+    ListingParse {
+        /// Human-readable serde failure detail.
+        detail: String,
+    },
+
+    /// The `php.json` manifest declared a schema version this build does not
+    /// understand (a producer-side breaking change).
+    #[error("unsupported php.json schema {found} (this build understands {supported})")]
+    UnsupportedListingSchema {
+        /// The schema version found in the manifest.
+        found: u32,
+        /// The schema version this build supports.
+        supported: u32,
+    },
+
+    /// The `php.json` manifest failed minisign signature verification, so its
+    /// contents are not trusted. Constructed by the daemon after the fetch.
+    #[error("php.json listing failed signature verification")]
+    ListingUntrusted,
+
+    /// A downloaded tarball's SHA-256 did not match the manifest's value.
+    #[error("sha256 mismatch for {file}")]
+    ShaMismatch {
+        /// The manifest `file` whose bytes failed verification.
+        file: String,
     },
 
     /// Downloading an artifact failed.

--- a/crates/yerd-php/src/error.rs
+++ b/crates/yerd-php/src/error.rs
@@ -139,7 +139,7 @@ pub enum PhpError {
     /// A downloaded tarball's SHA-256 did not match the manifest's value.
     #[error("sha256 mismatch for {file}")]
     ShaMismatch {
-        /// The manifest `file` whose bytes failed verification.
+        /// The artifact URL whose downloaded bytes failed SHA-256 verification.
         file: String,
     },
 

--- a/crates/yerd-php/src/lib.rs
+++ b/crates/yerd-php/src/lib.rs
@@ -22,8 +22,9 @@ pub use manager::{DumpExtSettings, PhpManager, PoolRunState, PoolSnapshot};
 pub use pool::{PoolConfig, ProcessManagerMode};
 pub use real::{SystemClock, TokioChild, TokioProcessSpawner};
 pub use release::{
-    artifact_url, available_minors, current_os_arch, is_newer, is_safe_member, listing_url,
-    patch_of, resolve_from_listing, Arch, Artifact, BinaryKind, Os,
+    available_minors, current_os_arch, display_build, is_newer_build, is_safe_member,
+    listing_sig_url, listing_url, patch_of, resolve_from_listing, Arch, Artifact, BinaryKind, Os,
+    PHP_LISTING_BASE_URL, PHP_LISTING_SCHEMA,
 };
 pub use traits::{ChildHandle, Clock, Downloader, HealthProbe, ProcessSpawner};
 pub use version::discover_bundled;

--- a/crates/yerd-php/src/release.rs
+++ b/crates/yerd-php/src/release.rs
@@ -243,6 +243,17 @@ pub fn resolve_from_listing(
         .find(|b| b.os == os.as_str() && b.arch == arch.as_str() && b.minor == want_minor)
         .ok_or(PhpError::VersionUnavailable { version })?;
 
+    if entry.revision == 0 {
+        return Err(PhpError::ListingParse {
+            detail: format!(
+                "build {} ({}-{}) has revision 0, but published builds must be >= 1",
+                entry.php,
+                os.as_str(),
+                arch.as_str()
+            ),
+        });
+    }
+
     Ok(Artifact {
         install_dir_name: format!("php-{}.{}", version.major, version.minor),
         revision: entry.revision,
@@ -458,6 +469,19 @@ mod tests {
         match resolve_from_listing("not json", PhpVersion::new(8, 5), Os::Linux, Arch::X86_64) {
             Err(PhpError::ListingParse { .. }) => {}
             other => panic!("expected ListingParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_rejects_revision_zero() {
+        let bad = r#"{ "schema": 1, "builds": [
+            { "php": "8.5.7", "minor": "8.5", "os": "linux", "arch": "x86_64", "revision": 0,
+              "cli": { "file": "c.tar.gz", "sha256": "aa", "size": 1 },
+              "fpm": { "file": "f.tar.gz", "sha256": "bb", "size": 1 } }
+        ] }"#;
+        match resolve_from_listing(bad, PhpVersion::new(8, 5), Os::Linux, Arch::X86_64) {
+            Err(PhpError::ListingParse { .. }) => {}
+            other => panic!("expected ListingParse for revision 0, got {other:?}"),
         }
     }
 

--- a/crates/yerd-php/src/release.rs
+++ b/crates/yerd-php/src/release.rs
@@ -1,49 +1,110 @@
 //! Pure resolution of prebuilt static-PHP download artifacts.
 //!
-//! Versions are discovered **dynamically** from the static-php-cli distribution
-//! (`dl.static-php.dev`) so yerd needs no release to support a new PHP patch:
-//! the daemon fetches the directory listing and `resolve_from_listing` (pure)
-//! picks the latest patch of the requested minor and builds the download URLs.
-//! Integrity rests on HTTPS to the distribution host (it publishes no checksum
-//! sidecars); there is no sha256 pinning - a deliberate trade-off so the
-//! supported set isn't frozen into the binary.
+//! Versions come from yerd's **own** signed manifest `php.json`, published on a
+//! single rolling GitHub release of the `forjedio/yerd-php` build repo. Those
+//! binaries link libcurl **without c-ares**, so PHP
+//! resolves yerd's scoped `.test` resolver (issue #59); the previous upstream
+//! `dl.static-php.dev` builds did not. The daemon fetches `php.json` +
+//! `php.json.minisig`, verifies the minisign signature (at the I/O edge), then
+//! hands the JSON body to [`resolve_from_listing`] / [`available_minors`] (both
+//! pure). Each build carries a per-tarball SHA-256 (verified after download) and
+//! a **revision** (`-N`) counter so a rebuild of an unchanged patch surfaces as
+//! an available upgrade to existing installs.
+//!
+//! ## Manifest format (`php.json`)
+//!
+//! ```json
+//! {
+//!   "schema": 1,
+//!   "builds": [
+//!     {
+//!       "php": "8.5.7", "minor": "8.5", "os": "macos", "arch": "aarch64",
+//!       "revision": 1,
+//!       "cli": { "file": "php-8.5.7-1-cli-macos-aarch64.tar.gz", "sha256": "…", "size": 123 },
+//!       "fpm": { "file": "php-8.5.7-1-fpm-macos-aarch64.tar.gz", "sha256": "…", "size": 123 }
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! We consume the manifest's `file` field **verbatim** to build the download URL
+//! (never reconstruct it), so a future naming tweak can't desync producer and
+//! consumer. The `schema` field gates compatibility - an unknown schema is
+//! rejected rather than misparsed.
 
+use serde::Deserialize;
 use yerd_core::PhpVersion;
 
 use crate::error::PhpError;
 
 /// Lowest PHP minor Yerd supports installing. The bundled `pcov` / `yerd-dump`
 /// extensions are only built for 8.2+, so older minors are filtered out of the
-/// installable list and rejected at resolve time even when the distribution
-/// still publishes them.
+/// installable list and rejected at resolve time even when the manifest still
+/// publishes them.
 pub const MIN_SUPPORTED: PhpVersion = PhpVersion::new(8, 2);
 
-/// Base URL of the static-php-cli prebuilt distribution for `os`.
+/// The `php.json` schema version this build understands. A producer-side bump
+/// signals an incompatible format change (additive changes do not bump it).
+pub const PHP_LISTING_SCHEMA: u32 = 1;
+
+/// Base URL of yerd's hosted, signed PHP distribution.
 ///
-/// Both platforms use the **bulk** extension set so a real-world Laravel app
-/// has what it needs out of the box - notably `intl` (ICU), plus `sodium`,
-/// `mysqli`, `xsl`, `readline`, `apcu`, … which the leaner `common` channel
-/// omits. The cost is a larger binary (~38 MB compressed); acceptable for a dev
-/// tool, and it keeps macOS and Linux on the *same* extension set.
-///
-/// Linux specifically needs the **`gnu-bulk`** (glibc) variant rather than the
-/// musl `bulk`: a fully-static musl PHP **cannot `dlopen` a shared extension**,
-/// which yerd needs for the `yerd-dump` / `pcov` extensions. The trade-off is a
-/// glibc-linked binary that no longer "runs on any libc" (Alpine/musl-only hosts
-/// are unsupported). macOS uses plain **`bulk`** (macOS permits `dlopen`
-/// regardless, and there is no separate glibc channel for it).
-const fn channel_base(os: Os) -> &'static str {
-    match os {
-        Os::Linux => "https://dl.static-php.dev/static-php-cli/gnu-bulk",
-        Os::Macos => "https://dl.static-php.dev/static-php-cli/bulk",
+/// A single rolling `php` release of the **separate** `forjedio/yerd-php` build
+/// repo holds every `php-<full>-<revision>-<cli|fpm>-<os>-<arch>.tar.gz` asset
+/// plus the generated `php.json` manifest and its detached `php.json.minisig`
+/// signature. Asset URLs 302-redirect to the blob; the daemon's downloader
+/// follows redirects. This crate is a pure *consumer* - the producer lives
+/// entirely in `forjedio/yerd-php`.
+pub const PHP_LISTING_BASE_URL: &str = "https://github.com/forjedio/yerd-php/releases/download/php";
+
+// ── manifest wire shape (private; deserialised from `php.json`) ──────────────
+
+#[derive(Debug, Deserialize)]
+struct Listing {
+    schema: u32,
+    #[serde(default)]
+    builds: Vec<BuildEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BuildEntry {
+    php: String,
+    minor: String,
+    os: String,
+    arch: String,
+    revision: u32,
+    cli: FileEntry,
+    fpm: FileEntry,
+}
+
+#[derive(Debug, Deserialize)]
+struct FileEntry {
+    file: String,
+    sha256: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    size: u64,
+}
+
+/// Parse + schema-check a `php.json` body.
+fn parse_listing(listing: &str) -> Result<Listing, PhpError> {
+    let parsed: Listing = serde_json::from_str(listing).map_err(|e| PhpError::ListingParse {
+        detail: e.to_string(),
+    })?;
+    if parsed.schema != PHP_LISTING_SCHEMA {
+        return Err(PhpError::UnsupportedListingSchema {
+            found: parsed.schema,
+            supported: PHP_LISTING_SCHEMA,
+        });
     }
+    Ok(parsed)
 }
 
 /// Target operating system for a prebuilt artifact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Os {
-    /// Linux (glibc `gnu-bulk` build - can load shared extensions; **not** the
-    /// musl `bulk` build, which can't `dlopen`).
+    /// Linux (glibc build - can load shared extensions; the manifest never
+    /// ships a fully-static musl build, which can't `dlopen`).
     Linux,
     /// macOS.
     Macos,
@@ -125,44 +186,45 @@ impl BinaryKind {
 pub struct Artifact {
     /// The requested major.minor version.
     pub version: PhpVersion,
-    /// The resolved full patch version (e.g. `"8.5.6"`).
+    /// The resolved full patch version (e.g. `"8.5.7"`).
     pub full_version: String,
+    /// Rebuild counter of the resolved build (the `-N` suffix; `>= 1`). Written
+    /// to the install's `.yerd-revision` marker and compared for upgrades.
+    pub revision: u32,
     /// Per-version install directory name (e.g. `"php-8.5"`).
     pub install_dir_name: String,
     /// URL of the CLI tarball.
     pub cli_url: String,
+    /// Expected SHA-256 (lowercase hex) of the CLI tarball bytes.
+    pub cli_sha256: String,
     /// URL of the FPM tarball.
     pub fpm_url: String,
+    /// Expected SHA-256 (lowercase hex) of the FPM tarball bytes.
+    pub fpm_sha256: String,
 }
 
-/// Build the canonical artifact URL for a `(full_version, kind, os, arch)`.
+/// URL of the signed `php.json` manifest (the daemon fetches this, verifies its
+/// signature, then hands the body to [`resolve_from_listing`]).
 #[must_use]
-pub fn artifact_url(full_version: &str, kind: BinaryKind, os: Os, arch: Arch) -> String {
-    format!(
-        "{}/php-{full_version}-{}-{}-{}.tar.gz",
-        channel_base(os),
-        kind.as_str(),
-        os.as_str(),
-        arch.as_str()
-    )
+pub fn listing_url() -> String {
+    format!("{PHP_LISTING_BASE_URL}/php.json")
 }
 
-/// URL of the distribution's directory listing for `os` (the daemon fetches
-/// this, then hands the body to [`resolve_from_listing`]). The channel differs
-/// per OS (see [`channel_base`]), so the listing URL does too.
+/// URL of the detached minisign signature over [`listing_url`]'s `php.json`.
 #[must_use]
-pub fn listing_url(os: Os) -> String {
-    format!("{}/", channel_base(os))
+pub fn listing_sig_url() -> String {
+    format!("{PHP_LISTING_BASE_URL}/php.json.minisig")
 }
 
-/// Resolve a requested major.minor version + platform to an [`Artifact`] by
-/// scanning the distribution's directory `listing` for the **latest patch**.
+/// Resolve a requested major.minor version + platform to an [`Artifact`] from
+/// the `php.json` manifest body.
 ///
-/// Looks for filenames `php-<maj>.<min>.<patch>-cli-<os>-<arch>.tar.gz` (the
-/// `php-<maj>.<min>.` prefix carries a trailing dot, so `8.5` never matches
-/// `8.50`; the `-cli-<os>-<arch>` suffix anchors the arch), takes the highest
-/// patch, and builds both the CLI and FPM URLs. Errors with
-/// [`PhpError::VersionUnavailable`] when no matching build is published.
+/// Retention guarantees at most one build per `(minor, os, arch)`, so this
+/// selects the single matching entry (no patch scanning) and builds both URLs
+/// from the manifest's `file` fields **verbatim**. Errors with
+/// [`PhpError::VersionUnavailable`] when no matching build is published, and
+/// with [`PhpError::ListingParse`] / [`PhpError::UnsupportedListingSchema`] when
+/// the manifest is malformed or a newer schema.
 pub fn resolve_from_listing(
     listing: &str,
     version: PhpVersion,
@@ -172,104 +234,57 @@ pub fn resolve_from_listing(
     if version < MIN_SUPPORTED {
         return Err(PhpError::VersionUnavailable { version });
     }
-    let prefix = format!("php-{}.{}.", version.major, version.minor);
-    let suffix = format!(
-        "-{}-{}-{}.tar.gz",
-        BinaryKind::Cli.as_str(),
-        os.as_str(),
-        arch.as_str()
-    );
+    let parsed = parse_listing(listing)?;
+    let want_minor = format!("{}.{}", version.major, version.minor);
 
-    let mut best: Option<u32> = None;
-    let mut chunks = listing.split(prefix.as_str());
-    let _ = chunks.next();
-    for chunk in chunks {
-        let digits: String = chunk.chars().take_while(char::is_ascii_digit).collect();
-        if digits.is_empty() {
-            continue;
-        }
-        let Some(remainder) = chunk.strip_prefix(&digits) else {
-            continue;
-        };
-        if remainder.starts_with(&suffix) {
-            if let Ok(patch) = digits.parse::<u32>() {
-                best = Some(best.map_or(patch, |b| b.max(patch)));
-            }
-        }
-    }
+    let entry = parsed
+        .builds
+        .into_iter()
+        .find(|b| b.os == os.as_str() && b.arch == arch.as_str() && b.minor == want_minor)
+        .ok_or(PhpError::VersionUnavailable { version })?;
 
-    let patch = best.ok_or(PhpError::VersionUnavailable { version })?;
-    let full_version = format!("{}.{}.{}", version.major, version.minor, patch);
     Ok(Artifact {
         install_dir_name: format!("php-{}.{}", version.major, version.minor),
-        cli_url: artifact_url(&full_version, BinaryKind::Cli, os, arch),
-        fpm_url: artifact_url(&full_version, BinaryKind::Fpm, os, arch),
-        full_version,
+        revision: entry.revision,
+        cli_url: format!("{PHP_LISTING_BASE_URL}/{}", entry.cli.file),
+        cli_sha256: entry.cli.sha256,
+        fpm_url: format!("{PHP_LISTING_BASE_URL}/{}", entry.fpm.file),
+        fpm_sha256: entry.fpm.sha256,
+        full_version: entry.php,
         version,
     })
 }
 
-/// Every distinct major.minor in `listing` that has a CLI build for
-/// `(os, arch)`, ascending. Pure; the daemon fetches the listing and hands the
+/// Every distinct major.minor in the manifest that has a build for `(os, arch)`,
+/// ascending. Pure; the daemon fetches + verifies the manifest and hands the
 /// body here to populate the "installable versions" list (the GUI dropdown /
 /// `yerd list php --available`).
 ///
-/// Scans for filenames `php-<maj>.<min>.<patch>-cli-<os>-<arch>.tar.gz`,
-/// parsing `<maj>` and `<min>` as **integers** (not substrings) so `8.5` and
-/// `8.50` stay distinct. Entries whose major/minor overflow `u8`, or that lack
-/// the exact CLI/arch suffix, are skipped. The result is sorted and deduped.
+/// A malformed or unknown-schema manifest yields an empty list (the caller
+/// treats PHP as uninstallable rather than erroring); use
+/// [`resolve_from_listing`] when a hard error is wanted.
 #[must_use]
 pub fn available_minors(listing: &str, os: Os, arch: Arch) -> Vec<PhpVersion> {
-    let suffix = format!(
-        "-{}-{}-{}.tar.gz",
-        BinaryKind::Cli.as_str(),
-        os.as_str(),
-        arch.as_str()
-    );
-
-    let mut out: Vec<PhpVersion> = Vec::new();
-    let mut chunks = listing.split("php-");
-    let _ = chunks.next();
-    for chunk in chunks {
-        let Some((major, rest)) = take_u8(chunk) else {
-            continue;
-        };
-        let Some(rest) = rest.strip_prefix('.') else {
-            continue;
-        };
-        let Some((minor, rest)) = take_u8(rest) else {
-            continue;
-        };
-        let Some(rest) = rest.strip_prefix('.') else {
-            continue;
-        };
-        let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
-        if digits.is_empty() {
-            continue;
-        }
-        let Some(after_patch) = rest.strip_prefix(&digits) else {
-            continue;
-        };
-        if after_patch.starts_with(&suffix) {
-            let v = PhpVersion::new(major, minor);
-            if v >= MIN_SUPPORTED {
-                out.push(v);
-            }
-        }
-    }
-
+    let Ok(parsed) = parse_listing(listing) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PhpVersion> = parsed
+        .builds
+        .iter()
+        .filter(|b| b.os == os.as_str() && b.arch == arch.as_str())
+        .filter_map(|b| parse_minor(&b.minor))
+        .filter(|v| *v >= MIN_SUPPORTED)
+        .collect();
     out.sort_unstable();
     out.dedup();
     out
 }
 
-/// Take a leading run of ASCII digits as a `u8`, returning it with the rest of
-/// the string. `None` if there are no leading digits or they overflow `u8`.
-fn take_u8(s: &str) -> Option<(u8, &str)> {
-    let digits: String = s.chars().take_while(char::is_ascii_digit).collect();
-    let value: u8 = digits.parse().ok()?;
-    let rest = s.strip_prefix(&digits)?;
-    Some((value, rest))
+/// Parse a `"<maj>.<min>"` minor string into a [`PhpVersion`]; `None` if either
+/// component is missing or overflows `u8`.
+fn parse_minor(s: &str) -> Option<PhpVersion> {
+    let (major, minor) = s.split_once('.')?;
+    Some(PhpVersion::new(major.parse().ok()?, minor.parse().ok()?))
 }
 
 /// Detect the running platform, erroring on anything yerd can't install for
@@ -313,13 +328,38 @@ pub fn patch_of(full_version: &str) -> Option<u32> {
     full_version.split('.').nth(2)?.parse().ok()
 }
 
-/// Whether `candidate` is a newer patch than `installed` (same major.minor
-/// assumed; malformed inputs → `false`).
+/// Whether the candidate build `(patch, revision)` is newer than the installed
+/// one (same major.minor assumed). True when the candidate patch is higher, or
+/// the patch is equal and the candidate revision is higher. A malformed patch on
+/// either side → `false`.
+///
+/// The revision dimension is what makes a *rebuild of an unchanged patch* (e.g.
+/// the c-ares cutover, `8.5.7-1`) reach an existing `8.5.7` install recorded as
+/// revision 0. It never downgrades.
 #[must_use]
-pub fn is_newer(installed_full: &str, candidate_full: &str) -> bool {
-    match (patch_of(installed_full), patch_of(candidate_full)) {
-        (Some(installed), Some(candidate)) => candidate > installed,
+pub fn is_newer_build(
+    installed_patch: &str,
+    installed_rev: u32,
+    candidate_patch: &str,
+    candidate_rev: u32,
+) -> bool {
+    match (patch_of(installed_patch), patch_of(candidate_patch)) {
+        (Some(installed), Some(candidate)) => {
+            candidate > installed || (candidate == installed && candidate_rev > installed_rev)
+        }
         _ => false,
+    }
+}
+
+/// The user-visible build identity `"<patch>-<revision>"`, e.g. `"8.5.7-1"`.
+/// A revision of 0 (a legacy install predating the `.yerd-revision` marker)
+/// renders as the bare patch, so pre-cutover installs keep their old display.
+#[must_use]
+pub fn display_build(patch: &str, revision: u32) -> String {
+    if revision >= 1 {
+        format!("{patch}-{revision}")
+    } else {
+        patch.to_owned()
     }
 }
 
@@ -328,146 +368,149 @@ pub fn is_newer(installed_full: &str, candidate_full: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// A listing snippet shaped like the real autoindex (href + duplicate text
-    /// node), spanning several patches, minors, kinds, and arches.
-    const LISTING: &str = r#"
-        <a href="/static-php-cli/gnu-bulk/php-8.5.2-cli-linux-x86_64.tar.gz">php-8.5.2-cli-linux-x86_64.tar.gz</a>
-        <a href="/static-php-cli/gnu-bulk/php-8.5.6-cli-linux-x86_64.tar.gz">php-8.5.6-cli-linux-x86_64.tar.gz</a>
-        <a href="/static-php-cli/gnu-bulk/php-8.5.6-fpm-linux-x86_64.tar.gz">php-8.5.6-fpm-linux-x86_64.tar.gz</a>
-        <a href="/static-php-cli/gnu-bulk/php-8.5.4-cli-linux-aarch64.tar.gz">php-8.5.4-cli-linux-aarch64.tar.gz</a>
-        <a href="/static-php-cli/gnu-bulk/php-8.50.1-cli-linux-x86_64.tar.gz">php-8.50.1-cli-linux-x86_64.tar.gz</a>
-        <a href="/static-php-cli/gnu-bulk/php-8.4.21-cli-linux-x86_64.tar.gz">php-8.4.21-cli-linux-x86_64.tar.gz</a>
-    "#;
+    /// A `php.json` body spanning several minors and all four targets, shaped
+    /// like the real manifest (§7). 8.1 is below the floor; 8.5 has a rebuild.
+    const LISTING: &str = r#"{
+        "schema": 1,
+        "generated_at": "2026-07-01T00:00:00Z",
+        "builds": [
+            { "php": "8.1.31", "minor": "8.1", "os": "linux", "arch": "x86_64", "revision": 1,
+              "cli": { "file": "php-8.1.31-1-cli-linux-x86_64.tar.gz", "sha256": "aa", "size": 1 },
+              "fpm": { "file": "php-8.1.31-1-fpm-linux-x86_64.tar.gz", "sha256": "bb", "size": 1 } },
+            { "php": "8.4.21", "minor": "8.4", "os": "linux", "arch": "x86_64", "revision": 3,
+              "cli": { "file": "php-8.4.21-3-cli-linux-x86_64.tar.gz", "sha256": "cc", "size": 1 },
+              "fpm": { "file": "php-8.4.21-3-fpm-linux-x86_64.tar.gz", "sha256": "dd", "size": 1 } },
+            { "php": "8.5.7", "minor": "8.5", "os": "linux", "arch": "x86_64", "revision": 2,
+              "cli": { "file": "php-8.5.7-2-cli-linux-x86_64.tar.gz", "sha256": "ee", "size": 1 },
+              "fpm": { "file": "php-8.5.7-2-fpm-linux-x86_64.tar.gz", "sha256": "ff", "size": 1 } },
+            { "php": "8.5.7", "minor": "8.5", "os": "linux", "arch": "aarch64", "revision": 2,
+              "cli": { "file": "php-8.5.7-2-cli-linux-aarch64.tar.gz", "sha256": "11", "size": 1 },
+              "fpm": { "file": "php-8.5.7-2-fpm-linux-aarch64.tar.gz", "sha256": "22", "size": 1 } },
+            { "php": "8.5.7", "minor": "8.5", "os": "macos", "arch": "aarch64", "revision": 2,
+              "cli": { "file": "php-8.5.7-2-cli-macos-aarch64.tar.gz", "sha256": "33", "size": 1 },
+              "fpm": { "file": "php-8.5.7-2-fpm-macos-aarch64.tar.gz", "sha256": "44", "size": 1 } }
+        ]
+    }"#;
 
     #[test]
-    fn resolve_from_listing_picks_max_patch_and_builds_urls() {
+    fn resolve_from_listing_selects_entry_and_builds_urls() {
         let a =
             resolve_from_listing(LISTING, PhpVersion::new(8, 5), Os::Linux, Arch::X86_64).unwrap();
-        assert_eq!(a.full_version, "8.5.6");
+        assert_eq!(a.full_version, "8.5.7");
+        assert_eq!(a.revision, 2);
         assert_eq!(a.install_dir_name, "php-8.5");
         assert_eq!(
             a.cli_url,
-            "https://dl.static-php.dev/static-php-cli/gnu-bulk/php-8.5.6-cli-linux-x86_64.tar.gz"
+            "https://github.com/forjedio/yerd-php/releases/download/php/php-8.5.7-2-cli-linux-x86_64.tar.gz"
         );
+        assert_eq!(a.cli_sha256, "ee");
         assert_eq!(
             a.fpm_url,
-            "https://dl.static-php.dev/static-php-cli/gnu-bulk/php-8.5.6-fpm-linux-x86_64.tar.gz"
+            "https://github.com/forjedio/yerd-php/releases/download/php/php-8.5.7-2-fpm-linux-x86_64.tar.gz"
         );
+        assert_eq!(a.fpm_sha256, "ff");
     }
 
     #[test]
-    fn channel_differs_by_os() {
+    fn listing_urls_point_at_the_signed_manifest() {
         assert_eq!(
-            artifact_url("8.5.6", BinaryKind::Fpm, Os::Linux, Arch::X86_64),
-            "https://dl.static-php.dev/static-php-cli/gnu-bulk/php-8.5.6-fpm-linux-x86_64.tar.gz"
+            listing_url(),
+            "https://github.com/forjedio/yerd-php/releases/download/php/php.json"
         );
         assert_eq!(
-            listing_url(Os::Linux),
-            "https://dl.static-php.dev/static-php-cli/gnu-bulk/"
+            listing_sig_url(),
+            "https://github.com/forjedio/yerd-php/releases/download/php/php.json.minisig"
         );
-        assert_eq!(
-            artifact_url("8.5.6", BinaryKind::Cli, Os::Macos, Arch::Aarch64),
-            "https://dl.static-php.dev/static-php-cli/bulk/php-8.5.6-cli-macos-aarch64.tar.gz"
-        );
-        assert_eq!(
-            listing_url(Os::Macos),
-            "https://dl.static-php.dev/static-php-cli/bulk/"
-        );
-    }
-
-    #[test]
-    fn resolve_from_listing_does_not_confuse_8_5_with_8_50() {
-        let only_850 = "php-8.50.1-cli-linux-x86_64.tar.gz";
-        assert!(matches!(
-            resolve_from_listing(only_850, PhpVersion::new(8, 5), Os::Linux, Arch::X86_64),
-            Err(PhpError::VersionUnavailable { .. })
-        ));
     }
 
     #[test]
     fn resolve_from_listing_anchors_arch() {
         let a =
             resolve_from_listing(LISTING, PhpVersion::new(8, 5), Os::Linux, Arch::Aarch64).unwrap();
-        assert_eq!(a.full_version, "8.5.4");
         assert!(a.cli_url.contains("linux-aarch64"));
+        assert_eq!(a.cli_sha256, "11");
     }
 
     #[test]
     fn resolve_from_listing_unknown_minor_errors() {
-        match resolve_from_listing(LISTING, PhpVersion::new(7, 4), Os::Linux, Arch::X86_64) {
+        match resolve_from_listing(LISTING, PhpVersion::new(8, 3), Os::Linux, Arch::X86_64) {
             Err(PhpError::VersionUnavailable { version }) => {
-                assert_eq!(version, PhpVersion::new(7, 4));
+                assert_eq!(version, PhpVersion::new(8, 3));
             }
             other => panic!("expected VersionUnavailable, got {other:?}"),
         }
     }
 
     #[test]
-    fn min_supported_floor_drops_8_0_and_8_1() {
-        let listing = "\
-            php-8.0.30-cli-linux-x86_64.tar.gz \
-            php-8.1.31-cli-linux-x86_64.tar.gz \
-            php-8.2.27-cli-linux-x86_64.tar.gz \
-            php-8.5.6-cli-linux-x86_64.tar.gz";
-        let got = available_minors(listing, Os::Linux, Arch::X86_64);
-        assert_eq!(got, vec![PhpVersion::new(8, 2), PhpVersion::new(8, 5)]);
-        for minor in [PhpVersion::new(8, 0), PhpVersion::new(8, 1)] {
-            match resolve_from_listing(listing, minor, Os::Linux, Arch::X86_64) {
-                Err(PhpError::VersionUnavailable { version }) => assert_eq!(version, minor),
-                other => panic!("expected VersionUnavailable for {minor}, got {other:?}"),
+    fn resolve_rejects_unknown_schema() {
+        let bad = r#"{ "schema": 99, "builds": [] }"#;
+        match resolve_from_listing(bad, PhpVersion::new(8, 5), Os::Linux, Arch::X86_64) {
+            Err(PhpError::UnsupportedListingSchema { found, supported }) => {
+                assert_eq!(found, 99);
+                assert_eq!(supported, PHP_LISTING_SCHEMA);
             }
+            other => panic!("expected UnsupportedListingSchema, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn resolve_reports_parse_error_on_garbage() {
+        match resolve_from_listing("not json", PhpVersion::new(8, 5), Os::Linux, Arch::X86_64) {
+            Err(PhpError::ListingParse { .. }) => {}
+            other => panic!("expected ListingParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn min_supported_floor_drops_below_8_2() {
+        let got = available_minors(LISTING, Os::Linux, Arch::X86_64);
+        assert_eq!(got, vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)]);
+        match resolve_from_listing(LISTING, PhpVersion::new(8, 1), Os::Linux, Arch::X86_64) {
+            Err(PhpError::VersionUnavailable { version }) => {
+                assert_eq!(version, PhpVersion::new(8, 1));
+            }
+            other => panic!("expected VersionUnavailable for 8.1, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn available_minors_anchors_platform() {
         assert_eq!(
-            resolve_from_listing(listing, PhpVersion::new(8, 2), Os::Linux, Arch::X86_64)
-                .unwrap()
-                .full_version,
-            "8.2.27"
+            available_minors(LISTING, Os::Macos, Arch::Aarch64),
+            vec![PhpVersion::new(8, 5)]
+        );
+        assert_eq!(
+            available_minors(LISTING, Os::Linux, Arch::Aarch64),
+            vec![PhpVersion::new(8, 5)]
         );
     }
 
     #[test]
-    fn available_minors_lists_distinct_cli_builds_for_platform() {
-        let got = available_minors(LISTING, Os::Linux, Arch::X86_64);
-        assert_eq!(
-            got,
-            vec![
-                PhpVersion::new(8, 4),
-                PhpVersion::new(8, 5),
-                PhpVersion::new(8, 50),
-            ]
-        );
-    }
-
-    #[test]
-    fn available_minors_anchors_arch() {
-        let got = available_minors(LISTING, Os::Linux, Arch::Aarch64);
-        assert_eq!(got, vec![PhpVersion::new(8, 5)]);
-    }
-
-    #[test]
-    fn available_minors_keeps_8_5_and_8_50_distinct() {
-        let got = available_minors(LISTING, Os::Linux, Arch::X86_64);
-        assert!(got.contains(&PhpVersion::new(8, 5)));
-        assert!(got.contains(&PhpVersion::new(8, 50)));
-        assert_ne!(PhpVersion::new(8, 5), PhpVersion::new(8, 50));
-    }
-
-    #[test]
-    fn available_minors_empty_listing_is_empty() {
+    fn available_minors_malformed_listing_is_empty() {
         assert!(available_minors("", Os::Linux, Arch::X86_64).is_empty());
-        let fpm_only = "php-8.5.6-fpm-linux-x86_64.tar.gz";
-        assert!(available_minors(fpm_only, Os::Linux, Arch::X86_64).is_empty());
+        assert!(available_minors("not json", Os::Linux, Arch::X86_64).is_empty());
+        let unknown_schema = r#"{ "schema": 2, "builds": [] }"#;
+        assert!(available_minors(unknown_schema, Os::Linux, Arch::X86_64).is_empty());
     }
 
     #[test]
-    fn is_newer_compares_patch() {
-        assert!(is_newer("8.5.6", "8.5.7"));
-        assert!(!is_newer("8.5.6", "8.5.6"));
-        assert!(!is_newer("8.5.7", "8.5.6"));
-        assert!(!is_newer("8.5", "8.5.7"));
-        assert!(!is_newer("8.5.6", "nope"));
-        assert_eq!(patch_of("8.5.6"), Some(6));
+    fn is_newer_build_covers_patch_revision_and_autoheal() {
+        assert!(is_newer_build("8.5.6", 1, "8.5.7", 1));
+        assert!(is_newer_build("8.5.7", 1, "8.5.7", 2));
+        assert!(is_newer_build("8.5.7", 0, "8.5.7", 1));
+        assert!(!is_newer_build("8.5.7", 1, "8.5.7", 1));
+        assert!(!is_newer_build("8.5.7", 2, "8.5.7", 1));
+        assert!(!is_newer_build("8.5.9", 1, "8.5.7", 1));
+        assert!(!is_newer_build("8.5", 0, "8.5.7", 1));
+        assert_eq!(patch_of("8.5.7"), Some(7));
         assert_eq!(patch_of("8.5"), None);
+    }
+
+    #[test]
+    fn display_build_omits_zero_revision() {
+        assert_eq!(display_build("8.5.7", 1), "8.5.7-1");
+        assert_eq!(display_build("8.5.7", 2), "8.5.7-2");
+        assert_eq!(display_build("8.5.7", 0), "8.5.7");
     }
 
     #[test]

--- a/crates/yerd-services/src/release.rs
+++ b/crates/yerd-services/src/release.rs
@@ -1,9 +1,9 @@
 //! Pure resolution of prebuilt service download artifacts from **yerd's own**
 //! hosted listing.
 //!
-//! Unlike PHP (which consumes the upstream `static-php-cli` distribution), there
-//! is no single multi-platform distribution for databases, so yerd builds and
-//! hosts its own (the `forjedio/yerd-services` build matrix) and publishes a
+//! Like PHP (whose signed `php.json` yerd hosts on `forjedio/yerd-php`), there
+//! is no ready-made multi-platform distribution for databases, so yerd builds
+//! and hosts its own (the `forjedio/yerd-services` build matrix) and publishes a
 //! machine-readable `services.json` listing. The daemon fetches the listing and
 //! hands the body to [`resolve_from_listing`] / [`available_versions`] (both
 //! pure).

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -12,6 +12,13 @@ use crate::{Asset, ReleaseMeta};
 /// The minisign public key whose secret half signs release artifacts.
 pub const UPDATE_PUBLIC_KEY: &str = "RWRXUQIpU8uZ3B6SV3yFsK3+aAWZX+efytjc8F+8PTuViL8/nNPsQxpi";
 
+/// The minisign public key whose secret half signs the `php.json` manifest in
+/// `forjedio/yerd-php`. A **dedicated** key, distinct from [`UPDATE_PUBLIC_KEY`]:
+/// PHP executes as the user, so the manifest is verified on the install critical
+/// path (not just app updates). Rotating it requires shipping a new yerd with the
+/// new key, since it is pinned in the binary.
+pub const PHP_LISTING_PUBLIC_KEY: &str = "RWRtVdsOqEEQ4/LBPGjnS97agmhMj0k/X18GXFHHOJfIuuzE4SMymlQD";
+
 /// The host platform an artifact targets. Decoupled from `cfg!` so selection is
 /// testable for every platform from any build; the daemon passes
 /// [`Platform::current`].

--- a/crates/yerd-update/src/lib.rs
+++ b/crates/yerd-update/src/lib.rs
@@ -19,7 +19,8 @@ use semver::Version;
 mod artifact;
 pub use artifact::{
     select_asset, sha256_for, sha256_hex, verify_minisign, verify_sha256, ArtifactKind,
-    ArtifactSelection, AssetError, PkgFormat, Platform, VerifyError, UPDATE_PUBLIC_KEY,
+    ArtifactSelection, AssetError, PkgFormat, Platform, VerifyError, PHP_LISTING_PUBLIC_KEY,
+    UPDATE_PUBLIC_KEY,
 };
 
 /// Self-update release channel.

--- a/docs/developer/crates/yerd-php.md
+++ b/docs/developer/crates/yerd-php.md
@@ -352,23 +352,22 @@ During `HealthCheck`, the driver `tokio::select!`s the FastCGI probe (wrapped in
 ## Version & release handling
 
 ::: tip PHP is downloaded, not bundled
-Yerd does not ship PHP. It downloads prebuilt, fully-static PHP builds from the [static-php-cli](https://dl.static-php.dev/static-php-cli/) distribution on demand when you run `yerd install php`. It uses the **bulk** extension set (glibc `gnu-bulk` on Linux, `bulk` on macOS) so common Laravel needs like `intl`, `sodium`, and `mysqli` are included. See the [PHP Versions guide](../../guide/php-versions).
+Yerd does not ship PHP. It downloads prebuilt, statically-linked PHP builds that Yerd publishes itself (the `forjedio/yerd-php` build repo) on demand when you run `yerd install php`. Those builds link libcurl **without c-ares** so PHP resolves Yerd's scoped `.test` resolver, and ship the **bulk** extension set (glibc on Linux) so common Laravel needs like `intl`, `sodium`, and `mysqli` are included. See the [PHP Versions guide](../../guide/php-versions).
 :::
 
-### `release.rs` - pure artifact resolution
+### `release.rs` - pure manifest resolution
 
-Supported versions are discovered **dynamically** from the distribution's directory listing, so Yerd needs no new release to support a new PHP patch. The daemon fetches the listing (over HTTPS - there is no checksum sidecar and no SHA pinning, a deliberate trade-off so the supported set isn't frozen into the binary) and hands the body to the pure functions here:
+Supported versions come from Yerd's signed `php.json` manifest. The daemon fetches `php.json` + its detached `php.json.minisig`, **verifies the minisign signature** (at the I/O edge, against the embedded `PHP_LISTING_PUBLIC_KEY`), then hands the trusted JSON body to the pure functions here. Each build also carries a per-tarball SHA-256 (verified after download) and a `revision` (`-N`) counter:
 
 | Function | Purpose |
 | --- | --- |
-| `resolve_from_listing(listing, version, os, arch)` | Scans for `php-<maj>.<min>.<patch>-cli-<os>-<arch>.tar.gz`, takes the highest patch, and returns an `Artifact` with both `cli_url` and `fpm_url`. Errors `VersionUnavailable` if none match. |
-| `available_minors(listing, os, arch)` | Every distinct major.minor with a CLI build for the platform, sorted + deduped. Feeds the GUI dropdown / `yerd list php`. |
-| `artifact_url(full, kind, os, arch)` | Builds a canonical `dl.static-php.dev` URL. |
-| `listing_url()` | URL of the directory listing the daemon fetches. |
+| `resolve_from_listing(listing, version, os, arch)` | Selects the single `(minor, os, arch)` build and returns an `Artifact` with `cli_url`/`fpm_url`, their `sha256`s, and the `revision`. Errors `VersionUnavailable` if none match, or `UnsupportedListingSchema` / `ListingParse` on a bad manifest. |
+| `available_minors(listing, os, arch)` | Every distinct major.minor with a build for the platform, sorted + deduped. Feeds the GUI dropdown / `yerd list php`. |
+| `listing_url()` / `listing_sig_url()` | URLs of the `php.json` manifest and its detached signature. |
 | `is_safe_member(name)` | Zip-slip guard: a tar member is trusted only if relative with no `..`, root, or prefix components. |
-| `is_newer` / `patch_of` | Patch-level comparison for update checks. |
+| `is_newer_build` / `patch_of` / `display_build` | Build-level `(patch, revision)` comparison for update checks, and the `<patch>-<revision>` display string. |
 
-The parsing is carefully anchored. The `php-<maj>.<min>.` prefix carries a **trailing dot**, so a request for `8.5` never matches a `8.50.x` artifact; `available_minors` parses major/minor as *integers* (not substrings) for the same reason, and the `-cli-<os>-<arch>` suffix anchors the architecture so an x86_64 query never picks up an aarch64-only patch. `Os` is `Linux | Macos` and `Arch` is `X86_64 | Aarch64`; `current_os_arch()` errors with `UnsupportedPlatform` on anything else (e.g. Windows, 32-bit) and must be called before any download.
+`Os` is `Linux | Macos` and `Arch` is `X86_64 | Aarch64` (the `std::env::consts` spellings the manifest uses); `current_os_arch()` errors with `UnsupportedPlatform` on anything else (e.g. Windows, 32-bit) and must be called before any download. The `revision` dimension is what makes a rebuild of an unchanged patch (e.g. the c-ares cutover, `8.5.7-1`) reach an existing install: a pre-cutover install recorded as revision 0 is offered the `-1` rebuild.
 
 `BinaryKind` (`Cli` / `Fpm`) maps to install layout: CLI installs to `bin/php`, FPM to `sbin/php-fpm`, and the archive members are named `php` / `php-fpm`.
 

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -1,6 +1,6 @@
 # PHP Versions
 
-Yerd runs **any number of PHP versions side by side** and lets you pick which one each site uses. PHP isn't bundled, so the install stays small. The first time you ask for a version, Yerd downloads a prebuilt static [`static-php-cli`](https://github.com/crazywhalecc/static-php-cli) build and supervises one PHP-FPM pool per version behind the [reverse proxy](./sites).
+Yerd runs **any number of PHP versions side by side** and lets you pick which one each site uses. PHP isn't bundled, so the install stays small. The first time you ask for a version, Yerd downloads a prebuilt, statically-linked PHP build that Yerd publishes itself (signed and checksummed) and supervises one PHP-FPM pool per version behind the [reverse proxy](./sites).
 
 ## In the desktop app
 
@@ -22,21 +22,21 @@ The fastest way to manage PHP is the **PHP** page (under the **Environment** gro
 yerd install php 8.5
 ```
 
-Yerd detects your platform (`linux`/`macos`, `x86_64`/`aarch64`), fetches the live listing from the static-php-cli distribution, resolves the latest published patch of that minor, downloads the CLI and FPM tarballs, then atomically swaps them into place. Versions are discovered from the distribution at runtime, so a brand-new PHP patch is installable the day it ships, with no Yerd release needed.
+Yerd detects your platform (`linux`/`macos`, `x86_64`/`aarch64`), fetches Yerd's signed `php.json` manifest, resolves the single published build for your platform and minor, downloads the CLI and FPM tarballs, verifies each against its published SHA-256, then atomically swaps them into place. The manifest is the source of truth for what's installable, so a new PHP patch becomes available as soon as Yerd's build pipeline publishes it.
 
-Installs are **idempotent**: running it again replaces the directory with a fresh download of the latest patch. If the version isn't published for your platform, the install fails cleanly and writes nothing. The running daemon picks up a new version automatically, no restart required.
+Installs are **idempotent**: running it again replaces the directory with a fresh download of the current build. If the version isn't published for your platform, the install fails cleanly and writes nothing. The running daemon picks up a new version automatically, no restart required.
 
 ::: info A version is always a major.minor
 A "PHP version" means a `major.minor` pair like `8.5`, never a full patch like `8.3.12`. Yerd installs and tracks the latest patch of the minor you ask for, and updates move you to a newer patch of that same minor. Input is `8.5` (or `php8.5`); major must be `5..=9`, minor `0..=99`.
 :::
 
-::: info Integrity is TLS-pinned, not hash-pinned
-The distribution publishes no checksums, so Yerd verifies downloads over HTTPS to the distribution host rather than a pinned SHA-256. That keeps the supported version set from being frozen into the binary. (Yerd's own release artifacts are separately verified against a `SHA256SUMS` manifest; see [Getting Started](./getting-started).)
+::: info Downloads are signed and hash-verified
+The `php.json` manifest is signed with a dedicated minisign key whose public half is embedded in Yerd; the daemon verifies that signature before trusting the manifest, then verifies each downloaded tarball against the SHA-256 the manifest lists. Because PHP runs as you, this verification is on the install critical path, not just updates.
 :::
 
 ### Bundled extensions
 
-Yerd uses static-php-cli's **bulk** extension set, so a real-world Laravel app has
+Yerd's builds ship the **bulk** extension set, so a real-world Laravel app has
 what it needs out of the box. Beyond the common extensions, this includes
 **`intl`** (ICU — required by Laravel's `Number` helper and many localization
 packages), **`sodium`**, **`mysqli`**, **`xsl`**, **`readline`**, and **`apcu`**,

--- a/docs/guide/tooling.md
+++ b/docs/guide/tooling.md
@@ -153,7 +153,7 @@ first (`yerd install php 8.4`); otherwise `composer` reports that no PHP is
 available. Node and Bun are standalone and have no such dependency.
 
 ::: tip ext-intl and friends
-Yerd's PHP builds ship the **bulk** static-php-cli extension set, including
+Yerd's PHP builds ship the **bulk** extension set, including
 `intl`, `sodium`, `mysqli`, and more — so Composer packages that require them
 install without extra steps. See [PHP Versions](./php-versions) for the bundled
 extension list.

--- a/docs/guide/upgrading-from-v1.md
+++ b/docs/guide/upgrading-from-v1.md
@@ -11,7 +11,7 @@ Yerd v2 (`forjedio/yerd`) is a ground-up Rust rewrite. Different binaries, a dif
 | Area | v1 (Go) | v2 (Rust) |
 |---|---|---|
 | Privileges | leaned on `sudo` for most operations | rootless; elevates once, then runs as your user |
-| PHP | built from source | prebuilt static builds (`static-php-cli`) downloaded on demand |
+| PHP | built from source | prebuilt, signed static builds downloaded on demand |
 | Platforms | - | macOS + Linux today (Windows on the [roadmap](./services)) |
 | Config & layout | v1's format | new, incompatible TOML config and layout |
 | Commands | v1's names | redesigned; don't assume names carry over |

--- a/docs/php-ext/architecture.md
+++ b/docs/php-ext/architecture.md
@@ -182,8 +182,8 @@ and debug flags. PHP refuses to load a `.so` whose build-id doesn't match the en
 arch) are fixed by how Yerd ships PHP, so they're statically known - no runtime
 introspection needed.
 
-**Build against the same PHP that Yerd ships** (static-php.dev: `gnu-bulk`/glibc on
-Linux, the macOS channel on macOS, all **NTS**) so the build-id matches. Mismatched
+**Build against the same PHP that Yerd ships** (the `forjedio/yerd-php` builds:
+glibc on Linux, all **NTS**) so the build-id matches. Mismatched
 NTS/debug/minor → load failure or crash.
 
 ### 5.2 Build matrix

--- a/docs/php-ext/implementation_plan.md
+++ b/docs/php-ext/implementation_plan.md
@@ -66,7 +66,7 @@ silences it; server-down is invisible to the app.
 
 ## Phase C - Build matrix & releases (CI)
 
-1. **Per-target builds** against the matching PHP headers (the same static-php.dev
+1. **Per-target builds** against the matching PHP headers (the same `forjedio/yerd-php`
    builds Yerd ships: glibc/NTS on Linux, NTS on macOS) so build-ids match. Cells:
    PHP minor × {macos-arm64, macos-x86_64, linux-x86_64, linux-aarch64}.
 2. **Artifact naming** `yerd-dump-<phpminor>-<os>-<arch>.so`; publish to GitHub


### PR DESCRIPTION
## What does this PR do?

Cut PHP installs over from scraping dl.static-php.dev to a signed, self-hosted php.json manifest (fixes #59: c-ares-free builds resolve .test). Adds minisign + per-tarball SHA-256 verification and a revision (-N) dimension that auto-heals existing installs (e.g. 8.5.7 → 8.5.7-1), and restarts the FPM pool after an update.

**BEFORE:**
<img width="1080" height="355" alt="image" src="https://github.com/user-attachments/assets/0586c1ea-f15e-4be0-8541-5a578b4327a6" />

**AFTER:**
<img width="1069" height="350" alt="image" src="https://github.com/user-attachments/assets/adcd9afe-b02e-4895-b0ae-f117f6f7fed1" />

SSL error to be resolved as part of a separate PR

## Related issues

Closes #59 

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PHP installs and updates are now driven by a signed `php.json` manifest with build revision tracking.
  * Update operations restart only currently active PHP-FPM pools that were updated.
* **Bug Fixes**
  * PHP tarball downloads are pinned to manifest SHA-256; mismatches abort safely without writing.
  * Update polling tolerates temporary manifest fetch/verification issues without breaking cached update state.
* **Documentation**
  * Updated PHP install/upgrade guides to explain signed-manifest verification, checksum pinning, and revision-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->