### PR TITLE
[Fix] Allow static sites (index.html/htm serving)

### DIFF
--- a/crates/yerd-proxy/src/forward/static_file.rs
+++ b/crates/yerd-proxy/src/forward/static_file.rs
@@ -39,7 +39,8 @@ pub async fn try_serve(
     }
 
     let rel = static_candidate(uri_path)?;
-    let real_file = canonical_within(&served_root.join(&rel), served_root).await?;
+    let real_root = tokio::fs::canonicalize(served_root).await.ok()?;
+    let real_file = canonical_within(&served_root.join(&rel), &real_root).await?;
 
     if is_php_source(&real_file) {
         return None;
@@ -77,7 +78,8 @@ pub async fn try_serve_index(
     }
 
     let rel = directory_candidate(uri_path)?;
-    let real_dir = canonical_within(&served_root.join(&rel), served_root).await?;
+    let real_root = tokio::fs::canonicalize(served_root).await.ok()?;
+    let real_dir = canonical_within(&served_root.join(&rel), &real_root).await?;
 
     if !tokio::fs::metadata(&real_dir).await.ok()?.is_dir() {
         return None;
@@ -90,7 +92,7 @@ pub async fn try_serve_index(
     }
 
     for name in ["index.html", "index.htm"] {
-        let Some(real_file) = canonical_within(&real_dir.join(name), served_root).await else {
+        let Some(real_file) = canonical_within(&real_dir.join(name), &real_root).await else {
             continue;
         };
         if is_php_source(&real_file) {
@@ -107,29 +109,36 @@ pub async fn try_serve_index(
     None
 }
 
-/// Canonicalise `candidate` and verify it's still within `served_root`
-/// (defence-in-depth against symlink traversal beyond the string-level guard
-/// in the `pure` candidate functions).
-async fn canonical_within(candidate: &Path, served_root: &Path) -> Option<PathBuf> {
+/// Canonicalise `candidate` and verify it's still within `real_root`,
+/// defence-in-depth against symlink traversal beyond the string-level guard
+/// in the `pure` candidate functions. `real_root` is an already-canonicalised
+/// `served_root`, passed in so a caller checking several candidates against
+/// the same root (e.g. `try_serve_index`'s directory plus each index-file
+/// probe) only resolves `served_root` once.
+async fn canonical_within(candidate: &Path, real_root: &Path) -> Option<PathBuf> {
     let real = tokio::fs::canonicalize(candidate).await.ok()?;
-    let real_root = tokio::fs::canonicalize(served_root).await.ok()?;
-    real.starts_with(&real_root).then_some(real)
+    real.starts_with(real_root).then_some(real)
 }
 
-/// Read `path` and build a 200 response with a guessed `Content-Type`, empty
-/// body for `HEAD` requests.
+/// Build a 200 response with a guessed `Content-Type`. `HEAD` stats `path`
+/// for its length and returns an empty body without reading the file's
+/// contents; any other method reads and returns the full body.
 async fn respond_with_file(method: &Method, path: &Path) -> Option<Response<BoxBody>> {
-    let bytes = tokio::fs::read(path).await.ok()?;
-    let len = bytes.len();
     let content_type = content_type_for(path);
-    let head_only = *method == Method::HEAD;
 
-    let body: BoxBody = if head_only || bytes.is_empty() {
-        empty_body()
+    let (body, len): (BoxBody, u64) = if *method == Method::HEAD {
+        (empty_body(), tokio::fs::metadata(path).await.ok()?.len())
     } else {
-        http_body_util::Full::new(Bytes::from(bytes))
-            .map_err(|never| match never {})
-            .boxed()
+        let bytes = tokio::fs::read(path).await.ok()?;
+        let len = bytes.len() as u64;
+        let body = if bytes.is_empty() {
+            empty_body()
+        } else {
+            http_body_util::Full::new(Bytes::from(bytes))
+                .map_err(|never| match never {})
+                .boxed()
+        };
+        (body, len)
     };
 
     Response::builder()

--- a/crates/yerd-proxy/src/forward/static_file.rs
+++ b/crates/yerd-proxy/src/forward/static_file.rs
@@ -7,8 +7,13 @@
 //! returns `None`, and the caller forwards to FastCGI (`index.php`) exactly as
 //! before. Without this, `/favicon.ico` and other static assets were handed to
 //! the PHP framework, which has no route for them.
+//!
+//! A directory request (trailing `/`, including the site root) with no
+//! `index.php` falls to [`try_serve_index`], which serves `index.html` or
+//! `index.htm` from that directory - the same fallback Caddy/nginx apply, so
+//! plain static sites work without a PHP front controller.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 use http::{header, HeaderValue, Method, StatusCode};
@@ -16,7 +21,9 @@ use http_body_util::BodyExt;
 use hyper::Response;
 
 use crate::forward::{empty_body, BoxBody};
-use crate::pure::try_files::{content_type_for, is_php_source, static_candidate};
+use crate::pure::try_files::{
+    content_type_for, directory_candidate, is_php_source, static_candidate,
+};
 
 /// Try to serve `uri_path` as a static file under `served_root`.
 ///
@@ -32,13 +39,7 @@ pub async fn try_serve(
     }
 
     let rel = static_candidate(uri_path)?;
-    let candidate = served_root.join(&rel);
-
-    let real_file = tokio::fs::canonicalize(&candidate).await.ok()?;
-    let real_root = tokio::fs::canonicalize(served_root).await.ok()?;
-    if !real_file.starts_with(&real_root) {
-        return None;
-    }
+    let real_file = canonical_within(&served_root.join(&rel), served_root).await?;
 
     if is_php_source(&real_file) {
         return None;
@@ -49,9 +50,78 @@ pub async fn try_serve(
         return None;
     }
 
-    let bytes = tokio::fs::read(&real_file).await.ok()?;
+    respond_with_file(method, &real_file).await
+}
+
+/// Try to serve a directory-index file (`index.html`, then `index.htm`) for a
+/// directory-style request under `served_root`, when that directory has no
+/// `index.php` - the front controller wins if one is present, matching the
+/// FastCGI "everything to index.php" policy in `pure::cgi_params`.
+///
+/// Each candidate index file is canonicalised and re-checked against
+/// `served_root` (not just the directory it lives in), so a symlinked
+/// `index.html`/`index.htm` cannot serve a file - PHP source included -
+/// from outside the site root.
+///
+/// `Some(response)` - an index file was found and served (200). `None` - the
+/// request isn't a directory request, the directory has an `index.php`, or no
+/// index file exists there; the caller should fall through to the PHP front
+/// controller.
+pub async fn try_serve_index(
+    method: &Method,
+    uri_path: &str,
+    served_root: &Path,
+) -> Option<Response<BoxBody>> {
+    if *method != Method::GET && *method != Method::HEAD {
+        return None;
+    }
+
+    let rel = directory_candidate(uri_path)?;
+    let real_dir = canonical_within(&served_root.join(&rel), served_root).await?;
+
+    if !tokio::fs::metadata(&real_dir).await.ok()?.is_dir() {
+        return None;
+    }
+    if tokio::fs::metadata(real_dir.join("index.php"))
+        .await
+        .is_ok()
+    {
+        return None;
+    }
+
+    for name in ["index.html", "index.htm"] {
+        let Some(real_file) = canonical_within(&real_dir.join(name), served_root).await else {
+            continue;
+        };
+        if is_php_source(&real_file) {
+            continue;
+        }
+        if tokio::fs::metadata(&real_file)
+            .await
+            .is_ok_and(|meta| meta.is_file())
+        {
+            return respond_with_file(method, &real_file).await;
+        }
+    }
+
+    None
+}
+
+/// Canonicalise `candidate` and verify it's still within `served_root`
+/// (defence-in-depth against symlink traversal beyond the string-level guard
+/// in the `pure` candidate functions).
+async fn canonical_within(candidate: &Path, served_root: &Path) -> Option<PathBuf> {
+    let real = tokio::fs::canonicalize(candidate).await.ok()?;
+    let real_root = tokio::fs::canonicalize(served_root).await.ok()?;
+    real.starts_with(&real_root).then_some(real)
+}
+
+/// Read `path` and build a 200 response with a guessed `Content-Type`, empty
+/// body for `HEAD` requests.
+async fn respond_with_file(method: &Method, path: &Path) -> Option<Response<BoxBody>> {
+    let bytes = tokio::fs::read(path).await.ok()?;
     let len = bytes.len();
-    let content_type = content_type_for(&real_file);
+    let content_type = content_type_for(path);
     let head_only = *method == Method::HEAD;
 
     let body: BoxBody = if head_only || bytes.is_empty() {

--- a/crates/yerd-proxy/src/pure/try_files.rs
+++ b/crates/yerd-proxy/src/pure/try_files.rs
@@ -47,6 +47,39 @@ pub fn static_candidate(url_path: &str) -> Option<PathBuf> {
     Some(rel)
 }
 
+/// Turn a request URL path into a safe relative **directory** path under the
+/// served root, for resolving a directory-index file (`index.html` /
+/// `index.htm`) when no `index.php` is present there.
+///
+/// `None` for anything that isn't a directory request (no trailing `/`, and
+/// not the bare root `/`), or that fails the traversal guard. Percent-decoding
+/// and traversal rules match [`static_candidate`]; unlike it, this accepts a
+/// trailing `/` and returns the directory itself (the root `/` decodes to an
+/// empty relative path, i.e. `served_root` itself).
+#[must_use]
+pub fn directory_candidate(url_path: &str) -> Option<PathBuf> {
+    let path = url_path.split('?').next().unwrap_or(url_path);
+    if !path.starts_with('/') || (path != "/" && !path.ends_with('/')) {
+        return None;
+    }
+
+    let mut rel = PathBuf::new();
+    for raw in path.split('/') {
+        if raw.is_empty() {
+            continue;
+        }
+        let seg = percent_decode(raw)?;
+        if seg.is_empty() || seg == "." || seg == ".." {
+            return None;
+        }
+        if seg.bytes().any(|b| b == b'/' || b == b'\\' || b == 0) {
+            return None;
+        }
+        rel.push(seg);
+    }
+    Some(rel)
+}
+
 /// Whether `path` looks like PHP source - these must never be served as a static
 /// file (it would leak source), so the front controller handles them instead.
 #[must_use]
@@ -184,6 +217,32 @@ mod tests {
     }
 
     #[test]
+    fn directory_candidate_accepts_root_and_trailing_slashes() {
+        assert_eq!(directory_candidate("/"), Some(PathBuf::new()));
+        assert_eq!(directory_candidate("/foo/"), Some(PathBuf::from("foo")));
+        assert_eq!(
+            directory_candidate("/foo/bar/"),
+            Some(PathBuf::from("foo/bar"))
+        );
+        assert_eq!(directory_candidate("/foo/?x=1"), Some(PathBuf::from("foo")));
+    }
+
+    #[test]
+    fn directory_candidate_rejects_non_directory_paths() {
+        assert_eq!(directory_candidate(""), None);
+        assert_eq!(directory_candidate("/foo"), None);
+        assert_eq!(directory_candidate("/foo/bar"), None);
+    }
+
+    #[test]
+    fn directory_candidate_rejects_traversal() {
+        assert_eq!(directory_candidate("/../"), None);
+        assert_eq!(directory_candidate("/foo/../../bar/"), None);
+        assert_eq!(directory_candidate("/%2e%2e/"), None);
+        assert_eq!(directory_candidate("/foo%2fbar/"), None);
+    }
+
+    #[test]
     fn php_sources_are_flagged() {
         assert!(is_php_source(Path::new("index.php")));
         assert!(is_php_source(Path::new("legacy.PHTML")));
@@ -193,6 +252,14 @@ mod tests {
 
     #[test]
     fn content_types_cover_common_assets() {
+        assert_eq!(
+            content_type_for(Path::new("index.html")),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(
+            content_type_for(Path::new("index.htm")),
+            "text/html; charset=utf-8"
+        );
         assert_eq!(content_type_for(Path::new("favicon.ico")), "image/x-icon");
         assert_eq!(
             content_type_for(Path::new("app.css")),

--- a/crates/yerd-proxy/src/pure/try_files.rs
+++ b/crates/yerd-proxy/src/pure/try_files.rs
@@ -25,23 +25,8 @@ pub fn static_candidate(url_path: &str) -> Option<PathBuf> {
         return None;
     }
 
-    let mut rel = PathBuf::new();
-    let mut segments = 0usize;
-    for raw in path.split('/') {
-        if raw.is_empty() {
-            continue;
-        }
-        let seg = percent_decode(raw)?;
-        if seg.is_empty() || seg == "." || seg == ".." {
-            return None;
-        }
-        if seg.bytes().any(|b| b == b'/' || b == b'\\' || b == 0) {
-            return None;
-        }
-        rel.push(seg);
-        segments += 1;
-    }
-    if segments == 0 {
+    let rel = resolve_segments(path)?;
+    if rel.as_os_str().is_empty() {
         return None;
     }
     Some(rel)
@@ -63,6 +48,16 @@ pub fn directory_candidate(url_path: &str) -> Option<PathBuf> {
         return None;
     }
 
+    resolve_segments(path)
+}
+
+/// Percent-decode and traversal-guard every `/`-separated segment of `path`,
+/// building the safe relative path. `None` if any segment is a malformed
+/// escape, empty, `.`/`..`, or contains an embedded `/`, `\`, or NUL after
+/// decoding. Shared by [`static_candidate`] and [`directory_candidate`] so
+/// the traversal guard can't drift between the two; each caller applies its
+/// own path-shape gate (root/trailing-slash rules) before calling this.
+fn resolve_segments(path: &str) -> Option<PathBuf> {
     let mut rel = PathBuf::new();
     for raw in path.split('/') {
         if raw.is_empty() {

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -348,6 +348,11 @@ async fn dispatch<R: BackendResolver>(
             {
                 return Ok(resp);
             }
+            if let Some(resp) =
+                static_file::try_serve_index(req.method(), req.uri().path(), &document_root).await
+            {
+                return Ok(resp);
+            }
             fcgi::forward(req, bk, document_root, server_addr, peer_addr, https).await
         }
     }

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -346,6 +346,403 @@ async fn static_file_is_served_without_touching_fcgi() {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn directory_index_html_served_when_no_index_php() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.html"), b"<h1>static site</h1>").unwrap();
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    // No FastCGI backend is reachable at this address - if the request ever
+    // fell through to `fcgi::forward` it would hard-fail, so a 200 here
+    // proves the directory index short-circuited it.
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp {
+            addr: "127.0.0.1:1".parse().unwrap(),
+        },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, content_type, body) = client_get_response(proxy_addr, "app.test", "/").await;
+    assert_eq!(status, 200);
+    assert_eq!(content_type.as_deref(), Some("text/html; charset=utf-8"));
+    assert_eq!(body, b"<h1>static site</h1>");
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn directory_index_htm_served_as_fallback() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::create_dir(docroot.path().join("blog")).unwrap();
+    std::fs::write(docroot.path().join("blog/index.htm"), b"blog home").unwrap();
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp {
+            addr: "127.0.0.1:1".parse().unwrap(),
+        },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, content_type, body) = client_get_response(proxy_addr, "app.test", "/blog/").await;
+    assert_eq!(status, 200);
+    assert_eq!(content_type.as_deref(), Some("text/html; charset=utf-8"));
+    assert_eq!(body, b"blog home");
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn index_php_present_wins_over_index_html() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.php"), b"<?php ?>").unwrap();
+    std::fs::write(docroot.path().join("index.html"), b"should not be served").unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let body = client_get(proxy_addr, "app.test", "/").await;
+    assert_eq!(body, b"from fpm");
+
+    // The body alone can't distinguish "correctly deferred to the front
+    // controller" from "the fix is entirely absent" (both forward to fcgi and
+    // get the same canned reply) - assert the FastCGI params actually show
+    // the request reached the front controller.
+    let params = captured.lock().await.clone();
+    assert_eq!(
+        params.get("SCRIPT_NAME").map(String::as_str),
+        Some("/index.php")
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn directory_with_no_index_at_all_falls_through_to_fcgi() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::create_dir(docroot.path().join("empty")).unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    // A real directory (docroot/empty) with none of index.php/html/htm must
+    // still reach the front controller, not dead-end in a 404.
+    let body = client_get(proxy_addr, "app.test", "/empty/").await;
+    assert_eq!(body, b"from fpm");
+    assert_eq!(
+        captured.lock().await.get("SCRIPT_NAME").map(String::as_str),
+        Some("/index.php")
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nonexistent_directory_falls_through_to_fcgi() {
+    let docroot = tempfile::tempdir().unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    // The shape of every trailing-slash pretty-URL framework route
+    // (/blog/some-post/) where nothing on disk matches the path at all -
+    // canonicalize() fails, and the request must still reach index.php.
+    let body = client_get(proxy_addr, "app.test", "/blog/some-post/").await;
+    assert_eq!(body, b"from fpm");
+    assert_eq!(
+        captured.lock().await.get("SCRIPT_NAME").map(String::as_str),
+        Some("/index.php")
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn head_request_to_directory_index_returns_empty_body() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.html"), b"<h1>hello</h1>").unwrap();
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp {
+            addr: "127.0.0.1:1".parse().unwrap(),
+        },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let stream = TcpStream::connect(proxy_addr).await.unwrap();
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = Request::builder()
+        .method("HEAD")
+        .uri("/")
+        .header("Host", "app.test")
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+    let resp = sender.send_request(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get(hyper::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok()),
+        Some("14")
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert!(body.is_empty());
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+}
+
+/// Regression test for a symlink-escape hole: `try_serve_index` used to
+/// canonicalise only the *directory*, then serve `directory.join("index.html")`
+/// without re-canonicalising the resolved file. A symlink named `index.html`
+/// pointing outside `served_root` (or at PHP source inside it) was served
+/// verbatim as a 200 `text/html` response.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn symlinked_index_html_escaping_root_is_not_served() {
+    let secret_dir = tempfile::tempdir().unwrap();
+    let secret_path = secret_dir.path().join("secret.php");
+    std::fs::write(&secret_path, b"<?php secret_credentials(); ?>").unwrap();
+
+    let docroot = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(&secret_path, docroot.path().join("index.html")).unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(fcgi_listener, stdout_payload, captured));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    // Must fall through to the front controller, never leak the symlink
+    // target's contents.
+    let body = client_get(proxy_addr, "app.test", "/").await;
+    assert_eq!(body, b"from fpm");
+    assert!(!body
+        .windows(b"secret_credentials".len())
+        .any(|w| w == b"secret_credentials"));
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
 // ─── Hyper client helpers ───────────────────────────────────────────
 
 async fn client_get(addr: SocketAddr, host: &str, path: &str) -> Vec<u8> {

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -346,6 +346,10 @@ async fn static_file_is_served_without_touching_fcgi() {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
 }
 
+/// The configured FastCGI backend (`127.0.0.1:1`) is deliberately
+/// unreachable: if the request ever fell through to `fcgi::forward` it
+/// would hard-fail, so a 200 here proves the directory index short-circuited
+/// the front-controller path.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn directory_index_html_served_when_no_index_php() {
     let docroot = tempfile::tempdir().unwrap();
@@ -361,9 +365,6 @@ async fn directory_index_html_served_when_no_index_php() {
     router.insert(site).unwrap();
     let router = Arc::new(tokio::sync::RwLock::new(router));
 
-    // No FastCGI backend is reachable at this address - if the request ever
-    // fell through to `fcgi::forward` it would hard-fail, so a 200 here
-    // proves the directory index short-circuited it.
     let resolver = Arc::new(StaticResolver {
         backend: Backend::PhpFpmTcp {
             addr: "127.0.0.1:1".parse().unwrap(),
@@ -438,6 +439,10 @@ async fn directory_index_htm_served_as_fallback() {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
 }
 
+/// The response body alone can't distinguish "correctly deferred to the
+/// front controller" from "the fix is entirely absent" - both forward to
+/// FastCGI and get the same canned reply. The assertion on `SCRIPT_NAME`
+/// below is what proves the request actually reached `index.php`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn index_php_present_wins_over_index_html() {
     let docroot = tempfile::tempdir().unwrap();
@@ -486,10 +491,6 @@ async fn index_php_present_wins_over_index_html() {
     let body = client_get(proxy_addr, "app.test", "/").await;
     assert_eq!(body, b"from fpm");
 
-    // The body alone can't distinguish "correctly deferred to the front
-    // controller" from "the fix is entirely absent" (both forward to fcgi and
-    // get the same canned reply) - assert the FastCGI params actually show
-    // the request reached the front controller.
     let params = captured.lock().await.clone();
     assert_eq!(
         params.get("SCRIPT_NAME").map(String::as_str),
@@ -501,6 +502,8 @@ async fn index_php_present_wins_over_index_html() {
     let _ = fake_task.await;
 }
 
+/// A real directory with none of index.php/html/htm must still reach the
+/// front controller rather than dead-ending in a 404.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn directory_with_no_index_at_all_falls_through_to_fcgi() {
     let docroot = tempfile::tempdir().unwrap();
@@ -545,8 +548,6 @@ async fn directory_with_no_index_at_all_falls_through_to_fcgi() {
         .await;
     });
 
-    // A real directory (docroot/empty) with none of index.php/html/htm must
-    // still reach the front controller, not dead-end in a 404.
     let body = client_get(proxy_addr, "app.test", "/empty/").await;
     assert_eq!(body, b"from fpm");
     assert_eq!(
@@ -559,6 +560,9 @@ async fn directory_with_no_index_at_all_falls_through_to_fcgi() {
     let _ = fake_task.await;
 }
 
+/// Covers the trailing-slash pretty-URL framework route (e.g.
+/// `/blog/some-post/`) where nothing on disk matches the path:
+/// `canonicalize()` fails, and the request must still reach `index.php`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn nonexistent_directory_falls_through_to_fcgi() {
     let docroot = tempfile::tempdir().unwrap();
@@ -602,9 +606,6 @@ async fn nonexistent_directory_falls_through_to_fcgi() {
         .await;
     });
 
-    // The shape of every trailing-slash pretty-URL framework route
-    // (/blog/some-post/) where nothing on disk matches the path at all -
-    // canonicalize() fails, and the request must still reach index.php.
     let body = client_get(proxy_addr, "app.test", "/blog/some-post/").await;
     assert_eq!(body, b"from fpm");
     assert_eq!(
@@ -730,8 +731,6 @@ async fn symlinked_index_html_escaping_root_is_not_served() {
         .await;
     });
 
-    // Must fall through to the front controller, never leak the symlink
-    // target's contents.
     let body = client_get(proxy_addr, "app.test", "/").await;
     assert_eq!(body, b"from fpm");
     assert!(!body

--- a/docs/developer/crates/yerd-proxy.md
+++ b/docs/developer/crates/yerd-proxy.md
@@ -26,11 +26,11 @@ crates/yerd-proxy/src/
 │   ├── mod.rs
 │   ├── cgi_params.rs   # build the CGI/1.1 param list for FastCGI
 │   ├── fcgi_codec.rs   # FastCGI record framing (encode/decode)
-│   ├── try_files.rs    # static-file candidate resolution + MIME map
+│   ├── try_files.rs    # static-file/directory-index candidate resolution + MIME map
 │   └── redirect.rs     # HTTP → HTTPS redirect URI builder
 └── forward/         # async per-backend forwarding I/O
     ├── mod.rs          # BoxBody + body helpers
-    ├── static_file.rs  # serve a real static file from the served root
+    ├── static_file.rs  # serve a real static file, or a directory's index.html/.htm
     ├── fcgi.rs         # FastCGI forwarder (PHP-FPM)
     ├── http.rs         # plain HTTP/1.1 forwarder (FrankenPHP)
     └── upgrade.rs      # Connection: Upgrade tunnel (WebSocket etc.)
@@ -93,7 +93,7 @@ For requests that reach FastCGI, the policy is Caddy-style front-controller rout
 - `PATH_INFO       = <original path>`
 - `REQUEST_URI     = <original path_and_query>`
 
-Static files are handled *before* this, by a `try_files`-style short-circuit (see [`try_files`](#try_files-static-file-resolution) and [`static_file`](#static_file-serving-real-files)): a request that resolves to a real, non-PHP file under the served root is returned directly, and only everything else falls through to the front controller. Arbitrary on-disk `.php` scripts are still routed through `index.php` (and PHP source is never served as a static file).
+Static files are handled *before* this, by a `try_files`-style short-circuit (see [`try_files`](#try_files-static-file-resolution) and [`static_file`](#static_file-serving-real-files)): a request that resolves to a real, non-PHP file under the served root is returned directly. A directory-style request (trailing slash, including the site root) with no `index.php` falls back to that directory's `index.html`/`index.htm` next, so a plain static site works without a front controller at all. Only everything else falls through to FastCGI. Arbitrary on-disk `.php` scripts are still routed through `index.php` (and PHP source is never served as a static file, directly or via a directory index).
 :::
 
 ::: info `document_root` here is the site's *served web root*
@@ -117,6 +117,7 @@ It strips any inbound port from `host` (handling both `host:80` and bracketed IP
 `try_files` decides, purely, whether a request *could* be a static file and what its safe relative path and MIME type would be. It does no I/O - the [`static_file`](#static_file-serving-real-files) forwarder does the actual stat/read.
 
 - **`static_candidate(path)`** maps a URL path to a safe relative `PathBuf`, or `None` when the request must go to the front controller instead. It returns `None` for `/`, for a directory-style request (trailing slash), and for any traversal attempt. It percent-decodes the path and rejects encoded slashes and NUL bytes, so a decoded segment can never escape the served root.
+- **`directory_candidate(path)`** is `static_candidate`'s counterpart for directory-index resolution: it maps a *directory-style* URL path (trailing slash, or the bare root `/`) to a safe relative directory `PathBuf`, or `None` for anything else. Same percent-decoding and traversal rules as `static_candidate` - the two intentionally partition every URL shape between them (a path never satisfies both).
 - **`is_php_source(path)`** flags PHP source extensions (`php`, `phtml`, `php3`/`php4`/`php5`/`php7`, `phps`, `pht`) so they are *never* served as static bytes - they fall through to FastCGI.
 - **`content_type_for(path)`** maps a file extension to a `Content-Type` for the response (a small MIME table, defaulting to `application/octet-stream`).
 
@@ -244,7 +245,8 @@ The hyper service is **infallible** - internal errors are logged and turned into
 4. **Resolve backend** via `BackendResolver::backend_for(&site)`. Errors already in the connect/protocol/resolver family pass through; any other variant is wrapped in `ProxyError::BackendResolver { host, source }`.
 5. **Upgrade dispatch.** If `upgrade::is_upgrade(headers)`, forward to `upgrade::forward` for `FrankenPhp`, or return `501 Not Implemented` for FastCGI backends (FastCGI cannot model a duplex byte stream).
 6. **Static-file short-circuit.** For the FastCGI backends (`PhpFpm`/`PhpFpmTcp`), `static_file::try_serve` is attempted first: a GET/HEAD request that resolves to a real, non-PHP file under the served root is returned directly with a guessed `Content-Type`. (`FrankenPhp` serves its own static files, so this step is skipped for it.)
-7. **Normal dispatch.** Anything not served as a static file goes to the front controller: `FrankenPhp` → `http::forward`; `PhpFpm`/`PhpFpmTcp` → `fcgi::forward`.
+7. **Directory-index short-circuit.** Still FastCGI-only: if `try_serve` didn't match, `static_file::try_serve_index` is tried next - a GET/HEAD directory-style request (trailing slash, including the site root) with no `index.php` in that directory serves its `index.html`/`index.htm` directly, so plain static sites work with no PHP front controller at all.
+8. **Normal dispatch.** Anything not served as a static file or directory index goes to the front controller: `FrankenPhp` → `http::forward`; `PhpFpm`/`PhpFpmTcp` → `fcgi::forward`.
 
 The `Listener::{Http, Https}` discriminator is threaded through so the redirect rule and the `HTTPS=on` CGI var both know which listener the connection arrived on.
 
@@ -268,6 +270,16 @@ with `empty_body()` (for 301/404/501/101) and `bytes_body(&'static [u8])` helper
 4. on a hit, reads the file and returns `200 OK` with the `Content-Type` from `content_type_for` and the `Server: <PROXY_SERVER_ID>` header (a `HEAD` returns an empty body).
 
 A `None` result simply means "not a static file" and the request continues to the front controller.
+
+`static_file::try_serve_index` is the directory-index counterpart, tried next when `try_serve` misses. Given the served root and the request, it:
+
+1. asks [`try_files::directory_candidate`](#try_files-static-file-resolution) for a safe relative directory path (returns `None` for anything that isn't a directory-style request, or a non-GET/HEAD method);
+2. joins the candidate onto the served root, canonicalises, and verifies it's still inside the root and is actually a directory;
+3. defers to the front controller (`None`) if that directory contains `index.php` - the front controller always wins when present;
+4. otherwise probes `index.html`, then `index.htm`: each candidate is joined onto the (already-canonical) directory and **re-canonicalised in its own right** before being served, so a symlinked `index.html`/`index.htm` that escapes the served root - or points at PHP source inside it - is rejected, not served. This mirrors `try_serve`'s canonicalise-the-full-path guarantee rather than only canonicalising the directory.
+5. on a hit, serves the file exactly like `try_serve` (same `Content-Type` lookup, `HEAD` handling, headers).
+
+A `None` result here means no index file exists (or `index.php` won) and the request falls through to `fcgi::forward` exactly as it did before this short-circuit existed.
 
 ### `fcgi` - the PHP-FPM forwarder
 
@@ -306,7 +318,7 @@ A `None` result simply means "not a static file" and the request continues to th
 ## Tests and invariants
 
 - **`pure/` unit tests** pin the wire format and policy: `fcgi_codec` round-trips headers and verifies short/long name-value encoding; `cgi_params` asserts the Caddy-style mapping, the `HTTPS=on` rule, and `HTTP_*` translation; `redirect` runs the full host/port table.
-- **`tests/integration_http.rs`** drives `ProxyServer::serve` against a fake FastCGI listener and a hyper client, asserting both the round-trip body (`hello`) and the captured CGI params (`REQUEST_METHOD`, `REQUEST_URI`, `SCRIPT_NAME`, `PATH_INFO`, `QUERY_STRING`, `SERVER_NAME`). It also covers the `404` (unknown host) and `400` (missing Host) paths.
+- **`tests/integration_http.rs`** drives `ProxyServer::serve` against a fake FastCGI listener and a hyper client, asserting both the round-trip body (`hello`) and the captured CGI params (`REQUEST_METHOD`, `REQUEST_URI`, `SCRIPT_NAME`, `PATH_INFO`, `QUERY_STRING`, `SERVER_NAME`). It also covers the `404` (unknown host) and `400` (missing Host) paths, plain static-file serving, and the directory-index fallback end to end: `index.html`/`index.htm` served when there's no `index.php`, `index.php` winning when both are present (asserted via the captured `SCRIPT_NAME`, not just the response body), a directory with no index of any kind and a nonexistent directory both still falling through to FastCGI, `HEAD` returning an empty body, and a symlinked `index.html` escaping the served root being refused rather than served.
 - **`tests/integration_https.rs`** issues a real CA + leaf from [`yerd-tls`](./yerd-tls), serves over TLS with a single-host `CertStore`, and drives a rustls hyper client through the full SNI handshake to the fake backend.
 - **`tests/no_runtime_deps.rs`** is a dependency-graph guard: it walks `cargo metadata` and asserts the runtime graph never pulls `anyhow`, the OpenSSL/native-tls family, `hyper-tls`, `tokio-native-tls`, or `webpki-roots`, and that `hyper`, `rustls`, `tokio`, and `time` each resolve to a single version. This keeps the proxy on a pure-Rust, rustls-only TLS stack.
 

--- a/docs/guide/sites.md
+++ b/docs/guide/sites.md
@@ -258,7 +258,7 @@ Detection runs in the daemon when a site is registered and whenever its project 
 The served path shows up in `yerd sites` (the `SERVED` column, `/` meaning the project root itself).
 
 ::: info Static files are served directly
-A request that resolves to a real file under the served root (a stylesheet, image, `favicon.ico`, compiled JS, …) is returned straight from disk by the proxy, with a guessed `Content-Type` - it never touches PHP. Everything else is handed to the framework's front controller (`index.php`). PHP source files are never served as static bytes, and a symlink that escapes the served root is refused.
+A request that resolves to a real file under the served root (a stylesheet, image, `favicon.ico`, compiled JS, …) is returned straight from disk by the proxy, with a guessed `Content-Type` - it never touches PHP. A directory request (including the site root) falls back to `index.html` or `index.htm` from that directory when there's no `index.php` there, so a plain static site (no PHP at all) works with no extra configuration. Everything else is handed to the framework's front controller (`index.php`). PHP source files are never served as static bytes, and a symlink that escapes the served root is refused.
 :::
 
 ### Overriding the served path


### PR DESCRIPTION
## What does this PR do?

Static sites (no index.php) were returning "File not found" on any directory request. The proxy now falls back to index.html/index.htm when a directory has no front controller, matching Caddy/nginx try_files semantics - index.php still wins whenever present.

## Related issues

Closes #71 

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory-style requests now auto-serve `index.html` or `index.htm` when `index.php` is absent.
  * Static files still serve directly from disk with correct `Content-Type` (including UTF-8 charset for `index.*`).
* **Bug Fixes**
  * Strengthened protections against path traversal and symlink escapes during static and directory-index resolution.
  * `HEAD` requests for directory indexes return headers (including `Content-Length`) with an empty body.
  * When no matching index file exists, requests correctly fall through to the PHP handler.
* **Documentation**
  * Updated site and proxy docs to reflect directory-index fallback and security behavior.
* **Tests**
  * Added HTTP integration coverage for index precedence, fallthrough behavior, `HEAD`, and symlink-escape regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->