### PR TITLE
[Fix] Arch linux GUI bug

### DIFF
--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -6,8 +6,9 @@
 //! `unwrap`/`expect`/`panic` under clippy). The OS service mechanism
 //! (systemd/launchd/SMAppService) lives in [`crate::autostart`]; this module owns
 //! binary resolution, the start/stop orchestration, and the optional
-//! "install the bundled CLI on PATH" helper. The daemon binary is **bundled**
-//! inside the app (Tauri `externalBin`) - there is no runtime download.
+//! "install the bundled CLI on PATH" helper (macOS and Linux; PATH management
+//! isn't wired up for Windows yet). The daemon binary is **bundled** inside the
+//! app (Tauri `externalBin`) - there is no runtime download.
 
 use std::path::PathBuf;
 
@@ -115,13 +116,18 @@ pub fn daemon_installed() -> bool {
     resolve_yerdd().is_some()
 }
 
-// ── optional: install the bundled `yerd` CLI on PATH (macOS) ─────────────────
+// ── optional: install the bundled `yerd` CLI on PATH (macOS + Linux) ────────
 //
-// Linux already exposes `yerd` on PATH (the `.deb` postinst symlinks it into
-// `/usr/bin`), so this is macOS-only. We symlink the bundled `yerd` into
-// `{data}/bin` - the exact dir the `yerd path` rc-block puts on PATH - and shell
-// out to the bundled `yerd path install` to manage the rc block (we do NOT depend
-// on the `bin/yerd` crate; that would violate the dep-flow rule).
+// `yerd` itself is already on PATH on a packaged Linux install (the `.deb`/Arch
+// package puts it in `/usr/bin`), but the PHP/tool shims it manages (`php`,
+// `composer`, ...) live in `{data}/bin`, which is the *same* directory this
+// helper's `yerd path install` call puts on PATH - so running it on Linux too
+// fixes the real gap (GUI-only installs never invoke the CLI's own
+// `ensure_installed_after_tool`, so `{data}/bin` never lands on PATH without
+// this). We symlink the bundled `yerd` into `{data}/bin` - harmless when `yerd`
+// is already reachable elsewhere - and shell out to the bundled `yerd path
+// install` to manage the rc block (we do NOT depend on the `bin/yerd` crate;
+// that would violate the dep-flow rule).
 
 /// `{data}/bin/yerd` - where the CLI symlink lives (matches `yerd path`).
 fn cli_symlink_path() -> Result<PathBuf, GuiError> {
@@ -153,11 +159,12 @@ pub fn cli_path_status() -> Result<CliPathStatus, GuiError> {
 }
 
 /// Symlink the bundled `yerd` into `{data}/bin` and ensure that dir is on PATH.
-/// macOS-only behaviour - Linux already exposes `yerd` on PATH via the `.deb`.
+/// macOS and Linux; PATH management isn't wired up for Windows yet.
 #[tauri::command]
 pub async fn install_cli_to_path() -> Result<(), GuiError> {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
+        #[cfg(target_os = "macos")]
         if crate::autostart::is_translocated() {
             return Err(GuiError::internal(
                 "Move Yerd to your Applications folder first, then install the CLI.",
@@ -193,10 +200,10 @@ pub async fn install_cli_to_path() -> Result<(), GuiError> {
         .await
         .map_err(|e| GuiError::internal(format!("install task failed: {e}")))?
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         Err(GuiError::internal(
-            "The Yerd CLI is already installed on this platform.",
+            "PATH installation is not supported on this platform yet.",
         ))
     }
 }

--- a/apps/yerd-gui/src/composables/usePlatform.ts
+++ b/apps/yerd-gui/src/composables/usePlatform.ts
@@ -1,0 +1,39 @@
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+
+import { hostPlatform } from "@/ipc/client";
+
+// Module-level singleton (mirrors useDaemon/useOnboarding): the host OS is
+// fetched once for the whole app, so every view that gates UI on it (Welcome
+// journey, Settings → General) agrees instead of each re-probing and
+// duplicating isMac/isLinux/supportsPathInstall.
+const platform = ref("");
+let loadPromise: Promise<void> | null = null;
+
+/** Fetch the host platform once; safe to call from multiple components. */
+export function loadPlatform(): Promise<void> {
+  if (!loadPromise) {
+    loadPromise = hostPlatform()
+      .then((p) => {
+        platform.value = p;
+      })
+      .catch(() => {});
+  }
+  return loadPromise;
+}
+
+export interface PlatformInfo {
+  platform: Ref<string>;
+  isMac: ComputedRef<boolean>;
+  isLinux: ComputedRef<boolean>;
+  /** macOS and Linux only - PATH management isn't wired up for Windows yet. */
+  supportsPathInstall: ComputedRef<boolean>;
+}
+
+export function usePlatform(): PlatformInfo {
+  return {
+    platform,
+    isMac: computed(() => platform.value === "macos"),
+    isLinux: computed(() => platform.value === "linux"),
+    supportsPathInstall: computed(() => platform.value === "macos" || platform.value === "linux"),
+  };
+}

--- a/apps/yerd-gui/src/composables/usePlatform.ts
+++ b/apps/yerd-gui/src/composables/usePlatform.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type ComputedRef, type Ref } from "vue";
+import { computed, readonly, ref, type ComputedRef, type Ref } from "vue";
 
 import { hostPlatform } from "@/ipc/client";
 
@@ -9,20 +9,24 @@ import { hostPlatform } from "@/ipc/client";
 const platform = ref("");
 let loadPromise: Promise<void> | null = null;
 
-/** Fetch the host platform once; safe to call from multiple components. */
+/** Fetch the host platform once; safe to call from multiple components. A
+ *  failed call clears the cache so a later call can retry, rather than
+ *  leaving `platform` permanently empty. */
 export function loadPlatform(): Promise<void> {
   if (!loadPromise) {
     loadPromise = hostPlatform()
       .then((p) => {
         platform.value = p;
       })
-      .catch(() => {});
+      .catch(() => {
+        loadPromise = null;
+      });
   }
   return loadPromise;
 }
 
 export interface PlatformInfo {
-  platform: Ref<string>;
+  platform: Readonly<Ref<string>>;
   isMac: ComputedRef<boolean>;
   isLinux: ComputedRef<boolean>;
   /** macOS and Linux only - PATH management isn't wired up for Windows yet. */
@@ -31,7 +35,7 @@ export interface PlatformInfo {
 
 export function usePlatform(): PlatformInfo {
   return {
-    platform,
+    platform: readonly(platform),
     isMac: computed(() => platform.value === "macos"),
     isLinux: computed(() => platform.value === "linux"),
     supportsPathInstall: computed(() => platform.value === "macos" || platform.value === "linux"),

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -43,7 +43,10 @@ const autostart = ref<AutostartState | null>(null);
 // as a background login item registered via SMAppService; see below).
 const platform = ref("");
 const isMac = computed(() => platform.value === "macos");
-// macOS-only: whether the bundled `yerd` CLI is symlinked onto PATH.
+const isLinux = computed(() => platform.value === "linux");
+// macOS and Linux (not yet wired up on Windows): whether the bundled `yerd`
+// CLI is symlinked onto PATH.
+const supportsPathInstall = computed(() => isMac.value || isLinux.value);
 const cli = ref<CliPathStatus | null>(null);
 
 const themeOptions = [
@@ -63,7 +66,7 @@ async function loadAutostart(): Promise<void> {
   }
 }
 
-// ── CLI on PATH (macOS) + Login-Items approval ──
+// ── CLI on PATH (macOS + Linux) + Login-Items approval ──
 async function loadCli(): Promise<void> {
   try {
     cli.value = await cliPathStatus();
@@ -539,8 +542,10 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
         </CardContent>
       </Card>
 
-      <!-- Terminal CLI (macOS) - Linux exposes `yerd` on PATH via the package (.deb/.pkg.tar.zst). -->
-      <Card v-if="isMac">
+      <!-- Terminal CLI (macOS + Linux). `yerd` itself is already on PATH on a
+           packaged Linux install, but this also puts the PHP/tool shims dir on
+           PATH, so it's still useful there. -->
+      <Card v-if="supportsPathInstall">
         <CardHeader>
           <CardTitle>Terminal CLI</CardTitle>
           <CardDescription>Use the <code>yerd</code> command in your terminal.</CardDescription>
@@ -552,7 +557,7 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
               <p class="text-xs text-muted-foreground">
                 {{ cli?.installed
                   ? "Installed - run `yerd` in a new terminal window."
-                  : "Symlinks the bundled CLI into your shell PATH." }}
+                  : "Adds yerd and your installed tools (php, composer, ...) to your shell PATH." }}
               </p>
             </div>
             <Button

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -15,13 +15,13 @@ import Spinner from "@/components/ui/Spinner.vue";
 import Switch from "@/components/ui/Switch.vue";
 import { useDaemon } from "@/composables/useDaemon";
 import { MIN_PORT, MAX_PORT, useFallbackPorts } from "@/composables/useFallbackPorts";
+import { loadPlatform, usePlatform } from "@/composables/usePlatform";
 import { useToast } from "@/composables/useToast";
 import {
   cliPathStatus,
   daemonInfo,
   dumpsStatus,
   getAutostart,
-  hostPlatform,
   installCliToPath,
   IpcError,
   openLoginItems,
@@ -40,13 +40,9 @@ const { pref, setTheme } = useTheme();
 const busy = ref<string | null>(null);
 const autostart = ref<AutostartState | null>(null);
 // Host platform - drives macOS-specific daemon copy (on macOS the daemon runs
-// as a background login item registered via SMAppService; see below).
-const platform = ref("");
-const isMac = computed(() => platform.value === "macos");
-const isLinux = computed(() => platform.value === "linux");
-// macOS and Linux (not yet wired up on Windows): whether the bundled `yerd`
-// CLI is symlinked onto PATH.
-const supportsPathInstall = computed(() => isMac.value || isLinux.value);
+// as a background login item registered via SMAppService; see below) and
+// whether the bundled `yerd` CLI on-PATH card is shown.
+const { isMac, supportsPathInstall } = usePlatform();
 const cli = ref<CliPathStatus | null>(null);
 
 const themeOptions = [
@@ -101,9 +97,7 @@ async function openApproval(): Promise<void> {
 
 onMounted(() => {
   loadAutostart();
-  hostPlatform()
-    .then((p) => (platform.value = p))
-    .catch(() => {});
+  void loadPlatform();
   loadCli();
   if (running.value) {
     void loadApplicationPorts();

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -23,12 +23,12 @@ import { useDaemon } from "@/composables/useDaemon";
 import { useDaemonStart } from "@/composables/useDaemonStart";
 import { MIN_PORT, MAX_PORT, useFallbackPorts } from "@/composables/useFallbackPorts";
 import { useOnboarding } from "@/composables/useOnboarding";
+import { loadPlatform, usePlatform } from "@/composables/usePlatform";
 import { useToast } from "@/composables/useToast";
 import {
   availablePhp,
   cliPathStatus,
   getAutostart,
-  hostPlatform,
   installCliToPath,
   installPhpWithProgress,
   IpcError,
@@ -275,10 +275,7 @@ async function doInstallPhp(): Promise<void> {
 // packaged Linux install, but the PHP/tool shims it manages live in the same
 // `{data}/bin` dir this installs onto PATH, so it's still useful there.
 // Optional and recommended; it never blocks "Next". ──
-const platform = ref("");
-const isMac = computed(() => platform.value === "macos");
-const isLinux = computed(() => platform.value === "linux");
-const supportsPathInstall = computed(() => isMac.value || isLinux.value);
+const { supportsPathInstall } = usePlatform();
 const cli = ref<CliPathStatus | null>(null);
 const cliBusy = ref(false);
 
@@ -305,12 +302,7 @@ async function installCli(): Promise<void> {
 }
 
 onMounted(() => {
-  hostPlatform()
-    .then((p) => {
-      platform.value = p;
-      void loadCliStatus();
-    })
-    .catch(() => {});
+  void loadPlatform().then(() => loadCliStatus());
 });
 
 // ── step 3: park a folder ──

--- a/apps/yerd-gui/src/views/WelcomeView.vue
+++ b/apps/yerd-gui/src/views/WelcomeView.vue
@@ -270,16 +270,20 @@ async function doInstallPhp(): Promise<void> {
   }
 }
 
-// ── step 2: install yerd on PATH (macOS only; the Linux package (.deb/.pkg.tar.zst)
-// already ships it on PATH, so the button is hidden there - see `isMac`). Optional
-// and recommended; it never blocks "Next". ──
+// ── step 2: install yerd on PATH. macOS and Linux (not yet wired up on
+// Windows - see `supportsPathInstall`). `yerd` itself is already on PATH on a
+// packaged Linux install, but the PHP/tool shims it manages live in the same
+// `{data}/bin` dir this installs onto PATH, so it's still useful there.
+// Optional and recommended; it never blocks "Next". ──
 const platform = ref("");
 const isMac = computed(() => platform.value === "macos");
+const isLinux = computed(() => platform.value === "linux");
+const supportsPathInstall = computed(() => isMac.value || isLinux.value);
 const cli = ref<CliPathStatus | null>(null);
 const cliBusy = ref(false);
 
 async function loadCliStatus(): Promise<void> {
-  if (!isMac.value) return;
+  if (!supportsPathInstall.value) return;
   try {
     cli.value = await cliPathStatus();
   } catch {
@@ -590,22 +594,22 @@ function onBack(): void {
               PHP page.
             </p>
 
-            <!-- Optional (recommended): put the `yerd` CLI on PATH. macOS only -
-                 the Linux package (.deb/.pkg.tar.zst) already ships it. Never blocks Continue. -->
+            <!-- Optional (recommended): put `yerd` and its managed tool shims (php,
+                 composer, ...) on PATH. Never blocks Continue. -->
             <div
-              v-if="isMac"
+              v-if="supportsPathInstall"
               class="flex items-center justify-between gap-4 rounded-md border bg-muted/30 p-3"
             >
               <div>
                 <p class="text-sm font-medium">
-                  Install <code>yerd</code> on your PATH
+                  Add <code>yerd</code> to your PATH
                   <span class="text-muted-foreground">(recommended)</span>
                 </p>
                 <p class="text-xs text-muted-foreground">
                   {{
                     cli?.installed
                       ? "Installed - run `yerd` in a new terminal window."
-                      : "Symlinks the bundled CLI so you can run `yerd` in your terminal."
+                      : "Lets you run `yerd`, `php`, and installed tools directly in your terminal."
                   }}
                 </p>
               </div>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -21,8 +21,14 @@ license=('MIT')
 # GUI; libayatana-appindicator + librsvg are dlopen'd (not ELF-NEEDED) so namcap
 # can't infer them — list explicitly. cairo/pango/gdk-pixbuf2/glib2 come in via
 # gtk3. libcap provides setcap, used by the install scriptlet (namcap will report
-# it "not needed" — a false positive, it is not ELF-linked).
-depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'librsvg' 'libcap')
+# it "not needed" — a false positive, it is not ELF-linked). libxcrypt-compat
+# ships libcrypt.so.1: Yerd's managed PHP builds (fetched at runtime, not part of
+# this package - see crates/yerd-php) are glibc-dynamic and still link against
+# the legacy crypt() ABI, which stock Arch dropped in favour of libxcrypt.so.2;
+# without it `php`/composer/etc. fail with "libcrypt.so.1: cannot open shared
+# object file". namcap can't infer this either, since it isn't ELF-NEEDED by
+# anything in this package.
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'librsvg' 'libcap' 'libxcrypt-compat')
 makedepends=('rust' 'cargo' 'nodejs' 'npm')
 # !lto is required: Arch's makepkg.conf enables LTO by default, which archives
 # ring's hand-written crypto assembly as LLVM bitcode and drops the real symbol
@@ -38,7 +44,15 @@ build() {
   ( cd apps/yerd-gui && npm ci && npm run build )
   # Build the daemon with the pacman self-update format (`yerdd/pacman` →
   # `yerd-update/pacman`) plus the CLI, helper, and GUI binaries.
-  cargo build --release --locked --features yerdd/pacman \
+  #
+  # `tauri/custom-protocol` must be enabled here: unlike `tauri build`/`npm run
+  # tauri build` (which the .deb/.dmg release path uses and which inject this
+  # feature automatically), a raw `cargo build` does not. Without it, Tauri's
+  # generate_context!() bakes `dev: true` into the binary and it tries to load
+  # devUrl (http://localhost:1420) at runtime instead of the embedded frontend
+  # dist, failing with "Could not connect to localhost: Connection refused".
+  cargo build --release --locked \
+    --features yerdd/pacman,tauri/custom-protocol \
     -p yerd -p yerdd -p yerd-helper -p yerd-gui
 }
 


### PR DESCRIPTION
## What does this PR do?

Resolves an issue where Yerd was unable to start on Arch Linux based environments. 

## Related issues

Resolves #67

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PATH installation support extended to both Linux and macOS.
  * Welcome/setup flow and “Terminal CLI” settings now adapt to whether PATH installation is supported, with updated instructions for managed shims/tools (e.g., PHP/composer).

* **Bug Fixes**
  * Improved messaging when PATH installation isn’t available so guidance matches the current platform.

* **Packaging**
  * Arch package now includes an additional required runtime library so PHP/Composer tool binaries work correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->