### PR TITLE
[Fix] Strip raw ANSI escape codes

### DIFF
--- a/bin/yerdd/src/ansi.rs
+++ b/bin/yerdd/src/ansi.rs
@@ -13,6 +13,13 @@
 ///
 /// Works over `char`s (via `.get()`, never indexing) so multi-byte UTF-8 text
 /// around an escape sequence is never split mid-codepoint.
+///
+/// Recognises three escape forms, each consumed in full:
+/// - CSI: `ESC '[' [0x30-0x3F]* [0x20-0x2F]* [0x40-0x7E]` (colour, cursor
+///   movement, private-mode toggles like `?25l`/`?25h`, etc).
+/// - OSC: `ESC ']' ...` terminated by BEL or `ESC '\'` (e.g. window-title
+///   sequences).
+/// - Two-byte forms, e.g. `ESC c`, `ESC =`, `ESC 7`.
 pub fn strip(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let mut out = String::with_capacity(input.len());
@@ -25,7 +32,6 @@ pub fn strip(input: &str) -> String {
         }
         match chars.get(i + 1) {
             Some('[') => {
-                // CSI: ESC '[' [0x30-0x3F]* [0x20-0x2F]* [0x40-0x7E]
                 let mut j = i + 2;
                 while matches!(chars.get(j), Some(c) if ('0'..='?').contains(c)) {
                     j += 1;
@@ -39,7 +45,6 @@ pub fn strip(input: &str) -> String {
                 i = j;
             }
             Some(']') => {
-                // OSC: ESC ']' ... terminated by BEL or ESC '\'
                 let mut j = i + 2;
                 loop {
                     match chars.get(j) {
@@ -57,7 +62,7 @@ pub fn strip(input: &str) -> String {
                 }
                 i = j;
             }
-            Some(_) => i += 2, // two-byte forms, e.g. `ESC c`, `ESC =`, `ESC 7`
+            Some(_) => i += 2,
             None => i += 1,
         }
     }

--- a/bin/yerdd/src/ansi.rs
+++ b/bin/yerdd/src/ansi.rs
@@ -17,8 +17,9 @@
 /// Recognises three escape forms, each consumed in full:
 /// - CSI: `ESC '[' [0x30-0x3F]* [0x20-0x2F]* [0x40-0x7E]` (colour, cursor
 ///   movement, private-mode toggles like `?25l`/`?25h`, etc).
-/// - OSC: `ESC ']' ...` terminated by BEL or `ESC '\'` (e.g. window-title
-///   sequences).
+/// - String-type sequences - OSC (`]`), DCS (`P`), SOS (`X`), PM (`^`), APC
+///   (`_`) - `ESC <introducer> ...` terminated by BEL or `ESC '\'` (e.g.
+///   window-title sequences and device-control payloads).
 /// - Two-byte forms, e.g. `ESC c`, `ESC =`, `ESC 7`.
 pub fn strip(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
@@ -44,7 +45,7 @@ pub fn strip(input: &str) -> String {
                 }
                 i = j;
             }
-            Some(']') => {
+            Some(']' | 'P' | 'X' | '^' | '_') => {
                 let mut j = i + 2;
                 loop {
                     match chars.get(j) {
@@ -104,6 +105,16 @@ mod tests {
     #[test]
     fn strips_osc_terminated_by_string_terminator() {
         assert_eq!(strip("\x1b]0;title\x1b\\visible"), "visible");
+    }
+
+    #[test]
+    fn strips_dcs_terminated_by_string_terminator() {
+        assert_eq!(strip("\x1bPsome device payload\x1b\\visible"), "visible");
+    }
+
+    #[test]
+    fn strips_apc_terminated_by_bel() {
+        assert_eq!(strip("\x1b_app payload\x07visible"), "visible");
     }
 
     #[test]

--- a/bin/yerdd/src/ansi.rs
+++ b/bin/yerdd/src/ansi.rs
@@ -1,0 +1,121 @@
+//! Strip ANSI escape sequences from subprocess output.
+//!
+//! Scaffolding/install jobs force `NO_COLOR=1` + `TERM=dumb` and `--no-ansi` on
+//! the child (see [`crate::create_site`]), but some tools (npm, git, and
+//! Laravel's own installer spinner among them) still emit colour or
+//! cursor-control escapes regardless of those hints. The job log is rendered in
+//! a plain `<pre>` with no terminal emulator, so anything that slips through
+//! renders as literal garbage. [`strip`] is a last-resort filter applied to
+//! every line before it's stored, per [`crate::jobs::JobRegistry::push_log`].
+
+/// Remove ANSI escape sequences (CSI, OSC, and two-byte `ESC x` forms) from
+/// `input`, passing all other characters through unchanged.
+///
+/// Works over `char`s (via `.get()`, never indexing) so multi-byte UTF-8 text
+/// around an escape sequence is never split mid-codepoint.
+pub fn strip(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while let Some(&c) = chars.get(i) {
+        if c != '\u{1b}' {
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        match chars.get(i + 1) {
+            Some('[') => {
+                // CSI: ESC '[' [0x30-0x3F]* [0x20-0x2F]* [0x40-0x7E]
+                let mut j = i + 2;
+                while matches!(chars.get(j), Some(c) if ('0'..='?').contains(c)) {
+                    j += 1;
+                }
+                while matches!(chars.get(j), Some(c) if (' '..='/').contains(c)) {
+                    j += 1;
+                }
+                if matches!(chars.get(j), Some(c) if ('@'..='~').contains(c)) {
+                    j += 1;
+                }
+                i = j;
+            }
+            Some(']') => {
+                // OSC: ESC ']' ... terminated by BEL or ESC '\'
+                let mut j = i + 2;
+                loop {
+                    match chars.get(j) {
+                        None => break,
+                        Some('\u{7}') => {
+                            j += 1;
+                            break;
+                        }
+                        Some('\u{1b}') if chars.get(j + 1) == Some(&'\\') => {
+                            j += 2;
+                            break;
+                        }
+                        Some(_) => j += 1,
+                    }
+                }
+                i = j;
+            }
+            Some(_) => i += 2, // two-byte forms, e.g. `ESC c`, `ESC =`, `ESC 7`
+            None => i += 1,
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_plain_text_through_unchanged() {
+        assert_eq!(
+            strip("Creating Laravel application..."),
+            "Creating Laravel application..."
+        );
+    }
+
+    #[test]
+    fn strips_sgr_color_codes() {
+        assert_eq!(strip("\x1b[36mCreating\x1b[39m"), "Creating");
+    }
+
+    #[test]
+    fn strips_cursor_hide_show() {
+        assert_eq!(strip("\x1b[?25lworking\x1b[?25h"), "working");
+    }
+
+    #[test]
+    fn strips_cursor_movement_and_column_reset() {
+        assert_eq!(strip("\x1b[2A\x1b[999Ddone"), "done");
+    }
+
+    #[test]
+    fn strips_osc_terminated_by_bel() {
+        assert_eq!(strip("\x1b]0;title\x07visible"), "visible");
+    }
+
+    #[test]
+    fn strips_osc_terminated_by_string_terminator() {
+        assert_eq!(strip("\x1b]0;title\x1b\\visible"), "visible");
+    }
+
+    #[test]
+    fn strips_two_byte_escape() {
+        assert_eq!(strip("\x1b=visible"), "visible");
+    }
+
+    #[test]
+    fn preserves_multi_byte_utf8_around_escapes() {
+        assert_eq!(
+            strip("\x1b[32m✔\x1b[39m Creating Laravel application…"),
+            "✔ Creating Laravel application…"
+        );
+    }
+
+    #[test]
+    fn dangling_escape_at_end_of_input_is_dropped() {
+        assert_eq!(strip("done\x1b"), "done");
+    }
+}

--- a/bin/yerdd/src/create_site.rs
+++ b/bin/yerdd/src/create_site.rs
@@ -231,8 +231,10 @@ async fn run_inner(
 ///
 /// `--no-ansi` is included because the stream is rendered in a plain text panel
 /// with no ANSI interpreter; it is forwarded to the composer/npm commands the
-/// installer shells out to, so no raw escape sequences leak (the daemon also
-/// forces NO_COLOR/TERM=dumb on the child, see `run_scaffold`).
+/// installer shells out to, cutting down on raw escape sequences (the daemon
+/// also forces NO_COLOR/TERM=dumb on the child, see `run_scaffold`). Anything
+/// that still slips through is stripped defensively in
+/// `crate::jobs::JobRegistry::push_log`.
 fn build_new_args(name: &str, o: &LaravelOptions) -> Vec<String> {
     let mut a = vec![
         "new".to_owned(),
@@ -482,7 +484,9 @@ enum ScaffoldOutcome {
 /// ANSI colour and cursor-control (spinner redraws) from the inherited TERM. The
 /// job log is shown in a plain `<pre>` with no terminal emulator, so those escapes
 /// render literally and spinner frames stack as duplicate lines; the two env vars
-/// make the installer fall back to undecorated, single-line output.
+/// push most tools toward undecorated, single-line output, and
+/// `crate::jobs::JobRegistry::push_log` strips whatever colour/cursor escapes
+/// still get through (some spinners write them unconditionally).
 #[allow(clippy::too_many_arguments)]
 async fn run_scaffold(
     id: &str,

--- a/bin/yerdd/src/jobs.rs
+++ b/bin/yerdd/src/jobs.rs
@@ -74,13 +74,19 @@ impl JobRegistry {
         (id, rx)
     }
 
-    /// Append a log line to a job (no-op if the job is gone). ANSI escapes are
-    /// stripped first - the log is rendered in a plain-text panel, and some
-    /// subprocesses (npm, git, the Laravel installer's spinner) emit them even
-    /// with `NO_COLOR`/`TERM=dumb`/`--no-ansi` set on the child (see
-    /// `crate::create_site::run_scaffold`).
+    /// Append a log line to a job (no-op if the job is gone or the line is
+    /// blank after stripping). ANSI escapes are stripped first - the log is
+    /// rendered in a plain-text panel, and some subprocesses (npm, git, the
+    /// Laravel installer's spinner) emit them even with
+    /// `NO_COLOR`/`TERM=dumb`/`--no-ansi` set on the child (see
+    /// `crate::create_site::run_scaffold`). A line made up entirely of escapes
+    /// (e.g. a bare cursor-hide/show or OSC title-set) strips to empty and is
+    /// dropped rather than left as a blank entry.
     pub async fn push_log(&self, id: &str, line: String) {
         let line = crate::ansi::strip(&line);
+        if line.is_empty() {
+            return;
+        }
         let mut map = self.inner.lock().await;
         if let Some(job) = map.get_mut(id) {
             job.log.push(line);
@@ -203,6 +209,20 @@ mod tests {
         let r = reg.poll(&id, 0).await;
         let (_, log, _, _) = progress(&r);
         assert_eq!(log, ["Creating Laravel application..."]);
+    }
+
+    #[tokio::test]
+    async fn push_log_drops_lines_that_are_ansi_only() {
+        let reg = JobRegistry::default();
+        let (id, _cancel) = reg.create().await;
+
+        reg.push_log(&id, "\x1b[?25l".into()).await;
+        reg.push_log(&id, "visible".into()).await;
+
+        let r = reg.poll(&id, 0).await;
+        let (_, log, next, _) = progress(&r);
+        assert_eq!(log, ["visible"]);
+        assert_eq!(next, 1);
     }
 
     #[tokio::test]

--- a/bin/yerdd/src/jobs.rs
+++ b/bin/yerdd/src/jobs.rs
@@ -74,8 +74,13 @@ impl JobRegistry {
         (id, rx)
     }
 
-    /// Append a log line to a job (no-op if the job is gone).
+    /// Append a log line to a job (no-op if the job is gone). ANSI escapes are
+    /// stripped first - the log is rendered in a plain-text panel, and some
+    /// subprocesses (npm, git, the Laravel installer's spinner) emit them even
+    /// with `NO_COLOR`/`TERM=dumb`/`--no-ansi` set on the child (see
+    /// `crate::create_site::run_scaffold`).
     pub async fn push_log(&self, id: &str, line: String) {
+        let line = crate::ansi::strip(&line);
         let mut map = self.inner.lock().await;
         if let Some(job) = map.get_mut(id) {
             job.log.push(line);
@@ -182,6 +187,22 @@ mod tests {
             } => (*state, log.as_slice(), *next_cursor, error.as_deref()),
             other => panic!("expected JobProgress, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn push_log_strips_ansi_escapes() {
+        let reg = JobRegistry::default();
+        let (id, _cancel) = reg.create().await;
+
+        reg.push_log(
+            &id,
+            "\x1b[36mCreating Laravel application...\x1b[39m".into(),
+        )
+        .await;
+
+        let r = reg.poll(&id, 0).await;
+        let (_, log, _, _) = progress(&r);
+        assert_eq!(log, ["Creating Laravel application..."]);
     }
 
     #[tokio::test]

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -10,6 +10,7 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::doc_markdown)]
 
+pub mod ansi;
 pub mod args;
 pub mod backend_resolver;
 pub mod cert_store;


### PR DESCRIPTION
## What does this PR do?

Fixed raw ANSI escape codes (colors/cursor-control) leaking into the GUI's Laravel-site-creation log panel by stripping them centrally in the daemon's shared job-log choke point, since the existing NO_COLOR/--no-ansi suppression didn't fully stop the installer's spinner from emitting them.

## Related issues

<img width="669" height="484" alt="image" src="https://github.com/user-attachments/assets/27126745-20e4-417d-b854-48bebd33b044" />

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logs are now stored and displayed as plain text by stripping ANSI color and cursor-control escape codes.
  * Log entries that contain only escape sequences are no longer retained.
* **New Features**
  * Added a reusable ANSI escape stripping utility and exposed it for broader use.
* **Tests**
  * Added unit and async coverage for passthrough text, styled/controlled sequences removal, UTF-8 preservation, OSC termination handling, and dropping incomplete/dangling escapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->