### PR TITLE
[Fix] Resolve black tray menu icons on Linux dark themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3d60bee1a1d38c2077030f4788e1b4e31058d2e79a8cfc8f2b440bd44db290"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,10 +125,21 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -140,6 +169,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,9 +218,20 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -174,14 +240,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-lite",
  "rustix 1.1.4",
 ]
@@ -213,6 +279,32 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -353,11 +445,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -366,7 +467,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -782,6 +883,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "dark-light"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e1a09f280e29a8b00bc7e81eca5ac87dca0575639c9422a5fa25a07bb884b8"
+dependencies = [
+ "ashpd",
+ "async-std",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "web-sys",
+ "winreg 0.52.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,9 +1084,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1183,6 +1298,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -1198,7 +1319,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1628,6 +1749,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2248,6 +2381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2479,9 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "mail-parser"
@@ -2457,10 +2602,10 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.1",
  "serde",
@@ -2616,6 +2761,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,9 +2793,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-foundation",
@@ -2642,7 +2803,7 @@ dependencies = [
  "objc2-core-image",
  "objc2-core-text",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-quartz-core",
 ]
 
@@ -2653,8 +2814,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2664,8 +2825,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2676,7 +2837,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2687,7 +2848,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -2698,8 +2859,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2708,8 +2869,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2719,7 +2880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -2731,7 +2892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
@@ -2754,14 +2915,26 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2772,7 +2945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2783,9 +2956,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2795,8 +2968,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-foundation",
@@ -2804,7 +2977,7 @@ dependencies = [
  "objc2-core-image",
  "objc2-core-location",
  "objc2-core-text",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-quartz-core",
  "objc2-user-notifications",
 ]
@@ -2815,8 +2988,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2826,11 +2999,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3020,6 +3193,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -3481,17 +3660,17 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
  "js-sys",
  "log",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4047,10 +4226,10 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
@@ -4206,7 +4385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
@@ -4222,9 +4401,9 @@ dependencies = [
  "log",
  "ndk",
  "ndk-sys",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "once_cell",
  "parking_lot",
@@ -4290,9 +4469,9 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "percent-encoding",
@@ -4439,7 +4618,7 @@ dependencies = [
  "dunce",
  "glob",
  "log",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -4462,7 +4641,7 @@ dependencies = [
  "dunce",
  "glob",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "open",
  "schemars 0.8.22",
  "serde",
@@ -4501,7 +4680,7 @@ dependencies = [
  "gtk",
  "http",
  "jni",
- "objc2",
+ "objc2 0.6.4",
  "objc2-ui-kit",
  "objc2-web-kit",
  "raw-window-handle",
@@ -4525,7 +4704,7 @@ dependencies = [
  "http",
  "jni",
  "log",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "once_cell",
  "percent-encoding",
@@ -4987,11 +5166,11 @@ dependencies = [
  "dirs 6.0.0",
  "libappindicator",
  "muda",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.1",
  "serde",
@@ -5133,6 +5312,12 @@ dependencies = [
  "getrandom 0.2.17",
  "serde",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version-compare"
@@ -5431,10 +5616,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -5959,6 +6144,16 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5980,7 +6175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -5994,10 +6189,10 @@ dependencies = [
  "jni",
  "libc",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -6151,16 +6346,17 @@ dependencies = [
 name = "yerd-gui"
 version = "2.0.2-rc.10"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.9.4",
  "core-foundation-sys",
+ "dark-light",
  "dispatch2",
  "glib",
  "interprocess",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "pem",
  "security-framework",
  "security-framework-sys",
@@ -6412,7 +6608,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-lite",
  "hex",
@@ -6527,6 +6723,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",

--- a/apps/yerd-gui/src-tauri/Cargo.toml
+++ b/apps/yerd-gui/src-tauri/Cargo.toml
@@ -56,6 +56,13 @@ sha2 = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 glib       = "0.18"
 webkit2gtk = "=2.0.2"
+# Dark-mode probe for the tray menu icons (tray.rs's `dark_menu_bar`), read via
+# the xdg-desktop-portal `Settings` interface so it works across desktop
+# environments (GNOME, KDE Plasma, ...) rather than a GTK/GSettings-only check.
+# Brings in `ashpd` plus its own `async-std` executor as a self-contained stack
+# (not otherwise in the dependency graph); its D-Bus I/O never touches our
+# tokio runtime, so it's safe to call off the main thread.
+dark-light = "2"
 
 # macOS: re-apply the Dock icon after an activation-policy change (dev builds have
 # no .app bundle, so the recreated Dock tile would otherwise show the generic

--- a/apps/yerd-gui/src-tauri/Cargo.toml
+++ b/apps/yerd-gui/src-tauri/Cargo.toml
@@ -59,9 +59,11 @@ webkit2gtk = "=2.0.2"
 # Dark-mode probe for the tray menu icons (tray.rs's `dark_menu_bar`), read via
 # the xdg-desktop-portal `Settings` interface so it works across desktop
 # environments (GNOME, KDE Plasma, ...) rather than a GTK/GSettings-only check.
-# Brings in `ashpd` plus its own `async-std` executor as a self-contained stack
-# (not otherwise in the dependency graph); its D-Bus I/O never touches our
-# tokio runtime, so it's safe to call off the main thread.
+# Brings in `ashpd` (its async-std feature) plus its own `async-std` executor as
+# a self-contained stack (not otherwise in the dependency graph). zbus resolves
+# to its async-io backend here, not its `tokio` feature, so the D-Bus I/O runs
+# independent of our tokio runtime - re-check this if a future version bump
+# ever pulls zbus's `tokio` feature in.
 dark-light = "2"
 
 # macOS: re-apply the Dock icon after an activation-policy change (dev builds have

--- a/apps/yerd-gui/src-tauri/src/tray.rs
+++ b/apps/yerd-gui/src-tauri/src/tray.rs
@@ -15,7 +15,10 @@
 //! began its fetch before the action can't overwrite the action's transient menu.
 //! `MENU_LOCK` is only ever taken from spawned worker tasks, never the main
 //! thread (a worker blocks on the main thread while `set_menu` marshals, so a
-//! main-thread lock would cycle-deadlock).
+//! main-thread lock would cycle-deadlock). Callers read `dark_menu_bar()`
+//! themselves *before* taking the lock (on Linux it's a bounded D-Bus round
+//! trip) and pass the result in, so the lock only ever wraps the menu-building
+//! and `set_menu`/`set_icon` marshalling it was meant to serialize.
 
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -127,7 +130,7 @@ struct TrayState {
 /// "Open Yerd" item opens the main window. (Windows convention is left-click =
 /// open the app; revisit if/when Windows support lands.)
 pub(crate) fn build_tray(app: &AppHandle) -> tauri::Result<()> {
-    let menu = build_menu(app, &TrayState::default())?;
+    let menu = build_menu(app, &TrayState::default(), dark_menu_bar())?;
     let mut builder = TrayIconBuilder::with_id(TRAY_ID)
         .tooltip("Yerd")
         .menu(&menu)
@@ -168,9 +171,10 @@ pub(crate) fn spawn_tray_poller(app: AppHandle) {
             if last.as_ref() == Some(&state) {
                 continue;
             }
+            let dark = dark_menu_bar();
             let guard = lock_menu();
             if !TRANSITION.load(Ordering::Acquire) {
-                apply(&app, &state);
+                apply(&app, &state, dark);
                 last = Some(state);
             }
             drop(guard);
@@ -221,10 +225,12 @@ impl Badges {
 
 /// Build + install the menu for `state`, and badge the icon for waiting updates
 /// and/or unread mail. No lock / no transition logic - callers hold `MENU_LOCK`
-/// as needed. On macOS a coloured badge can't be a template, so templating is
-/// dropped while any badge shows (and restored when none do).
-fn apply(app: &AppHandle, state: &TrayState) {
-    let Ok(menu) = build_menu(app, state) else {
+/// as needed, and must read `dark_menu_bar()` themselves *before* taking it (see
+/// the module concurrency note) since this only threads `dark` through. On
+/// macOS a coloured badge can't be a template, so templating is dropped while
+/// any badge shows (and restored when none do).
+fn apply(app: &AppHandle, state: &TrayState, dark: bool) {
+    let Ok(menu) = build_menu(app, state, dark) else {
         return;
     };
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
@@ -360,11 +366,17 @@ fn dark_menu_bar() -> bool {
 /// a colour that reads against the theme (muda menu icons aren't templates, and
 /// there's no single GTK/Qt API across desktops to ask for the exact label
 /// colour). Reads the xdg-desktop-portal `Settings` `color-scheme` preference
-/// (GNOME, KDE Plasma, and other portal-backed desktops all implement it), via
-/// `dark-light`'s own executor - independent of our tokio runtime, so it's safe
-/// to call from the tray poller's worker thread as well as the main thread. Any
-/// failure (no portal, older desktop) reads as light, which just leaves the
-/// glyph at its original black - the current behaviour, so no regression.
+/// (GNOME, KDE Plasma, and other portal-backed desktops all implement it) via
+/// `dark-light`'s own async-std executor (zbus's async-io backend here, not its
+/// `tokio` feature - see the Cargo.toml comment), so its blocking D-Bus round
+/// trip (typically sub-25ms against a live portal; unbounded only if the
+/// session bus itself is wedged) runs independent of our tokio runtime and is
+/// safe to call from the tray poller's worker thread as well as the main
+/// thread.
+/// Callers take this reading *before* `MENU_LOCK` (see the module concurrency
+/// note) so the probe never runs while the lock is held. Any failure (no
+/// portal, older desktop) reads as light, which just leaves the glyph at its
+/// original black - the current behaviour, so no regression.
 #[cfg(target_os = "linux")]
 fn dark_menu_bar() -> bool {
     matches!(dark_light::detect(), Ok(dark_light::Mode::Dark))
@@ -393,9 +405,10 @@ fn apply_transient(app: &AppHandle, label: &str) {
 /// the menu. Used by the non-lifecycle actions (set-default-PHP, update check).
 async fn refresh_now(app: &AppHandle) {
     let state = fetch_state().await;
+    let dark = dark_menu_bar();
     let guard = lock_menu();
     if !TRANSITION.load(Ordering::Acquire) {
-        apply(app, &state);
+        apply(app, &state, dark);
     }
     drop(guard);
 }
@@ -423,7 +436,9 @@ fn mail_label(unread: u32) -> String {
     }
 }
 
-/// The full menu for the current daemon state.
+/// The full menu for the current daemon state. `dark` is a single
+/// `dark_menu_bar()` reading the caller took before taking `MENU_LOCK` (see the
+/// module concurrency note), threaded through every icon in this build.
 ///
 /// Layout: a top zone (Open Yerd, plus Update Yerd / Update PHP while an update
 /// waits) before the status header, then the running- or stopped-daemon block,
@@ -431,9 +446,8 @@ fn mail_label(unread: u32) -> String {
 /// "Default PHP:" label, each indented with a tick drawn into the label text
 /// itself (rather than the fixed native checkmark column) so it nests with the
 /// versions; picking one switches the default and the tick moves.
-fn build_menu(app: &AppHandle, state: &TrayState) -> tauri::Result<Menu<Wry>> {
+fn build_menu(app: &AppHandle, state: &TrayState, dark: bool) -> tauri::Result<Menu<Wry>> {
     let mut items: Vec<Box<dyn IsMenuItem<Wry>>> = Vec::new();
-    let dark = dark_menu_bar();
 
     push(
         &mut items,
@@ -738,8 +752,9 @@ fn spawn_lifecycle(app: AppHandle, kind: Lifecycle) {
         }
 
         let state = fetch_state().await;
+        let dark = dark_menu_bar();
         let guard = lock_menu();
-        apply(&app, &state);
+        apply(&app, &state, dark);
         TRANSITION.store(false, Ordering::Release);
         drop(guard);
     });
@@ -815,5 +830,39 @@ async fn wait_until_restarted(prev: Option<u64>) {
             },
             _ => saw_down = true,
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{icons, menu_icon};
+
+    #[test]
+    fn menu_icon_light_leaves_pixels_unchanged() {
+        let raw = tauri::image::Image::from_bytes(icons::OPEN).expect("bundled icon decodes");
+        let light = menu_icon(icons::OPEN, false).expect("bundled icon decodes");
+        assert_eq!(light.rgba(), raw.rgba());
+    }
+
+    #[test]
+    fn menu_icon_dark_recolors_opaque_pixels_white() {
+        let dark = menu_icon(icons::OPEN, true).expect("bundled icon decodes");
+        for px in dark.rgba().chunks_exact(4) {
+            if let [r, g, b, a] = *px {
+                if a > 0 {
+                    assert_eq!((r, g, b), (255, 255, 255));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn menu_icon_dark_preserves_alpha_channel() {
+        let raw = tauri::image::Image::from_bytes(icons::OPEN).expect("bundled icon decodes");
+        let dark = menu_icon(icons::OPEN, true).expect("bundled icon decodes");
+        let raw_alpha: Vec<u8> = raw.rgba().chunks_exact(4).map(|px| px[3]).collect();
+        let dark_alpha: Vec<u8> = dark.rgba().chunks_exact(4).map(|px| px[3]).collect();
+        assert_eq!(raw_alpha, dark_alpha);
     }
 }

--- a/apps/yerd-gui/src-tauri/src/tray.rs
+++ b/apps/yerd-gui/src-tauri/src/tray.rs
@@ -343,9 +343,10 @@ fn draw_dot(rgba: &mut [u8], width: u32, height: u32, color: (u8, u8, u8), pos: 
     }
 }
 
-/// Whether the system is in Dark mode, so the badged (non-template) icon can
-/// paint its glyph in the matching label colour. Reads the thread-safe
-/// `AppleInterfaceStyle` user default, so it's fine off the main thread.
+/// Whether the system is in Dark mode, so the badged (non-template) icon and
+/// the menu-item glyphs can be painted in the matching colour. Reads the
+/// thread-safe `AppleInterfaceStyle` user default, so it's fine off the main
+/// thread.
 #[cfg(target_os = "macos")]
 fn dark_menu_bar() -> bool {
     use objc2_foundation::{NSString, NSUserDefaults};
@@ -353,6 +354,27 @@ fn dark_menu_bar() -> bool {
     defaults
         .stringForKey(&NSString::from_str("AppleInterfaceStyle"))
         .is_some_and(|s| s.to_string().eq_ignore_ascii_case("dark"))
+}
+
+/// Whether the desktop prefers dark mode, so `menu_icon` can paint the glyph in
+/// a colour that reads against the theme (muda menu icons aren't templates, and
+/// there's no single GTK/Qt API across desktops to ask for the exact label
+/// colour). Reads the xdg-desktop-portal `Settings` `color-scheme` preference
+/// (GNOME, KDE Plasma, and other portal-backed desktops all implement it), via
+/// `dark-light`'s own executor - independent of our tokio runtime, so it's safe
+/// to call from the tray poller's worker thread as well as the main thread. Any
+/// failure (no portal, older desktop) reads as light, which just leaves the
+/// glyph at its original black - the current behaviour, so no regression.
+#[cfg(target_os = "linux")]
+fn dark_menu_bar() -> bool {
+    matches!(dark_light::detect(), Ok(dark_light::Mode::Dark))
+}
+
+/// No dark-mode signal on other targets (Windows isn't implemented yet) - the
+/// menu-item glyphs just stay at their original black, today's behaviour.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn dark_menu_bar() -> bool {
+    false
 }
 
 /// Install the transient menu shown while a lifecycle action is in flight.
@@ -411,18 +433,22 @@ fn mail_label(unread: u32) -> String {
 /// versions; picking one switches the default and the tick moves.
 fn build_menu(app: &AppHandle, state: &TrayState) -> tauri::Result<Menu<Wry>> {
     let mut items: Vec<Box<dyn IsMenuItem<Wry>>> = Vec::new();
+    let dark = dark_menu_bar();
 
-    push(&mut items, action(app, "open", "Open Yerd", icons::OPEN)?);
+    push(
+        &mut items,
+        action(app, "open", "Open Yerd", icons::OPEN, dark)?,
+    );
     if state.update_target.is_some() {
         push(
             &mut items,
-            action(app, "update:apply", "Update Yerd", icons::UPDATE)?,
+            action(app, "update:apply", "Update Yerd", icons::UPDATE, dark)?,
         );
     }
     if state.php_update {
         push(
             &mut items,
-            action(app, "update:php", "Update PHP", icons::UPDATE_PHP)?,
+            action(app, "update:php", "Update PHP", icons::UPDATE_PHP, dark)?,
         );
     }
     push(&mut items, PredefinedMenuItem::separator(app)?);
@@ -446,16 +472,23 @@ fn build_menu(app: &AppHandle, state: &TrayState) -> tauri::Result<Menu<Wry>> {
                     "update:check",
                     "Check for updates",
                     icons::CHECK_UPDATES,
+                    dark,
                 )?,
             );
         }
         push(
             &mut items,
-            action(app, "daemon:restart", "Restart daemon", icons::RESTART)?,
+            action(
+                app,
+                "daemon:restart",
+                "Restart daemon",
+                icons::RESTART,
+                dark,
+            )?,
         );
         push(
             &mut items,
-            action(app, "daemon:stop", "Stop daemon", icons::STOP)?,
+            action(app, "daemon:stop", "Stop daemon", icons::STOP, dark)?,
         );
         push(&mut items, PredefinedMenuItem::separator(app)?);
 
@@ -474,25 +507,28 @@ fn build_menu(app: &AppHandle, state: &TrayState) -> tauri::Result<Menu<Wry>> {
 
         push(
             &mut items,
-            action(app, "new-site", "New Laravel site…", icons::NEW_SITE)?,
+            action(app, "new-site", "New Laravel site…", icons::NEW_SITE, dark)?,
         );
         push(
             &mut items,
-            action(app, "sites:link", "Link Site", icons::LINK)?,
+            action(app, "sites:link", "Link Site", icons::LINK, dark)?,
         );
         push(
             &mut items,
-            action(app, "sites:park", "Park Directory", icons::PARK)?,
+            action(app, "sites:park", "Park Directory", icons::PARK, dark)?,
         );
         push(&mut items, PredefinedMenuItem::separator(app)?);
         push(
             &mut items,
-            action(app, "mail", mail_label(state.unread), icons::MAIL)?,
+            action(app, "mail", mail_label(state.unread), icons::MAIL, dark)?,
         );
-        push(&mut items, action(app, "dumps", "Dumps", icons::DUMPS)?);
+        push(
+            &mut items,
+            action(app, "dumps", "Dumps", icons::DUMPS, dark)?,
+        );
         push(&mut items, PredefinedMenuItem::separator(app)?);
         for (id, label, icon) in NAV_ITEMS {
-            push(&mut items, action(app, *id, *label, icon)?);
+            push(&mut items, action(app, *id, *label, icon, dark)?);
         }
         push(&mut items, PredefinedMenuItem::separator(app)?);
     } else {
@@ -502,18 +538,24 @@ fn build_menu(app: &AppHandle, state: &TrayState) -> tauri::Result<Menu<Wry>> {
         );
         push(
             &mut items,
-            action(app, "daemon:start", "Start daemon", icons::START)?,
+            action(app, "daemon:start", "Start daemon", icons::START, dark)?,
         );
         push(&mut items, PredefinedMenuItem::separator(app)?);
         push(
             &mut items,
-            action(app, "mail", mail_label(state.unread), icons::MAIL)?,
+            action(app, "mail", mail_label(state.unread), icons::MAIL, dark)?,
         );
-        push(&mut items, action(app, "dumps", "Dumps", icons::DUMPS)?);
+        push(
+            &mut items,
+            action(app, "dumps", "Dumps", icons::DUMPS, dark)?,
+        );
         push(&mut items, PredefinedMenuItem::separator(app)?);
     }
 
-    push(&mut items, action(app, "quit", "Quit Yerd", icons::QUIT)?);
+    push(
+        &mut items,
+        action(app, "quit", "Quit Yerd", icons::QUIT, dark)?,
+    );
     finish_menu(app, &items)
 }
 
@@ -522,36 +564,48 @@ fn build_menu(app: &AppHandle, state: &TrayState) -> tauri::Result<Menu<Wry>> {
 /// second start/stop/restart can't fire mid-transition and clear `TRANSITION`.
 fn build_transient_menu(app: &AppHandle, label: &str) -> tauri::Result<Menu<Wry>> {
     let mut items: Vec<Box<dyn IsMenuItem<Wry>>> = Vec::new();
+    let dark = dark_menu_bar();
     push(&mut items, disabled(app, "noop:transient", label)?);
     push(&mut items, PredefinedMenuItem::separator(app)?);
-    push(&mut items, action(app, "open", "Open Yerd", icons::OPEN)?);
-    push(&mut items, action(app, "mail", "Mail", icons::MAIL)?);
-    push(&mut items, action(app, "dumps", "Dumps", icons::DUMPS)?);
+    push(
+        &mut items,
+        action(app, "open", "Open Yerd", icons::OPEN, dark)?,
+    );
+    push(&mut items, action(app, "mail", "Mail", icons::MAIL, dark)?);
+    push(
+        &mut items,
+        action(app, "dumps", "Dumps", icons::DUMPS, dark)?,
+    );
     push(&mut items, PredefinedMenuItem::separator(app)?);
-    push(&mut items, action(app, "quit", "Quit Yerd", icons::QUIT)?);
+    push(
+        &mut items,
+        action(app, "quit", "Quit Yerd", icons::QUIT, dark)?,
+    );
     finish_menu(app, &items)
 }
 
-/// A clickable item with a leading icon.
+/// A clickable item with a leading icon, recoloured per `dark` (see
+/// `menu_icon`).
 fn action(
     app: &AppHandle,
     id: impl Into<tauri::menu::MenuId>,
     text: impl AsRef<str>,
     icon: &[u8],
+    dark: bool,
 ) -> tauri::Result<IconMenuItem<Wry>> {
-    IconMenuItem::with_id(app, id, text, true, menu_icon(icon), None::<&str>)
+    IconMenuItem::with_id(app, id, text, true, menu_icon(icon, dark), None::<&str>)
 }
 
-/// Decode a bundled menu-item PNG, recolouring its black glyph to white in dark
-/// mode so it reads on the menu background (muda menu icons aren't templates, so
-/// they don't auto-tint).
-fn menu_icon(png: &[u8]) -> Option<tauri::image::Image<'static>> {
+/// Decode a bundled menu-item PNG, recolouring its black glyph to white when
+/// `dark` (muda menu icons aren't templates, so they don't auto-tint). Callers
+/// pass one `dark_menu_bar()` reading per menu build rather than probing per
+/// icon - on Linux that reading is a D-Bus round trip, so this keeps a rebuild
+/// at one portal query instead of one per item.
+fn menu_icon(png: &[u8], dark: bool) -> Option<tauri::image::Image<'static>> {
     let img = tauri::image::Image::from_bytes(png).ok()?;
     let (w, h) = (img.width(), img.height());
-    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut rgba = img.rgba().to_vec();
-    #[cfg(target_os = "macos")]
-    if dark_menu_bar() {
+    if dark {
         for px in rgba.chunks_exact_mut(4) {
             if let [r, g, b, a] = px {
                 if *a > 0 {


### PR DESCRIPTION
## What does this PR do?

Tray dropdown menu icons now recolor to white when the desktop prefers dark mode (via the xdg-desktop-portal), matching the native menu text instead of staying solid black.

## Related issues

<img width="323" height="578" alt="image" src="https://github.com/user-attachments/assets/f823a36e-89f1-4caf-9282-8d8d5f5c1fd8" />

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tray menu icons now automatically adapt to dark mode on Linux (via desktop portal color-scheme detection) as well as macOS.
  * Dark-mode styling is applied consistently to both standard and transient tray menus, including lifecycle transition rebuilds.

* **Bug Fixes**
  * Improved icon recoloring to keep glyphs visually consistent across all tray states; failures in dark-mode detection safely fall back to the light appearance.

* **Tests**
  * Added coverage to verify dark vs. light icon pixel recoloring and that transparency is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->