### PR TITLE
[Feat] Automatically check for updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6183,6 +6183,7 @@ dependencies = [
  "yerd-core",
  "yerd-ipc",
  "yerd-platform",
+ "yerd-update",
 ]
 
 [[package]]

--- a/apps/yerd-gui/src-tauri/Cargo.toml
+++ b/apps/yerd-gui/src-tauri/Cargo.toml
@@ -20,6 +20,10 @@ tauri-build = { version = "2", features = [] }
 yerd-core     = { path = "../../../crates/yerd-core" }
 yerd-ipc      = { path = "../../../crates/yerd-ipc", features = ["transport"] }
 yerd-platform = { path = "../../../crates/yerd-platform" }
+# Pure `is_check_due` due-check for the launch-time auto-update trigger
+# (tray.rs) - reuses the same decision crate the daemon uses rather than
+# reimplementing the cadence in the GUI.
+yerd-update   = { path = "../../../crates/yerd-update" }
 
 # `image-png` enables Image::from_bytes for the macOS template tray icon (the
 # bundled app icon is embedded as RGBA by codegen and needs no runtime decoder).

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -43,6 +43,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             show_main(app);
+            tray::spawn_launch_update_check(app.clone());
         }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
@@ -211,6 +212,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     app.set_menu(build_app_menu(app.handle())?)?;
     tray::build_tray(app.handle())?;
     tray::spawn_tray_poller(app.handle().clone());
+    tray::spawn_launch_update_check(app.handle().clone());
     show_initial_window(app);
     #[cfg(target_os = "macos")]
     std::thread::spawn(|| {

--- a/apps/yerd-gui/src-tauri/src/tray.rs
+++ b/apps/yerd-gui/src-tauri/src/tray.rs
@@ -705,14 +705,41 @@ fn spawn_set_default_php(app: AppHandle, version: String) {
 
 /// Run a live (network) self-update check bounded by a timeout - a `None` channel
 /// resolves the daemon's persisted preference - then refresh the menu.
+async fn run_update_check(app: &AppHandle) {
+    let _ = exchange_timeout(
+        &Request::CheckUpdate { channel: None },
+        Duration::from_secs(20),
+    )
+    .await;
+    refresh_now(app).await;
+}
+
+/// Spawn [`run_update_check`] in the background; used by the tray's "Check for
+/// updates" menu item.
 fn spawn_update_check(app: AppHandle) {
+    tauri::async_runtime::spawn(async move { run_update_check(&app).await });
+}
+
+/// Fire once at GUI launch (and on a subsequent single-instance re-invoke): if
+/// the daemon's last self-update check is already stale (`yerd_update::
+/// CHECK_INTERVAL_SECS`, 4h), kick a live check immediately rather than
+/// waiting for the daemon's own wall-clock-gated poll to catch up. Silent and
+/// non-blocking - an unreachable daemon or fetch failure is swallowed exactly
+/// like the daemon's own failure-tolerant polling.
+pub(crate) fn spawn_launch_update_check(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
-        let _ = exchange_timeout(
-            &Request::CheckUpdate { channel: None },
-            Duration::from_secs(20),
-        )
-        .await;
-        refresh_now(&app).await;
+        let checked_at = match exchange_timeout(&Request::CachedUpdateStatus, PROBE_TIMEOUT).await {
+            Ok(Response::UpdateStatus {
+                checked_at_epoch, ..
+            }) => checked_at_epoch,
+            _ => None,
+        };
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        if yerd_update::is_check_due(checked_at, now) {
+            run_update_check(&app).await;
+        }
     });
 }
 

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -149,17 +149,28 @@ async fn run_until_shutdown(
         let mut rx = shutdown_rx.clone();
         tokio::spawn(async move {
             let dl = crate::php_install::ReqwestDownloader::new();
-            let mut tick = tokio::time::interval(Duration::from_secs(12 * 60 * 60));
+            let mut php_tick = tokio::time::interval(Duration::from_secs(12 * 60 * 60));
+            // Short wake so the wall-clock due-check in `poll_if_due` recovers
+            // quickly after the process was suspended (see self_update::poll_if_due).
+            // Default MissedTickBehavior::Burst means a burst of missed ticks
+            // (e.g. from runtime starvation, not suspend itself - a stalled
+            // monotonic clock accrues no missed ticks) fires back-to-back on
+            // resume. Harmless either way: each is awaited serially, and
+            // `poll_if_due` wall-clock-gates every tick, so only the first
+            // (or, on repeated fetch failures, the first few) actually fetch.
+            let mut self_tick = tokio::time::interval(Duration::from_secs(15 * 60));
             loop {
                 tokio::select! {
-                    _ = tick.tick() => {
+                    _ = php_tick.tick() => {
                         crate::php_updates::poll_and_refresh(
                             &state,
                             &dl,
                             yerd_update::PHP_LISTING_PUBLIC_KEY,
                         )
                         .await;
-                        crate::self_update::poll_and_refresh(&state, &dl).await;
+                    }
+                    _ = self_tick.tick() => {
+                        crate::self_update::poll_if_due(&state, &dl).await;
                     }
                     _ = rx.changed() => break,
                 }

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -82,6 +82,15 @@ pub async fn run_with_daemon(daemon: Daemon) -> Result<Outcome, DaemonError> {
     result
 }
 
+/// Self-update poll wake interval. Short (15 min) so the wall-clock due-check
+/// in `self_update::poll_if_due` recovers quickly after the process was
+/// suspended. The default `MissedTickBehavior::Burst` means missed ticks from
+/// runtime starvation (not suspend itself: a stalled monotonic clock accrues
+/// no missed ticks) fire back-to-back on resume. Harmless either way: each is
+/// awaited serially and `poll_if_due` wall-clock-gates every tick, so only the
+/// first (or, on repeated fetch failures, the first few) actually fetch.
+const SELF_UPDATE_WAKE: Duration = Duration::from_secs(15 * 60);
+
 #[allow(clippy::too_many_lines)]
 async fn run_until_shutdown(
     daemon: Daemon,
@@ -150,15 +159,7 @@ async fn run_until_shutdown(
         tokio::spawn(async move {
             let dl = crate::php_install::ReqwestDownloader::new();
             let mut php_tick = tokio::time::interval(Duration::from_secs(12 * 60 * 60));
-            // Short wake so the wall-clock due-check in `poll_if_due` recovers
-            // quickly after the process was suspended (see self_update::poll_if_due).
-            // Default MissedTickBehavior::Burst means a burst of missed ticks
-            // (e.g. from runtime starvation, not suspend itself - a stalled
-            // monotonic clock accrues no missed ticks) fires back-to-back on
-            // resume. Harmless either way: each is awaited serially, and
-            // `poll_if_due` wall-clock-gates every tick, so only the first
-            // (or, on repeated fetch failures, the first few) actually fetch.
-            let mut self_tick = tokio::time::interval(Duration::from_secs(15 * 60));
+            let mut self_tick = tokio::time::interval(SELF_UPDATE_WAKE);
             loop {
                 tokio::select! {
                     _ = php_tick.tick() => {

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -287,10 +287,27 @@ pub async fn cached_update_status(state: &DaemonState) -> Response {
     }
 }
 
+/// Poll only if the wall-clock interval (`yerd_update::CHECK_INTERVAL_SECS`,
+/// 4h) has elapsed since the last recorded check. Robust across daemon
+/// restarts, since `state.update_snapshot` is seeded from the persisted
+/// snapshot at startup, and across OS sleep, since this compares epoch time
+/// rather than trusting the caller's tick cadence.
+pub async fn poll_if_due(state: &DaemonState, dl: &dyn Downloader) {
+    let last_checked = state
+        .update_snapshot
+        .read()
+        .await
+        .as_ref()
+        .map(|s| s.checked_at);
+    if yerd_update::is_check_due(last_checked, now_epoch()) {
+        poll_and_refresh(state, dl).await;
+    }
+}
+
 /// Poll GitHub once and refresh `state.yerd_update`. **Failure-tolerant**: a
 /// fetch error logs at `debug` and leaves the cache untouched. Notify-only: logs
 /// (does not install) when a newer version is available on the configured
-/// channel. Run at startup and every 12h alongside the PHP checker.
+/// channel. Called by [`poll_if_due`] on its wall-clock-gated cadence.
 pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader) {
     let Some(releases) = fetch_releases(dl).await else {
         return;

--- a/crates/yerd-update/src/lib.rs
+++ b/crates/yerd-update/src/lib.rs
@@ -127,6 +127,20 @@ pub struct UpdateDecision {
     pub ahead_of_stable: bool,
 }
 
+/// How often a self-update check should run.
+pub const CHECK_INTERVAL_SECS: u64 = 4 * 60 * 60;
+
+/// Whether a new check is due, given the last check time and "now" (both Unix
+/// epoch seconds). `None` (never checked) is always due. Uses saturating
+/// subtraction so a `last_checked` that is (implausibly) in the future - e.g.
+/// after a backward clock jump - is treated as "just checked", not due.
+#[must_use]
+pub fn is_check_due(last_checked_epoch: Option<u64>, now_epoch: u64) -> bool {
+    last_checked_epoch.map_or(true, |last| {
+        now_epoch.saturating_sub(last) >= CHECK_INTERVAL_SECS
+    })
+}
+
 /// Strip an optional leading `v`/`V` from a release tag and parse it as semver.
 /// Returns `None` for tags that are not valid semver (the caller skips them).
 #[must_use]
@@ -308,5 +322,25 @@ mod tests {
         let releases = [rel("v2.0.5", false)];
         let d = select_target(&releases, Channel::Stable, &ver("2.0.5+build.7"));
         assert_eq!(d.target, None);
+    }
+
+    #[test]
+    fn never_checked_is_due() {
+        assert!(is_check_due(None, 1_000));
+    }
+
+    #[test]
+    fn due_at_exact_interval_boundary() {
+        assert!(is_check_due(Some(1_000), 1_000 + CHECK_INTERVAL_SECS));
+    }
+
+    #[test]
+    fn not_due_one_second_under_interval() {
+        assert!(!is_check_due(Some(1_000), 1_000 + CHECK_INTERVAL_SECS - 1));
+    }
+
+    #[test]
+    fn future_last_checked_is_not_due() {
+        assert!(!is_check_due(Some(2_000), 1_000));
     }
 }

--- a/docs/developer/binaries/yerdd.md
+++ b/docs/developer/binaries/yerdd.md
@@ -24,7 +24,7 @@ flowchart TD
     DNS["DNS task (yerd-dns)"]
     PROXY["proxy task (yerd-proxy)"]
     IPC["IPC task (ipc_server)"]
-    UPD["PHP update-check task (poll every 12h)"]
+    UPD["update-check task (PHP every 12h; Yerd self-update wall-clock-gated at 4h)"]
     WATCH["fs-watch task (re-scan parked roots on change)"]
 
     PROXY -->|"resolves backends,<br/>ensure() FPM pools"| HELPER
@@ -105,7 +105,8 @@ The daemon's modules (`src/lib.rs` re-exports each as `pub mod`):
 | `fs_watch` | Debounced filesystem watcher that re-scans parked roots as projects appear/change. |
 | `mutate` | Pure, I/O-free config-mutation logic (`Park`/`Link`/`SetPhp`/…). |
 | `php_install` | Download + unpack prebuilt PHP builds; `reqwest` downloader. |
-| `php_updates` | Update poller + cache (notify-only). |
+| `php_updates` | PHP update poller + cache (notify-only). |
+| `self_update` | Yerd self-update poller: fetches the GitHub Releases API, decides via the pure `yerd-update` crate, and persists a snapshot (`checked_at` + decision) both to disk and in `DaemonState` (notify-only). |
 | `dump_server` | Loopback TCP server reading newline-delimited JSON dump frames from the native `yerd-dump` extension into a bounded ring buffer; serves the ring to the GUI over IPC (`ListDumps`/`DumpsStatus`/…). |
 | `ext_install` | Downloads + SHA-256-verifies native PHP extension `.so`s per installed PHP version (from the `forjedio/yerd-php-ext` releases) into `{data}/php-ext/php-<ver>/`. An `ExtSpec` abstraction drives one fetch loop for **both** `yerd-dump` (`DUMP_SPEC`, gated on dumps) and `pcov` (`PCOV_SPEC`, ungated) - two manifests, one release. |
 | `tools` | Dev-tool installers (Composer, Node, Bun): download + SHA-256-verify self-contained binaries into `{data}/tools/<id>/` and reconcile their `{data}/bin` shims. See [Dev-tool installers](../dev-tools). |
@@ -191,7 +192,12 @@ The mutation path is the only place that holds two locks, and always in the orde
    - **proxy** (`yerd_proxy::ProxyServer::serve` with the `DaemonBackendResolver` and an `HttpsBinding` carrying the cert store),
    - **IPC** (`ipc_server::run`),
    - the **dump-telemetry server** (`dump_server::run`) - a loopback TCP listener receiving newline-delimited JSON frames from the native PHP `yerd-dump` extension into a ring buffer; it rebinds on a port change and a bind failure is non-fatal (logged, retried on the next rebind),
-   - a **PHP update checker** (poll once, then every 12h; notify-only),
+   - an **update checker** covering two independent cadences in one task: a
+     **PHP checker** (poll once, then every 12h) and a **Yerd self-update
+     checker** (`self_update::poll_if_due`, woken every 15 minutes but only
+     fetching when `yerd_update::is_check_due` says its own 4h wall-clock
+     interval has elapsed - robust to the process being suspended, unlike a
+     plain `tokio::time::interval`). Both are notify-only,
    - the **filesystem watcher** (`fs_watch::run`, see above), and
    - conditionally, the **mail-capture SMTP task** (`yerd_mail::serve`) - spawned only when `daemon.mail_listener` is `Some` (mail capture enabled *and* the SMTP port bound at startup; a disabled or failed bind is non-fatal and already logged in `bring_up`).
 

--- a/docs/developer/gui.md
+++ b/docs/developer/gui.md
@@ -207,6 +207,14 @@ are the only categories the frontend's `IpcError` needs to distinguish.
 - **`tauri-plugin-single-instance` is registered first**: a second launch shows
   and focuses the existing `main` window instead of spawning a duplicate (which
   would risk a duplicate daemon connection or tray).
+- **Launch-time update check** (`tray::spawn_launch_update_check`): fired from
+  both `setup_app` and the single-instance callback, so it runs on a cold start
+  and on every re-invoke of an already-running app. It asks the daemon for the
+  cached self-update status and, only if `yerd_update::is_check_due` says the
+  last check is stale (the same 4h threshold the daemon's own background poll
+  uses), kicks a bounded live check. Silent and non-blocking - an unreachable
+  daemon or fetch failure is swallowed exactly like the daemon's own
+  failure-tolerant polling.
 - `tauri-plugin-opener` and `tauri-plugin-dialog` back the host helpers
   (`openInBrowser`, `openPath`, `pickDirectory`).
 - **Close-to-tray**: `WindowEvent::CloseRequested` hides the window and calls

--- a/docs/guide/daemon.md
+++ b/docs/guide/daemon.md
@@ -18,7 +18,7 @@ For internal architecture (task wiring, shutdown channel, lock ordering) see [ye
 | DNS responder | A loopback-only resolver answering `*.test`. See [DNS & .test Domains](./dns). |
 | PHP-FPM pools | One supervised pool per installed PHP version, started on demand. See [PHP Versions](./php-versions). |
 | IPC server | A Unix-socket listener for the CLI and desktop app. See [the desktop app](./desktop-app). |
-| Update checker | Polls for newer PHP patch releases every 12 hours and logs them. It never installs anything. |
+| Update checker | Polls for newer PHP patch releases every 12 hours, and for newer Yerd releases roughly every 4 hours (checked immediately if stale when the desktop app launches). Notify-only - it never installs anything. |
 | Local CA | Loads (or on first run generates) the local certificate authority used to issue per-site certs. |
 
 All of this runs as you, never as root. The only operations needing privilege (trusting the CA, configuring the system resolver, granting the port capability) are handled once by a separate audited helper. See [Elevation & Privileges](./elevation).

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -28,6 +28,7 @@ The window is something you summon, not keep open.
 - Closing the window hides it to the tray instead of quitting. The daemon and your sites keep running.
 - The tray menu is a **live dropdown**, not a static list. It shows daemon status (running/stopped, with the bound HTTP/HTTPS ports) and **Restart** / **Stop** (or **Start** when stopped); an inline **Default PHP** switcher over your installed versions (a tick marks the current default, pick another to switch); **Update Yerd** / **Update PHP** when an update is waiting (otherwise **Check for updates**); shortcuts to open the **Mail** and **Dumps** viewer windows; **New Laravel site**, **Link Site**, **Park Directory**; page-navigation shortcuts; **Open Yerd**; and **Quit** (exits the GUI, not the daemon). The menu refreshes from the daemon even while the window is hidden to the tray.
 - The tray icon also carries status badges: a small red dot when a Yerd or PHP update is available, and an orange dot when there's unread captured mail.
+- You don't need to click **Check for updates** for the badge to stay current: the daemon checks for new Yerd releases on its own roughly every 4 hours, and the app also checks immediately on launch (or when you re-open an already-running Yerd) if the last check is more than 4 hours old.
 - On macOS, left-click the tray icon to open the menu. On Linux (AppIndicator), use the menu's **Open Yerd** to reshow the window.
 - Single-instance: launching again re-focuses the existing window.
 


### PR DESCRIPTION
## What does this PR do?

Yerd automatically checks for updates every 4 hours. 

## Related issues

Closes #64

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets` is clean
- [ ] `cargo test` passes
- [ ] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [ ] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update checks now run more intelligently at startup and in the background, helping the app stay current without unnecessary checks.

* **Bug Fixes**
  * Improved tray and self-update behavior so update status refreshes more reliably after launch and follows separate timing for different update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->