### PR TITLE
[Fix] Improve "External" description for developer tooling

### DIFF
--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -491,6 +491,12 @@ export interface ToolStatus {
    * exclusive with `installed`.
    */
   external?: boolean;
+  /**
+   * Absolute path where the external tool was found on the user's PATH (e.g.
+   * `/opt/homebrew/bin/node`), when `external` is true. Skipped on the wire
+   * when absent.
+   */
+  external_path?: string | null;
 }
 
 /** One user database in a SQL service (mirrors the daemon's `DatabaseSummary`). */

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -492,11 +492,12 @@ export interface ToolStatus {
    */
   external?: boolean;
   /**
-   * Absolute path where the external tool was found on the user's PATH (e.g.
-   * `/opt/homebrew/bin/node`), when `external` is true. Skipped on the wire
-   * when absent.
+   * Where the external tool was found on the user's PATH (e.g.
+   * `/opt/homebrew/bin/node`), when `external` is true. Not guaranteed to be
+   * absolute. Skipped on the wire (key absent, not null) when there's nothing
+   * to report.
    */
-  external_path?: string | null;
+  external_path?: string;
 }
 
 /** One user database in a SQL service (mirrors the daemon's `DatabaseSummary`). */

--- a/apps/yerd-gui/src/views/ToolingView.vue
+++ b/apps/yerd-gui/src/views/ToolingView.vue
@@ -54,6 +54,14 @@ function blockedNoComposer(t: ToolStatus): boolean {
   return t.id === "laravel" && !composerInstalled.value;
 }
 
+/** Explains an External tool: it's not a problem, just not Yerd's to manage. */
+function externalHint(t: ToolStatus): string {
+  const found = t.external_path
+    ? `Already on your PATH at ${t.external_path}`
+    : "Already on your PATH from another install";
+  return `${found} - Yerd isn't managing this copy, so there's nothing to install or update.`;
+}
+
 const uninstallOpen = ref(false);
 const uninstallTarget = ref<ToolStatus | null>(null);
 
@@ -187,7 +195,12 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
                   <Badge v-if="t.installed" variant="secondary">
                     {{ t.version ?? "installed" }}
                   </Badge>
-                  <Badge v-else-if="t.external" variant="outline">
+                  <Badge
+                    v-else-if="t.external"
+                    variant="outline"
+                    class="cursor-help"
+                    :title="externalHint(t)"
+                  >
                     External
                   </Badge>
                   <span v-else class="text-xs text-muted-foreground">
@@ -221,8 +234,13 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
                         <Trash2 class="size-3.5" />
                       </Button>
                     </template>
-                    <!-- External tools are managed by the user, not Yerd: no actions. -->
-                    <template v-else-if="t.external" />
+                    <span
+                      v-else-if="t.external"
+                      class="text-xs text-muted-foreground"
+                      :title="externalHint(t)"
+                    >
+                      Managed by you
+                    </span>
                     <Button
                       v-else
                       size="sm"

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -646,12 +646,12 @@ fn format_services(services: &[ServiceStatus]) -> String {
     out
 }
 
-/// Render `yerd tools` as a tab-separated table (tool, status, commands).
+/// Render `yerd tools` as a tab-separated table (tool, status, commands, location).
 fn format_tools(tools: &[ToolStatus]) -> String {
     if tools.is_empty() {
         return "no tools".to_owned();
     }
-    let mut out = String::from("TOOL\tSTATUS\tCOMMANDS");
+    let mut out = String::from("TOOL\tSTATUS\tCOMMANDS\tLOCATION");
     for t in tools {
         let status = if t.installed {
             t.version.as_deref().unwrap_or("installed")
@@ -660,7 +660,15 @@ fn format_tools(tools: &[ToolStatus]) -> String {
         } else {
             "not installed"
         };
-        let _ = write!(out, "\n{}\t{}\t{}", t.id, status, t.binaries.join(","));
+        let location = t.external_path.as_deref().unwrap_or("-");
+        let _ = write!(
+            out,
+            "\n{}\t{}\t{}\t{}",
+            t.id,
+            status,
+            t.binaries.join(","),
+            location
+        );
     }
     out
 }
@@ -1458,20 +1466,34 @@ mod tests {
 
         let tools = render(
             &Response::Tools {
-                tools: vec![ToolStatus {
-                    id: "node".into(),
-                    display_name: "Node.js".into(),
-                    installed: true,
-                    version: Some("v24.17.0".into()),
-                    binaries: vec!["node".into(), "npm".into(), "npx".into()],
-                    external: false,
-                }],
+                tools: vec![
+                    ToolStatus {
+                        id: "node".into(),
+                        display_name: "Node.js".into(),
+                        installed: true,
+                        version: Some("v24.17.0".into()),
+                        binaries: vec!["node".into(), "npm".into(), "npx".into()],
+                        external: false,
+                        external_path: None,
+                    },
+                    ToolStatus {
+                        id: "bun".into(),
+                        display_name: "Bun".into(),
+                        installed: false,
+                        version: None,
+                        binaries: vec!["bun".into(), "bunx".into()],
+                        external: true,
+                        external_path: Some("/opt/homebrew/bin/bun".into()),
+                    },
+                ],
             },
             false,
         );
         assert!(tools.stdout.contains("node"));
         assert!(tools.stdout.contains("v24.17.0"));
         assert!(tools.stdout.contains("npm"));
+        assert!(tools.stdout.contains("external"));
+        assert!(tools.stdout.contains("/opt/homebrew/bin/bun"));
         assert_eq!(tools.code, 0);
 
         let site = Site::linked("foo", "/srv/foo", PhpVersion::new(8, 3)).unwrap();

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1111,8 +1111,9 @@ async fn list_tools_with_external(state: &DaemonState) -> Vec<yerd_ipc::ToolStat
             continue;
         }
         if let Some(tool) = crate::tools::Tool::parse(&t.id) {
-            t.external =
-                crate::tools::external::external_tool(&dirs, tool, &data_bin, data_root).is_some();
+            let found = crate::tools::external::external_tool(&dirs, tool, &data_bin, data_root);
+            t.external = found.is_some();
+            t.external_path = found.map(|p| p.display().to_string());
         }
     }
     tools

--- a/bin/yerdd/src/tools/mod.rs
+++ b/bin/yerdd/src/tools/mod.rs
@@ -154,6 +154,7 @@ pub fn status(dirs: &PlatformDirs, tool: Tool) -> ToolStatus {
             .map(|s| (*s).to_owned())
             .collect(),
         external: false,
+        external_path: None,
     }
 }
 

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -539,6 +539,7 @@ mod variant_name_pinning {
                 version: Some("v24.17.0".into()),
                 binaries: vec!["node".into(), "npm".into(), "npx".into()],
                 external: false,
+                external_path: None,
             }],
         });
         pin_response(Response::JobStarted {

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -387,10 +387,12 @@ pub struct ToolStatus {
     /// for older clients; defaulted on decode for older daemons.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub external: bool,
-    /// Absolute path where the external tool was found on the user's `PATH`
-    /// (e.g. `/opt/homebrew/bin/node`), when `external` is `true`. `None` when
-    /// managed or not installed. `#[serde(default, skip_serializing_if)]` keeps
-    /// the wire additive for older clients/daemons.
+    /// Where the external tool was found on the user's `PATH` (e.g.
+    /// `/opt/homebrew/bin/node`), when `external` is `true`. Not guaranteed to
+    /// be absolute - it mirrors whatever `PATH` entry matched, which is
+    /// conventionally but not necessarily absolute. `None` when managed or not
+    /// installed. `#[serde(default, skip_serializing_if)]` keeps the wire
+    /// additive for older clients/daemons.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_path: Option<String>,
 }

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -387,6 +387,12 @@ pub struct ToolStatus {
     /// for older clients; defaulted on decode for older daemons.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub external: bool,
+    /// Absolute path where the external tool was found on the user's `PATH`
+    /// (e.g. `/opt/homebrew/bin/node`), when `external` is `true`. `None` when
+    /// managed or not installed. `#[serde(default, skip_serializing_if)]` keeps
+    /// the wire additive for older clients/daemons.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_path: Option<String>,
 }
 
 /// A single doctor finding.

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -1542,10 +1542,30 @@ fn response_tools_byte_shape() {
             version: Some("v24.17.0".into()),
             binaries: vec!["node".into(), "npm".into(), "npx".into()],
             external: false,
+            external_path: None,
         }],
     };
     let s = serde_json::to_string(&r).unwrap();
     let expected = r#"{"type":"tools","tools":[{"id":"node","display_name":"Node.js","installed":true,"version":"v24.17.0","binaries":["node","npm","npx"]}]}"#;
+    assert_eq!(s, expected);
+    assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+}
+
+#[test]
+fn response_tools_external_byte_shape() {
+    let r = Response::Tools {
+        tools: vec![ToolStatus {
+            id: "node".into(),
+            display_name: "Node.js".into(),
+            installed: false,
+            version: None,
+            binaries: vec!["node".into(), "npm".into(), "npx".into()],
+            external: true,
+            external_path: Some("/opt/homebrew/bin/node".into()),
+        }],
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    let expected = r#"{"type":"tools","tools":[{"id":"node","display_name":"Node.js","installed":false,"version":null,"binaries":["node","npm","npx"],"external":true,"external_path":"/opt/homebrew/bin/node"}]}"#;
     assert_eq!(s, expected);
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
 }

--- a/docs/reference/cli/tooling.md
+++ b/docs/reference/cli/tooling.md
@@ -26,11 +26,16 @@ yerd tools
 ```
 
 ```text
-TOOL      STATUS          COMMANDS
-composer  2.10.1          composer
-node      v24.17.0        node,npm,npx
-bun       not installed   bun,bunx
+TOOL      STATUS          COMMANDS       LOCATION
+composer  2.10.1          composer       -
+node      external        node,npm,npx   /opt/homebrew/bin/node
+bun       not installed   bun,bunx       -
 ```
+
+`LOCATION` is only populated for `external` tools - ones already on your
+`PATH` from somewhere other than Yerd (Homebrew, `nvm`/`fnm`, a global
+Composer, …). See the [Tooling guide](../../guide/tooling#external-tools) for
+what that means and why there's no install/update action for them.
 
 Add `--json` for machine-readable output.
 


### PR DESCRIPTION
## What does this PR do?

Adds a "found at <path>" tooltip and location detail to the Tooling page's External badge, CLI output, and docs so users understand why an already-installed tool can't be managed by Yerd.

## Related issues

Closes #66

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The tools list now displays where externally available tools were detected on your system.
  * Tool status and CLI output include a new **LOCATION** column for applicable external entries.
* **Bug Fixes**
  * External tools are clearly marked with helpful tooltips and a “Managed by you” label.
  * External tool status now preserves and surfaces the detected external path when available.
* **Documentation**
  * Updated the `yerd tools` command reference and example output to reflect the new **LOCATION** column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->