### PR TITLE
[Fix] Resolve MacOs startup error on upgrade

### DIFF
--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -696,10 +696,15 @@ fn repair_log(line: &str) {
 /// version has advanced (in-place or automated upgrade), and refuse an older GUI
 /// reconfiguring a newer daemon. Run from `setup_app` (covers both upgrade kinds)
 /// and `daemon_start`. Serialized by [`DAEMON_REG_LOCK`].
+///
+/// Returns `Ok(true)` when it re-registered and kickstarted the daemon from this
+/// bundle (upgrade / phantom re-register), `Ok(false)` when nothing needed doing.
+/// The daemon-start plan uses that to keep a single-kickstart-per-start invariant
+/// (see [`plan_start`]).
 #[cfg(target_os = "macos")]
-pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
+pub(crate) fn ensure_daemon_registration() -> Result<bool, GuiError> {
     if !use_smappservice() {
-        return Ok(());
+        return Ok(false);
     }
     let _guard = DAEMON_REG_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let gui = gui_version();
@@ -712,7 +717,7 @@ pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
             s.daemon_version_conflict = None;
             let _ = save_settings(&s);
         }
-        return Ok(());
+        return Ok(false);
     }
 
     let stored = s
@@ -745,7 +750,7 @@ pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
                 s.daemon_version_conflict = None;
                 let _ = save_settings(&s);
             }
-            return Ok(());
+            return Ok(false);
         }
         RegAction::Reregister => {}
     }
@@ -768,7 +773,7 @@ pub(crate) fn ensure_daemon_registration() -> Result<(), GuiError> {
             let _ = save_settings(&s);
             nudge_if_requires_approval();
             repair_log(&format!("self-repair: OK, daemon registered for {gui}"));
-            Ok(())
+            Ok(true)
         }
         Err(e) => {
             repair_log(&format!("self-repair FAILED: {}", e.message));
@@ -1072,6 +1077,14 @@ fn reg_phase() -> StartPhase {
 /// label probes `launchctl`, the Linux label reads the unit file), so
 /// `daemon.rs` calls it inside `spawn_blocking`. Each step keeps the same work
 /// the former one-shot `daemon_start` did; only the timeout is now per-phase.
+///
+/// macOS single-kickstart invariant: on the upgrade / phantom re-register path
+/// [`ensure_daemon_registration`] already kickstarts the daemon from the fresh
+/// bundle, so the Starting step skips its own `kickstart -k` (it reports back via
+/// the register step's return). A second kill inside launchd's minimum-runtime
+/// window would trip the daemon's `ThrottleInterval`, blocking `kickstart` past
+/// `START_BUDGET` and surfacing a false "service manager did not respond" even
+/// though the throttled daemon then comes up on its own.
 pub(crate) fn plan_start(nudge: bool) -> Result<Vec<StartStep>, GuiError> {
     #[cfg(target_os = "linux")]
     {
@@ -1109,19 +1122,28 @@ pub(crate) fn plan_start(nudge: bool) -> Result<Vec<StartStep>, GuiError> {
     #[cfg(target_os = "macos")]
     {
         if use_smappservice() {
+            use std::sync::atomic::{AtomicBool, Ordering};
+            use std::sync::Arc;
+            let restarted = Arc::new(AtomicBool::new(false));
+            let restarted_by_reg = Arc::clone(&restarted);
             Ok(vec![
                 StartStep {
                     phase: reg_phase(),
                     budget: REGISTER_BUDGET,
                     run: Box::new(move || {
-                        ensure_daemon_registration()?;
-                        smapp_enable(nudge)
+                        let did_restart = ensure_daemon_registration()?;
+                        smapp_enable(nudge)?;
+                        restarted_by_reg.store(did_restart, Ordering::SeqCst);
+                        Ok(())
                     }),
                 },
                 StartStep {
                     phase: StartPhase::Starting,
                     budget: START_BUDGET,
-                    run: Box::new(|| {
+                    run: Box::new(move || {
+                        if restarted.load(Ordering::SeqCst) {
+                            return Ok(());
+                        }
                         let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);
                         Ok(())
                     }),

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -697,10 +697,12 @@ fn repair_log(line: &str) {
 /// reconfiguring a newer daemon. Run from `setup_app` (covers both upgrade kinds)
 /// and `daemon_start`. Serialized by [`DAEMON_REG_LOCK`].
 ///
-/// Returns `Ok(true)` when it re-registered and kickstarted the daemon from this
-/// bundle (upgrade / phantom re-register), `Ok(false)` when nothing needed doing.
-/// The daemon-start plan uses that to keep a single-kickstart-per-start invariant
-/// (see [`plan_start`]).
+/// Returns `Ok(true)` when it re-registered the daemon from this bundle (upgrade /
+/// phantom re-register) and therefore already issued a `kickstart -k`; `Ok(false)`
+/// when nothing needed doing. The re-register itself starts the daemon via the
+/// agent's `RunAtLoad`, so the accompanying kickstart is best-effort (its result is
+/// deliberately discarded). The daemon-start plan reads this flag to keep a
+/// single-kickstart-per-start invariant (see [`plan_start`]).
 #[cfg(target_os = "macos")]
 pub(crate) fn ensure_daemon_registration() -> Result<bool, GuiError> {
     if !use_smappservice() {
@@ -1124,16 +1126,16 @@ pub(crate) fn plan_start(nudge: bool) -> Result<Vec<StartStep>, GuiError> {
         if use_smappservice() {
             use std::sync::atomic::{AtomicBool, Ordering};
             use std::sync::Arc;
-            let restarted = Arc::new(AtomicBool::new(false));
-            let restarted_by_reg = Arc::clone(&restarted);
+            let reg_kickstarted = Arc::new(AtomicBool::new(false));
+            let reg_kickstarted_setter = Arc::clone(&reg_kickstarted);
             Ok(vec![
                 StartStep {
                     phase: reg_phase(),
                     budget: REGISTER_BUDGET,
                     run: Box::new(move || {
-                        let did_restart = ensure_daemon_registration()?;
+                        let kickstart_issued = ensure_daemon_registration()?;
                         smapp_enable(nudge)?;
-                        restarted_by_reg.store(did_restart, Ordering::SeqCst);
+                        reg_kickstarted_setter.store(kickstart_issued, Ordering::SeqCst);
                         Ok(())
                     }),
                 },
@@ -1141,7 +1143,7 @@ pub(crate) fn plan_start(nudge: bool) -> Result<Vec<StartStep>, GuiError> {
                     phase: StartPhase::Starting,
                     budget: START_BUDGET,
                     run: Box::new(move || {
-                        if restarted.load(Ordering::SeqCst) {
+                        if reg_kickstarted.load(Ordering::SeqCst) {
                             return Ok(());
                         }
                         let _ = run_ok("launchctl", &["kickstart", "-k", &service_target()]);


### PR DESCRIPTION
## What does this PR do?

MacOs displays an error when starting the daemon post upgrade, however, the daemon starts shortly after.  This PR fixes this issue. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS startup behavior for the daemon, making registration and launch handling more reliable.
  * Prevented duplicate restart attempts during app startup, reducing false “service did not respond” failures.
  * Better handled cases where the daemon was already registered or needed a repair, helping the app recover more smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->