### PR TITLE
[Feat] Add /~ route to clear the pin cookie and return to the site picker

### DIFF
--- a/crates/yerd-proxy/src/pure/unbound.rs
+++ b/crates/yerd-proxy/src/pure/unbound.rs
@@ -12,6 +12,10 @@
 //! With none of those, a browser navigation gets a **picker page** listing the
 //! sites; selecting one forwards the originally-requested path.
 //!
+//! A pinned browser can get back to the picker via the bare **`/~`** path,
+//! which clears the pin cookie and redirects to `/` - an escape hatch, not a
+//! fourth selection mechanism.
+//!
 //! Everything here is synchronous, I/O-free, and unit-tested. The orchestration
 //! that needs the live [`yerd_core::SiteRouter`] and async drop ordering lives
 //! in [`crate::server`].
@@ -97,6 +101,14 @@ pub fn parse_switch(path: &str) -> Option<SwitchParse<'_>> {
         return None;
     }
     Some(SwitchParse { domain, remainder })
+}
+
+/// Returns `true` for the bare "back to picker" path (`/~` or `/~/`), as
+/// opposed to `/~<domain>` (see [`parse_switch`]). Checked ahead of the pin
+/// cookie so it always wins and clears an existing pin.
+#[must_use]
+pub fn is_clear_switch(path: &str) -> bool {
+    matches!(path, "/~" | "/~/")
 }
 
 /// Extract the `yerd-site` value from a `Cookie:` header, tolerating other
@@ -310,6 +322,22 @@ mod tests {
         for (path, want) in cases {
             let got = parse_switch(path).map(|s| (s.domain, s.remainder));
             assert_eq!(got, *want, "path {path:?}");
+        }
+    }
+
+    #[test]
+    fn is_clear_switch_table() {
+        let cases: &[(&str, bool)] = &[
+            ("/~", true),
+            ("/~/", true),
+            ("/~app.test", false),
+            ("/~app", false),
+            ("/~/x", false),
+            ("/", false),
+            ("/foo", false),
+        ];
+        for (path, want) in cases {
+            assert_eq!(is_clear_switch(path), *want, "path {path:?}");
         }
     }
 

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -432,6 +432,7 @@ async fn resolve_request(
             Ok(Routed::Respond(picker_response(body, clear)?))
         }
         UnboundDecision::NotFound { clear } => Ok(Routed::Respond(unbound_not_found(clear)?)),
+        UnboundDecision::ClearPin => Ok(Routed::Respond(clear_response()?)),
     }
 }
 
@@ -446,13 +447,16 @@ enum UnboundDecision {
     Picker { dest: String, clear: bool },
     /// `404`; `clear` also drops a stale pin cookie.
     NotFound { clear: bool },
+    /// `303` to `/`, clearing the pin cookie - the bare `/~` escape hatch.
+    ClearPin,
 }
 
 /// Classify a loopback request that didn't resolve via the normal `Host` path.
 ///
-/// Priority: explicit `X-Yerd-Site` header → `/~domain` switch → pin cookie →
-/// picker (browser navigations) / `404` (everything else). Pure: returns owned
-/// data so the caller can drop the router guard immediately.
+/// Priority: explicit `X-Yerd-Site` header → bare `/~` clear → `/~domain`
+/// switch → pin cookie → picker (browser navigations) / `404` (everything
+/// else). Pure: returns owned data so the caller can drop the router guard
+/// immediately.
 fn classify_unbound(
     router: &SiteRouter,
     method: &Method,
@@ -469,6 +473,10 @@ fn classify_unbound(
             Some(site) => UnboundDecision::Serve(site.clone()),
             None => UnboundDecision::NotFound { clear: false },
         };
+    }
+
+    if unbound::is_clear_switch(path) {
+        return UnboundDecision::ClearPin;
     }
 
     if let Some(sw) = unbound::parse_switch(path) {
@@ -556,6 +564,23 @@ fn switch_response(name: &str, location: &str) -> Result<Response<BoxBody>, Prox
         .header(SERVER, server_header())
         .body(empty_body())
         .map_err(|_| synthetic_error("switch response build failed"))
+}
+
+/// `303 See Other` to `/`, clearing the pin cookie - the bare `/~` escape
+/// hatch back to the picker.
+fn clear_response() -> Result<Response<BoxBody>, ProxyError> {
+    Response::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header(LOCATION, HeaderValue::from_static("/"))
+        .header(
+            SET_COOKIE,
+            HeaderValue::from_str(&unbound::build_clear_cookie())
+                .map_err(|_| synthetic_error("invalid clear cookie"))?,
+        )
+        .header(CACHE_CONTROL, "no-store")
+        .header(SERVER, server_header())
+        .body(empty_body())
+        .map_err(|_| synthetic_error("clear response build failed"))
 }
 
 /// `200` picker page; clears a stale pin cookie when `clear` is set.
@@ -682,6 +707,7 @@ mod unbound_tests {
             UnboundDecision::Switch { .. } => "Switch",
             UnboundDecision::Picker { .. } => "Picker",
             UnboundDecision::NotFound { .. } => "NotFound",
+            UnboundDecision::ClearPin => "ClearPin",
         }
     }
 
@@ -746,6 +772,47 @@ mod unbound_tests {
             },
             "blog"
         );
+    }
+
+    #[test]
+    fn bare_tilde_clears_pin() {
+        for path in ["/~", "/~/"] {
+            assert!(
+                matches!(
+                    classify(path, None, None, None, HTML),
+                    UnboundDecision::ClearPin
+                ),
+                "path {path:?} with no cookie"
+            );
+            assert!(
+                matches!(
+                    classify(path, None, None, Some("yerd-site=app"), HTML),
+                    UnboundDecision::ClearPin
+                ),
+                "path {path:?} should clear an existing pin"
+            );
+        }
+    }
+
+    #[test]
+    fn header_beats_bare_clear() {
+        assert_eq!(
+            served_name(classify("/~", None, Some("app.test"), None, HTML)),
+            "app"
+        );
+    }
+
+    #[test]
+    fn domain_switch_not_confused_with_clear() {
+        for path in ["/~app.test", "/~app.test/"] {
+            assert!(
+                matches!(
+                    classify(path, None, None, None, HTML),
+                    UnboundDecision::Switch { .. }
+                ),
+                "path {path:?} should still switch"
+            );
+        }
     }
 
     #[test]
@@ -875,6 +942,17 @@ mod unbound_tests {
         assert_eq!(header(&resp, LOCATION).as_deref(), Some("/x?y=1"));
         assert_eq!(header(&resp, CACHE_CONTROL).as_deref(), Some("no-store"));
         assert!(header(&resp, SET_COOKIE).unwrap().contains("yerd-site=app"));
+    }
+
+    #[test]
+    fn clear_response_shape() {
+        let resp = clear_response().unwrap();
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(header(&resp, LOCATION).as_deref(), Some("/"));
+        assert_eq!(header(&resp, CACHE_CONTROL).as_deref(), Some("no-store"));
+        let set_cookie = header(&resp, SET_COOKIE).unwrap();
+        assert!(set_cookie.contains("Max-Age=0"));
+        assert!(set_cookie.contains("yerd-site=;"));
     }
 
     #[test]
@@ -1116,6 +1194,7 @@ mod classify_fallthrough_tests {
                 UnboundDecision::Switch { .. } => "Switch",
                 UnboundDecision::Picker { .. } => "Picker",
                 UnboundDecision::NotFound { .. } => "NotFound",
+                UnboundDecision::ClearPin => "ClearPin",
             };
             f.write_str(label)
         }

--- a/docs/guide/localhost-access.md
+++ b/docs/guide/localhost-access.md
@@ -8,6 +8,7 @@ This page is the way out. Yerd serves **every** site through plain `http://local
 
 - `*.test` not resolving? Open **`http://localhost:8080/~app.test`** - Yerd pins that origin to `app.test` and you're in.
 - No URL in mind? Open **`http://localhost:8080/`** and pick a site from the list.
+- Pinned to the wrong site? Open **`http://localhost:8080/~`** to clear the pin and see the picker again.
 - Scripting against it? Send **`X-Yerd-Site: app.test`** and skip the cookie dance.
 - It's **HTTP-only** and **one site per browser at a time** (see [the caveats](#the-caveats)).
 
@@ -50,6 +51,8 @@ sequenceDiagram
 ```
 
 A **bare label** works too: `http://localhost:8080/~app` pins `app` just like `/~app.test`.
+
+**Back to the picker:** open `http://localhost:8080/~` (no domain) to clear the pin and get redirected to `/`, which shows the picker again.
 
 ### 2. The site picker
 
@@ -94,7 +97,7 @@ The fix is to point those at the localhost origin (e.g. `APP_URL=http://localhos
 :::
 
 ::: warning One site per browser at a time
-The pin is a cookie on the `localhost` origin, so a browser serves **one** pinned site at a time. Switching is one click (another `/~` link or the picker). Different sites simultaneously means different browsers/profiles - or installing the resolver. API clients using `X-Yerd-Site` aren't affected; each request stands alone.
+The pin is a cookie on the `localhost` origin, so a browser serves **one** pinned site at a time. Switching is one click (another `/~` link or the picker); `http://localhost:8080/~` clears the pin outright and sends you back to the picker. Different sites simultaneously means different browsers/profiles - or installing the resolver. API clients using `X-Yerd-Site` aren't affected; each request stands alone.
 :::
 
 ::: info Nothing serving?


### PR DESCRIPTION
## What does this PR do?

Lets a browser stuck on a pinned localhost:8080 site get back to the site-listing picker by visiting /~, instead of requiring manual cookie deletion.

## Related issues

Closes #32 

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now use `http://localhost:8080/~` to clear the current pinned site and return to the site picker.
  * Requests to `/~` now take priority as a “back to picker” action, even if a pin cookie is present.

* **Bug Fixes**
  * Improved handling of localhost switching so clearing a pin works consistently.
  * Updated documentation to explain the unpin flow and clarify that API clients using `X-Yerd-Site` are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->