### PR TITLE
[Feat] Improve yerd link: optional shorthand + root detection

### DIFF
--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -26,12 +26,17 @@ pub enum Command {
         /// Directory to park.
         path: PathBuf,
     },
-    /// Link a single directory as a named site.
+    /// Link a single directory as a named site. With one argument, infers
+    /// whichever of name/path is missing; with none, links the current
+    /// directory under its folder name.
     Link {
-        /// Site name (a single DNS label).
-        name: String,
-        /// Directory to serve.
-        path: PathBuf,
+        /// A site name (bare word), or a directory to link (its folder name
+        /// becomes the site name). Omit entirely to link the current
+        /// directory.
+        name_or_path: Option<String>,
+        /// Directory to serve, when the first argument is a name. Omit to
+        /// use the current directory.
+        path: Option<PathBuf>,
     },
     /// Remove a linked site by name.
     Unlink {

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -560,7 +560,8 @@ pub fn resolve_link(
         map::validate_name(n)?;
         n.to_owned()
     } else {
-        let folder = resolved_path
+        let normalized = normalize_lexically(&resolved_path);
+        let folder = normalized
             .file_name()
             .map(|s| s.to_string_lossy())
             .unwrap_or_default();
@@ -577,6 +578,33 @@ pub fn resolve_link(
         name: resolved_name,
         path: resolved_path,
     })
+}
+
+/// Lexically resolve `.`/`..` components out of `path` without touching the
+/// filesystem (no `canonicalize` - `resolve_link` deliberately doesn't
+/// require the target to exist), so `Path::file_name()` sees the folder
+/// actually being linked. `Path::file_name()` already normalises a trailing
+/// `.` away on its own, but a trailing `..` survives as-is (it can't tell
+/// what it cancels without looking further back), so e.g. `yerd link ..`
+/// would otherwise fail to derive the parent folder's name even though it's
+/// well-defined.
+fn normalize_lexically(path: &std::path::Path) -> std::path::PathBuf {
+    use std::path::{Component, PathBuf};
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+                    out.pop();
+                } else {
+                    out.push("..");
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
 }
 
 /// A synthetic `daemon_down` FAIL diagnosis, used when `yerd doctor` can't reach
@@ -855,12 +883,50 @@ mod tests {
         assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
     }
 
-    /// ".." looks like a path, but `Path::new("..").file_name()` is `None`,
-    /// so there's no folder name to slugify.
+    /// "/" normalises to the filesystem root, which has no `Normal`
+    /// component left to derive a name from.
     #[test]
-    fn resolve_link_path_with_no_file_name_errors() {
-        let err = resolve_link(Some(".."), None).unwrap_err();
+    fn resolve_link_root_path_has_no_file_name_errors() {
+        let err = resolve_link(Some("/"), None).unwrap_err();
         assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn resolve_link_trailing_curdir_derives_name() {
+        let req = resolve_link(Some("some/dir/."), None).unwrap();
+        let Request::Link { name, .. } = req else {
+            panic!("expected Link");
+        };
+        assert_eq!(name, "dir");
+    }
+
+    #[test]
+    fn resolve_link_trailing_parentdir_derives_name() {
+        let req = resolve_link(Some("some/parent/child/.."), None).unwrap();
+        let Request::Link { name, .. } = req else {
+            panic!("expected Link");
+        };
+        assert_eq!(name, "parent");
+    }
+
+    // ─── normalize_lexically ────────────────────────────────────────
+
+    #[test]
+    fn normalize_lexically_cases() {
+        let cases: &[(&str, &str)] = &[
+            ("/home/user/myapp/.", "/home/user/myapp"),
+            ("/home/user/myapp/..", "/home/user"),
+            ("/a/b/../c", "/a/c"),
+            ("/../../foo", "/../../foo"),
+            ("/", "/"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                normalize_lexically(Path::new(input)),
+                Path::new(expected),
+                "input {input:?}"
+            );
+        }
     }
 
     // ─── daemon_down_response ───────────────────────────────────────

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -35,6 +35,7 @@ use cli::{Cli, Command};
 /// render the response. Returns the process exit code:
 /// `0` success, `1` daemon error response, `2` usage error, `69` daemon
 /// unreachable, `74` other transport/IO failure.
+#[allow(clippy::too_many_lines)]
 pub async fn run(cli: Cli) -> ExitCode {
     match &cli.command {
         Command::Elevate { target } => return elevate::run_elevate(*target, false).await,
@@ -62,10 +63,15 @@ pub async fn run(cli: Cli) -> ExitCode {
         _ => {}
     }
 
-    let req = match map::to_request(&cli.command)
-        .map(canonicalize_unpark)
-        .and_then(canonicalize_db_paths)
-    {
+    let req = match &cli.command {
+        Command::Link { name_or_path, path } => {
+            resolve_link(name_or_path.as_deref(), path.as_deref())
+        }
+        _ => map::to_request(&cli.command)
+            .map(canonicalize_unpark)
+            .and_then(canonicalize_db_paths),
+    };
+    let req = match req {
         Ok(r) => r,
         Err(e) => {
             eprintln!("yerd: {e}");
@@ -514,6 +520,65 @@ fn absolutise(path: &std::path::Path) -> Result<std::path::PathBuf, ClientError>
     Ok(cwd.join(path))
 }
 
+/// Whether a single positional argument to `yerd link` should be treated as
+/// a directory rather than a bare site name: contains a path separator, or
+/// is `.`/`..`. Bare words (`yerd link project`) are always names, even if a
+/// same-named subdirectory happens to exist.
+fn looks_like_path(s: &str) -> bool {
+    s == "." || s == ".." || s.contains('/') || s.contains(std::path::MAIN_SEPARATOR)
+}
+
+/// Resolve `yerd link`'s optional name/path into a concrete `Request::Link`.
+/// Cwd-dependent (reads `std::env::current_dir()` when path is omitted) and
+/// therefore not part of the pure `map::to_request` pipeline - kept here at
+/// the I/O boundary, mirroring `absolutise`/`canonicalize_db_paths`.
+///
+/// Public so `tests/cli_e2e.rs` can drive the same CLI-side resolution this
+/// crate's `run()` uses, then exchange the result with a real daemon.
+pub fn resolve_link(
+    name_or_path: Option<&str>,
+    path: Option<&std::path::Path>,
+) -> Result<yerd_ipc::Request, ClientError> {
+    let explicit_path = path.or_else(|| {
+        name_or_path
+            .filter(|s| looks_like_path(s))
+            .map(std::path::Path::new)
+    });
+    let explicit_name = if path.is_some() {
+        name_or_path
+    } else {
+        name_or_path.filter(|s| !looks_like_path(s))
+    };
+
+    let resolved_path = match explicit_path {
+        Some(p) => absolutise(p)?,
+        None => std::env::current_dir()
+            .map_err(|e| ClientError::Usage(format!("cannot resolve current directory: {e}")))?,
+    };
+
+    let resolved_name = if let Some(n) = explicit_name {
+        map::validate_name(n)?;
+        n.to_owned()
+    } else {
+        let folder = resolved_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        yerd_core::slugify_site_name(folder).ok_or_else(|| {
+            ClientError::Usage(format!(
+                "cannot derive a site name from '{}'; run `yerd link <name> {}` to set one explicitly",
+                resolved_path.display(),
+                resolved_path.display(),
+            ))
+        })?
+    };
+
+    Ok(yerd_ipc::Request::Link {
+        name: resolved_name,
+        path: resolved_path,
+    })
+}
+
 /// A synthetic `daemon_down` FAIL diagnosis, used when `yerd doctor` can't reach
 /// the daemon. Routed through `map::render` so it honours `--json` and exits 1.
 fn daemon_down_response() -> yerd_ipc::Response {
@@ -702,6 +767,100 @@ mod tests {
         assert!(out.is_absolute());
         let cwd = std::env::current_dir().unwrap();
         assert_eq!(out, cwd.join(rel));
+    }
+
+    // ─── looks_like_path ────────────────────────────────────────────
+
+    #[test]
+    fn looks_like_path_classifies_bare_words_vs_paths() {
+        let cases: &[(&str, bool)] = &[
+            ("project", false),
+            ("my-app", false),
+            (".", true),
+            ("..", true),
+            ("./project", true),
+            ("~/sites/example", true),
+            ("/abs/path", true),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(looks_like_path(input), *expected, "input {input:?}");
+        }
+    }
+
+    // ─── resolve_link ───────────────────────────────────────────────
+
+    #[test]
+    fn resolve_link_no_args_uses_cwd_and_derives_name() {
+        let req = resolve_link(None, None).unwrap();
+        let Request::Link { name, path } = req else {
+            panic!("expected Link");
+        };
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(path, cwd);
+        let folder = cwd.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        assert_eq!(Some(name), yerd_core::slugify_site_name(folder));
+    }
+
+    #[test]
+    fn resolve_link_bare_word_uses_cwd_as_path() {
+        let req = resolve_link(Some("myapp"), None).unwrap();
+        let Request::Link { name, path } = req else {
+            panic!("expected Link");
+        };
+        assert_eq!(name, "myapp");
+        assert_eq!(path, std::env::current_dir().unwrap());
+    }
+
+    #[test]
+    fn resolve_link_single_path_arg_derives_name() {
+        let req = resolve_link(Some("../my-app"), None).unwrap();
+        let Request::Link { name, path } = req else {
+            panic!("expected Link");
+        };
+        assert_eq!(name, "my-app");
+        assert!(path.is_absolute());
+        assert!(path.ends_with("../my-app"));
+    }
+
+    #[test]
+    fn resolve_link_explicit_name_and_path_unchanged() {
+        let req = resolve_link(Some("blog"), Some(Path::new("rel/blog"))).unwrap();
+        let Request::Link { name, path } = req else {
+            panic!("expected Link");
+        };
+        assert_eq!(name, "blog");
+        assert!(path.is_absolute());
+        assert!(path.ends_with("rel/blog"));
+    }
+
+    #[test]
+    fn resolve_link_undecipherable_name_errors() {
+        // "weird/???" looks like a path (contains '/'), so the name is
+        // derived from its final component "???", which slugifies to `None`.
+        let err = resolve_link(Some("weird/???"), None).unwrap_err();
+        assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn resolve_link_rejects_invalid_explicit_name() {
+        let err = resolve_link(Some("bad name"), Some(Path::new("/x"))).unwrap_err();
+        assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn resolve_link_empty_string_name_errors() {
+        // "" doesn't look like a path, so it's routed to explicit-name
+        // validation, which rejects an empty name.
+        let err = resolve_link(Some(""), None).unwrap_err();
+        assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn resolve_link_path_with_no_file_name_errors() {
+        // ".." looks like a path, but `Path::new("..").file_name()` is
+        // `None`, so there's no folder name to slugify.
+        let err = resolve_link(Some(".."), None).unwrap_err();
+        assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
     }
 
     // ─── daemon_down_response ───────────────────────────────────────

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -562,9 +562,9 @@ pub fn resolve_link(
     } else {
         let folder = resolved_path
             .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("");
-        yerd_core::slugify_site_name(folder).ok_or_else(|| {
+            .map(|s| s.to_string_lossy())
+            .unwrap_or_default();
+        yerd_core::slugify_site_name(&folder).ok_or_else(|| {
             ClientError::Usage(format!(
                 "cannot derive a site name from '{}'; run `yerd link <name> {}` to set one explicitly",
                 resolved_path.display(),
@@ -833,10 +833,10 @@ mod tests {
         assert!(path.ends_with("rel/blog"));
     }
 
+    /// "weird/???" looks like a path (contains '/'), so the name is derived
+    /// from its final component "???", which slugifies to `None`.
     #[test]
     fn resolve_link_undecipherable_name_errors() {
-        // "weird/???" looks like a path (contains '/'), so the name is
-        // derived from its final component "???", which slugifies to `None`.
         let err = resolve_link(Some("weird/???"), None).unwrap_err();
         assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
     }
@@ -847,18 +847,18 @@ mod tests {
         assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
     }
 
+    /// "" doesn't look like a path, so it's routed to explicit-name
+    /// validation, which rejects an empty name.
     #[test]
     fn resolve_link_empty_string_name_errors() {
-        // "" doesn't look like a path, so it's routed to explicit-name
-        // validation, which rejects an empty name.
         let err = resolve_link(Some(""), None).unwrap_err();
         assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
     }
 
+    /// ".." looks like a path, but `Path::new("..").file_name()` is `None`,
+    /// so there's no folder name to slugify.
     #[test]
     fn resolve_link_path_with_no_file_name_errors() {
-        // ".." looks like a path, but `Path::new("..").file_name()` is
-        // `None`, so there's no folder name to slugify.
         let err = resolve_link(Some(".."), None).unwrap_err();
         assert!(matches!(err, ClientError::Usage(_)), "got: {err:?}");
     }

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -2152,6 +2152,10 @@ mod tests {
             Command::Path {
                 action: crate::cli::PathAction::Install,
             },
+            Command::Link {
+                name_or_path: None,
+                path: None,
+            },
         ] {
             match to_request(&cmd) {
                 Err(ClientError::Usage(_)) => {}

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -25,13 +25,6 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
         Command::Ping => Request::Ping,
         Command::Sites => Request::ListSites,
         Command::Park { path } => Request::Park { path: path.clone() },
-        Command::Link { name, path } => {
-            validate_name(name)?;
-            Request::Link {
-                name: name.clone(),
-                path: path.clone(),
-            }
-        }
         Command::Unlink { name } => {
             validate_name(name)?;
             Request::Unlink { name: name.clone() }
@@ -189,6 +182,11 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
         Command::Path { .. } => {
             return Err(ClientError::Usage(
                 "path is handled locally, not over IPC".to_owned(),
+            ));
+        }
+        Command::Link { .. } => {
+            return Err(ClientError::Usage(
+                "link is handled locally, not over IPC".to_owned(),
             ));
         }
     })
@@ -378,7 +376,7 @@ fn validate_php_setting(setting: &str, value: Option<&str>) -> Result<(), Client
 
 /// Validate a site name client-side by constructing a throwaway `Site` (the
 /// document root is irrelevant - only the name is checked).
-fn validate_name(name: &str) -> Result<(), ClientError> {
+pub(crate) fn validate_name(name: &str) -> Result<(), ClientError> {
     Site::linked(name, "/", PhpVersion::new(8, 3))
         .map(|_| ())
         .map_err(|e| ClientError::Usage(format!("invalid site name {name:?}: {e}")))
@@ -1049,17 +1047,6 @@ mod tests {
             }
         );
         assert_eq!(
-            to_request(&Command::Link {
-                name: "foo".into(),
-                path: PathBuf::from("/srv/foo")
-            })
-            .unwrap(),
-            Request::Link {
-                name: "foo".into(),
-                path: PathBuf::from("/srv/foo")
-            }
-        );
-        assert_eq!(
             to_request(&Command::Unlink { name: "foo".into() }).unwrap(),
             Request::Unlink { name: "foo".into() }
         );
@@ -1359,13 +1346,6 @@ mod tests {
         match to_request(&Command::Use {
             first: "not-a-version".into(),
             version: None,
-        }) {
-            Err(ClientError::Usage(_)) => {}
-            other => panic!("expected Usage error, got {other:?}"),
-        }
-        match to_request(&Command::Link {
-            name: "bad name".into(),
-            path: PathBuf::from("/x"),
         }) {
             Err(ClientError::Usage(_)) => {}
             other => panic!("expected Usage error, got {other:?}"),

--- a/bin/yerd/tests/cli_e2e.rs
+++ b/bin/yerd/tests/cli_e2e.rs
@@ -54,6 +54,15 @@ mod tests {
         transport::exchange_at(sock, &req).await.expect("exchange")
     }
 
+    /// Drives `Command::Link`'s CLI-side resolution (`resolve_link`) directly
+    /// and exchanges the resulting `Request::Link` with the daemon -
+    /// `Command::Link` never reaches `map::to_request`, so `send()` can't be
+    /// used for it.
+    async fn link(sock: &std::path::Path, name: &str, path: &std::path::Path) -> Response {
+        let req = yerd::resolve_link(Some(name), Some(path)).expect("resolve_link");
+        transport::exchange_at(sock, &req).await.expect("exchange")
+    }
+
     fn site_names(resp: &Response) -> Vec<String> {
         match resp {
             Response::Sites { sites } => sites.iter().map(|s| s.name().to_owned()).collect(),
@@ -149,17 +158,8 @@ mod tests {
         ));
         assert!(site_names(&send(&sock, &Command::Sites).await).contains(&"blog".to_owned()));
 
-        // `Command::Link`'s cwd-resolution (`resolve_link`) is CLI-only and
-        // never reaches `map::to_request`, so drive `resolve_link` itself
-        // (explicit name+path here - the cwd-inferring forms are unit-tested
-        // in `lib.rs`) and exchange its `Request::Link` with the real daemon,
-        // proving the CLI resolution and the daemon's link-time web-root
-        // auto-detection work together end to end over the socket.
-        let link_req = yerd::resolve_link(Some("app"), Some(&linked_dir)).expect("resolve_link");
         assert!(matches!(
-            transport::exchange_at(&sock, &link_req)
-                .await
-                .expect("exchange"),
+            link(&sock, "app", &linked_dir).await,
             Response::Ok
         ));
         assert!(site_names(&send(&sock, &Command::Sites).await).contains(&"app".to_owned()));

--- a/bin/yerd/tests/cli_e2e.rs
+++ b/bin/yerd/tests/cli_e2e.rs
@@ -109,7 +109,9 @@ mod tests {
         let sites_root = tmp.path().join("Sites");
         std::fs::create_dir_all(sites_root.join("blog")).unwrap();
         let linked_dir = tmp.path().join("standalone");
-        std::fs::create_dir_all(&linked_dir).unwrap();
+        std::fs::create_dir_all(linked_dir.join("public")).unwrap();
+        std::fs::write(linked_dir.join("artisan"), b"").unwrap();
+        std::fs::write(linked_dir.join("public/index.php"), b"").unwrap();
 
         let daemon =
             yerdd::startup::bring_up_with_dirs(dirs.clone(), valid_config(), cfg_path.clone())
@@ -147,18 +149,31 @@ mod tests {
         ));
         assert!(site_names(&send(&sock, &Command::Sites).await).contains(&"blog".to_owned()));
 
+        // `Command::Link`'s cwd-resolution (`resolve_link`) is CLI-only and
+        // never reaches `map::to_request`, so drive `resolve_link` itself
+        // (explicit name+path here - the cwd-inferring forms are unit-tested
+        // in `lib.rs`) and exchange its `Request::Link` with the real daemon,
+        // proving the CLI resolution and the daemon's link-time web-root
+        // auto-detection work together end to end over the socket.
+        let link_req = yerd::resolve_link(Some("app"), Some(&linked_dir)).expect("resolve_link");
         assert!(matches!(
-            send(
-                &sock,
-                &Command::Link {
-                    name: "app".into(),
-                    path: linked_dir.clone()
-                }
-            )
-            .await,
+            transport::exchange_at(&sock, &link_req)
+                .await
+                .expect("exchange"),
             Response::Ok
         ));
         assert!(site_names(&send(&sock, &Command::Sites).await).contains(&"app".to_owned()));
+        match send(&sock, &Command::Sites).await {
+            Response::Sites { sites } => {
+                let app = sites.iter().find(|s| s.name() == "app").unwrap();
+                assert_eq!(
+                    app.web_subpath(),
+                    std::path::Path::new("public"),
+                    "linking a Laravel-shaped dir should auto-detect its web root"
+                );
+            }
+            other => panic!("expected Sites, got {other:?}"),
+        }
 
         assert!(matches!(
             send(

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1546,13 +1546,20 @@ fn php_error_code(e: &yerd_php::PhpError) -> ErrorCode {
 
 /// Apply a mutation: canonicalise paths, run the pure delta, validate, persist,
 /// and swap the live router - **build-then-validate-then-commit** so a failed
-/// mutation leaves disk and the live router untouched.
+/// mutation leaves disk and the live router untouched. A `Link`'s web-root
+/// detection scan runs here, before `state.config` is locked, so a slow or
+/// network-mounted project directory can't stall other mutating requests
+/// that share the lock.
 pub(crate) async fn handle_mutation(req: Request, state: &DaemonState) -> Response {
     let canonical = match &req {
         Request::Park { path } | Request::Link { path, .. } => match canonicalize_dir(path) {
             Ok(p) => Some(p),
             Err(resp) => return resp,
         },
+        _ => None,
+    };
+    let link_web_subpath = match &req {
+        Request::Link { .. } => canonical.as_deref().map(detect_web_subpath),
         _ => None,
     };
 
@@ -1589,11 +1596,10 @@ pub(crate) async fn handle_mutation(req: Request, state: &DaemonState) -> Respon
         },
     };
 
-    if let Request::Link { name, .. } = &req {
+    if let (Request::Link { name, .. }, Some(subpath)) = (&req, &link_web_subpath) {
         let name_lc = name.to_ascii_lowercase();
         if let Some(site) = new.linked.iter_mut().find(|s| s.name() == name_lc) {
-            let doc_root = site.document_root().to_path_buf();
-            site.set_web_subpath(detect_web_subpath(&doc_root));
+            site.set_web_subpath(subpath);
         }
     }
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1589,6 +1589,14 @@ pub(crate) async fn handle_mutation(req: Request, state: &DaemonState) -> Respon
         },
     };
 
+    if let Request::Link { name, .. } = &req {
+        let name_lc = name.to_ascii_lowercase();
+        if let Some(site) = new.linked.iter_mut().find(|s| s.name() == name_lc) {
+            let doc_root = site.document_root().to_path_buf();
+            site.set_web_subpath(detect_web_subpath(&doc_root));
+        }
+    }
+
     if let Err(e) = new.validate() {
         return internal(format!("config validation failed: {e}"));
     }
@@ -1658,6 +1666,16 @@ async fn handle_group_mutation(req: Request, state: &DaemonState) -> Response {
     Response::Ok
 }
 
+/// Auto-detect the web subpath to serve for a project at `doc_root` (e.g.
+/// `public` for Laravel). Shared by `SetWebRoot`'s auto-detect branch and
+/// `Link`'s creation-time auto-detect.
+fn detect_web_subpath(doc_root: &Path) -> String {
+    yerd_core::detect(&yerd_platform::gather_project_signals(doc_root))
+        .subpath
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// Resolve a `SetWebRoot` request against `new`, doing the filesystem I/O
 /// (containment check, or re-detection) the pure `mutate::apply` can't. A
 /// **linked** site stores the chosen subpath on its `Site`; a **parked** site
@@ -1676,10 +1694,7 @@ fn resolve_web_root_mutation(
         let rel = if let Some(p) = path {
             resolve_web_root_within(&doc_root, p)?
         } else {
-            yerd_core::detect(&yerd_platform::gather_project_signals(&doc_root))
-                .subpath
-                .to_string_lossy()
-                .into_owned()
+            detect_web_subpath(&doc_root)
         };
         site.set_web_subpath(&rel);
         return Ok(mutate::Applied {
@@ -2086,6 +2101,52 @@ Subject: Captured\r\n\r\nhi\r\n";
             Response::Error { code, .. } => assert_eq!(code, ErrorCode::AlreadyExists),
             other => panic!("expected AlreadyExists error, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn link_auto_detects_web_root_for_laravel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let docroot = tmp.path().join("app");
+        std::fs::create_dir_all(docroot.join("public")).unwrap();
+        std::fs::write(docroot.join("artisan"), b"").unwrap();
+        std::fs::write(docroot.join("public/index.php"), b"").unwrap();
+        let state = state_in(tmp.path());
+
+        let ok = dispatch(
+            Request::Link {
+                name: "app".into(),
+                path: docroot,
+            },
+            &state,
+        )
+        .await;
+        assert!(matches!(ok, Response::Ok), "got {ok:?}");
+        assert_eq!(
+            web_subpath_of(&state, "app").await,
+            std::path::PathBuf::from("public")
+        );
+    }
+
+    #[tokio::test]
+    async fn link_plain_php_serves_document_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let docroot = tmp.path().join("plain");
+        std::fs::create_dir_all(&docroot).unwrap();
+        let state = state_in(tmp.path());
+
+        let ok = dispatch(
+            Request::Link {
+                name: "plain".into(),
+                path: docroot,
+            },
+            &state,
+        )
+        .await;
+        assert!(matches!(ok, Response::Ok), "got {ok:?}");
+        assert_eq!(
+            web_subpath_of(&state, "plain").await,
+            std::path::PathBuf::new()
+        );
     }
 
     #[tokio::test]

--- a/crates/yerd-core/src/lib.rs
+++ b/crates/yerd-core/src/lib.rs
@@ -41,5 +41,5 @@ pub use error::{CoreError, PhpVersionErrorReason, SiteNameErrorReason, TldErrorR
 pub use php::PhpVersion;
 pub use php_settings::{PhpSettingError, ValueErrorReason};
 pub use router::{RouterConfig, SiteRouter};
-pub use site::{Site, SiteKind};
+pub use site::{slugify_site_name, Site, SiteKind};
 pub use tld::Tld;

--- a/crates/yerd-core/src/site.rs
+++ b/crates/yerd-core/src/site.rs
@@ -220,6 +220,44 @@ fn err(name: &str, reason: SiteNameErrorReason) -> CoreError {
     }
 }
 
+/// Derive a valid site name from an arbitrary string (typically a directory's
+/// last path component), for `yerd link`'s auto-naming: lowercases, replaces
+/// every byte outside `[a-z0-9-]` with `-`, collapses runs of `-`, trims
+/// leading/trailing `-`, and caps at the 63-byte DNS-label limit. Returns
+/// `None` if nothing valid remains.
+///
+/// The output alphabet is always `[a-z0-9-]` with no leading/trailing/doubled
+/// `-`, so unlike [`validate_and_lowercase_name`] it never needs to reject its
+/// own result.
+#[must_use]
+pub fn slugify_site_name(raw: &str) -> Option<String> {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.is_empty() && !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        return None;
+    }
+    if out.chars().count() > 63 {
+        out = out.chars().take(63).collect();
+        while out.ends_with('-') {
+            out.pop();
+        }
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
 /// A web subpath is safe to join onto the document root iff it is a plain
 /// relative path: no root, no drive/UNC prefix, and no `..` component. Such a
 /// path can only ever resolve to a descendant of the document root. Used by
@@ -388,6 +426,51 @@ mod tests {
                 ..
             }) => {}
             other => panic!("ContainsDot expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slugify_site_name_cases() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("My Project", Some("my-project")),
+            ("my_app", Some("my-app")),
+            ("example.com", Some("example-com")),
+            ("a..b", Some("a-b")),
+            ("-leading", Some("leading")),
+            ("trailing-", Some("trailing")),
+            ("already-valid", Some("already-valid")),
+            ("???", None),
+            ("", None),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                slugify_site_name(input).as_deref(),
+                *expected,
+                "input {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn slugify_site_name_caps_at_63_bytes_without_trailing_hyphen() {
+        let long = "a".repeat(65);
+        let slug = slugify_site_name(&long).unwrap();
+        assert_eq!(slug.len(), 63);
+        assert!(!slug.ends_with('-'));
+
+        // A separator right at the 63-byte boundary must not leave a
+        // dangling trailing hyphen after truncation.
+        let boundary = format!("{} {}", "a".repeat(62), "b".repeat(5));
+        let slug = slugify_site_name(&boundary).unwrap();
+        assert_eq!(slug.len(), 62);
+        assert!(!slug.ends_with('-'));
+    }
+
+    #[test]
+    fn slugify_site_name_result_is_always_valid() {
+        for input in ["My Project", "my_app", "example.com", "a..b"] {
+            let slug = slugify_site_name(input).unwrap();
+            assert!(Site::parked(&slug, "/x", v83()).is_ok(), "slug {slug:?}");
         }
     }
 

--- a/crates/yerd-core/src/site.rs
+++ b/crates/yerd-core/src/site.rs
@@ -457,9 +457,12 @@ mod tests {
         let slug = slugify_site_name(&long).unwrap();
         assert_eq!(slug.len(), 63);
         assert!(!slug.ends_with('-'));
+    }
 
-        // A separator right at the 63-byte boundary must not leave a
-        // dangling trailing hyphen after truncation.
+    /// A separator that lands exactly on the 63-byte truncation boundary
+    /// must not leave a dangling trailing hyphen in the result.
+    #[test]
+    fn slugify_site_name_boundary_separator_has_no_trailing_hyphen() {
         let boundary = format!("{} {}", "a".repeat(62), "b".repeat(5));
         let slug = slugify_site_name(&boundary).unwrap();
         assert_eq!(slug.len(), 62);

--- a/docs/guide/sites.md
+++ b/docs/guide/sites.md
@@ -105,6 +105,23 @@ yerd link my-app ~/code/my-app
 #   ->  http://my-app.test
 ```
 
+Name and directory are both optional shorthand for the current directory:
+
+```sh
+cd ~/code/my-app
+
+yerd link              # links the cwd, named "my-app" after its folder
+yerd link my-app       # same, with an explicit name
+yerd link ../other-app # links a relative path, named "other-app" after its folder
+```
+
+A single positional argument is treated as a directory (and the name derived from its
+folder) when it contains a path separator or is `.`/`..`; otherwise it's treated as a
+bare name and the current directory is linked. Web-root detection (`public/` for
+Laravel, etc. - see [Web root](#web-root-the-served-directory)) runs automatically the
+first time a site is linked, so a Laravel app's `SERVED` directory is usually already
+correct with no extra `yerd root` step.
+
 To remove it, unlink by name:
 
 ```sh
@@ -156,7 +173,7 @@ yerd sites --json
 |---|---|
 | `yerd park <dir>` | Park a directory; each child folder is served at `<name>.test`. |
 | `yerd unpark <dir>` | Un-park a directory. Linked sites are untouched. |
-| `yerd link <name> <dir>` | Serve a single directory as a named site. |
+| `yerd link [name] [dir]` | Serve a directory as a named site; both args are optional shorthand for the current directory. |
 | `yerd unlink <name>` | Remove a site by name. |
 | `yerd sites` | List every site (name, kind, PHP, secure, served path, doc-root). |
 | `yerd list parked` | List parked roots, including empty ones. |

--- a/docs/reference/cli/sites.md
+++ b/docs/reference/cli/sites.md
@@ -38,7 +38,7 @@ yerd sites
 :::
 
 ::: tip Web root detection
-Yerd auto-detects the directory each site is served from (e.g. `public/` for Laravel, the project root for WordPress). For a **parked** site it re-detects continuously as the project changes. For a **linked** site detection runs once, when the site is first linked; it isn't re-run automatically afterwards. `yerd root <name> <path>` pins it explicitly for either kind; `yerd root <name> --auto` (or with no path) re-runs detection immediately and returns to auto-detection. The path must resolve to a directory inside the site's folder. See the [Sites guide](../../guide/sites#web-root-the-served-directory).
+Yerd auto-detects the directory each site is served from (e.g. `public/` for Laravel, the project root for WordPress). For a **parked** site it re-detects continuously as the project changes. For a **linked** site detection runs once, when the site is first linked; it isn't re-run automatically afterward. `yerd root <name> <path>` pins it explicitly for either kind. `yerd root <name> --auto` (or with no path) returns to auto-detection: for a linked site this re-runs the one-shot detection immediately and pins the fresh result; for a parked site it clears the pin and hands the site back to the continuous watched detection. The path must resolve to a directory inside the site's folder. See the [Sites guide](../../guide/sites#web-root-the-served-directory).
 :::
 
 ::: warning About `unpark`

--- a/docs/reference/cli/sites.md
+++ b/docs/reference/cli/sites.md
@@ -7,7 +7,10 @@ A directory tree is served in one of two ways: **park** a parent directory so ea
 | `yerd sites` | List every parked or linked site. | `yerd sites` |
 | `yerd park <PATH>` | Park a directory: each of its child directories becomes a `.test` site. | `yerd park ~/Sites` |
 | `yerd unpark <PATH>` | Un-park a directory so its children stop being served. Linked sites are untouched. | `yerd unpark ~/Sites` |
-| `yerd link <NAME> <PATH>` | Link a single directory as a named site. | `yerd link blog ~/code/blog` |
+| `yerd link` | Link the current directory, named after its folder. | `yerd link` |
+| `yerd link <NAME>` | Link the current directory under an explicit name. | `yerd link blog` |
+| `yerd link <PATH>` | Link a directory, named after its folder. | `yerd link ~/code/blog` |
+| `yerd link <NAME> <PATH>` | Link a directory under an explicit name. | `yerd link blog ~/code/blog` |
 | `yerd unlink <NAME>` | Remove a linked site by name. | `yerd unlink blog` |
 | `yerd root <NAME> <PATH>` | Set the served directory (web root) for a site, relative to its folder. | `yerd root blog public` |
 | `yerd root <NAME> --auto` | Reset a site to automatic web-root detection. | `yerd root blog --auto` |
@@ -19,6 +22,9 @@ yerd park ~/Sites
 # Link one project under a specific name (serves https://blog.test once secured)
 yerd link blog ~/code/blog
 
+# Link the current project, named after its folder
+cd ~/code/blog && yerd link
+
 # See everything yerd is serving
 yerd sites
 ```
@@ -27,10 +33,12 @@ yerd sites
 
 ::: details How site names are validated
 `link`, `unlink`, `secure`, `unsecure`, and `root` validate the name client-side before connecting: a name must be a single valid DNS label. A bad name (e.g. `bad name` or `bad/name`) fails immediately with a usage error and exit code `2`, before any request reaches the daemon.
+
+`link` accepts a single positional argument as either a name or a path: an argument containing a path separator (or `.`/`..`) is treated as a directory, and the site name is derived from its folder name (lowercased, with runs of invalid characters collapsed to a single `-`); a bare word is always treated as a name, even if a same-named subdirectory happens to exist. With no arguments at all, the current directory is linked and named after its own folder.
 :::
 
 ::: tip Web root detection
-Yerd auto-detects the directory each site is served from (e.g. `public/` for Laravel, the project root for WordPress) and re-detects when the project changes. `yerd root <name> <path>` pins it explicitly; `yerd root <name> --auto` (or with no path) returns to auto-detection. The path must resolve to a directory inside the site's folder. See the [Sites guide](../../guide/sites#web-root-the-served-directory).
+Yerd auto-detects the directory each site is served from (e.g. `public/` for Laravel, the project root for WordPress). For a **parked** site it re-detects continuously as the project changes. For a **linked** site detection runs once, when the site is first linked; it isn't re-run automatically afterwards. `yerd root <name> <path>` pins it explicitly for either kind; `yerd root <name> --auto` (or with no path) re-runs detection immediately and returns to auto-detection. The path must resolve to a directory inside the site's folder. See the [Sites guide](../../guide/sites#web-root-the-served-directory).
 :::
 
 ::: warning About `unpark`


### PR DESCRIPTION
## What does this PR do?

Lets yerd link be called with no arguments, just a name, or just a path (inferring whichever is omitted from the current directory or the given path's folder name), and now auto-detects the web root (e.g. Laravel's public/) at link time instead of requiring a follow-up yerd root call.

## Related issues

Closes #84 

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `yerd link` now supports shorthand forms: link the current directory, or provide a name, a path, or both.
  * When linking, site names can be inferred from the linked folder when appropriate.
  * Web root is automatically detected on first link (e.g., Laravel `public/`).

* **Bug Fixes**
  * Improved classification of ambiguous link arguments (name vs path) and clearer validation/error handling for invalid or empty names.
  * End-to-end linking now more accurately reflects real-world link behavior, including web-root selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->