### PR TITLE
[Fix] Allow in site directory symlinks

### DIFF
--- a/crates/yerd-proxy/src/forward/fcgi.rs
+++ b/crates/yerd-proxy/src/forward/fcgi.rs
@@ -27,7 +27,7 @@ const REQUEST_ID: u16 = 1;
 pub async fn forward(
     req: Request<Incoming>,
     backend: Backend,
-    document_root: PathBuf,
+    served_root: PathBuf,
     server_addr: SocketAddr,
     peer_addr: SocketAddr,
     https: bool,
@@ -53,7 +53,7 @@ pub async fn forward(
         parts.method.as_str(),
         path_and_query_of(&parts.uri),
         &parts.headers,
-        &document_root,
+        &served_root,
         https,
         peer_addr,
         server_addr,

--- a/crates/yerd-proxy/src/forward/static_file.rs
+++ b/crates/yerd-proxy/src/forward/static_file.rs
@@ -4,9 +4,20 @@
 //! A GET/HEAD whose URL resolves to a real, non-PHP file under the served root
 //! is streamed from disk with a guessed `Content-Type`. Anything else (missing
 //! file, directory, PHP source, non-idempotent method, traversal attempt)
-//! returns `None`, and the caller forwards to FastCGI (`index.php`) exactly as
-//! before. Without this, `/favicon.ico` and other static assets were handed to
-//! the PHP framework, which has no route for them.
+//! reports [`StaticOutcome::NotFound`], and the caller forwards to FastCGI
+//! (`index.php`) exactly as before. Without this, `/favicon.ico` and other
+//! static assets were handed to the PHP framework, which has no route for
+//! them.
+//!
+//! A candidate is allowed to resolve, via a symlink, anywhere within the
+//! site's `document_root` - not just the served subdirectory - so a symlink
+//! like Laravel's `public/storage -> ../storage/app/public` is served
+//! normally. A candidate that resolves outside `document_root` entirely is
+//! reported as [`StaticOutcome::SymlinkEscape`], which the caller turns into
+//! an explicit `403` via [`symlink_escape_response`] instead of silently
+//! falling through to PHP-FPM. The resolved path and the allowed root are
+//! logged, not echoed in the response body, since a site can be exposed
+//! beyond loopback via `yerd-tunnel`.
 //!
 //! A directory request (trailing `/`, including the site root) with no
 //! `index.php` falls to [`try_serve_index`], which serves `index.html` or
@@ -20,38 +31,81 @@ use http::{header, HeaderValue, Method, StatusCode};
 use http_body_util::BodyExt;
 use hyper::Response;
 
-use crate::forward::{empty_body, BoxBody};
+use crate::forward::{empty_body, owned_bytes_body, BoxBody};
 use crate::pure::try_files::{
     content_type_for, directory_candidate, is_php_source, static_candidate,
 };
 
-/// Try to serve `uri_path` as a static file under `served_root`.
-///
-/// `Some(response)` - a file was found and served (200). `None` - the request
-/// should fall through to the PHP front controller.
+/// Outcome of a static-file or directory-index lookup.
+pub enum StaticOutcome {
+    /// A file was found and served - return this response as-is.
+    Served(Response<BoxBody>),
+    /// Not a static-file match (missing, directory, PHP source, wrong
+    /// method, no index file present) - fall through to the front
+    /// controller, exactly as a `None` result did before this type existed.
+    NotFound,
+    /// The candidate resolved, via a symlink, to a real path outside
+    /// `allowed_root`. The caller must answer with a 403, not fall through -
+    /// falling through here previously handed the request to PHP-FPM, which
+    /// rejected it with its own unexplained, unlogged 403.
+    SymlinkEscape {
+        /// The original request-URI path, as received.
+        requested_path: String,
+        /// The canonicalised real path the candidate resolved to.
+        resolved: PathBuf,
+        /// The canonicalised root the resolved path must stay within.
+        allowed_root: PathBuf,
+    },
+}
+
+/// Try to serve `uri_path` as a static file under `served_root`, allowing
+/// symlinks that resolve anywhere within `allowed_root` (the site's
+/// `document_root` - a superset of `served_root` when the site is served
+/// from a subdirectory, e.g. Laravel's `public/`).
 pub async fn try_serve(
     method: &Method,
     uri_path: &str,
     served_root: &Path,
-) -> Option<Response<BoxBody>> {
+    allowed_root: &Path,
+) -> StaticOutcome {
     if *method != Method::GET && *method != Method::HEAD {
-        return None;
+        return StaticOutcome::NotFound;
     }
 
-    let rel = static_candidate(uri_path)?;
-    let real_root = tokio::fs::canonicalize(served_root).await.ok()?;
-    let real_file = canonical_within(&served_root.join(&rel), &real_root).await?;
+    let Some(rel) = static_candidate(uri_path) else {
+        return StaticOutcome::NotFound;
+    };
+    let Ok(real_root) = tokio::fs::canonicalize(allowed_root).await else {
+        return StaticOutcome::NotFound;
+    };
+
+    let real_file = match canonical_within(&served_root.join(&rel), &real_root).await {
+        Some(Containment::Ok(path)) => path,
+        Some(Containment::Escaped(resolved)) => {
+            return StaticOutcome::SymlinkEscape {
+                requested_path: uri_path.to_owned(),
+                resolved,
+                allowed_root: real_root,
+            };
+        }
+        None => return StaticOutcome::NotFound,
+    };
 
     if is_php_source(&real_file) {
-        return None;
+        return StaticOutcome::NotFound;
     }
 
-    let meta = tokio::fs::metadata(&real_file).await.ok()?;
+    let Ok(meta) = tokio::fs::metadata(&real_file).await else {
+        return StaticOutcome::NotFound;
+    };
     if !meta.is_file() {
-        return None;
+        return StaticOutcome::NotFound;
     }
 
-    respond_with_file(method, &real_file).await
+    match respond_with_file(method, &real_file).await {
+        Some(resp) => StaticOutcome::Served(resp),
+        None => StaticOutcome::NotFound,
+    }
 }
 
 /// Try to serve a directory-index file (`index.html`, then `index.htm`) for a
@@ -60,64 +114,160 @@ pub async fn try_serve(
 /// FastCGI "everything to index.php" policy in `pure::cgi_params`.
 ///
 /// Each candidate index file is canonicalised and re-checked against
-/// `served_root` (not just the directory it lives in), so a symlinked
+/// `allowed_root` (not just the directory it lives in), so a symlinked
 /// `index.html`/`index.htm` cannot serve a file - PHP source included -
-/// from outside the site root.
+/// from outside the site's document root. If one candidate escapes but
+/// another is servable, the servable one still wins; an escape is only
+/// reported when it's the reason nothing could be served.
 ///
-/// `Some(response)` - an index file was found and served (200). `None` - the
-/// request isn't a directory request, the directory has an `index.php`, or no
-/// index file exists there; the caller should fall through to the PHP front
-/// controller.
+/// `allowed_root` is the site's `document_root` - a superset of
+/// `served_root` when the site is served from a subdirectory.
 pub async fn try_serve_index(
     method: &Method,
     uri_path: &str,
     served_root: &Path,
-) -> Option<Response<BoxBody>> {
+    allowed_root: &Path,
+) -> StaticOutcome {
     if *method != Method::GET && *method != Method::HEAD {
-        return None;
+        return StaticOutcome::NotFound;
     }
 
-    let rel = directory_candidate(uri_path)?;
-    let real_root = tokio::fs::canonicalize(served_root).await.ok()?;
-    let real_dir = canonical_within(&served_root.join(&rel), &real_root).await?;
+    let Some(rel) = directory_candidate(uri_path) else {
+        return StaticOutcome::NotFound;
+    };
+    let Ok(real_root) = tokio::fs::canonicalize(allowed_root).await else {
+        return StaticOutcome::NotFound;
+    };
 
-    if !tokio::fs::metadata(&real_dir).await.ok()?.is_dir() {
-        return None;
+    let real_dir = match canonical_within(&served_root.join(&rel), &real_root).await {
+        Some(Containment::Ok(path)) => path,
+        Some(Containment::Escaped(resolved)) => {
+            return StaticOutcome::SymlinkEscape {
+                requested_path: uri_path.to_owned(),
+                resolved,
+                allowed_root: real_root,
+            };
+        }
+        None => return StaticOutcome::NotFound,
+    };
+
+    let Ok(dir_meta) = tokio::fs::metadata(&real_dir).await else {
+        return StaticOutcome::NotFound;
+    };
+    if !dir_meta.is_dir() {
+        return StaticOutcome::NotFound;
     }
     if tokio::fs::metadata(real_dir.join("index.php"))
         .await
         .is_ok()
     {
-        return None;
+        return StaticOutcome::NotFound;
     }
+
+    let mut first_escape: Option<PathBuf> = None;
 
     for name in ["index.html", "index.htm"] {
-        let Some(real_file) = canonical_within(&real_dir.join(name), &real_root).await else {
-            continue;
-        };
-        if is_php_source(&real_file) {
-            continue;
-        }
-        if tokio::fs::metadata(&real_file)
-            .await
-            .is_ok_and(|meta| meta.is_file())
-        {
-            return respond_with_file(method, &real_file).await;
+        match canonical_within(&real_dir.join(name), &real_root).await {
+            Some(Containment::Ok(real_file)) => {
+                if is_php_source(&real_file) {
+                    continue;
+                }
+                let is_file = tokio::fs::metadata(&real_file)
+                    .await
+                    .is_ok_and(|meta| meta.is_file());
+                if !is_file {
+                    continue;
+                }
+                if let Some(resp) = respond_with_file(method, &real_file).await {
+                    return StaticOutcome::Served(resp);
+                }
+            }
+            Some(Containment::Escaped(resolved)) if first_escape.is_none() => {
+                first_escape = Some(resolved);
+            }
+            Some(Containment::Escaped(_)) | None => {}
         }
     }
 
-    None
+    match first_escape {
+        Some(resolved) => StaticOutcome::SymlinkEscape {
+            requested_path: uri_path.to_owned(),
+            resolved,
+            allowed_root: real_root,
+        },
+        None => StaticOutcome::NotFound,
+    }
 }
 
-/// Canonicalise `candidate` and verify it's still within `real_root`,
-/// defence-in-depth against symlink traversal beyond the string-level guard
-/// in the `pure` candidate functions. `real_root` is an already-canonicalised
-/// `served_root`, passed in so a caller checking several candidates against
-/// the same root (e.g. `try_serve_index`'s directory plus each index-file
-/// probe) only resolves `served_root` once.
-async fn canonical_within(candidate: &Path, real_root: &Path) -> Option<PathBuf> {
+/// Whether canonicalising a path candidate stayed within `real_root` or
+/// escaped it. Returned by [`canonical_within`] so callers can tell "escaped"
+/// apart from "doesn't exist" (`None`), which they need to treat differently.
+enum Containment {
+    /// Canonicalised and still within `real_root`.
+    Ok(PathBuf),
+    /// Canonicalised fine, but resolved outside `real_root`.
+    Escaped(PathBuf),
+}
+
+/// Canonicalise `candidate` and check it against `real_root`, defence-in-depth
+/// against symlink traversal beyond the string-level guard in the `pure`
+/// candidate functions. `real_root` is an already-canonicalised `allowed_root`,
+/// passed in so a caller checking several candidates against the same root
+/// (e.g. `try_serve_index`'s directory plus each index-file probe) only
+/// resolves it once. `None` means `candidate` doesn't exist or otherwise
+/// failed to canonicalise (missing file, broken symlink, permission error) -
+/// distinct from [`Containment::Escaped`], which means it resolved to a real
+/// path that just isn't under `real_root`.
+async fn canonical_within(candidate: &Path, real_root: &Path) -> Option<Containment> {
     let real = tokio::fs::canonicalize(candidate).await.ok()?;
-    real.starts_with(real_root).then_some(real)
+    if real.starts_with(real_root) {
+        Some(Containment::Ok(real))
+    } else {
+        Some(Containment::Escaped(real))
+    }
+}
+
+/// Build the `403 Forbidden` response for a [`StaticOutcome::SymlinkEscape`],
+/// logging it first so the escape shows up in daemon logs even though the
+/// client only sees the response body.
+///
+/// The resolved path and allowed root are only logged, not returned in the
+/// body: sites can be exposed beyond loopback via `yerd-tunnel`, so absolute
+/// local filesystem paths (which could reveal the OS username and directory
+/// layout to a remote client) stay in the daemon log, which never leaves the
+/// machine.
+pub fn symlink_escape_response(
+    requested_path: &str,
+    resolved: &Path,
+    allowed_root: &Path,
+) -> Response<BoxBody> {
+    tracing::warn!(
+        target: "yerd_proxy::static_file",
+        requested_path = %requested_path,
+        resolved = %resolved.display(),
+        allowed_root = %allowed_root.display(),
+        "symlink escapes site's document root, refusing to serve",
+    );
+
+    let body = format!(
+        "403 Forbidden\n\n\
+The requested path \"{requested_path}\" resolves, via a symlink, to a location \
+outside this site's root directory.\n\n\
+See the yerdd daemon log for the resolved path and the site's document root.\n",
+    );
+
+    Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .header(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; charset=utf-8"),
+        )
+        .header(
+            header::SERVER,
+            HeaderValue::from_static(yerd_core::PROXY_SERVER_ID),
+        )
+        .body(owned_bytes_body(body.into_bytes()))
+        .unwrap_or_else(|_| Response::new(empty_body()))
 }
 
 /// Build a 200 response with a guessed `Content-Type`. `HEAD` stats `path`
@@ -151,4 +301,199 @@ async fn respond_with_file(method: &Method, path: &Path) -> Option<Response<BoxB
         )
         .body(body)
         .ok()
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    async fn body_bytes(resp: Response<BoxBody>) -> Vec<u8> {
+        resp.into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn try_serve_serves_plain_file_under_served_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("app.css"), b"body{}").unwrap();
+
+        let outcome = try_serve(&Method::GET, "/app.css", root.path(), root.path()).await;
+        match outcome {
+            StaticOutcome::Served(resp) => {
+                assert_eq!(resp.status(), StatusCode::OK);
+                assert_eq!(body_bytes(resp).await, b"body{}");
+            }
+            _ => panic!("expected Served"),
+        }
+    }
+
+    #[tokio::test]
+    async fn try_serve_missing_file_is_not_found() {
+        let root = tempfile::tempdir().unwrap();
+        let outcome = try_serve(&Method::GET, "/nope.css", root.path(), root.path()).await;
+        assert!(matches!(outcome, StaticOutcome::NotFound));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn try_serve_serves_symlink_inside_document_root_but_outside_served_root() {
+        let docroot = tempfile::tempdir().unwrap();
+        let storage_dir = docroot.path().join("storage/app/public");
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        std::fs::write(storage_dir.join("logo.png"), b"logo-bytes").unwrap();
+
+        let served_root = docroot.path().join("public");
+        std::fs::create_dir_all(&served_root).unwrap();
+        std::os::unix::fs::symlink(&storage_dir, served_root.join("storage")).unwrap();
+
+        let outcome = try_serve(
+            &Method::GET,
+            "/storage/logo.png",
+            &served_root,
+            docroot.path(),
+        )
+        .await;
+        match outcome {
+            StaticOutcome::Served(resp) => {
+                assert_eq!(body_bytes(resp).await, b"logo-bytes");
+            }
+            _ => panic!("expected Served"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn try_serve_symlink_escaping_document_root_is_reported() {
+        let docroot = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), b"leaked").unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("secret.txt"),
+            docroot.path().join("evil.txt"),
+        )
+        .unwrap();
+
+        let outcome = try_serve(&Method::GET, "/evil.txt", docroot.path(), docroot.path()).await;
+        match outcome {
+            StaticOutcome::SymlinkEscape {
+                requested_path,
+                resolved,
+                allowed_root,
+            } => {
+                assert_eq!(requested_path, "/evil.txt");
+                assert_eq!(
+                    resolved,
+                    tokio::fs::canonicalize(outside.path().join("secret.txt"))
+                        .await
+                        .unwrap()
+                );
+                assert_eq!(
+                    allowed_root,
+                    tokio::fs::canonicalize(docroot.path()).await.unwrap()
+                );
+            }
+            _ => panic!("expected SymlinkEscape"),
+        }
+    }
+
+    #[tokio::test]
+    async fn try_serve_index_serves_index_html() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("index.html"), b"<h1>hi</h1>").unwrap();
+
+        let outcome = try_serve_index(&Method::GET, "/", root.path(), root.path()).await;
+        match outcome {
+            StaticOutcome::Served(resp) => {
+                assert_eq!(body_bytes(resp).await, b"<h1>hi</h1>");
+            }
+            _ => panic!("expected Served"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn try_serve_index_falls_back_to_index_htm_when_index_html_escapes() {
+        let docroot = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.html"), b"leaked").unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("secret.html"),
+            docroot.path().join("index.html"),
+        )
+        .unwrap();
+        std::fs::write(docroot.path().join("index.htm"), b"fallback").unwrap();
+
+        let outcome = try_serve_index(&Method::GET, "/", docroot.path(), docroot.path()).await;
+        match outcome {
+            StaticOutcome::Served(resp) => {
+                assert_eq!(body_bytes(resp).await, b"fallback");
+            }
+            _ => panic!("expected Served"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn try_serve_index_reports_escape_when_no_candidate_is_servable() {
+        let docroot = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.html"), b"leaked").unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("secret.html"),
+            docroot.path().join("index.html"),
+        )
+        .unwrap();
+
+        let outcome = try_serve_index(&Method::GET, "/", docroot.path(), docroot.path()).await;
+        assert!(matches!(outcome, StaticOutcome::SymlinkEscape { .. }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn try_serve_index_directory_symlink_escaping_document_root_is_reported() {
+        let docroot = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("index.html"), b"leaked").unwrap();
+        std::os::unix::fs::symlink(outside.path(), docroot.path().join("photos")).unwrap();
+
+        let outcome =
+            try_serve_index(&Method::GET, "/photos/", docroot.path(), docroot.path()).await;
+        assert!(matches!(outcome, StaticOutcome::SymlinkEscape { .. }));
+    }
+
+    #[tokio::test]
+    async fn symlink_escape_response_shape() {
+        let resp = symlink_escape_response(
+            "/storage/x.png",
+            Path::new("/outside/x.png"),
+            Path::new("/project"),
+        );
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/plain; charset=utf-8")
+        );
+        assert_eq!(
+            resp.headers()
+                .get(header::SERVER)
+                .and_then(|v| v.to_str().ok()),
+            Some(yerd_core::PROXY_SERVER_ID)
+        );
+        let body = String::from_utf8(body_bytes(resp).await).unwrap();
+        assert!(body.contains("/storage/x.png"));
+        assert!(!body.contains("/outside/x.png"));
+        assert!(!body.contains("/project"));
+    }
 }

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -301,7 +301,8 @@ async fn dispatch<R: BackendResolver>(
         Routed::Site { site, unbound } => (site, unbound),
         Routed::Respond(resp) => return Ok(resp),
     };
-    let document_root = site.served_root();
+    let served_root = site.served_root();
+    let allowed_root = site.document_root().to_path_buf();
 
     if matches!(listener, Listener::Http) && !unbound {
         if let (true, Some(port)) = (site.secure(), redirect_port) {
@@ -348,18 +349,42 @@ async fn dispatch<R: BackendResolver>(
     match backend {
         Backend::FrankenPhp { addr } => http_fwd::forward(req, addr).await,
         bk @ (Backend::PhpFpm { .. } | Backend::PhpFpmTcp { .. }) => {
-            if let Some(resp) =
-                static_file::try_serve(req.method(), req.uri().path(), &document_root).await
-            {
+            let outcome =
+                static_file::try_serve(req.method(), req.uri().path(), &served_root, &allowed_root)
+                    .await;
+            if let Some(resp) = resolve_static_outcome(outcome) {
                 return Ok(resp);
             }
-            if let Some(resp) =
-                static_file::try_serve_index(req.method(), req.uri().path(), &document_root).await
-            {
+            let outcome = static_file::try_serve_index(
+                req.method(),
+                req.uri().path(),
+                &served_root,
+                &allowed_root,
+            )
+            .await;
+            if let Some(resp) = resolve_static_outcome(outcome) {
                 return Ok(resp);
             }
-            fcgi::forward(req, bk, document_root, server_addr, peer_addr, https).await
+            fcgi::forward(req, bk, served_root, server_addr, peer_addr, https).await
         }
+    }
+}
+
+/// Turn a [`static_file::StaticOutcome`] into a response to return
+/// immediately, or `None` to fall through to the front controller.
+fn resolve_static_outcome(outcome: static_file::StaticOutcome) -> Option<Response<BoxBody>> {
+    match outcome {
+        static_file::StaticOutcome::Served(resp) => Some(resp),
+        static_file::StaticOutcome::SymlinkEscape {
+            requested_path,
+            resolved,
+            allowed_root,
+        } => Some(static_file::symlink_escape_response(
+            &requested_path,
+            &resolved,
+            &allowed_root,
+        )),
+        static_file::StaticOutcome::NotFound => None,
     }
 }
 

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -741,8 +741,10 @@ async fn symlink_within_document_root_outside_served_root_is_served() {
 }
 
 /// A symlink that escapes the site's `document_root` entirely still gets
-/// rejected - but now with an explicit `403` from yerd-proxy naming the
-/// requested and resolved paths, instead of a silent fallthrough to FastCGI.
+/// rejected - but now with an explicit `403` from yerd-proxy naming only the
+/// requested path (the resolved path and allowed root are logged, not echoed,
+/// to avoid leaking local absolute paths), instead of a silent fallthrough to
+/// FastCGI.
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn symlink_escaping_document_root_returns_403() {

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -682,26 +682,22 @@ async fn head_request_to_directory_index_returns_empty_body() {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
 }
 
-/// Regression test for a symlink-escape hole: `try_serve_index` used to
-/// canonicalise only the *directory*, then serve `directory.join("index.html")`
-/// without re-canonicalising the resolved file. A symlink named `index.html`
-/// pointing outside `served_root` (or at PHP source inside it) was served
-/// verbatim as a 200 `text/html` response.
+/// Regression test for the Laravel `public/storage -> ../storage/app/public`
+/// shape: a symlink under the served root that points outside it, but stays
+/// within the site's `document_root`, must be served normally rather than
+/// rejected. Uses a relative symlink target, matching exactly what
+/// `artisan storage:link` creates (as opposed to an absolute target).
 #[cfg(unix)]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn symlinked_index_html_escaping_root_is_not_served() {
-    let secret_dir = tempfile::tempdir().unwrap();
-    let secret_path = secret_dir.path().join("secret.php");
-    std::fs::write(&secret_path, b"<?php secret_credentials(); ?>").unwrap();
-
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn symlink_within_document_root_outside_served_root_is_served() {
     let docroot = tempfile::tempdir().unwrap();
-    std::os::unix::fs::symlink(&secret_path, docroot.path().join("index.html")).unwrap();
+    let storage_dir = docroot.path().join("storage/app/public");
+    std::fs::create_dir_all(&storage_dir).unwrap();
+    std::fs::write(storage_dir.join("logo.png"), b"logo-bytes").unwrap();
 
-    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let fcgi_addr = fcgi_listener.local_addr().unwrap();
-    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
-    let fake_task = tokio::spawn(run_fake_fcgi(fcgi_listener, stdout_payload, captured));
+    let public_dir = docroot.path().join("public");
+    std::fs::create_dir_all(&public_dir).unwrap();
+    std::os::unix::fs::symlink("../storage/app/public", public_dir.join("storage")).unwrap();
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let proxy_addr = proxy_listener.local_addr().unwrap();
@@ -709,12 +705,16 @@ async fn symlinked_index_html_escaping_root_is_not_served() {
     let tld = Tld::new("test").unwrap();
     let cfg = RouterConfig::with_tld(tld);
     let mut router = SiteRouter::new(cfg);
-    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    let mut site =
+        Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    site.set_web_subpath("public");
     router.insert(site).unwrap();
     let router = Arc::new(tokio::sync::RwLock::new(router));
 
     let resolver = Arc::new(StaticResolver {
-        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        backend: Backend::PhpFpmTcp {
+            addr: "127.0.0.1:1".parse().unwrap(),
+        },
     });
 
     let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
@@ -731,15 +731,130 @@ async fn symlinked_index_html_escaping_root_is_not_served() {
         .await;
     });
 
-    let body = client_get(proxy_addr, "app.test", "/").await;
-    assert_eq!(body, b"from fpm");
+    let (status, _content_type, body) =
+        client_get_response(proxy_addr, "app.test", "/storage/logo.png").await;
+    assert_eq!(status, 200);
+    assert_eq!(body, b"logo-bytes");
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+}
+
+/// A symlink that escapes the site's `document_root` entirely still gets
+/// rejected - but now with an explicit `403` from yerd-proxy naming the
+/// requested and resolved paths, instead of a silent fallthrough to FastCGI.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn symlink_escaping_document_root_returns_403() {
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::write(outside.path().join("secret.txt"), b"leaked-secret").unwrap();
+
+    let docroot = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(
+        outside.path().join("secret.txt"),
+        docroot.path().join("evil.txt"),
+    )
+    .unwrap();
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp {
+            addr: "127.0.0.1:1".parse().unwrap(),
+        },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, _content_type, body) =
+        client_get_response(proxy_addr, "app.test", "/evil.txt").await;
+    assert_eq!(status, 403);
+    assert!(!body
+        .windows(b"leaked-secret".len())
+        .any(|w| w == b"leaked-secret"));
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(body_str.contains("/evil.txt"));
+    assert!(!body_str.contains(&docroot.path().to_string_lossy().into_owned()));
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+}
+
+/// Regression test for a symlink-escape hole: `try_serve_index` used to
+/// canonicalise only the *directory*, then serve `directory.join("index.html")`
+/// without re-canonicalising the resolved file. A symlink named `index.html`
+/// pointing outside the site's `document_root` (or at PHP source inside it)
+/// was served verbatim as a 200 `text/html` response. It's now rejected with
+/// an explicit `403 Forbidden` from yerd-proxy rather than a silent
+/// fallthrough to FastCGI.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn symlinked_index_html_escaping_root_is_not_served() {
+    let secret_dir = tempfile::tempdir().unwrap();
+    let secret_path = secret_dir.path().join("secret.php");
+    std::fs::write(&secret_path, b"<?php secret_credentials(); ?>").unwrap();
+
+    let docroot = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(&secret_path, docroot.path().join("index.html")).unwrap();
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp {
+            addr: "127.0.0.1:1".parse().unwrap(),
+        },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, _content_type, body) = client_get_response(proxy_addr, "app.test", "/").await;
+    assert_eq!(status, 403);
     assert!(!body
         .windows(b"secret_credentials".len())
         .any(|w| w == b"secret_credentials"));
 
     let _ = tx_shutdown.send(());
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
-    let _ = fake_task.await;
 }
 
 // ─── Hyper client helpers ───────────────────────────────────────────

--- a/docs/developer/crates/yerd-proxy.md
+++ b/docs/developer/crates/yerd-proxy.md
@@ -247,8 +247,8 @@ The hyper service is **infallible** - internal errors are logged and turned into
 3. **HTTP → HTTPS redirect.** On the HTTP listener, if `site.secure()` is true and a `redirect_port` is set, return `301 Moved Permanently` with `Location` built by `build_redirect_uri`.
 4. **Resolve backend** via `BackendResolver::backend_for(&site)`. Errors already in the connect/protocol/resolver family pass through; any other variant is wrapped in `ProxyError::BackendResolver { host, source }`.
 5. **Upgrade dispatch.** If `upgrade::is_upgrade(headers)`, forward to `upgrade::forward` for `FrankenPhp`, or return `501 Not Implemented` for FastCGI backends (FastCGI cannot model a duplex byte stream).
-6. **Static-file short-circuit.** For the FastCGI backends (`PhpFpm`/`PhpFpmTcp`), `static_file::try_serve` is attempted first: a GET/HEAD request that resolves to a real, non-PHP file under the served root is returned directly with a guessed `Content-Type`. (`FrankenPhp` serves its own static files, so this step is skipped for it.)
-7. **Directory-index short-circuit.** Still FastCGI-only: if `try_serve` didn't match, `static_file::try_serve_index` is tried next - a GET/HEAD directory-style request (trailing slash, including the site root) with no `index.php` in that directory serves its `index.html`/`index.htm` directly, so plain static sites work with no PHP front controller at all.
+6. **Static-file short-circuit.** For the FastCGI backends (`PhpFpm`/`PhpFpmTcp`), `static_file::try_serve` is attempted first: a GET/HEAD request that resolves to a real, non-PHP file under the served root - allowing symlinks that resolve anywhere within the site's `document_root`, not just the served subdirectory - is returned directly with a guessed `Content-Type`. A candidate that resolves outside `document_root` gets an explicit `403 Forbidden` from yerd-proxy instead of falling through. (`FrankenPhp` serves its own static files, so this step is skipped for it.)
+7. **Directory-index short-circuit.** Still FastCGI-only: if `try_serve` didn't match, `static_file::try_serve_index` is tried next - a GET/HEAD directory-style request (trailing slash, including the site root) with no `index.php` in that directory serves its `index.html`/`index.htm` directly, so plain static sites work with no PHP front controller at all. Same `document_root` containment and `403` behavior as `try_serve`.
 8. **Normal dispatch.** Anything not served as a static file or directory index goes to the front controller: `FrankenPhp` → `http::forward`; `PhpFpm`/`PhpFpmTcp` → `fcgi::forward`.
 
 The `Listener::{Http, Https}` discriminator is threaded through so the redirect rule and the `HTTPS=on` CGI var both know which listener the connection arrived on.
@@ -265,24 +265,24 @@ with `empty_body()` (for 301/404/501/101) and `bytes_body(&'static [u8])` helper
 
 ### `static_file` - serving real files {#static_file-serving-real-files}
 
-`static_file::try_serve` is the static short-circuit for the FastCGI backends. Given the served root and the request, it:
+Both lookup functions return a `StaticOutcome`: `Served(Response)`, `NotFound` (fall through to the front controller, same as a bare `None` before this type existed), or `SymlinkEscape { requested_path, resolved, allowed_root }` (the candidate resolved via symlink to somewhere outside the site's `document_root` - the caller turns this into a `403` via `symlink_escape_response`, never a silent fallthrough). The `403` body names only `requested_path`; `resolved` and `allowed_root` go to a `tracing::warn!` (target `yerd_proxy::static_file`) instead, since a site can be exposed beyond loopback via `yerd-tunnel` and absolute local paths shouldn't reach a remote client.
 
-1. asks [`try_files::static_candidate`](#try_files-static-file-resolution) for a safe relative path (returns `None` - fall through to FastCGI - for `/`, directory requests, traversal, or a non-GET/HEAD method);
+`static_file::try_serve` is the static short-circuit for the FastCGI backends. Given the served root, the site's `document_root`, and the request, it:
+
+1. asks [`try_files::static_candidate`](#try_files-static-file-resolution) for a safe relative path (`NotFound` for `/`, directory requests, traversal, or a non-GET/HEAD method);
 2. refuses PHP source (`is_php_source`) so a `.php` file is never returned as bytes;
-3. joins the candidate onto the served root, **canonicalises**, and verifies the result is still inside the root - a symlink that escapes the root is rejected (fall through, not served);
+3. joins the candidate onto the served root, **canonicalises**, and verifies the result is still inside the site's `document_root` - not just the served subdirectory, so e.g. Laravel's `public/storage -> ../storage/app/public` symlink is served normally even though it points outside `public/`. A candidate that canonicalises fine but lands outside `document_root` entirely is a `SymlinkEscape`; a candidate that simply doesn't exist is `NotFound`, unchanged;
 4. on a hit, reads the file and returns `200 OK` with the `Content-Type` from `content_type_for` and the `Server: <PROXY_SERVER_ID>` header (a `HEAD` returns an empty body).
 
-A `None` result simply means "not a static file" and the request continues to the front controller.
+`static_file::try_serve_index` is the directory-index counterpart, tried next when `try_serve` misses. Given the same served root, `document_root`, and the request, it:
 
-`static_file::try_serve_index` is the directory-index counterpart, tried next when `try_serve` misses. Given the served root and the request, it:
-
-1. asks [`try_files::directory_candidate`](#try_files-static-file-resolution) for a safe relative directory path (returns `None` for anything that isn't a directory-style request, or a non-GET/HEAD method);
-2. joins the candidate onto the served root, canonicalises, and verifies it's still inside the root and is actually a directory;
-3. defers to the front controller (`None`) if that directory contains `index.php` - the front controller always wins when present;
-4. otherwise probes `index.html`, then `index.htm`: each candidate is joined onto the (already-canonical) directory and **re-canonicalised in its own right** before being served, so a symlinked `index.html`/`index.htm` that escapes the served root - or points at PHP source inside it - is rejected, not served. This mirrors `try_serve`'s canonicalise-the-full-path guarantee rather than only canonicalising the directory.
+1. asks [`try_files::directory_candidate`](#try_files-static-file-resolution) for a safe relative directory path (`NotFound` for anything that isn't a directory-style request, or a non-GET/HEAD method);
+2. joins the candidate onto the served root, canonicalises, and verifies it's still inside `document_root` and is actually a directory - an escaped directory candidate is reported immediately, since there's no other candidate to fall back to;
+3. defers to the front controller (`NotFound`) if that directory contains `index.php` - the front controller always wins when present;
+4. otherwise probes `index.html`, then `index.htm`: each candidate is joined onto the (already-canonical) directory and **re-canonicalised in its own right** against `document_root` before being served. If one candidate escapes but the other is servable, the servable one still wins - a `SymlinkEscape` is only reported once every candidate has been tried and none served.
 5. on a hit, serves the file exactly like `try_serve` (same `Content-Type` lookup, `HEAD` handling, headers).
 
-A `None` result here means no index file exists (or `index.php` won) and the request falls through to `fcgi::forward` exactly as it did before this short-circuit existed.
+A `NotFound` result here means no index file exists (or `index.php` won) and the request falls through to `fcgi::forward` exactly as it did before this short-circuit existed.
 
 ### `fcgi` - the PHP-FPM forwarder
 

--- a/docs/guide/sites.md
+++ b/docs/guide/sites.md
@@ -258,7 +258,7 @@ Detection runs in the daemon when a site is registered and whenever its project 
 The served path shows up in `yerd sites` (the `SERVED` column, `/` meaning the project root itself).
 
 ::: info Static files are served directly
-A request that resolves to a real file under the served root (a stylesheet, image, `favicon.ico`, compiled JS, …) is returned straight from disk by the proxy, with a guessed `Content-Type` - it never touches PHP. A directory request (including the site root) falls back to `index.html` or `index.htm` from that directory when there's no `index.php` there, so a plain static site (no PHP at all) works with no extra configuration. Everything else is handed to the framework's front controller (`index.php`). PHP source files are never served as static bytes, and a symlink that escapes the served root is refused.
+A request that resolves to a real file under the served root (a stylesheet, image, `favicon.ico`, compiled JS, …) is returned straight from disk by the proxy, with a guessed `Content-Type` - it never touches PHP. A directory request (including the site root) falls back to `index.html` or `index.htm` from that directory when there's no `index.php` there, so a plain static site (no PHP at all) works with no extra configuration. Everything else is handed to the framework's front controller (`index.php`). PHP source files are never served as static bytes. A symlink is allowed to point anywhere inside the site's project directory - so Laravel's `public/storage -> ../storage/app/public` link works with no extra setup - but a symlink that escapes the project directory entirely is refused with an explicit `403 Forbidden` naming the requested path, rather than being silently handed to PHP.
 :::
 
 ### Overriding the served path


### PR DESCRIPTION
## What does this PR do?

Fix symlink protection to allow same-project symlinks (e.g. Laravel's public/storage link) while returning a diagnostic 403 for symlinks that escape the project root instead of an opaque PHP-FPM error.

## Related issues

Closes #88

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static file handling now allows safe symlinks inside the site’s project directory, while still blocking links that escape it.
  * Requests that escape the allowed area now return a clear **403 Forbidden** response.

* **Bug Fixes**
  * Improved directory-index lookup so valid `index.html` and `index.htm` files are still served when reachable.
  * Added stronger protection against symlink-based path traversal in static file requests.

* **Documentation**
  * Updated site and proxy docs to reflect the new symlink and static-file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->