### PR TITLE
[Feat] Ability to change the tray icon

### DIFF
--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -1383,6 +1383,7 @@ pub fn set_tray_icon_variant(
     let mut s = load_settings();
     s.tray_icon_variant = variant;
     save_settings(&s)?;
+    crate::tray::set_cached_variant(variant);
     crate::tray::spawn_refresh(app);
     Ok(())
 }

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -23,6 +23,7 @@ use std::process::Command;
 use tauri_plugin_autostart::ManagerExt as _;
 
 use crate::error::GuiError;
+use crate::tray::TrayIconVariant;
 
 // ── GUI settings file (Rust-readable, beside yerd.toml) ──────────────────────
 
@@ -61,6 +62,11 @@ struct GuiSettings {
     /// Overview banner. Cleared once the versions agree again.
     #[serde(default)]
     daemon_version_conflict: Option<String>,
+    /// User-selected tray icon appearance override; `Auto` (default) keeps
+    /// today's per-OS behavior. `#[serde(default)]` is mandatory - an existing
+    /// gui-settings.json without this field must still deserialize.
+    #[serde(default)]
+    tray_icon_variant: TrayIconVariant,
 }
 
 /// Outcome of comparing the running GUI/daemon version against the version that
@@ -162,6 +168,11 @@ fn save_settings(s: &GuiSettings) -> Result<(), GuiError> {
 /// Read the persisted "start minimized" preference (used by `main`'s setup).
 pub(crate) fn gui_minimized() -> bool {
     load_settings().gui_minimized
+}
+
+/// Read the persisted tray icon variant (used by `tray.rs`).
+pub(crate) fn tray_icon_variant() -> TrayIconVariant {
+    load_settings().tray_icon_variant
 }
 
 // ── onboarding / first-run state ─────────────────────────────────────────────
@@ -1357,14 +1368,40 @@ pub fn set_gui_minimized(on: bool) -> Result<(), GuiError> {
     save_settings(&s)
 }
 
+/// Current tray icon variant, for the Settings screen.
+#[tauri::command]
+pub fn get_tray_icon_variant() -> TrayIconVariant {
+    tray_icon_variant()
+}
+
+/// Persist the chosen tray icon variant and repaint the live tray immediately.
+#[tauri::command]
+pub fn set_tray_icon_variant(
+    app: tauri::AppHandle,
+    variant: TrayIconVariant,
+) -> Result<(), GuiError> {
+    let mut s = load_settings();
+    s.tray_icon_variant = variant;
+    save_settings(&s)?;
+    crate::tray::spawn_refresh(app);
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{decide, reg_action, reg_plan, Decision, RegAction, StartPhase};
+    use super::{decide, reg_action, reg_plan, Decision, GuiSettings, RegAction, StartPhase};
+    use crate::tray::TrayIconVariant;
     use semver::Version;
 
     fn v(s: &str) -> Version {
         Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn gui_settings_without_tray_icon_variant_field_deserializes_to_auto() {
+        let s: GuiSettings = serde_json::from_str("{}").expect("empty object deserializes");
+        assert_eq!(s.tray_icon_variant, TrayIconVariant::Auto);
     }
 
     #[test]

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -161,6 +161,8 @@ fn main() {
             autostart::set_autostart_daemon,
             autostart::set_autostart_gui,
             autostart::set_gui_minimized,
+            autostart::get_tray_icon_variant,
+            autostart::set_tray_icon_variant,
             autostart::setup_state,
             autostart::mark_onboarded,
             autostart::daemon_version_conflict,

--- a/apps/yerd-gui/src-tauri/src/tray.rs
+++ b/apps/yerd-gui/src-tauri/src/tray.rs
@@ -138,6 +138,29 @@ pub(crate) enum TrayIconVariant {
     Full,
 }
 
+/// In-memory cache of the persisted tray icon variant, seeded once from disk
+/// at startup (`build_tray`) and kept in sync by [`set_cached_variant`]
+/// (called by `crate::autostart::set_tray_icon_variant` right after it saves
+/// a change). The poller and refresh paths read this instead of hitting disk
+/// (`crate::autostart::tray_icon_variant`, a `std::fs::read` +
+/// `serde_json::from_slice`) on every tick.
+static CACHED_VARIANT: Mutex<TrayIconVariant> = Mutex::new(TrayIconVariant::Auto);
+
+/// The cached tray icon variant (see [`CACHED_VARIANT`]).
+fn cached_variant() -> TrayIconVariant {
+    *CACHED_VARIANT
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Update the cached tray icon variant; called right after persisting a
+/// change so the next poll tick / repaint picks it up without a disk read.
+pub(crate) fn set_cached_variant(variant: TrayIconVariant) {
+    *CACHED_VARIANT
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = variant;
+}
+
 /// Build the tray and register it; called once from `setup_app`.
 ///
 /// The dynamic menu is the primary surface, so it opens on a plain left-click
@@ -153,11 +176,12 @@ pub(crate) fn build_tray(app: &AppHandle) -> tauri::Result<()> {
         .on_menu_event(on_menu_event);
 
     let variant = crate::autostart::tray_icon_variant();
+    set_cached_variant(variant);
     let no_badges = Badges {
         update: false,
         unread: false,
     };
-    if let Some(icon) = tray_icon(app, no_badges, variant) {
+    if let Some(icon) = tray_icon(app, no_badges, variant, dark_menu_bar()) {
         builder = builder.icon(icon);
     }
     #[cfg(target_os = "macos")]
@@ -189,7 +213,7 @@ pub(crate) fn spawn_tray_poller(app: AppHandle) {
                 continue;
             }
             let dark = dark_menu_bar();
-            let variant = crate::autostart::tray_icon_variant();
+            let variant = cached_variant();
             let guard = lock_menu();
             if !TRANSITION.load(Ordering::Acquire) {
                 apply(&app, &state, dark, variant);
@@ -258,7 +282,7 @@ fn apply(app: &AppHandle, state: &TrayState, dark: bool, variant: TrayIconVarian
             update: state.update_target.is_some() || state.php_update,
             unread: state.unread > 0,
         };
-        if let Some(icon) = tray_icon(app, badges, variant) {
+        if let Some(icon) = tray_icon(app, badges, variant, dark) {
             let _ = tray.set_icon(Some(icon));
             #[cfg(target_os = "macos")]
             {
@@ -294,21 +318,19 @@ enum DotPos {
 /// other OSes the full-colour app icon. `LightY`/`DarkY` force the same
 /// glyph to a fixed colour on every OS, regardless of appearance or badges.
 /// `Full` is the full-colour app icon on every OS, including macOS.
+///
+/// `dark` is the caller's single `dark_menu_bar()` reading (see the module
+/// concurrency note) - only the macOS `Auto`-and-badged case reads it, so it's
+/// unused on other targets.
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
 fn tray_icon(
     app: &AppHandle,
     badges: Badges,
     variant: TrayIconVariant,
+    dark: bool,
 ) -> Option<tauri::image::Image<'static>> {
     match variant {
-        TrayIconVariant::Full => {
-            let base = app.default_window_icon()?;
-            let (w, h) = (base.width(), base.height());
-            let rgba = base.rgba().to_vec();
-            if !badges.any() {
-                return Some(tauri::image::Image::new_owned(rgba, w, h));
-            }
-            Some(draw_badges(rgba, w, h, badges))
-        }
+        TrayIconVariant::Full => full_color_icon(app, badges),
         TrayIconVariant::LightY | TrayIconVariant::DarkY => {
             let (rgba, w, h) = y_glyph_rgba(variant == TrayIconVariant::LightY)?;
             if !badges.any() {
@@ -325,21 +347,27 @@ fn tray_icon(
                 if !badges.any() {
                     return Some(tauri::image::Image::new_owned(rgba, w, h));
                 }
-                recolor_opaque(&mut rgba, dark_menu_bar());
+                recolor_opaque(&mut rgba, dark);
                 Some(draw_badges(rgba, w, h, badges))
             }
             #[cfg(not(target_os = "macos"))]
             {
-                let base = app.default_window_icon()?;
-                let (w, h) = (base.width(), base.height());
-                let rgba = base.rgba().to_vec();
-                if !badges.any() {
-                    return Some(tauri::image::Image::new_owned(rgba, w, h));
-                }
-                Some(draw_badges(rgba, w, h, badges))
+                full_color_icon(app, badges)
             }
         }
     }
+}
+
+/// The full-colour app icon, optionally badged. Shared by `Full` (every OS)
+/// and `Auto` on non-macOS (today's per-OS default there).
+fn full_color_icon(app: &AppHandle, badges: Badges) -> Option<tauri::image::Image<'static>> {
+    let base = app.default_window_icon()?;
+    let (w, h) = (base.width(), base.height());
+    let rgba = base.rgba().to_vec();
+    if !badges.any() {
+        return Some(tauri::image::Image::new_owned(rgba, w, h));
+    }
+    Some(draw_badges(rgba, w, h, badges))
 }
 
 /// Decode the "Y" glyph and force it to solid white (`light`) or solid black.
@@ -472,7 +500,7 @@ fn apply_transient(app: &AppHandle, label: &str) {
 async fn refresh_now(app: &AppHandle) {
     let state = fetch_state().await;
     let dark = dark_menu_bar();
-    let variant = crate::autostart::tray_icon_variant();
+    let variant = cached_variant();
     let guard = lock_menu();
     if !TRANSITION.load(Ordering::Acquire) {
         apply(app, &state, dark, variant);
@@ -820,7 +848,7 @@ fn spawn_lifecycle(app: AppHandle, kind: Lifecycle) {
 
         let state = fetch_state().await;
         let dark = dark_menu_bar();
-        let variant = crate::autostart::tray_icon_variant();
+        let variant = cached_variant();
         let guard = lock_menu();
         apply(&app, &state, dark, variant);
         TRANSITION.store(false, Ordering::Release);

--- a/apps/yerd-gui/src-tauri/src/tray.rs
+++ b/apps/yerd-gui/src-tauri/src/tray.rs
@@ -310,10 +310,7 @@ fn tray_icon(
             Some(draw_badges(rgba, w, h, badges))
         }
         TrayIconVariant::LightY | TrayIconVariant::DarkY => {
-            let base = tauri::image::Image::from_bytes(TRAY_ICON_MAC).ok()?;
-            let (w, h) = (base.width(), base.height());
-            let mut rgba = base.rgba().to_vec();
-            recolor_opaque(&mut rgba, variant == TrayIconVariant::LightY);
+            let (rgba, w, h) = y_glyph_rgba(variant == TrayIconVariant::LightY)?;
             if !badges.any() {
                 return Some(tauri::image::Image::new_owned(rgba, w, h));
             }
@@ -343,6 +340,17 @@ fn tray_icon(
             }
         }
     }
+}
+
+/// Decode the "Y" glyph and force it to solid white (`light`) or solid black.
+/// Pure (no `AppHandle`), so it's the part of the `LightY`/`DarkY` icon path
+/// that's directly unit-testable.
+fn y_glyph_rgba(light: bool) -> Option<(Vec<u8>, u32, u32)> {
+    let base = tauri::image::Image::from_bytes(TRAY_ICON_MAC).ok()?;
+    let (w, h) = (base.width(), base.height());
+    let mut rgba = base.rgba().to_vec();
+    recolor_opaque(&mut rgba, light);
+    Some((rgba, w, h))
 }
 
 /// Recolour every opaque pixel in `rgba` to solid white (`to_white`) or solid
@@ -923,7 +931,7 @@ async fn wait_until_restarted(prev: Option<u64>) {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{icons, menu_icon, recolor_opaque};
+    use super::{icons, menu_icon, recolor_opaque, y_glyph_rgba, TrayIconVariant};
 
     #[test]
     fn menu_icon_light_leaves_pixels_unchanged() {
@@ -967,5 +975,45 @@ mod tests {
         recolor_opaque(&mut rgba, false);
         assert_eq!(&rgba[0..4], &[0, 0, 0, 255]);
         assert_eq!(&rgba[4..8], &[40, 50, 60, 0]);
+    }
+
+    #[test]
+    fn y_glyph_rgba_light_is_white() {
+        let (rgba, _, _) = y_glyph_rgba(true).expect("bundled tray glyph decodes");
+        for px in rgba.chunks_exact(4) {
+            if let [r, g, b, a] = *px {
+                if a > 0 {
+                    assert_eq!((r, g, b), (255, 255, 255));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn y_glyph_rgba_dark_is_black() {
+        let (rgba, _, _) = y_glyph_rgba(false).expect("bundled tray glyph decodes");
+        for px in rgba.chunks_exact(4) {
+            if let [r, g, b, a] = *px {
+                if a > 0 {
+                    assert_eq!((r, g, b), (0, 0, 0));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn tray_icon_variant_wire_names_are_kebab_case() {
+        let cases = [
+            (TrayIconVariant::Auto, "\"auto\""),
+            (TrayIconVariant::LightY, "\"light-y\""),
+            (TrayIconVariant::DarkY, "\"dark-y\""),
+            (TrayIconVariant::Full, "\"full\""),
+        ];
+        for (variant, wire) in cases {
+            assert_eq!(
+                serde_json::to_string(&variant).expect("enum serializes"),
+                wire
+            );
+        }
     }
 }

--- a/apps/yerd-gui/src-tauri/src/tray.rs
+++ b/apps/yerd-gui/src-tauri/src/tray.rs
@@ -81,8 +81,9 @@ const NAV_ITEMS: &[(&str, &str, &[u8])] = &[
     ("nav:/about", "About", icons::ABOUT),
 ];
 
-/// macOS menu-bar template icon (see `main.rs` for the rationale).
-#[cfg(target_os = "macos")]
+/// The bare "Y" glyph (solid black stroke, transparent ground), source for the
+/// macOS template icon and for the [`TrayIconVariant::LightY`]/`DarkY`
+/// overrides on every OS (see `main.rs` for the macOS template rationale).
 const TRAY_ICON_MAC: &[u8] = include_bytes!("../icons/tray-mac.png");
 
 /// Set while a tray-initiated daemon lifecycle action owns the menu.
@@ -123,6 +124,20 @@ struct TrayState {
     unread: u32,
 }
 
+/// User-selectable tray icon appearance; `Auto` (default) keeps today's
+/// per-OS behavior (macOS auto-tints a template; other OSes show the full
+/// color app icon). Persisted in `gui-settings.json` via
+/// `crate::autostart::tray_icon_variant`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum TrayIconVariant {
+    #[default]
+    Auto,
+    LightY,
+    DarkY,
+    Full,
+}
+
 /// Build the tray and register it; called once from `setup_app`.
 ///
 /// The dynamic menu is the primary surface, so it opens on a plain left-click
@@ -137,15 +152,17 @@ pub(crate) fn build_tray(app: &AppHandle) -> tauri::Result<()> {
         .show_menu_on_left_click(true)
         .on_menu_event(on_menu_event);
 
+    let variant = crate::autostart::tray_icon_variant();
+    let no_badges = Badges {
+        update: false,
+        unread: false,
+    };
+    if let Some(icon) = tray_icon(app, no_badges, variant) {
+        builder = builder.icon(icon);
+    }
     #[cfg(target_os = "macos")]
     {
-        builder = builder
-            .icon(tauri::image::Image::from_bytes(TRAY_ICON_MAC)?)
-            .icon_as_template(true);
-    }
-    #[cfg(not(target_os = "macos"))]
-    if let Some(icon) = app.default_window_icon().cloned() {
-        builder = builder.icon(icon);
+        builder = builder.icon_as_template(variant == TrayIconVariant::Auto);
     }
 
     builder.build(app)?;
@@ -172,9 +189,10 @@ pub(crate) fn spawn_tray_poller(app: AppHandle) {
                 continue;
             }
             let dark = dark_menu_bar();
+            let variant = crate::autostart::tray_icon_variant();
             let guard = lock_menu();
             if !TRANSITION.load(Ordering::Acquire) {
-                apply(&app, &state, dark);
+                apply(&app, &state, dark, variant);
                 last = Some(state);
             }
             drop(guard);
@@ -224,12 +242,13 @@ impl Badges {
 }
 
 /// Build + install the menu for `state`, and badge the icon for waiting updates
-/// and/or unread mail. No lock / no transition logic - callers hold `MENU_LOCK`
-/// as needed, and must read `dark_menu_bar()` themselves *before* taking it (see
-/// the module concurrency note) since this only threads `dark` through. On
-/// macOS a coloured badge can't be a template, so templating is dropped while
-/// any badge shows (and restored when none do).
-fn apply(app: &AppHandle, state: &TrayState, dark: bool) {
+/// and/or unread mail, in the user's chosen `variant`. No lock / no transition
+/// logic - callers hold `MENU_LOCK` as needed, and must read `dark_menu_bar()`
+/// and the tray icon variant themselves *before* taking it (see the module
+/// concurrency note) since this only threads `dark`/`variant` through. On
+/// macOS a coloured badge (or a non-`Auto` variant) can't be a template, so
+/// templating only ever applies to the plain `Auto` icon.
+fn apply(app: &AppHandle, state: &TrayState, dark: bool, variant: TrayIconVariant) {
     let Ok(menu) = build_menu(app, state, dark) else {
         return;
     };
@@ -239,11 +258,12 @@ fn apply(app: &AppHandle, state: &TrayState, dark: bool) {
             update: state.update_target.is_some() || state.php_update,
             unread: state.unread > 0,
         };
-        if let Some(icon) = tray_icon(app, badges) {
+        if let Some(icon) = tray_icon(app, badges, variant) {
             let _ = tray.set_icon(Some(icon));
             #[cfg(target_os = "macos")]
             {
-                let _ = tray.set_icon_as_template(!badges.any());
+                let _ =
+                    tray.set_icon_as_template(variant == TrayIconVariant::Auto && !badges.any());
             }
         }
     }
@@ -263,41 +283,79 @@ enum DotPos {
     BottomLeft,
 }
 
-/// The tray icon for the current state. Plain icon when nothing's waiting; a copy
-/// with a red dot (bottom-right) for a waiting update and/or an orange dot
-/// (bottom-left) for unread mail. On macOS the plain icon is the monochrome template
-/// (auto-tinted); a colour dot can't be a template, so the badged copy paints the
-/// glyph in the current appearance's label colour (black in light, white in dark)
-/// to stay native-looking, and `apply` flips the template flag to match.
-#[cfg_attr(target_os = "macos", allow(unused_variables))]
-fn tray_icon(app: &AppHandle, badges: Badges) -> Option<tauri::image::Image<'static>> {
-    #[cfg(target_os = "macos")]
-    {
-        let base = tauri::image::Image::from_bytes(TRAY_ICON_MAC).ok()?;
-        let (w, h) = (base.width(), base.height());
-        let mut rgba = base.rgba().to_vec();
-        if !badges.any() {
-            return Some(tauri::image::Image::new_owned(rgba, w, h));
+/// The tray icon for the current state + the user's chosen `variant`. Plain
+/// icon when nothing's waiting; a copy with a red dot (bottom-right) for a
+/// waiting update and/or an orange dot (bottom-left) for unread mail.
+///
+/// `Auto` is today's per-OS default: on macOS the monochrome template
+/// (auto-tinted by the OS when unbadged; a coloured dot can't be a template,
+/// so the badged copy is forced to the current appearance's label colour -
+/// black in light, white in dark - and `apply` drops templating to match), on
+/// other OSes the full-colour app icon. `LightY`/`DarkY` force the same
+/// glyph to a fixed colour on every OS, regardless of appearance or badges.
+/// `Full` is the full-colour app icon on every OS, including macOS.
+fn tray_icon(
+    app: &AppHandle,
+    badges: Badges,
+    variant: TrayIconVariant,
+) -> Option<tauri::image::Image<'static>> {
+    match variant {
+        TrayIconVariant::Full => {
+            let base = app.default_window_icon()?;
+            let (w, h) = (base.width(), base.height());
+            let rgba = base.rgba().to_vec();
+            if !badges.any() {
+                return Some(tauri::image::Image::new_owned(rgba, w, h));
+            }
+            Some(draw_badges(rgba, w, h, badges))
         }
-        let glyph = if dark_menu_bar() { 255u8 } else { 0u8 };
-        for px in rgba.chunks_exact_mut(4) {
-            if let [r, g, b, a] = px {
-                if *a > 0 {
-                    (*r, *g, *b) = (glyph, glyph, glyph);
+        TrayIconVariant::LightY | TrayIconVariant::DarkY => {
+            let base = tauri::image::Image::from_bytes(TRAY_ICON_MAC).ok()?;
+            let (w, h) = (base.width(), base.height());
+            let mut rgba = base.rgba().to_vec();
+            recolor_opaque(&mut rgba, variant == TrayIconVariant::LightY);
+            if !badges.any() {
+                return Some(tauri::image::Image::new_owned(rgba, w, h));
+            }
+            Some(draw_badges(rgba, w, h, badges))
+        }
+        TrayIconVariant::Auto => {
+            #[cfg(target_os = "macos")]
+            {
+                let base = tauri::image::Image::from_bytes(TRAY_ICON_MAC).ok()?;
+                let (w, h) = (base.width(), base.height());
+                let mut rgba = base.rgba().to_vec();
+                if !badges.any() {
+                    return Some(tauri::image::Image::new_owned(rgba, w, h));
                 }
+                recolor_opaque(&mut rgba, dark_menu_bar());
+                Some(draw_badges(rgba, w, h, badges))
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let base = app.default_window_icon()?;
+                let (w, h) = (base.width(), base.height());
+                let rgba = base.rgba().to_vec();
+                if !badges.any() {
+                    return Some(tauri::image::Image::new_owned(rgba, w, h));
+                }
+                Some(draw_badges(rgba, w, h, badges))
             }
         }
-        Some(draw_badges(rgba, w, h, badges))
     }
-    #[cfg(not(target_os = "macos"))]
-    {
-        let base = app.default_window_icon()?;
-        let (w, h) = (base.width(), base.height());
-        let rgba = base.rgba().to_vec();
-        if !badges.any() {
-            return Some(tauri::image::Image::new_owned(rgba, w, h));
+}
+
+/// Recolour every opaque pixel in `rgba` to solid white (`to_white`) or solid
+/// black, preserving alpha. Shared by [`tray_icon`]'s `LightY`/`DarkY`/badged-
+/// `Auto` paths and [`menu_icon`]'s dark-mode recolor.
+fn recolor_opaque(rgba: &mut [u8], to_white: bool) {
+    let value = if to_white { 255u8 } else { 0u8 };
+    for px in rgba.chunks_exact_mut(4) {
+        if let [r, g, b, a] = px {
+            if *a > 0 {
+                (*r, *g, *b) = (value, value, value);
+            }
         }
-        Some(draw_badges(rgba, w, h, badges))
     }
 }
 
@@ -406,11 +464,18 @@ fn apply_transient(app: &AppHandle, label: &str) {
 async fn refresh_now(app: &AppHandle) {
     let state = fetch_state().await;
     let dark = dark_menu_bar();
+    let variant = crate::autostart::tray_icon_variant();
     let guard = lock_menu();
     if !TRANSITION.load(Ordering::Acquire) {
-        apply(app, &state, dark);
+        apply(app, &state, dark, variant);
     }
     drop(guard);
+}
+
+/// Spawn [`refresh_now`] in the background; used to repaint the tray
+/// immediately after the user changes the tray icon variant in Settings.
+pub(crate) fn spawn_refresh(app: AppHandle) {
+    tauri::async_runtime::spawn(async move { refresh_now(&app).await });
 }
 
 /// Push an owned menu item as a boxed trait object (lets the builder mix
@@ -620,13 +685,7 @@ fn menu_icon(png: &[u8], dark: bool) -> Option<tauri::image::Image<'static>> {
     let (w, h) = (img.width(), img.height());
     let mut rgba = img.rgba().to_vec();
     if dark {
-        for px in rgba.chunks_exact_mut(4) {
-            if let [r, g, b, a] = px {
-                if *a > 0 {
-                    (*r, *g, *b) = (255, 255, 255);
-                }
-            }
-        }
+        recolor_opaque(&mut rgba, true);
     }
     Some(tauri::image::Image::new_owned(rgba, w, h))
 }
@@ -753,8 +812,9 @@ fn spawn_lifecycle(app: AppHandle, kind: Lifecycle) {
 
         let state = fetch_state().await;
         let dark = dark_menu_bar();
+        let variant = crate::autostart::tray_icon_variant();
         let guard = lock_menu();
-        apply(&app, &state, dark);
+        apply(&app, &state, dark, variant);
         TRANSITION.store(false, Ordering::Release);
         drop(guard);
     });
@@ -863,7 +923,7 @@ async fn wait_until_restarted(prev: Option<u64>) {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{icons, menu_icon};
+    use super::{icons, menu_icon, recolor_opaque};
 
     #[test]
     fn menu_icon_light_leaves_pixels_unchanged() {
@@ -891,5 +951,21 @@ mod tests {
         let raw_alpha: Vec<u8> = raw.rgba().chunks_exact(4).map(|px| px[3]).collect();
         let dark_alpha: Vec<u8> = dark.rgba().chunks_exact(4).map(|px| px[3]).collect();
         assert_eq!(raw_alpha, dark_alpha);
+    }
+
+    #[test]
+    fn recolor_opaque_to_white_sets_opaque_pixels_white() {
+        let mut rgba = vec![10, 20, 30, 255, 40, 50, 60, 0];
+        recolor_opaque(&mut rgba, true);
+        assert_eq!(&rgba[0..4], &[255, 255, 255, 255]);
+        assert_eq!(&rgba[4..8], &[40, 50, 60, 0]);
+    }
+
+    #[test]
+    fn recolor_opaque_to_black_sets_opaque_pixels_black() {
+        let mut rgba = vec![10, 20, 30, 255, 40, 50, 60, 0];
+        recolor_opaque(&mut rgba, false);
+        assert_eq!(&rgba[0..4], &[0, 0, 0, 255]);
+        assert_eq!(&rgba[4..8], &[40, 50, 60, 0]);
     }
 }

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -37,6 +37,7 @@ import type {
   NamedTunnelsResponse,
   StatusReport,
   ToolStatus,
+  TrayIconVariant,
   TunnelsResponse,
   UpdateChannel,
   UpdateStatusResponse,
@@ -782,6 +783,14 @@ export async function setAutostartGui(on: boolean, nudge = true): Promise<void> 
 
 export async function setAutostartGuiMinimized(on: boolean): Promise<void> {
   await call<void>("set_gui_minimized", { on });
+}
+
+export async function getTrayIconVariant(): Promise<TrayIconVariant> {
+  return call<TrayIconVariant>("get_tray_icon_variant");
+}
+
+export async function setTrayIconVariant(variant: TrayIconVariant): Promise<void> {
+  await call<void>("set_tray_icon_variant", { variant });
 }
 
 // ── onboarding / first-run ───────────────────────────────────────────────────

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -589,6 +589,13 @@ export interface AutostartState {
 }
 
 /**
+ * Tray icon appearance (host commands `get_tray_icon_variant` /
+ * `set_tray_icon_variant`). `"auto"` (default) keeps the per-OS default: macOS
+ * auto-tints a monochrome template, other OSes show the full color app icon.
+ */
+export type TrayIconVariant = "auto" | "light-y" | "dark-y" | "full";
+
+/**
  * Why the daemon isn't up (host command `daemon_diagnostics`). Gathered when a
  * start attempt fails to connect - covers both the ran-and-crashed case
  * (`logTail`) and the never-launched cases (`startError`, `translocated`,

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -22,6 +22,7 @@ import {
   daemonInfo,
   dumpsStatus,
   getAutostart,
+  getTrayIconVariant,
   installCliToPath,
   IpcError,
   openLoginItems,
@@ -29,8 +30,9 @@ import {
   setAutostartDaemon,
   setAutostartGui,
   setAutostartGuiMinimized,
+  setTrayIconVariant,
 } from "@/ipc/client";
-import type { AutostartState, CliPathStatus } from "@/ipc/types";
+import type { AutostartState, CliPathStatus, TrayIconVariant } from "@/ipc/types";
 import { useTheme, type ThemePref } from "@/lib/theme";
 
 const { connected, report, refresh: refreshStatus } = useDaemon();
@@ -51,6 +53,14 @@ const themeOptions = [
   { value: "dark", label: "Dark" },
 ] as const;
 
+const trayIconVariant = ref<TrayIconVariant>("auto");
+const trayIconOptions = [
+  { value: "auto", label: "Automatic" },
+  { value: "light-y", label: "Light Y" },
+  { value: "dark-y", label: "Dark Y" },
+  { value: "full", label: "Full icon" },
+] as const;
+
 const running = computed(() => connected.value === true);
 
 // ── data loads ──
@@ -59,6 +69,25 @@ async function loadAutostart(): Promise<void> {
     autostart.value = await getAutostart();
   } catch (e) {
     toast.error("Couldn't load startup settings", (e as IpcError).message);
+  }
+}
+
+async function loadTrayIconVariant(): Promise<void> {
+  try {
+    trayIconVariant.value = await getTrayIconVariant();
+  } catch (e) {
+    toast.error("Couldn't load the tray icon setting", (e as IpcError).message);
+  }
+}
+
+async function setTrayIconVariantPref(variant: TrayIconVariant): Promise<void> {
+  const previous = trayIconVariant.value;
+  trayIconVariant.value = variant;
+  try {
+    await setTrayIconVariant(variant);
+  } catch (e) {
+    trayIconVariant.value = previous;
+    toast.error("Couldn't change the tray icon", (e as IpcError).message);
   }
 }
 
@@ -99,6 +128,7 @@ onMounted(() => {
   loadAutostart();
   void loadPlatform();
   loadCli();
+  void loadTrayIconVariant();
   if (running.value) {
     void loadApplicationPorts();
   }
@@ -571,9 +601,9 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
       <Card>
         <CardHeader>
           <CardTitle>Appearance</CardTitle>
-          <CardDescription>Theme used by the Yerd app.</CardDescription>
+          <CardDescription>Theme and tray icon used by the Yerd app.</CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent class="space-y-4">
           <div class="flex items-center justify-between gap-4">
             <div>
               <p class="text-sm font-medium">Theme</p>
@@ -586,6 +616,21 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
               :options="themeOptions"
               aria-label="Theme"
               @update:model-value="(v: ThemePref) => setTheme(v)"
+            />
+          </div>
+
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="text-sm font-medium">Tray icon</p>
+              <p class="text-xs text-muted-foreground">
+                Icon shown in the menu bar / system tray.
+              </p>
+            </div>
+            <Select
+              :model-value="trayIconVariant"
+              :options="trayIconOptions"
+              aria-label="Tray icon"
+              @update:model-value="setTrayIconVariantPref"
             />
           </div>
         </CardContent>


### PR DESCRIPTION
## What does this PR do?

Ability to change the icon for yerd

## Related issues

Closes #94

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tray icon setting so users can choose how the app appears in the system tray.
  * Added a tray icon option in the app’s settings screen, with choices that include automatic, light, dark, and full-color styles.
  * The selected tray icon style now loads on startup and updates immediately when changed.

* **Bug Fixes**
  * Kept older settings files working by defaulting to the automatic tray icon style when the new value is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->