### PR TITLE
[Feat] Poll for changes on the Sites/Overview pages

### DIFF
--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -25,6 +25,7 @@ import Spinner from "@/components/ui/Spinner.vue";
 import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useOnboarding } from "@/composables/useOnboarding";
+import { usePoll } from "@/composables/usePoll";
 import { useResource } from "@/composables/useResource";
 import { daemonVersionConflict, openInBrowser, sitesAndParked } from "@/ipc/client";
 import type { StatusReport } from "@/ipc/types";
@@ -71,6 +72,7 @@ onMounted(() => {
 watch(running, (up) => {
   if (up) void reloadSites();
 });
+usePoll(() => (running.value ? reloadSites() : Promise.resolve()), 5000);
 
 onUnmounted(
   registerViewActions({

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -42,6 +42,7 @@ import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { sitesIntent } from "@/lib/shortcuts/sitesIntent";
 import { useSitesGroupState } from "@/lib/sitesGroupState";
 import { useDaemon } from "@/composables/useDaemon";
+import { usePoll } from "@/composables/usePoll";
 import { useResource } from "@/composables/useResource";
 import { useToast } from "@/composables/useToast";
 import {
@@ -74,6 +75,7 @@ const { data, loading, error: resourceError, refresh: load } = useResource(
   "sites",
   sitesAndParked,
 );
+usePoll(() => load(), 5000);
 const sites = computed(() => data.value?.sites ?? []);
 const parked = computed(() => data.value?.parked ?? []);
 // Surface a load failure only when nothing is cached to show; a failed


### PR DESCRIPTION
## What does this PR do?

Creates a simple 5s poll on the sites and overview pages, allowing changes made via the CLI to be seen in the GUI without navigating away and back. 

## Related issues

n/a

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed

@coderabbitai ignore