### PR TITLE
[Feat] Title bar selection

### DIFF
--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -27,6 +27,23 @@ use crate::tray::TrayIconVariant;
 
 // ── GUI settings file (Rust-readable, beside yerd.toml) ──────────────────────
 
+/// User-selectable title bar control style, drawn entirely by the frontend
+/// (every window is decorationless - see `tauri.conf.json`). `Auto` (default)
+/// matches the host OS convention, resolved client-side from `host_platform`.
+/// Persisted in `gui-settings.json` via [`title_bar_style`]. Variant names are
+/// chosen so `#[serde(rename_all = "kebab-case")]` produces wire values that
+/// match `host_platform`'s own strings (`"macos"`, `"linux"`, `"windows"`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum TitleBarStyle {
+    #[default]
+    Auto,
+    Macos,
+    Linux,
+    LinuxReversed,
+    Windows,
+}
+
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 struct GuiSettings {
     /// User intent for "start the daemon at login" (the OS mechanism is applied
@@ -67,6 +84,11 @@ struct GuiSettings {
     /// gui-settings.json without this field must still deserialize.
     #[serde(default)]
     tray_icon_variant: TrayIconVariant,
+    /// User-selected title bar control style; `Auto` (default) keeps today's
+    /// per-OS behavior. `#[serde(default)]` is mandatory - an existing
+    /// gui-settings.json without this field must still deserialize.
+    #[serde(default)]
+    title_bar_style: TitleBarStyle,
 }
 
 /// Outcome of comparing the running GUI/daemon version against the version that
@@ -173,6 +195,11 @@ pub(crate) fn gui_minimized() -> bool {
 /// Read the persisted tray icon variant (used by `tray.rs`).
 pub(crate) fn tray_icon_variant() -> TrayIconVariant {
     load_settings().tray_icon_variant
+}
+
+/// Read the persisted title bar style (used by the `get_title_bar_style` command).
+fn title_bar_style() -> TitleBarStyle {
+    load_settings().title_bar_style
 }
 
 // ── onboarding / first-run state ─────────────────────────────────────────────
@@ -1388,10 +1415,28 @@ pub fn set_tray_icon_variant(
     Ok(())
 }
 
+/// Current title bar style, for the Settings screen.
+#[tauri::command]
+pub fn get_title_bar_style() -> TitleBarStyle {
+    title_bar_style()
+}
+
+/// Persist the chosen title bar style. The style is drawn entirely by the
+/// frontend, so unlike the tray icon there's no live host-side repaint to
+/// trigger here - each open window picks up the change via its own broadcast.
+#[tauri::command]
+pub fn set_title_bar_style(style: TitleBarStyle) -> Result<(), GuiError> {
+    let mut s = load_settings();
+    s.title_bar_style = style;
+    save_settings(&s)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{decide, reg_action, reg_plan, Decision, GuiSettings, RegAction, StartPhase};
+    use super::{
+        decide, reg_action, reg_plan, Decision, GuiSettings, RegAction, StartPhase, TitleBarStyle,
+    };
     use crate::tray::TrayIconVariant;
     use semver::Version;
 
@@ -1403,6 +1448,36 @@ mod tests {
     fn gui_settings_without_tray_icon_variant_field_deserializes_to_auto() {
         let s: GuiSettings = serde_json::from_str("{}").expect("empty object deserializes");
         assert_eq!(s.tray_icon_variant, TrayIconVariant::Auto);
+    }
+
+    #[test]
+    fn gui_settings_without_title_bar_style_field_deserializes_to_auto() {
+        let s: GuiSettings = serde_json::from_str("{}").expect("empty object deserializes");
+        assert_eq!(s.title_bar_style, TitleBarStyle::Auto);
+    }
+
+    #[test]
+    fn title_bar_style_wire_values() {
+        assert_eq!(
+            serde_json::to_string(&TitleBarStyle::Auto).unwrap(),
+            "\"auto\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TitleBarStyle::Macos).unwrap(),
+            "\"macos\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TitleBarStyle::Linux).unwrap(),
+            "\"linux\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TitleBarStyle::LinuxReversed).unwrap(),
+            "\"linux-reversed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TitleBarStyle::Windows).unwrap(),
+            "\"windows\""
+        );
     }
 
     #[test]

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -163,6 +163,8 @@ fn main() {
             autostart::set_gui_minimized,
             autostart::get_tray_icon_variant,
             autostart::set_tray_icon_variant,
+            autostart::get_title_bar_style,
+            autostart::set_title_bar_style,
             autostart::setup_state,
             autostart::mark_onboarded,
             autostart::daemon_version_conflict,

--- a/apps/yerd-gui/src/components/TitleBar.vue
+++ b/apps/yerd-gui/src/components/TitleBar.vue
@@ -66,6 +66,7 @@ function toggleMaximize() {
 // existed before - Tauri's window API is queried directly (mirrors how
 // `lib/theme.ts` layers `onThemeChanged` on top of an initial read).
 const focused = ref(true);
+let disposed = false;
 let unlistenFocus: (() => void) | null = null;
 onMounted(() => {
   win.isFocused()
@@ -73,10 +74,22 @@ onMounted(() => {
     .catch(() => {});
   win
     .onFocusChanged(({ payload }) => (focused.value = payload))
-    .then((unlisten) => (unlistenFocus = unlisten))
+    .then((unlisten) => {
+      // The component may have unmounted while this registration was still in
+      // flight (e.g. the Welcome route swapping out for AppShell's titlebar) -
+      // in that case there's no later onUnmounted to call it, so do it now.
+      if (disposed) {
+        unlisten();
+      } else {
+        unlistenFocus = unlisten;
+      }
+    })
     .catch(() => {});
 });
-onUnmounted(() => unlistenFocus?.());
+onUnmounted(() => {
+  disposed = true;
+  unlistenFocus?.();
+});
 
 // Linux/Linux-Reversed/Windows controls, data-driven so the three styles share
 // one button template instead of triplicating the markup.

--- a/apps/yerd-gui/src/components/TitleBar.vue
+++ b/apps/yerd-gui/src/components/TitleBar.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { Minus, Plus, Square, X } from "lucide-vue-next";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { hostPlatform } from "@/ipc/client";
+import { useTitleBarStyle } from "@/lib/titleBarStyle";
 
 // The window is decorationless (see tauri.conf.json) so we draw our own
 // titlebar. It's a `data-tauri-drag-region`, giving native click-drag-to-move
 // and double-click-to-zoom for free; the controls below opt out by being their
 // own (non-drag) elements.
-//
-// Controls follow the host OS convention: macOS draws traffic lights on the
-// left; Linux (Pantheon/GNOME style) puts a close button on the left and
-// minimize/maximize at the far right.
 //
 // `title` lets a secondary window (the Mails viewer) reuse this bar with its own
 // caption; the optional `actions` slot draws window-scoped buttons on the right
@@ -29,15 +26,24 @@ function guessPlatform(): string {
   return "macos"; // default also covers macOS ("Macintosh")
 }
 const platform = ref(guessPlatform());
-// macOS gets traffic lights; every other host gets the left-close / right-min-max
-// layout. Keyed off `isMac` (not an `isLinux` allowlist) so an unclassified host
-// still renders working controls.
-const isMac = computed(() => platform.value === "macos");
 onMounted(() => {
   hostPlatform()
     .then((p) => (platform.value = p))
     .catch(() => {});
 });
+
+// "Automatic" resolves from the host platform; any other preference forces
+// that style regardless of host. Unclassified hosts keep today's fallback
+// (the left-close / right-min-max layout) so a control set always works.
+const { style: stylePref } = useTitleBarStyle();
+function platformToStyle(p: string): "macos" | "linux" | "windows" {
+  if (p === "macos") return "macos";
+  if (p === "windows") return "windows";
+  return "linux";
+}
+const resolved = computed(() =>
+  stylePref.value === "auto" ? platformToStyle(platform.value) : stylePref.value,
+);
 
 // Controls always target the window this titlebar is mounted in, so the one
 // component drives both the main window and the Mails window.
@@ -54,6 +60,68 @@ function minimize() {
 function toggleMaximize() {
   win.toggleMaximize();
 }
+
+// macOS-only: real traffic lights drop to a flat gray while the window is
+// unfocused, regaining color only once it's active again. No such tracking
+// existed before - Tauri's window API is queried directly (mirrors how
+// `lib/theme.ts` layers `onThemeChanged` on top of an initial read).
+const focused = ref(true);
+let unlistenFocus: (() => void) | null = null;
+onMounted(() => {
+  win.isFocused()
+    .then((f) => (focused.value = f))
+    .catch(() => {});
+  win
+    .onFocusChanged(({ payload }) => (focused.value = payload))
+    .then((unlisten) => (unlistenFocus = unlisten))
+    .catch(() => {});
+});
+onUnmounted(() => unlistenFocus?.());
+
+// Linux/Linux-Reversed/Windows controls, data-driven so the three styles share
+// one button template instead of triplicating the markup.
+type ControlKind = "close" | "minimize" | "maximize";
+
+const leftControls = computed<ControlKind[]>(() => {
+  if (resolved.value === "linux") return ["close"];
+  if (resolved.value === "linux-reversed") return ["minimize", "maximize"];
+  return [];
+});
+const rightControls = computed<ControlKind[]>(() => {
+  if (resolved.value === "linux") return ["minimize", "maximize"];
+  if (resolved.value === "linux-reversed") return ["close"];
+  if (resolved.value === "windows") return ["minimize", "maximize", "close"];
+  return [];
+});
+
+function controlLabel(kind: ControlKind): string {
+  if (kind === "close") return "Close";
+  if (kind === "minimize") return "Minimize";
+  return "Maximize";
+}
+function controlIcon(kind: ControlKind) {
+  if (kind === "close") return X;
+  if (kind === "minimize") return Minus;
+  return Square;
+}
+function controlIconClass(kind: ControlKind): string {
+  return kind === "maximize" ? "size-3.5" : "size-4";
+}
+function controlAction(kind: ControlKind): () => void {
+  if (kind === "close") return close;
+  if (kind === "minimize") return minimize;
+  return toggleMaximize;
+}
+// Windows convention: the close button gets a distinct red hover; the other
+// two share the neutral hover already used for Linux controls.
+function controlButtonClass(kind: ControlKind): string {
+  const base =
+    "flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors";
+  if (resolved.value === "windows" && kind === "close") {
+    return `${base} hover:bg-red-600 hover:text-white`;
+  }
+  return `${base} hover:bg-black/10 dark:hover:bg-white/10`;
+}
 </script>
 
 <template>
@@ -62,12 +130,14 @@ function toggleMaximize() {
     class="relative flex h-8 shrink-0 items-center border-b bg-muted px-3 text-foreground dark:bg-card"
     @dblclick="toggleMaximize"
   >
-    <!-- macOS: traffic lights (close / minimize / zoom), glyphs revealed on hover. -->
-    <div v-if="isMac" class="group flex items-center gap-2">
+    <!-- macOS: traffic lights (close / minimize / zoom). Colored while the
+         window is focused, flat gray otherwise; glyphs revealed on hover. -->
+    <div v-if="resolved === 'macos'" class="group flex items-center gap-2">
       <button
         type="button"
         aria-label="Close"
-        class="flex size-3 items-center justify-center rounded-full bg-[#ff5f57] text-black/60 transition-colors hover:bg-[#ff5f57]"
+        class="flex size-3 items-center justify-center rounded-full text-black/60 transition-colors"
+        :class="focused ? 'bg-[#ff5f57]' : 'bg-[#d3d3d3] dark:bg-[#4a4a4c]'"
         @click="close"
       >
         <X class="size-2 opacity-0 group-hover:opacity-100" stroke-width="3" />
@@ -75,7 +145,8 @@ function toggleMaximize() {
       <button
         type="button"
         aria-label="Minimize"
-        class="flex size-3 items-center justify-center rounded-full bg-[#febc2e] text-black/60 transition-colors"
+        class="flex size-3 items-center justify-center rounded-full text-black/60 transition-colors"
+        :class="focused ? 'bg-[#febc2e]' : 'bg-[#d3d3d3] dark:bg-[#4a4a4c]'"
         @click="minimize"
       >
         <Minus class="size-2 opacity-0 group-hover:opacity-100" stroke-width="3" />
@@ -83,25 +154,29 @@ function toggleMaximize() {
       <button
         type="button"
         aria-label="Zoom"
-        class="flex size-3 items-center justify-center rounded-full bg-[#28c840] text-black/60 transition-colors"
+        class="flex size-3 items-center justify-center rounded-full text-black/60 transition-colors"
+        :class="focused ? 'bg-[#28c840]' : 'bg-[#d3d3d3] dark:bg-[#4a4a4c]'"
         @click="toggleMaximize"
       >
         <Plus class="size-2 opacity-0 group-hover:opacity-100" stroke-width="3" />
       </button>
     </div>
 
-    <!-- Non-macOS (Linux/Pantheon convention, and any other host): close on the
-         left. `v-else` rather than `v-else-if="isLinux"` so a host that isn't
-         classified still gets a working close button. -->
-    <button
-      v-else
-      type="button"
-      aria-label="Close"
-      class="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-black/10 dark:hover:bg-white/10"
-      @click="close"
-    >
-      <X class="size-4" />
-    </button>
+    <!-- Linux: close on the left. Linux (Reversed): minimize/maximize on the
+         left instead. Windows: nothing on the left - its controls all sit at
+         the far right. -->
+    <div v-else-if="leftControls.length" class="flex items-center gap-1">
+      <button
+        v-for="kind in leftControls"
+        :key="kind"
+        type="button"
+        :aria-label="controlLabel(kind)"
+        :class="controlButtonClass(kind)"
+        @click="controlAction(kind)"
+      >
+        <component :is="controlIcon(kind)" :class="controlIconClass(kind)" />
+      </button>
+    </div>
 
     <!-- Centered window title (native feel); pointer-events stay with the drag region. -->
     <span
@@ -111,27 +186,20 @@ function toggleMaximize() {
     </span>
 
     <!-- Window-scoped actions (e.g. the Mails "clear all" button), right-aligned;
-         on Linux the minimize/maximize controls sit at the far right edge. -->
+         Linux's minimize/maximize, Linux (Reversed)'s close, and all of
+         Windows' controls sit at the far right edge. -->
     <div class="ml-auto flex items-center gap-1">
       <slot name="actions" />
-      <template v-if="!isMac">
-        <button
-          type="button"
-          aria-label="Minimize"
-          class="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-black/10 dark:hover:bg-white/10"
-          @click="minimize"
-        >
-          <Minus class="size-4" />
-        </button>
-        <button
-          type="button"
-          aria-label="Maximize"
-          class="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-black/10 dark:hover:bg-white/10"
-          @click="toggleMaximize"
-        >
-          <Square class="size-3.5" />
-        </button>
-      </template>
+      <button
+        v-for="kind in rightControls"
+        :key="kind"
+        type="button"
+        :aria-label="controlLabel(kind)"
+        :class="controlButtonClass(kind)"
+        @click="controlAction(kind)"
+      >
+        <component :is="controlIcon(kind)" :class="controlIconClass(kind)" />
+      </button>
     </div>
   </header>
 </template>

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -36,6 +36,7 @@ import type {
   Site,
   NamedTunnelsResponse,
   StatusReport,
+  TitleBarStyle,
   ToolStatus,
   TrayIconVariant,
   TunnelsResponse,
@@ -791,6 +792,14 @@ export async function getTrayIconVariant(): Promise<TrayIconVariant> {
 
 export async function setTrayIconVariant(variant: TrayIconVariant): Promise<void> {
   await call<void>("set_tray_icon_variant", { variant });
+}
+
+export async function getTitleBarStyle(): Promise<TitleBarStyle> {
+  return call<TitleBarStyle>("get_title_bar_style");
+}
+
+export async function setTitleBarStyle(style: TitleBarStyle): Promise<void> {
+  await call<void>("set_title_bar_style", { style });
 }
 
 // ── onboarding / first-run ───────────────────────────────────────────────────

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -596,6 +596,14 @@ export interface AutostartState {
 export type TrayIconVariant = "auto" | "light-y" | "dark-y" | "full";
 
 /**
+ * Title bar control style (host commands `get_title_bar_style` /
+ * `set_title_bar_style`). `"auto"` (default) matches the host OS convention,
+ * resolved client-side from `host_platform`. Drawn entirely by the frontend -
+ * the Rust side only persists the preference.
+ */
+export type TitleBarStyle = "auto" | "macos" | "linux" | "linux-reversed" | "windows";
+
+/**
  * Why the daemon isn't up (host command `daemon_diagnostics`). Gathered when a
  * start attempt fails to connect - covers both the ran-and-crashed case
  * (`logTail`) and the never-launched cases (`startError`, `translocated`,

--- a/apps/yerd-gui/src/lib/titleBarStyle.ts
+++ b/apps/yerd-gui/src/lib/titleBarStyle.ts
@@ -24,22 +24,31 @@ const TITLE_BAR_STYLE_EVENT = "yerd:title-bar-style-changed";
 /** The user's preference (reactive, persisted host-side). */
 const style = ref<TitleBarStyle>("auto");
 
+/** Bumped on every `setTitleBarStyle` call; lets a call tell whether a *newer*
+ *  one has since taken over, so two overlapping calls (the user changing the
+ *  selector again before the first IPC round-trip lands) can't have the
+ *  older one's rollback or broadcast clobber the newer one's result. */
+let latestCall = 0;
+
 /** Set + persist the preference, then broadcast to the app's other windows
  *  (mails/dumps) so they switch in lockstep. Optimistic: the ref updates
  *  immediately, but a failed IPC call rolls it back and does NOT broadcast -
  *  other windows must never see a value that wasn't actually persisted. */
 export async function setTitleBarStyle(next: TitleBarStyle): Promise<void> {
+  const call = ++latestCall;
   const previous = style.value;
   style.value = next;
   try {
     await ipcSetTitleBarStyle(next);
   } catch (e) {
-    style.value = previous;
+    if (call === latestCall) style.value = previous;
     throw e;
   }
-  void emit(TITLE_BAR_STYLE_EVENT, next).catch(() => {
-    // Not in Tauri (unit/dev) - nothing to broadcast.
-  });
+  if (call === latestCall) {
+    void emit(TITLE_BAR_STYLE_EVENT, next).catch(() => {
+      // Not in Tauri (unit/dev) - nothing to broadcast.
+    });
+  }
 }
 
 /** Reactive accessor for views/components (the General tab's selector and
@@ -51,17 +60,25 @@ export function useTitleBarStyle() {
 /** Load the persisted preference and wire up cross-window sync. Call once at
  *  boot, alongside `initTheme()`. */
 export function initTitleBarStyle(): void {
-  void getTitleBarStyle()
-    .then((s) => {
-      style.value = s;
-    })
-    .catch(() => {
-      // Keep the "auto" default if the host call fails.
-    });
+  // The initial fetch and the broadcast subscription are two independent
+  // round-trips with no ordering guarantee - if another window changes the
+  // preference while this fetch is still in flight, its broadcast could
+  // otherwise arrive first and then be clobbered by the now-stale fetch
+  // result. Once any broadcast has been seen, the fetch no longer applies.
+  let sawBroadcast = false;
 
   void listen<TitleBarStyle>(TITLE_BAR_STYLE_EVENT, ({ payload }) => {
+    sawBroadcast = true;
     style.value = payload;
   }).catch(() => {
     // Not in Tauri - single context, nothing to sync.
   });
+
+  void getTitleBarStyle()
+    .then((s) => {
+      if (!sawBroadcast) style.value = s;
+    })
+    .catch(() => {
+      // Keep the "auto" default if the host call fails.
+    });
 }

--- a/apps/yerd-gui/src/lib/titleBarStyle.ts
+++ b/apps/yerd-gui/src/lib/titleBarStyle.ts
@@ -1,0 +1,67 @@
+/**
+ * Title bar style store: a reactive user preference, persisted host-side
+ * (`gui-settings.json` via the `get_title_bar_style`/`set_title_bar_style`
+ * commands - mirrors the tray icon variant setting) and broadcast live to
+ * every open window.
+ *
+ * Unlike the theme preference (`lib/theme.ts`, `localStorage`), the source of
+ * truth here is the host settings file, since we mirror the tray-icon storage
+ * model. But the title bar - unlike the tray icon - is drawn once per window
+ * (main/mails/dumps), so a change still needs the same cross-window broadcast
+ * `theme.ts` uses: each webview is a separate JS context, so one window's
+ * change is invisible to the others without it.
+ */
+import { emit, listen } from "@tauri-apps/api/event";
+import { ref } from "vue";
+
+import { getTitleBarStyle, setTitleBarStyle as ipcSetTitleBarStyle } from "@/ipc/client";
+import type { TitleBarStyle } from "@/ipc/types";
+
+/** Cross-window broadcast: each webview (main, mails, dumps) is a separate JS
+ *  context + DOM, so a change in one is published to the others. */
+const TITLE_BAR_STYLE_EVENT = "yerd:title-bar-style-changed";
+
+/** The user's preference (reactive, persisted host-side). */
+const style = ref<TitleBarStyle>("auto");
+
+/** Set + persist the preference, then broadcast to the app's other windows
+ *  (mails/dumps) so they switch in lockstep. Optimistic: the ref updates
+ *  immediately, but a failed IPC call rolls it back and does NOT broadcast -
+ *  other windows must never see a value that wasn't actually persisted. */
+export async function setTitleBarStyle(next: TitleBarStyle): Promise<void> {
+  const previous = style.value;
+  style.value = next;
+  try {
+    await ipcSetTitleBarStyle(next);
+  } catch (e) {
+    style.value = previous;
+    throw e;
+  }
+  void emit(TITLE_BAR_STYLE_EVENT, next).catch(() => {
+    // Not in Tauri (unit/dev) - nothing to broadcast.
+  });
+}
+
+/** Reactive accessor for views/components (the General tab's selector and
+ *  `TitleBar.vue` itself). */
+export function useTitleBarStyle() {
+  return { style, setTitleBarStyle };
+}
+
+/** Load the persisted preference and wire up cross-window sync. Call once at
+ *  boot, alongside `initTheme()`. */
+export function initTitleBarStyle(): void {
+  void getTitleBarStyle()
+    .then((s) => {
+      style.value = s;
+    })
+    .catch(() => {
+      // Keep the "auto" default if the host call fails.
+    });
+
+  void listen<TitleBarStyle>(TITLE_BAR_STYLE_EVENT, ({ payload }) => {
+    style.value = payload;
+  }).catch(() => {
+    // Not in Tauri - single context, nothing to sync.
+  });
+}

--- a/apps/yerd-gui/src/main.ts
+++ b/apps/yerd-gui/src/main.ts
@@ -5,10 +5,12 @@ import { router } from "./router";
 import { initDesktopChrome } from "./lib/desktop";
 import { log } from "./lib/log";
 import { initTheme } from "./lib/theme";
+import { initTitleBarStyle } from "./lib/titleBarStyle";
 import "./style.css";
 
 // Follow the OS light/dark preference, and behave like a native window.
 initTheme();
+initTitleBarStyle();
 initDesktopChrome();
 
 // Funnel uncaught frontend errors into the GUI session log so they show up in

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -32,12 +32,14 @@ import {
   setAutostartGuiMinimized,
   setTrayIconVariant,
 } from "@/ipc/client";
-import type { AutostartState, CliPathStatus, TrayIconVariant } from "@/ipc/types";
+import type { AutostartState, CliPathStatus, TitleBarStyle, TrayIconVariant } from "@/ipc/types";
 import { useTheme, type ThemePref } from "@/lib/theme";
+import { useTitleBarStyle } from "@/lib/titleBarStyle";
 
 const { connected, report, refresh: refreshStatus } = useDaemon();
 const toast = useToast();
 const { pref, setTheme } = useTheme();
+const { style: titleBarStyle, setTitleBarStyle } = useTitleBarStyle();
 
 const busy = ref<string | null>(null);
 const autostart = ref<AutostartState | null>(null);
@@ -60,6 +62,22 @@ const trayIconOptions = [
   { value: "dark-y", label: "Dark Y" },
   { value: "full", label: "Full icon" },
 ] as const;
+
+const titleBarStyleOptions = [
+  { value: "auto", label: "Automatic" },
+  { value: "macos", label: "macOS" },
+  { value: "linux", label: "Linux" },
+  { value: "linux-reversed", label: "Linux (Reversed)" },
+  { value: "windows", label: "Windows" },
+] as const;
+
+async function setTitleBarStylePref(next: TitleBarStyle): Promise<void> {
+  try {
+    await setTitleBarStyle(next);
+  } catch (e) {
+    toast.error("Couldn't change the title bar style", (e as IpcError).message);
+  }
+}
 
 const running = computed(() => connected.value === true);
 
@@ -631,6 +649,21 @@ async function toggleGuiMinimized(on: boolean): Promise<void> {
               :options="trayIconOptions"
               aria-label="Tray icon"
               @update:model-value="setTrayIconVariantPref"
+            />
+          </div>
+
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="text-sm font-medium">Title bar</p>
+              <p class="text-xs text-muted-foreground">
+                Window control style used by the Yerd app.
+              </p>
+            </div>
+            <Select
+              :model-value="titleBarStyle"
+              :options="titleBarStyleOptions"
+              aria-label="Title bar"
+              @update:model-value="setTitleBarStylePref"
             />
           </div>
         </CardContent>


### PR DESCRIPTION
## What does this PR do?

Adds the ability to select one of 4 title bars the the application, which will auto-detect unless otherwise set. 

## Related issues

n/a

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Appearance setting to choose the app’s title bar style (Auto, macOS, Linux, Linux reversed, Windows).
  * Title bar controls are now driven by the selected style and resolve the control layout accordingly.
* **Bug Fixes**
  * Title bar style is now persisted in settings and restored on launch.
  * Title bar style changes sync reliably across open windows.
  * macOS-style traffic light button colors now respond to window focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->