### PR TITLE
[Feat] Detect cloudflared on PATH

### DIFF
--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -524,11 +524,16 @@ export interface TunnelInfo {
   hostname?: string;
 }
 
+/** crates/yerd-ipc/src/status.rs - CloudflaredSource. */
+export type CloudflaredSource = "managed" | "system";
+
 /** crates/yerd-ipc/src/status.rs - CloudflaredStatus. */
 export interface CloudflaredStatus {
   installed: boolean;
   /** Installed cloudflared version when known; absent otherwise. */
   version?: string;
+  /** Where the installed binary came from; absent when not installed. */
+  source?: CloudflaredSource;
   /** Whether a Cloudflare account is logged in (Phase 2). */
   logged_in: boolean;
 }

--- a/apps/yerd-gui/src/views/IntegrationsView.vue
+++ b/apps/yerd-gui/src/views/IntegrationsView.vue
@@ -61,6 +61,9 @@ const busy = ref<string | null>(null);
 
 const installed = computed(() => cloudflared.value?.installed ?? false);
 const loggedIn = computed(() => cloudflared.value?.logged_in ?? false);
+// Whether the active cloudflared came from the user's PATH rather than
+// Yerd's own managed download - offers a way to switch to the bundled copy.
+const isSystemCloudflared = computed(() => cloudflared.value?.source === "system");
 
 // Named tunnels (Phase 2). One consolidated tunnel exposes every enabled site.
 const namedTunnels = ref<NamedTunnelMeta[]>([]);
@@ -476,6 +479,7 @@ onUnmounted(registerViewActions({ refresh: () => void reload() }));
               <Badge v-if="installed" variant="secondary" class="gap-1">
                 <CheckCircle2 class="size-3 text-emerald-500" />
                 cloudflared {{ cloudflared?.version ?? "ready" }}
+                <span v-if="isSystemCloudflared" class="text-muted-foreground">(system)</span>
               </Badge>
               <span v-else class="text-muted-foreground">
                 Sharing needs <span class="font-medium text-foreground">cloudflared</span>,
@@ -488,6 +492,15 @@ onUnmounted(registerViewActions({ refresh: () => void reload() }));
               @click="doInstall"
             >
               <Download class="mr-1.5 size-3.5" /> Install cloudflared
+            </Button>
+            <Button
+              v-else-if="isSystemCloudflared"
+              variant="outline"
+              size="sm"
+              :disabled="busy !== null || connected !== true"
+              @click="doInstall"
+            >
+              <Download class="mr-1.5 size-3.5" /> Use Yerd's bundled version instead
             </Button>
           </div>
         </CardContent>

--- a/bin/yerdd/src/create_site.rs
+++ b/bin/yerdd/src/create_site.rs
@@ -740,6 +740,7 @@ mod tests {
             tunnel_manager: std::sync::Arc::new(tokio::sync::Mutex::new(
                 crate::tunnel::new_manager(),
             )),
+            cloudflared_resolution: tokio::sync::RwLock::new(None),
             tool_mutate: tokio::sync::Mutex::new(()),
             tunnel_mutate: tokio::sync::Mutex::new(()),
             php_mutate: tokio::sync::Mutex::new(()),

--- a/bin/yerdd/src/db_admin.rs
+++ b/bin/yerdd/src/db_admin.rs
@@ -467,6 +467,7 @@ mod tests {
             tunnel_manager: std::sync::Arc::new(tokio::sync::Mutex::new(
                 crate::tunnel::new_manager(),
             )),
+            cloudflared_resolution: tokio::sync::RwLock::new(None),
             tool_mutate: tokio::sync::Mutex::new(()),
             tunnel_mutate: tokio::sync::Mutex::new(()),
             php_mutate: tokio::sync::Mutex::new(()),

--- a/bin/yerdd/src/dump_server.rs
+++ b/bin/yerdd/src/dump_server.rs
@@ -873,6 +873,7 @@ mod tests {
             tunnel_manager: std::sync::Arc::new(tokio::sync::Mutex::new(
                 crate::tunnel::new_manager(),
             )),
+            cloudflared_resolution: tokio::sync::RwLock::new(None),
             tool_mutate: tokio::sync::Mutex::new(()),
             tunnel_mutate: tokio::sync::Mutex::new(()),
             php_mutate: tokio::sync::Mutex::new(()),

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1908,6 +1908,7 @@ mod tests {
             tunnel_manager: std::sync::Arc::new(tokio::sync::Mutex::new(
                 crate::tunnel::new_manager(),
             )),
+            cloudflared_resolution: tokio::sync::RwLock::new(None),
             tool_mutate: tokio::sync::Mutex::new(()),
             tunnel_mutate: tokio::sync::Mutex::new(()),
             php_mutate: tokio::sync::Mutex::new(()),

--- a/bin/yerdd/src/services.rs
+++ b/bin/yerdd/src/services.rs
@@ -635,6 +635,7 @@ mod tests {
             tunnel_manager: std::sync::Arc::new(tokio::sync::Mutex::new(
                 crate::tunnel::new_manager(),
             )),
+            cloudflared_resolution: tokio::sync::RwLock::new(None),
             tool_mutate: tokio::sync::Mutex::new(()),
             tunnel_mutate: tokio::sync::Mutex::new(()),
             php_mutate: tokio::sync::Mutex::new(()),

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -280,6 +280,7 @@ pub async fn bring_up_with_dirs(
         php_manager: php_manager.clone(),
         service_manager,
         tunnel_manager,
+        cloudflared_resolution: tokio::sync::RwLock::new(None),
         mail_store,
         mail: crate::state::MailRuntime {
             listening: mail_listening,

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -84,6 +84,11 @@ pub struct DaemonState {
     /// child per shared site; `TunnelStatus` reads live state from it. Quick
     /// tunnels are ephemeral (not persisted) and torn down on daemon shutdown.
     pub tunnel_manager: Arc<Mutex<crate::tunnel::DaemonTunnelManager>>,
+    /// Cache of which `cloudflared` binary to use (Yerd-managed or a
+    /// `PATH`-found system install) and its version, so the `--version` probe
+    /// of a system binary runs once rather than on every tunnel action or
+    /// status poll. See `tunnel::resolved_cloudflared`.
+    pub cloudflared_resolution: RwLock<Option<crate::tunnel::install::Resolved>>,
     /// Captured-mail store (the built-in SMTP sink writes here; IPC reads/clears
     /// it). Always present even when capture is disabled, so stored mail remains
     /// listable/clearable after the server is turned off.

--- a/bin/yerdd/src/tunnel/install.rs
+++ b/bin/yerdd/src/tunnel/install.rs
@@ -17,7 +17,10 @@
 //! the fetch to an attacker-controlled origin.
 
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
 
+use async_trait::async_trait;
 use serde::Deserialize;
 use yerd_php::{current_os_arch, Arch, Downloader, Os};
 use yerd_platform::PlatformDirs;
@@ -137,6 +140,159 @@ pub fn installed_version(dirs: &PlatformDirs) -> Option<String> {
     let v = std::fs::read_to_string(version_marker(dirs)).ok()?;
     let v = v.trim().to_owned();
     (!v.is_empty()).then_some(v)
+}
+
+/// Where the `cloudflared` binary Yerd is using came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloudflaredSource {
+    /// Downloaded and verified by Yerd into `{data}/tunnel/bin/cloudflared`.
+    Managed,
+    /// A pre-existing binary found on `PATH` that passed the minimum-version
+    /// check.
+    System,
+}
+
+/// The `cloudflared` binary Yerd will use, and where it came from.
+#[derive(Debug, Clone)]
+pub struct Resolved {
+    /// Path to the binary to spawn.
+    pub binary: PathBuf,
+    /// Where `binary` came from.
+    pub source: CloudflaredSource,
+    /// Its reported version, when known.
+    pub version: Option<String>,
+}
+
+/// Bound on the `cloudflared --version` probe used to validate a `PATH`
+/// candidate.
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Runs `<binary> --version` and returns its captured output, or `None` on
+/// spawn failure/timeout/non-zero exit. Behind a trait purely so `resolve()`'s
+/// parsing and version-gate logic is unit-testable without a real subprocess.
+#[async_trait]
+pub trait VersionProbe: Send + Sync + 'static {
+    /// Probe `binary`'s reported `--version` output, or `None` if it couldn't
+    /// be run to completion.
+    async fn probe(&self, binary: &Path) -> Option<String>;
+}
+
+/// The real `cloudflared --version` probe.
+pub struct RealVersionProbe;
+
+#[async_trait]
+impl VersionProbe for RealVersionProbe {
+    async fn probe(&self, binary: &Path) -> Option<String> {
+        let mut cmd = tokio::process::Command::new(binary);
+        cmd.arg("--version").stdin(Stdio::null()).kill_on_drop(true);
+        let out = tokio::time::timeout(VERSION_PROBE_TIMEOUT, cmd.output())
+            .await
+            .ok()?
+            .ok()?;
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+}
+
+/// Locates a `cloudflared` candidate on the host. Behind a trait (like
+/// [`VersionProbe`]) purely so `resolve()`'s System-adoption branch is
+/// unit-testable end-to-end without mutating the process's real `PATH`
+/// (parallel test execution would make that flaky).
+pub trait PathSearch: Send + Sync + 'static {
+    /// Find an executable named `cloudflared` on the host, or `None`.
+    fn find_cloudflared(&self) -> Option<PathBuf>;
+}
+
+/// The real `PATH` search.
+pub struct RealPathSearch;
+
+impl PathSearch for RealPathSearch {
+    fn find_cloudflared(&self) -> Option<PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        find_in_paths(&path)
+    }
+}
+
+/// The `PATH`-search logic, taking the `PATH` value directly so it's testable
+/// without mutating the process environment.
+fn find_in_paths(path_var: &std::ffi::OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path_var).find_map(|dir| {
+        let candidate = dir.join("cloudflared");
+        is_executable(&candidate).then_some(candidate)
+    })
+}
+
+/// Whether `path` is a regular, executable file. `pub(crate)` so
+/// `tunnel::resolved_cloudflared` can re-check a cached `System` binary is
+/// still there without re-running the `--version` probe.
+#[cfg(unix)]
+pub(crate) fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// Well past when all of `--no-autoupdate`/`--origincert`/`--http-host-header`/
+/// `--origin-server-name`/`--no-tls-verify`/`--credentials-file`/
+/// `--overwrite-dns` were stable in `cloudflared`, so any release at or above
+/// this floor is assumed to support every flag Yerd depends on.
+const MIN_SYSTEM_VERSION: (u32, u32, u32) = (2023, 3, 0);
+
+/// Parse the `YYYY.MM.N` version token out of `cloudflared --version` output
+/// (e.g. `cloudflared version 2024.6.1 (built 2024-06-11-1622 UTC)`),
+/// ignoring surrounding text. Returns `None` for unparseable/non-official
+/// builds so the caller falls back to the managed download rather than
+/// trusting a build it can't reason about.
+fn parse_cloudflared_version(text: &str) -> Option<(String, (u32, u32, u32))> {
+    text.split_whitespace().find_map(|tok| {
+        let mut parts = tok.split('.');
+        let year = parts.next()?.parse::<u32>().ok()?;
+        let month = parts.next()?.parse::<u32>().ok()?;
+        let patch = parts.next()?.parse::<u32>().ok()?;
+        if parts.next().is_some() || !(1900..=9999).contains(&year) {
+            return None;
+        }
+        Some((tok.to_owned(), (year, month, patch)))
+    })
+}
+
+/// Resolve which `cloudflared` binary Yerd should use: the managed copy if one
+/// is installed, otherwise a `PATH`-found binary that passes the
+/// minimum-version gate, otherwise `None` (nothing usable is available).
+///
+/// Uncached and directly unit-testable (both the `PATH` search and the
+/// version probe are injected); `resolved_cloudflared` in `tunnel::mod` is the
+/// cache-aware entry point call sites use, backed by [`RealPathSearch`] and
+/// [`RealVersionProbe`].
+pub async fn resolve<P: VersionProbe, S: PathSearch>(
+    dirs: &PlatformDirs,
+    probe: &P,
+    path_search: &S,
+) -> Option<Resolved> {
+    if is_installed(dirs) {
+        return Some(Resolved {
+            binary: binary_path(dirs),
+            source: CloudflaredSource::Managed,
+            version: installed_version(dirs),
+        });
+    }
+
+    let candidate = path_search.find_cloudflared()?;
+    let raw_version = probe.probe(&candidate).await?;
+    let (version, parsed) = parse_cloudflared_version(&raw_version)?;
+    if parsed < MIN_SYSTEM_VERSION {
+        return None;
+    }
+    Some(Resolved {
+        binary: candidate,
+        source: CloudflaredSource::System,
+        version: Some(version),
+    })
 }
 
 /// The `(asset_filename, is_tgz)` for the host.
@@ -334,6 +490,15 @@ fn set_executable(_path: &Path) -> Result<(), CloudflaredInstallError> {
     Ok(())
 }
 
+/// Test-only helper exposing `install_binary` to sibling test modules (e.g.
+/// `tunnel::mod`'s cache tests), which can't reach this module's own private
+/// `#[cfg(test)] mod tests`.
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+pub(crate) fn install_binary_for_test(dirs: &PlatformDirs, version: &str, bytes: &[u8]) {
+    install_binary(dirs, version, bytes).unwrap();
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic, clippy::indexing_slicing)]
 mod tests {
@@ -447,5 +612,202 @@ mod tests {
         }
         let out = extract_cloudflared_from_tgz(&gz).unwrap();
         assert_eq!(out, b"ELF-ish cloudflared bytes");
+    }
+
+    struct FakeVersionProbe(Option<&'static str>);
+
+    #[async_trait]
+    impl VersionProbe for FakeVersionProbe {
+        async fn probe(&self, _binary: &Path) -> Option<String> {
+            self.0.map(str::to_owned)
+        }
+    }
+
+    #[test]
+    fn parse_cloudflared_version_extracts_token_ignoring_surrounding_text() {
+        assert_eq!(
+            parse_cloudflared_version("cloudflared version 2024.6.1 (built 2024-06-11-1622 UTC)"),
+            Some(("2024.6.1".to_owned(), (2024, 6, 1)))
+        );
+        assert_eq!(
+            parse_cloudflared_version("cloudflared version DEV (built dev)"),
+            None
+        );
+        assert_eq!(parse_cloudflared_version(""), None);
+        assert_eq!(
+            parse_cloudflared_version("cloudflared version 2024.6.1.7"),
+            None,
+            "four dotted components should not parse as a date-style version"
+        );
+    }
+
+    #[test]
+    fn minimum_version_gate_is_inclusive_at_the_floor() {
+        assert!(MIN_SYSTEM_VERSION <= (2023, 3, 0));
+        assert!((2023, 3, 0) >= MIN_SYSTEM_VERSION);
+        assert!((2023, 2, 99) < MIN_SYSTEM_VERSION);
+        assert!((2026, 1, 0) >= MIN_SYSTEM_VERSION);
+    }
+
+    #[test]
+    fn find_in_paths_returns_first_executable_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = tmp.path().join("first");
+        let second = tmp.path().join("second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        // Only `second` has a `cloudflared` on it.
+        std::fs::write(second.join("cloudflared"), b"#!/bin/sh\n").unwrap();
+        set_executable(&second.join("cloudflared")).unwrap();
+        let path_var = std::env::join_paths([&first, &second]).unwrap();
+        assert_eq!(find_in_paths(&path_var), Some(second.join("cloudflared")));
+    }
+
+    #[test]
+    fn find_in_paths_ignores_non_executable_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("cloudflared"), b"not executable").unwrap();
+        let path_var = std::env::join_paths([tmp.path()]).unwrap();
+        assert_eq!(find_in_paths(&path_var), None);
+    }
+
+    struct PanicsIfCalled;
+    #[async_trait]
+    impl VersionProbe for PanicsIfCalled {
+        async fn probe(&self, _binary: &Path) -> Option<String> {
+            panic!("managed binary should short-circuit before any probe runs");
+        }
+    }
+
+    impl PathSearch for PanicsIfCalled {
+        fn find_cloudflared(&self) -> Option<PathBuf> {
+            panic!("managed binary should short-circuit before any PATH search runs");
+        }
+    }
+
+    /// A fixed `PATH` candidate, standing in for `RealPathSearch` without
+    /// touching the process's real `PATH` (parallel test execution would make
+    /// that flaky).
+    struct FakePathSearch(Option<PathBuf>);
+
+    impl PathSearch for FakePathSearch {
+        fn find_cloudflared(&self) -> Option<PathBuf> {
+            self.0.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_prefers_managed_over_system_without_probing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        install_binary(&dirs, "2026.6.1", b"#!/bin/sh\n").unwrap();
+
+        let resolved = resolve(&dirs, &PanicsIfCalled, &PanicsIfCalled)
+            .await
+            .unwrap();
+        assert_eq!(resolved.source, CloudflaredSource::Managed);
+        assert_eq!(resolved.binary, binary_path(&dirs));
+        assert_eq!(resolved.version.as_deref(), Some("2026.6.1"));
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_none_with_no_managed_binary_and_no_path_candidate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let resolved = resolve(
+            &dirs,
+            &FakeVersionProbe(Some("cloudflared version 2024.6.1")),
+            &FakePathSearch(None),
+        )
+        .await;
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_adopts_a_compatible_system_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let candidate = tmp.path().join("cloudflared");
+        std::fs::write(&candidate, b"#!/bin/sh\n").unwrap();
+        set_executable(&candidate).unwrap();
+
+        let resolved = resolve(
+            &dirs,
+            &FakeVersionProbe(Some(
+                "cloudflared version 2024.6.1 (built 2024-06-11-1622 UTC)",
+            )),
+            &FakePathSearch(Some(candidate.clone())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolved.source, CloudflaredSource::System);
+        assert_eq!(resolved.binary, candidate);
+        assert_eq!(resolved.version.as_deref(), Some("2024.6.1"));
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_a_system_binary_below_the_version_floor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let candidate = tmp.path().join("cloudflared");
+        std::fs::write(&candidate, b"#!/bin/sh\n").unwrap();
+        set_executable(&candidate).unwrap();
+
+        let resolved = resolve(
+            &dirs,
+            &FakeVersionProbe(Some("cloudflared version 2021.5.10 (built 2021-05-01 UTC)")),
+            &FakePathSearch(Some(candidate)),
+        )
+        .await;
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_a_system_binary_with_unparseable_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let candidate = tmp.path().join("cloudflared");
+        std::fs::write(&candidate, b"#!/bin/sh\n").unwrap();
+        set_executable(&candidate).unwrap();
+
+        let resolved = resolve(
+            &dirs,
+            &FakeVersionProbe(Some("cloudflared version DEV (built dev)")),
+            &FakePathSearch(Some(candidate)),
+        )
+        .await;
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_a_system_binary_when_the_probe_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let candidate = tmp.path().join("cloudflared");
+        std::fs::write(&candidate, b"#!/bin/sh\n").unwrap();
+        set_executable(&candidate).unwrap();
+
+        // `None` stands in for a spawn failure, timeout, or non-zero exit -
+        // `RealVersionProbe::probe` collapses all three to `None`.
+        let resolved = resolve(
+            &dirs,
+            &FakeVersionProbe(None),
+            &FakePathSearch(Some(candidate)),
+        )
+        .await;
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn version_gate_rejects_below_floor_and_unparseable_output() {
+        let too_old = "cloudflared version 2021.5.10 (built 2021-05-01 UTC)";
+        assert_eq!(
+            parse_cloudflared_version(too_old).map(|(_, v)| v < MIN_SYSTEM_VERSION),
+            Some(true)
+        );
+        assert_eq!(
+            parse_cloudflared_version("cloudflared version DEV (built dev)"),
+            None
+        );
     }
 }

--- a/bin/yerdd/src/tunnel/install.rs
+++ b/bin/yerdd/src/tunnel/install.rs
@@ -199,28 +199,53 @@ impl VersionProbe for RealVersionProbe {
 /// [`VersionProbe`]) purely so `resolve()`'s System-adoption branch is
 /// unit-testable end-to-end without mutating the process's real `PATH`
 /// (parallel test execution would make that flaky).
+#[async_trait]
 pub trait PathSearch: Send + Sync + 'static {
     /// Find an executable named `cloudflared` on the host, or `None`.
-    fn find_cloudflared(&self) -> Option<PathBuf>;
+    async fn find_cloudflared(&self) -> Option<PathBuf>;
 }
 
 /// The real `PATH` search.
+///
+/// `yerdd` is normally launched by a `launchd`/`SMAppService` `LaunchAgent`
+/// (macOS) or a `systemd --user` unit (Linux), neither of which sets an
+/// `Environment`/`EnvironmentVariables` override, so the daemon's own
+/// inherited `PATH` is a stripped service-manager default that omits Homebrew
+/// or other user-level install directories - it only looks complete when
+/// developing under `cargo run` from an interactive shell. So this checks the
+/// daemon's own `PATH` first (cheap, catches that dev/test case and anything
+/// already on the restricted default `PATH`), then falls back to
+/// [`crate::tools::external::resolve_user_path`] - the same
+/// interactive-login-shell resolution `tools::external` already uses to find
+/// Homebrew/fnm/global-Composer installs for the exact same reason.
 pub struct RealPathSearch;
 
+#[async_trait]
 impl PathSearch for RealPathSearch {
-    fn find_cloudflared(&self) -> Option<PathBuf> {
-        let path = std::env::var_os("PATH")?;
-        find_in_paths(&path)
+    async fn find_cloudflared(&self) -> Option<PathBuf> {
+        if let Some(path) = std::env::var_os("PATH") {
+            if let Some(found) = find_in_paths(&path) {
+                return Some(found);
+            }
+        }
+        let user_dirs = crate::tools::external::resolve_user_path().await?;
+        find_in_dirs(user_dirs)
     }
+}
+
+/// Search `dirs` in order for an executable file named `cloudflared`; first
+/// match wins.
+fn find_in_dirs(dirs: impl IntoIterator<Item = PathBuf>) -> Option<PathBuf> {
+    dirs.into_iter().find_map(|dir| {
+        let candidate = dir.join("cloudflared");
+        is_executable(&candidate).then_some(candidate)
+    })
 }
 
 /// The `PATH`-search logic, taking the `PATH` value directly so it's testable
 /// without mutating the process environment.
 fn find_in_paths(path_var: &std::ffi::OsStr) -> Option<PathBuf> {
-    std::env::split_paths(path_var).find_map(|dir| {
-        let candidate = dir.join("cloudflared");
-        is_executable(&candidate).then_some(candidate)
-    })
+    find_in_dirs(std::env::split_paths(path_var))
 }
 
 /// Whether `path` is a regular, executable file. `pub(crate)` so
@@ -282,7 +307,7 @@ pub async fn resolve<P: VersionProbe, S: PathSearch>(
         });
     }
 
-    let candidate = path_search.find_cloudflared()?;
+    let candidate = path_search.find_cloudflared().await?;
     let raw_version = probe.probe(&candidate).await?;
     let (version, parsed) = parse_cloudflared_version(&raw_version)?;
     if parsed < MIN_SYSTEM_VERSION {
@@ -679,8 +704,9 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl PathSearch for PanicsIfCalled {
-        fn find_cloudflared(&self) -> Option<PathBuf> {
+        async fn find_cloudflared(&self) -> Option<PathBuf> {
             panic!("managed binary should short-circuit before any PATH search runs");
         }
     }
@@ -690,8 +716,9 @@ mod tests {
     /// that flaky).
     struct FakePathSearch(Option<PathBuf>);
 
+    #[async_trait]
     impl PathSearch for FakePathSearch {
-        fn find_cloudflared(&self) -> Option<PathBuf> {
+        async fn find_cloudflared(&self) -> Option<PathBuf> {
             self.0.clone()
         }
     }

--- a/bin/yerdd/src/tunnel/mod.rs
+++ b/bin/yerdd/src/tunnel/mod.rs
@@ -45,13 +45,87 @@ pub(super) fn logfile(dirs: &PlatformDirs, site: &str) -> PathBuf {
 }
 
 /// `cloudflared` install + account status for the wire.
-#[must_use]
-pub fn cloudflared_status(dirs: &PlatformDirs) -> CloudflaredStatus {
+pub async fn cloudflared_status(state: &DaemonState) -> CloudflaredStatus {
+    let resolved = resolved_cloudflared(state).await;
     CloudflaredStatus {
-        installed: install::is_installed(dirs),
-        version: install::installed_version(dirs),
-        logged_in: named::is_logged_in(dirs),
+        installed: resolved.is_some(),
+        version: resolved.as_ref().and_then(|r| r.version.clone()),
+        source: resolved.map(|r| source_to_wire(r.source)),
+        logged_in: named::is_logged_in(&state.dirs),
     }
+}
+
+/// Map the daemon-internal source to its wire form.
+fn source_to_wire(source: install::CloudflaredSource) -> yerd_ipc::CloudflaredSource {
+    match source {
+        install::CloudflaredSource::Managed => yerd_ipc::CloudflaredSource::Managed,
+        install::CloudflaredSource::System => yerd_ipc::CloudflaredSource::System,
+    }
+}
+
+/// Resolve which `cloudflared` binary to use, maintaining
+/// `state.cloudflared_resolution` as a cache so a `PATH`-found system
+/// binary's `--version` probe runs at most once per resolution rather than on
+/// every tunnel action or status poll.
+///
+/// A cached `System` entry is re-checked for existence (cheap, no re-spawn)
+/// before use, so a binary removed or replaced out from under a live session
+/// is detected and dropped rather than silently spawned from a dangling path.
+/// A cached `Managed` entry is trusted as-is (it's invalidated explicitly by a
+/// fresh install instead, see `install_cloudflared_streamed`). On a cache
+/// miss this recomputes via `install::resolve` and writes the result back
+/// under a no-downgrade rule: a fresh `Managed` result always overwrites, but
+/// a `System` (or absent) result never overwrites an existing `Managed`
+/// entry, since a concurrent successful install may have raced ahead of a
+/// slow `PATH` probe that started before it committed.
+pub(super) async fn resolved_cloudflared(state: &DaemonState) -> Option<install::Resolved> {
+    if let Some(cached) = cached_cloudflared_if_valid(state).await {
+        return Some(cached);
+    }
+
+    let fresh = install::resolve(
+        &state.dirs,
+        &install::RealVersionProbe,
+        &install::RealPathSearch,
+    )
+    .await;
+
+    let mut guard = state.cloudflared_resolution.write().await;
+    if is_downgrade(guard.as_ref(), fresh.as_ref()) {
+        return guard.clone();
+    }
+    guard.clone_from(&fresh);
+    fresh
+}
+
+/// The cached resolution, if present and (for a `System` entry) still
+/// pointing at an existing executable file.
+async fn cached_cloudflared_if_valid(state: &DaemonState) -> Option<install::Resolved> {
+    let cached = state.cloudflared_resolution.read().await;
+    let resolved = cached.as_ref()?;
+    match resolved.source {
+        install::CloudflaredSource::Managed => Some(resolved.clone()),
+        install::CloudflaredSource::System => {
+            install::is_executable(&resolved.binary).then(|| resolved.clone())
+        }
+    }
+}
+
+/// Whether writing `fresh` over `existing` in the cache would downgrade an
+/// established `Managed` resolution to `System` or to nothing. Pure decision
+/// logic (no locks, no I/O) so it's directly unit-testable; `resolved_cloudflared`
+/// is the only caller, and always calls this under the cache's write lock so
+/// the check and the write it gates are atomic.
+fn is_downgrade(existing: Option<&install::Resolved>, fresh: Option<&install::Resolved>) -> bool {
+    let existing_is_managed = matches!(
+        existing.map(|r| r.source),
+        Some(install::CloudflaredSource::Managed)
+    );
+    let fresh_is_managed = matches!(
+        fresh.map(|r| r.source),
+        Some(install::CloudflaredSource::Managed)
+    );
+    existing_is_managed && !fresh_is_managed
 }
 
 /// `StartQuickTunnel`: publish a site at a random `*.trycloudflare.com` URL.
@@ -61,12 +135,12 @@ pub fn cloudflared_status(dirs: &PlatformDirs) -> CloudflaredStatus {
 /// model) so `StopTunnel`/`TunnelStatus`/shutdown stay responsive and a stuck
 /// connect can be cancelled.
 pub async fn start_quick_tunnel(site: &str, state: &DaemonState) -> Response {
-    if !install::is_installed(&state.dirs) {
+    let Some(resolved) = resolved_cloudflared(state).await else {
         return Response::Error {
             code: ErrorCode::NotFound,
             message: "cloudflared is not installed - install it from Integrations first".into(),
         };
-    }
+    };
 
     let Some((name, secure, tld)) = resolve_site(state, site).await else {
         return Response::Error {
@@ -80,6 +154,7 @@ pub async fn start_quick_tunnel(site: &str, state: &DaemonState) -> Response {
     run_to_ready(
         state,
         &name,
+        resolved.binary,
         args,
         pinned_home_env(state),
         TunnelKind::Quick,
@@ -135,17 +210,19 @@ pub(super) async fn resolve_site(
 
 /// Register + spawn a tunnel for `name` under a brief manager lock, then drive
 /// readiness with the lock released between ticks (see [`yerd_tunnel`]'s tick
-/// model). Shared by the Quick and Named start paths. Returns the live
-/// `Response::Tunnels` on readiness, or a `Response::Error` on failure.
+/// model). Shared by the Quick and Named start paths. `binary` is the
+/// already-resolved `cloudflared` to spawn (see `resolved_cloudflared`).
+/// Returns the live `Response::Tunnels` on readiness, or a `Response::Error`
+/// on failure.
 pub(super) async fn run_to_ready(
     state: &DaemonState,
     name: &str,
+    binary: PathBuf,
     args: Vec<std::ffi::OsString>,
     env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
     kind: TunnelKind,
     hostname: Option<String>,
 ) -> Response {
-    let binary = install::binary_path(&state.dirs);
     let logfile = logfile(&state.dirs, name);
     if let Some(parent) = logfile.parent() {
         if let Err(e) = crate::secure_fs::create_private_dir(parent) {
@@ -250,7 +327,7 @@ pub(super) async fn tunnels_response(state: &DaemonState) -> Response {
     };
     Response::Tunnels {
         tunnels,
-        cloudflared: cloudflared_status(&state.dirs),
+        cloudflared: cloudflared_status(state).await,
     }
 }
 
@@ -269,6 +346,21 @@ fn to_wire(s: TunnelSnapshot) -> TunnelInfo {
         url: s.url,
         hostname: s.hostname,
     }
+}
+
+/// Overwrite the `cloudflared`-resolution cache to the freshly installed
+/// managed binary right after a successful install, so `TunnelStatus` and the
+/// next tunnel action reflect it immediately rather than waiting on a stale
+/// cached `System` entry that hasn't yet failed its existence re-check (see
+/// `resolved_cloudflared`). Writing `Managed` here is never a downgrade, so it
+/// doesn't need the no-downgrade check `resolved_cloudflared` itself applies.
+async fn refresh_cloudflared_cache_after_install(state: &DaemonState) {
+    let resolved = install::Resolved {
+        binary: install::binary_path(&state.dirs),
+        source: install::CloudflaredSource::Managed,
+        version: install::installed_version(&state.dirs),
+    };
+    *state.cloudflared_resolution.write().await = Some(resolved);
 }
 
 /// `InstallCloudflaredStreamed`: download `cloudflared` as a background job,
@@ -313,6 +405,7 @@ pub async fn install_cloudflared_streamed(state: Arc<DaemonState>) -> Response {
 
         match result {
             Some(Ok(())) => {
+                refresh_cloudflared_cache_after_install(&state).await;
                 state
                     .jobs
                     .finish(&id, yerd_ipc::JobState::Succeeded, None)
@@ -333,4 +426,197 @@ pub async fn install_cloudflared_streamed(state: Arc<DaemonState>) -> Response {
         }
     });
     Response::JobStarted { job_id }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    use tokio::sync::{Mutex, RwLock};
+    use yerd_core::{RouterConfig, SiteRouter, Tld};
+
+    use super::*;
+
+    fn dirs_in(tmp: &std::path::Path) -> PlatformDirs {
+        PlatformDirs {
+            config: tmp.join("c"),
+            data: tmp.join("d"),
+            state: tmp.join("s"),
+            cache: tmp.join("ca"),
+            runtime: tmp.join("r"),
+        }
+    }
+
+    /// A `DaemonState` rooted at `tmp` with no engines installed. Copied
+    /// verbatim from the pattern in `db_admin`/`ipc_server`'s test modules
+    /// (each test module needs its own copy since it's private per-module).
+    fn state_in(tmp: &std::path::Path) -> DaemonState {
+        let dirs = dirs_in(tmp);
+        let router = SiteRouter::new(RouterConfig::with_tld(Tld::new("test").unwrap()));
+        let ca_path = dirs.data.join("ca.cert.pem");
+        let php_manager = Arc::new(Mutex::new(yerd_php::PhpManager::new(
+            yerd_php::TokioProcessSpawner,
+            yerd_php::SystemClock,
+            yerd_php::io::FastCgiProbe,
+            dirs.clone(),
+            yerd_platform::ActivePortBinder::new(),
+            std::process::id(),
+            std::collections::BTreeMap::new(),
+        )));
+        DaemonState {
+            config: Mutex::new(yerd_config::Config::default()),
+            router: Arc::new(RwLock::new(router)),
+            config_path: dirs.config.join("yerd.toml"),
+            dirs: dirs.clone(),
+            dns_addr: "127.0.0.1:1053".parse().unwrap(),
+            ca_path,
+            ca_fingerprint: yerd_platform::CaFingerprint::new([0u8; 32]),
+            php_ca_bundle: None,
+            php_updates: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            yerd_update: tokio::sync::RwLock::new(Vec::new()),
+            update_snapshot: tokio::sync::RwLock::new(None),
+            php_manager,
+            service_manager: Arc::new(Mutex::new(crate::services::new_manager(dirs.clone()))),
+            mail_store: Arc::new(yerd_mail::Store::open(tmp.join("mail")).unwrap()),
+            mail: crate::state::MailRuntime { listening: false },
+            http: yerd_ipc::PortStatus {
+                requested: 80,
+                bound: 8080,
+                fell_back: true,
+            },
+            https: yerd_ipc::PortStatus {
+                requested: 443,
+                bound: 8443,
+                fell_back: true,
+            },
+            redirect_https_port: std::sync::Arc::new(std::sync::atomic::AtomicU16::new(8443)),
+            web_unbound: None,
+            dns_unbound: None,
+            boot_id: 1,
+            started_at: std::time::Instant::now(),
+            shutdown_tx: tokio::sync::watch::channel(false).0,
+            restart_requested: AtomicBool::new(false),
+            detect_cache: Arc::new(crate::detect_cache::DetectCache::new()),
+            watch_dirty: tokio::sync::Notify::new(),
+            dumps: Arc::new(crate::dump_server::DumpStore::new()),
+            shim_reconcile: tokio::sync::Mutex::new(()),
+            tunnel_manager: Arc::new(Mutex::new(new_manager())),
+            cloudflared_resolution: tokio::sync::RwLock::new(None),
+            tool_mutate: tokio::sync::Mutex::new(()),
+            tunnel_mutate: tokio::sync::Mutex::new(()),
+            php_mutate: tokio::sync::Mutex::new(()),
+            jobs: crate::jobs::JobRegistry::default(),
+            reserved_names: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolved_cloudflared_reflects_a_fresh_install_without_restart() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+
+        // Nothing installed, and no `cloudflared` on this test's real `PATH`
+        // (near-certain in CI): resolves to `None`.
+        assert!(resolved_cloudflared(&state).await.is_none());
+
+        install::install_binary_for_test(&state.dirs, "2026.6.1", b"#!/bin/sh\n");
+        refresh_cloudflared_cache_after_install(&state).await;
+
+        let resolved = resolved_cloudflared(&state).await.unwrap();
+        assert_eq!(resolved.source, install::CloudflaredSource::Managed);
+        assert_eq!(resolved.version.as_deref(), Some("2026.6.1"));
+    }
+
+    fn managed(version: &str) -> install::Resolved {
+        install::Resolved {
+            binary: PathBuf::from("/managed/cloudflared"),
+            source: install::CloudflaredSource::Managed,
+            version: Some(version.to_owned()),
+        }
+    }
+
+    fn system(version: &str) -> install::Resolved {
+        install::Resolved {
+            binary: PathBuf::from("/usr/local/bin/cloudflared"),
+            source: install::CloudflaredSource::System,
+            version: Some(version.to_owned()),
+        }
+    }
+
+    /// Exhaustive, pure-logic coverage of the write-time no-downgrade guard
+    /// itself, independent of locks/timing - this is the actual regression
+    /// protection for "a stale System/None write must never clobber an
+    /// established Managed cache entry".
+    #[test]
+    fn is_downgrade_covers_every_existing_fresh_combination() {
+        // An established Managed entry must never be replaced by System or by
+        // nothing (a failed re-resolution).
+        assert!(is_downgrade(Some(&managed("1")), Some(&system("2"))));
+        assert!(is_downgrade(Some(&managed("1")), None));
+        // Managed may always be refreshed by a fresh Managed (e.g. a version
+        // bump from a second install).
+        assert!(!is_downgrade(Some(&managed("1")), Some(&managed("2"))));
+        // Nothing else is ever a downgrade: no existing entry, or an existing
+        // System entry, can freely be overwritten by any fresh result.
+        assert!(!is_downgrade(None, Some(&system("1"))));
+        assert!(!is_downgrade(None, Some(&managed("1"))));
+        assert!(!is_downgrade(None, None));
+        assert!(!is_downgrade(Some(&system("1")), Some(&system("2"))));
+        assert!(!is_downgrade(Some(&system("1")), Some(&managed("1"))));
+        assert!(!is_downgrade(Some(&system("1")), None));
+    }
+
+    #[tokio::test]
+    async fn resolved_cloudflared_never_downgrades_a_cached_managed_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+
+        install::install_binary_for_test(&state.dirs, "2026.6.1", b"#!/bin/sh\n");
+        refresh_cloudflared_cache_after_install(&state).await;
+        assert_eq!(
+            resolved_cloudflared(&state).await.unwrap().source,
+            install::CloudflaredSource::Managed
+        );
+
+        // A cached Managed entry short-circuits in `cached_cloudflared_if_valid`
+        // before any fresh resolution (and thus the no-downgrade write) is even
+        // attempted, so repeated calls keep reporting Managed regardless of
+        // what the real PATH/managed-dir state is.
+        for _ in 0..3 {
+            assert_eq!(
+                resolved_cloudflared(&state).await.unwrap().source,
+                install::CloudflaredSource::Managed
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_removed_system_binary_is_dropped_from_the_cache_on_next_read() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        let candidate = tmp.path().join("cloudflared");
+        std::fs::write(&candidate, b"#!/bin/sh\n").unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&candidate, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        *state.cloudflared_resolution.write().await = Some(install::Resolved {
+            binary: candidate.clone(),
+            source: install::CloudflaredSource::System,
+            version: Some("2024.6.1".into()),
+        });
+        assert!(
+            cached_cloudflared_if_valid(&state).await.is_some(),
+            "precondition: the cached System entry should still be valid"
+        );
+
+        std::fs::remove_file(&candidate).unwrap();
+        assert!(
+            cached_cloudflared_if_valid(&state).await.is_none(),
+            "a System entry whose binary has disappeared must not be served from cache"
+        );
+    }
 }

--- a/bin/yerdd/src/tunnel/named.rs
+++ b/bin/yerdd/src/tunnel/named.rs
@@ -14,7 +14,7 @@
 //! and runs the single tunnel that serves them all.
 
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -134,13 +134,14 @@ fn internal(message: String) -> Response {
 }
 
 /// Run a `cloudflared` subcommand to completion with `HOME`/origin-cert pinned,
-/// capturing its output. Bounded by [`ONESHOT_TIMEOUT`].
+/// capturing its output. Bounded by [`ONESHOT_TIMEOUT`]. `binary` is the
+/// already-resolved `cloudflared` to spawn (see `super::resolved_cloudflared`).
 async fn run_oneshot(
     dirs: &PlatformDirs,
+    binary: &Path,
     args: Vec<OsString>,
 ) -> Result<std::process::Output, String> {
-    let binary = install::binary_path(dirs);
-    let mut cmd = tokio::process::Command::new(&binary);
+    let mut cmd = tokio::process::Command::new(binary);
     cmd.args(&args)
         .env("HOME", install::tunnel_dir(dirs))
         .env("TUNNEL_ORIGIN_CERT", origincert(dirs))
@@ -167,9 +168,9 @@ fn last_error_line(out: &std::process::Output) -> String {
 /// surfacing the one-time auth URL in the job log for the GUI to open. Succeeds
 /// once the account cert lands on disk.
 pub async fn login_streamed(state: Arc<DaemonState>) -> Response {
-    if !install::is_installed(&state.dirs) {
+    let Some(resolved) = super::resolved_cloudflared(&state).await else {
         return not_installed();
-    }
+    };
     if let Err(e) = ensure_secret_dirs(&state.dirs) {
         return internal(e);
     }
@@ -181,7 +182,7 @@ pub async fn login_streamed(state: Arc<DaemonState>) -> Response {
             .jobs
             .set_phase(&id, "Waiting for Cloudflare login")
             .await;
-        let binary = install::binary_path(&state.dirs);
+        let binary = resolved.binary;
         let args = yerd_tunnel::args::login_args(&origincert(&state.dirs));
         let mut cmd = tokio::process::Command::new(&binary);
         cmd.args(&args)
@@ -276,9 +277,9 @@ where
 /// UUID. v1 supports a single tunnel: creating a second (differently-named) one
 /// is rejected. Re-running with the existing name is left to Cloudflare.
 pub async fn create(name: &str, state: &DaemonState) -> Response {
-    if !install::is_installed(&state.dirs) {
+    let Some(resolved) = super::resolved_cloudflared(state).await else {
         return not_installed();
-    }
+    };
     if !is_logged_in(&state.dirs) {
         return need_login();
     }
@@ -311,7 +312,7 @@ pub async fn create(name: &str, state: &DaemonState) -> Response {
         };
     }
     let args = yerd_tunnel::args::create_args(name, &origincert(&state.dirs), &creds);
-    let out = match run_oneshot(&state.dirs, args).await {
+    let out = match run_oneshot(&state.dirs, &resolved.binary, args).await {
         Ok(o) => o,
         Err(e) => return internal(e),
     };
@@ -386,9 +387,9 @@ pub async fn list(state: &DaemonState) -> Response {
 
 /// `RouteTunnelDns` - create the proxied CNAME routing `hostname` to `tunnel`.
 pub async fn route_dns(tunnel: &str, hostname: &str, state: &DaemonState) -> Response {
-    if !install::is_installed(&state.dirs) {
+    let Some(resolved) = super::resolved_cloudflared(state).await else {
         return not_installed();
-    }
+    };
     if !is_logged_in(&state.dirs) {
         return need_login();
     }
@@ -399,7 +400,7 @@ pub async fn route_dns(tunnel: &str, hostname: &str, state: &DaemonState) -> Res
         };
     }
     let args = yerd_tunnel::args::route_dns_args(tunnel, hostname, &origincert(&state.dirs));
-    match run_oneshot(&state.dirs, args).await {
+    match run_oneshot(&state.dirs, &resolved.binary, args).await {
         Ok(out) if out.status.success() => Response::Ok,
         Ok(out) => internal(format!("route dns failed: {}", last_error_line(&out))),
         Err(e) => internal(e),
@@ -451,9 +452,9 @@ pub async fn set_site_hostname(
 /// site (resolving each site's local origin), stops any running named process so
 /// the new config takes effect, then runs it through the shared tick driver.
 pub async fn start(state: &DaemonState) -> Response {
-    if !install::is_installed(&state.dirs) {
+    let Some(resolved) = super::resolved_cloudflared(state).await else {
         return not_installed();
-    }
+    };
     if !is_logged_in(&state.dirs) {
         return need_login();
     }
@@ -529,7 +530,16 @@ pub async fn start(state: &DaemonState) -> Response {
         "TUNNEL_ORIGIN_CERT".into(),
         origincert(&state.dirs).into_os_string(),
     ));
-    super::run_to_ready(state, NAMED_KEY, args, env, TunnelKind::Named, None).await
+    super::run_to_ready(
+        state,
+        NAMED_KEY,
+        resolved.binary,
+        args,
+        env,
+        TunnelKind::Named,
+        None,
+    )
+    .await
 }
 
 /// `StopNamedTunnel` - tear down the consolidated named tunnel.
@@ -554,9 +564,9 @@ pub async fn stop(state: &DaemonState) -> Response {
 /// and need removing in the Cloudflare dashboard). Best-effort cleanup; a failed
 /// `delete` is surfaced.
 pub async fn delete(name: &str, state: &DaemonState) -> Response {
-    if !install::is_installed(&state.dirs) {
+    let Some(resolved) = super::resolved_cloudflared(state).await else {
         return not_installed();
-    }
+    };
     if !is_logged_in(&state.dirs) {
         return need_login();
     }
@@ -591,8 +601,19 @@ pub async fn delete(name: &str, state: &DaemonState) -> Response {
     }
 
     let cert = origincert(&state.dirs);
-    let _ = run_oneshot(&state.dirs, yerd_tunnel::args::cleanup_args(name, &cert)).await;
-    match run_oneshot(&state.dirs, yerd_tunnel::args::delete_args(name, &cert)).await {
+    let _ = run_oneshot(
+        &state.dirs,
+        &resolved.binary,
+        yerd_tunnel::args::cleanup_args(name, &cert),
+    )
+    .await;
+    match run_oneshot(
+        &state.dirs,
+        &resolved.binary,
+        yerd_tunnel::args::delete_args(name, &cert),
+    )
+    .await
+    {
         Ok(out) if out.status.success() => {}
         Ok(out) => return internal(format!("delete tunnel failed: {}", last_error_line(&out))),
         Err(e) => return internal(e),

--- a/crates/yerd-ipc/src/lib.rs
+++ b/crates/yerd-ipc/src/lib.rs
@@ -48,10 +48,11 @@ pub use message::{decode_message, encode_message};
 pub use request::Request;
 pub use response::{ErrorCode, PhpUpdate, Response};
 pub use status::{
-    CaStatus, CloudflaredStatus, DatabaseSummary, Diagnosis, DiagnosisCode, FixReport, FixResult,
-    MailDetail, MailHeader, MailStatus, MailSummary, NamedTunnelMeta, PhpPoolStatus, PoolRunState,
-    PortStatus, ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts,
-    SiteHostname, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UnboundWeb,
+    CaStatus, CloudflaredSource, CloudflaredStatus, DatabaseSummary, Diagnosis, DiagnosisCode,
+    FixReport, FixResult, MailDetail, MailHeader, MailStatus, MailSummary, NamedTunnelMeta,
+    PhpPoolStatus, PoolRunState, PortStatus, ServiceAvailability, ServiceRunState, ServiceStatus,
+    Severity, SiteCounts, SiteHostname, StatusReport, ToolStatus, TunnelInfo, TunnelKind,
+    TunnelRunState, UnboundWeb,
 };
 pub use update::{Channel, StagedArtifact, UpdateSource};
 

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -579,6 +579,7 @@ mod variant_name_pinning {
             cloudflared: crate::status::CloudflaredStatus {
                 installed: true,
                 version: Some("2026.6.1".into()),
+                source: Some(crate::status::CloudflaredSource::Managed),
                 logged_in: false,
             },
         });

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -550,6 +550,17 @@ pub struct SiteHostname {
     pub hostname: String,
 }
 
+/// Where the `cloudflared` binary Yerd is using came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CloudflaredSource {
+    /// Downloaded and verified by Yerd into its own managed install dir.
+    Managed,
+    /// A pre-existing binary found on the user's `PATH`.
+    System,
+}
+
 /// `cloudflared` install / account status, reported alongside the live tunnels.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CloudflaredStatus {
@@ -558,6 +569,9 @@ pub struct CloudflaredStatus {
     /// The installed `cloudflared` version, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Where `installed`'s binary came from, when installed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<CloudflaredSource>,
     /// Whether a Cloudflare account is logged in (a `cert.pem` is present).
     #[serde(default)]
     pub logged_in: bool,

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -18,12 +18,12 @@ use std::path::PathBuf;
 
 use yerd_ipc::{
     types::{PhpVersion, Site},
-    CaStatus, Channel, CloudflaredStatus, DatabaseSummary, Diagnosis, DiagnosisCode, DumpCategory,
-    DumpCounts, DumpEvent, DumpExtStatus, ErrorCode, FixReport, FixResult, MailDetail, MailHeader,
-    MailStatus, MailSummary, NamedTunnelMeta, PhpPoolStatus, PoolRunState, PortStatus, Request,
-    Response, ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts,
-    SiteHostname, StagedArtifact, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState,
-    UpdateSource,
+    CaStatus, Channel, CloudflaredSource, CloudflaredStatus, DatabaseSummary, Diagnosis,
+    DiagnosisCode, DumpCategory, DumpCounts, DumpEvent, DumpExtStatus, ErrorCode, FixReport,
+    FixResult, MailDetail, MailHeader, MailStatus, MailSummary, NamedTunnelMeta, PhpPoolStatus,
+    PoolRunState, PortStatus, Request, Response, ServiceAvailability, ServiceRunState,
+    ServiceStatus, Severity, SiteCounts, SiteHostname, StagedArtifact, StatusReport, ToolStatus,
+    TunnelInfo, TunnelKind, TunnelRunState, UpdateSource,
 };
 
 // ---------- Request ----------
@@ -1875,11 +1875,12 @@ fn response_tunnels_byte_shape() {
         cloudflared: CloudflaredStatus {
             installed: true,
             version: Some("2026.6.1".into()),
+            source: Some(CloudflaredSource::Managed),
             logged_in: false,
         },
     };
     let s = serde_json::to_string(&r).unwrap();
-    let expected = r#"{"type":"tunnels","tunnels":[{"site":"app","kind":"quick","state":"running","url":"https://calm-river-1234.trycloudflare.com"}],"cloudflared":{"installed":true,"version":"2026.6.1","logged_in":false}}"#;
+    let expected = r#"{"type":"tunnels","tunnels":[{"site":"app","kind":"quick","state":"running","url":"https://calm-river-1234.trycloudflare.com"}],"cloudflared":{"installed":true,"version":"2026.6.1","source":"managed","logged_in":false}}"#;
     assert_eq!(s, expected);
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
 }
@@ -1899,6 +1900,7 @@ fn response_tunnels_named_and_empty_byte_shape() {
         cloudflared: CloudflaredStatus {
             installed: true,
             version: None,
+            source: Some(CloudflaredSource::System),
             logged_in: true,
         },
     };
@@ -1906,6 +1908,7 @@ fn response_tunnels_named_and_empty_byte_shape() {
     assert!(s.contains(r#""kind":"named""#), "{s}");
     assert!(s.contains(r#""hostname":"shop.example.com""#), "{s}");
     assert!(!s.contains(r#""url""#), "{s}");
+    assert!(s.contains(r#""source":"system""#), "{s}");
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), named);
 
     let empty = Response::Tunnels {
@@ -1913,6 +1916,7 @@ fn response_tunnels_named_and_empty_byte_shape() {
         cloudflared: CloudflaredStatus {
             installed: false,
             version: None,
+            source: None,
             logged_in: false,
         },
     };
@@ -1941,6 +1945,16 @@ fn tunnel_kind_each_variant_byte_shape() {
         (TunnelKind::Named, r#""named""#),
     ] {
         assert_eq!(serde_json::to_string(&k).unwrap(), expected);
+    }
+}
+
+#[test]
+fn cloudflared_source_each_variant_byte_shape() {
+    for (src, expected) in [
+        (CloudflaredSource::Managed, r#""managed""#),
+        (CloudflaredSource::System, r#""system""#),
+    ] {
+        assert_eq!(serde_json::to_string(&src).unwrap(), expected);
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Attempts to detect and reuse cloudflared if it exists on the PATH.  Otherwise, offers the user to download the latest version. 

## Related issues

Closes #65 

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer tunnel status details showing whether `cloudflared` comes from Yerd or the system.
  * When a system-installed `cloudflared` is detected, the app now offers an option to switch to the bundled version.

* **Bug Fixes**
  * Improved tunnel startup and login flows by using a consistent, cached binary selection.
  * Updated tunnel status reporting to better reflect the currently active `cloudflared` source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->