### PR TITLE
[Fix] Propagate pcov into PHP processes spawned by the cover shims

### DIFF
--- a/bin/yerd/Cargo.toml
+++ b/bin/yerd/Cargo.toml
@@ -27,6 +27,7 @@ tokio          = { workspace = true, features = ["rt", "io-util", "net", "time"]
 interprocess   = { workspace = true }
 serde_json     = { workspace = true }
 thiserror      = { workspace = true }
+tempfile       = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 # `user` resolves the invoking user (home/shell) under sudo for the full
@@ -36,7 +37,6 @@ nix            = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 yerdd          = { path = "../yerdd" }
-tempfile       = { workspace = true }
 tokio          = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
 
 [lints]

--- a/bin/yerd/src/cover_shim.rs
+++ b/bin/yerd/src/cover_shim.rs
@@ -2,14 +2,21 @@
 //!
 //! These names are symlinks in `{data}/bin` pointing at *this* `yerd` binary.
 //! When `yerd` is invoked under such a name (detected from `argv[0]` before clap),
-//! it resolves the matching PHP CLI binary plus that version's `pcov.so` and
-//! `exec`s PHP with coverage enabled - leaving the clean `php`/`php<ver>` shims
-//! untouched. Unix-only: cover shims are never created on other platforms.
+//! it resolves the matching PHP CLI binary plus that version's `pcov.so`, points
+//! `PHPRC` at a pcov-augmented copy of Yerd's CLI ini, and `exec`s PHP with
+//! coverage enabled - leaving the clean `php`/`php<ver>` shims untouched.
+//! `PHPRC` (rather than `-d` flags) is what it is: those flags are process-local,
+//! but this env var is inherited by any PHP process the exec'd one spawns in
+//! turn (e.g. `artisan test`'s child PHPUnit/Pest/paratest run), so coverage
+//! stays enabled across that hop too. Unix-only: cover shims are never created
+//! on other platforms.
 
+use std::io::Write as _;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
+use yerd_core::php_settings;
 use yerd_platform::{ActivePaths, Paths, PlatformDirs};
 
 use crate::shim::{cli_binary, fail, resolve_default_php};
@@ -60,22 +67,31 @@ fn run(spec: &CoverSpec) -> ExitCode {
         Ok(t) => t,
         Err(msg) => return fail(msg),
     };
-    let pcov = dirs
-        .data
-        .join("php-ext")
-        .join(format!("php-{minor}"))
-        .join("pcov.so");
+    let ext_dir = dirs.data.join("php-ext").join(format!("php-{minor}"));
+    let pcov = ext_dir.join("pcov.so");
     if !pcov.is_file() {
         return fail(format!(
             "pcov not installed for PHP {minor} — reinstall PHP or wait for the background fetch"
         ));
     }
 
+    let base = match std::fs::read_to_string(dirs.data.join("php-cli.ini")) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return fail(format!("cannot read Yerd's CLI php.ini: {e}")),
+    };
+    let Some(cover_ini) = php_settings::render_cover_ini(&base, &pcov) else {
+        return fail(
+            "cannot enable pcov: Yerd's data directory path isn't valid in an ini file".to_owned(),
+        );
+    };
+    let cover_ini_path = ext_dir.join("cover.ini");
+    if let Err(e) = atomic_write(&cover_ini_path, cover_ini.as_bytes()) {
+        return fail(format!("cannot write {}: {e}", cover_ini_path.display()));
+    }
+
     let err = Command::new(&php_bin)
-        .arg("-d")
-        .arg(format!("extension={}", pcov.display()))
-        .arg("-d")
-        .arg("pcov.enabled=1")
+        .env("PHPRC", &cover_ini_path)
         .args(std::env::args_os().skip(1))
         .exec();
     if err.kind() == std::io::ErrorKind::NotFound {
@@ -85,6 +101,22 @@ fn run(spec: &CoverSpec) -> ExitCode {
         ));
     }
     fail(format!("failed to exec {}: {err}", php_bin.display()))
+}
+
+/// Write `bytes` to `path` atomically (tempfile in the same directory +
+/// rename). `bin/yerd` doesn't otherwise depend on `yerd-php` (the FPM/
+/// site-pool crate), so this ~15-line helper is duplicated here rather than
+/// pulling in that whole crate for it - the same trade `yerd-php`'s own
+/// `io::atomic_write` already made against `yerd-config`'s equivalent.
+fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no parent")
+    })?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(bytes)?;
+    tmp.flush()?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
 }
 
 /// Resolve `(php_binary, "major.minor")` for the spec.

--- a/bin/yerd/src/cover_shim.rs
+++ b/bin/yerd/src/cover_shim.rs
@@ -81,9 +81,10 @@ fn run(spec: &CoverSpec) -> ExitCode {
         Err(e) => return fail(format!("cannot read Yerd's CLI php.ini: {e}")),
     };
     let Some(cover_ini) = php_settings::render_cover_ini(&base, &pcov) else {
-        return fail(
-            "cannot enable pcov: Yerd's data directory path isn't valid in an ini file".to_owned(),
-        );
+        return fail(format!(
+            "cannot enable pcov: {} isn't safe to use as an ini value (no control characters, `;`, or `#`, and it must be valid UTF-8) - move Yerd's data directory to a path without those",
+            pcov.display()
+        ));
     };
     let cover_ini_path = ext_dir.join("cover.ini");
     if let Err(e) = atomic_write(&cover_ini_path, cover_ini.as_bytes()) {

--- a/bin/yerd/tests/cover_shim_e2e.rs
+++ b/bin/yerd/tests/cover_shim_e2e.rs
@@ -1,0 +1,85 @@
+//! End-to-end: prove that `PHPRC`, set by the `phpcover`/`php<ver>cover` shim on
+//! the process it `exec`s, is inherited by a subsequent process that one
+//! re-execs itself - the actual mechanism that lets coverage survive `artisan
+//! test`'s child PHPUnit/Pest/paratest hop. Spawns the real built `yerd`
+//! binary under a `php8.4cover` name against a fully faked `PlatformDirs`
+//! layout (a stub shell script standing in for the PHP interpreter), rather
+//! than calling `cover_shim::dispatch()` in-process, because it resolves
+//! `ActivePaths::new().resolve()` internally with no dirs-injection seam.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+#[cfg(unix)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::process::Command;
+
+    use yerd_platform::PlatformDirs;
+
+    /// A `#!/bin/sh` stand-in for the PHP CLI binary: prints `$PHPRC`, then
+    /// re-execs itself once with `--grandchild` appended (the actual hop under
+    /// test - a plain re-exec inherits the parent's environment, same as
+    /// Symfony `Process` spawning `PHPUnit` via `PHP_BINARY`), then exits.
+    const STUB_PHP: &str = "#!/bin/sh\n\
+        printf '%s\\n' \"$PHPRC\"\n\
+        case \"$1\" in\n\
+        --grandchild) exit 0 ;;\n\
+        esac\n\
+        exec \"$0\" --grandchild\n";
+
+    #[test]
+    fn phprc_survives_a_re_exec_grandchild_hop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).expect("mkdir home");
+        let dirs = PlatformDirs::for_user(&home, 0);
+
+        let php_bin_dir = dirs.data.join("php").join("php-8.4").join("bin");
+        fs::create_dir_all(&php_bin_dir).expect("mkdir php bin");
+        let php_bin = php_bin_dir.join("php");
+        fs::write(&php_bin, STUB_PHP).expect("write stub php");
+        fs::set_permissions(&php_bin, fs::Permissions::from_mode(0o755)).expect("chmod +x");
+
+        let ext_dir = dirs.data.join("php-ext").join("php-8.4");
+        fs::create_dir_all(&ext_dir).expect("mkdir php-ext");
+        fs::write(ext_dir.join("pcov.so"), b"").expect("write stub pcov.so");
+
+        let cover_shim_bin = tmp.path().join("php8.4cover");
+        symlink(env!("CARGO_BIN_EXE_yerd"), &cover_shim_bin).expect("symlink cover shim");
+
+        let output = Command::new(&cover_shim_bin)
+            .env_clear()
+            .env("HOME", &home)
+            .env("XDG_DATA_HOME", home.join(".local").join("share"))
+            .env("XDG_CONFIG_HOME", home.join(".config"))
+            .env("XDG_STATE_HOME", home.join(".local").join("state"))
+            .env("XDG_CACHE_HOME", home.join(".cache"))
+            .output()
+            .expect("run php8.4cover");
+
+        assert!(
+            output.status.success(),
+            "php8.4cover failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let expected_phprc = ext_dir.join("cover.ini");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lines: Vec<&str> = stdout.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                expected_phprc.to_str().expect("utf8 path"),
+                expected_phprc.to_str().expect("utf8 path"),
+            ],
+            "PHPRC must be identical across the re-exec hop (top-level process and its grandchild)"
+        );
+        assert!(expected_phprc.is_file(), "cover.ini must have been written");
+    }
+}

--- a/crates/yerd-core/src/php_settings.rs
+++ b/crates/yerd-core/src/php_settings.rs
@@ -173,6 +173,23 @@ pub fn sanitize_ca_bundle_path(path: &std::path::Path) -> Option<String> {
     Some(s.to_owned())
 }
 
+/// Render the cover-shim ini: `base` (the CLI ini body) plus directives that
+/// load and enable pcov from `pcov_so`. Returns `None` if `pcov_so` isn't safe
+/// to emit as an unquoted ini value: the caller must treat that as a hard
+/// failure, not silently run without coverage.
+#[must_use]
+pub fn render_cover_ini(base: &str, pcov_so: &std::path::Path) -> Option<String> {
+    let path = sanitize_ca_bundle_path(pcov_so)?;
+    let mut out = base.to_owned();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str("extension = ");
+    out.push_str(&path);
+    out.push_str("\npcov.enabled = 1\n");
+    Some(out)
+}
+
 /// The FPM directive a setting renders as: `"php_flag"` for booleans, else
 /// `"php_value"`. `None` if the setting is not supported.
 #[must_use]
@@ -381,6 +398,46 @@ mod tests {
         assert!(sanitize_ca_bundle_path(Path::new("/d/ca\ncert.pem")).is_none());
         assert!(sanitize_ca_bundle_path(Path::new("/d/ca;cert.pem")).is_none());
         assert!(sanitize_ca_bundle_path(Path::new("/d/ca#cert.pem")).is_none());
+    }
+
+    #[test]
+    fn render_cover_ini_appends_pcov_directives() {
+        use std::path::Path;
+        let pcov = Path::new("/d/pcov.so");
+        assert_eq!(
+            render_cover_ini("", pcov).as_deref(),
+            Some("extension = /d/pcov.so\npcov.enabled = 1\n")
+        );
+        assert_eq!(
+            render_cover_ini("memory_limit = 512M\n", pcov).as_deref(),
+            Some("memory_limit = 512M\nextension = /d/pcov.so\npcov.enabled = 1\n")
+        );
+    }
+
+    #[test]
+    fn render_cover_ini_inserts_separator_when_base_lacks_trailing_newline() {
+        use std::path::Path;
+        let pcov = Path::new("/d/pcov.so");
+        assert_eq!(
+            render_cover_ini("memory_limit = 512M", pcov).as_deref(),
+            Some("memory_limit = 512M\nextension = /d/pcov.so\npcov.enabled = 1\n")
+        );
+    }
+
+    #[test]
+    fn render_cover_ini_appends_after_an_existing_pcov_directive() {
+        use std::path::Path;
+        let base = "pcov.enabled = 0\n";
+        let got = render_cover_ini(base, Path::new("/d/pcov.so")).unwrap();
+        assert!(got.starts_with(base));
+        assert!(got.ends_with("extension = /d/pcov.so\npcov.enabled = 1\n"));
+    }
+
+    #[test]
+    fn render_cover_ini_rejects_an_unsafe_pcov_path() {
+        use std::path::Path;
+        assert!(render_cover_ini("", Path::new("/d/pc;ov.so")).is_none());
+        assert!(render_cover_ini("", Path::new("/d/pc\nov.so")).is_none());
     }
 
     #[test]

--- a/docs/developer/binaries/yerd.md
+++ b/docs/developer/binaries/yerd.md
@@ -134,10 +134,29 @@ if let Some(code) = yerd::cover_shim::dispatch() {
   to the highest installed minor whose CLI binary exists).
 - It then locates that version's `{data}/php-ext/php-<ver>/pcov.so` (the daemon
   bundles it; see [yerdd · cover-shim reconciliation](./yerdd#cover-shim-reconciliation-and-pcov)),
-  and `exec`s PHP with `-d extension=<pcov.so> -d pcov.enabled=1` followed by the
-  caller's own args. `exec` replaces the process, so on success it never returns;
-  a missing binary or `pcov.so` prints a `yerd:` diagnostic and returns
+  reads Yerd's CLI ini (`{data}/php-cli.ini`, treating a missing file as empty),
+  appends pcov's `extension`/`pcov.enabled` directives
+  (`yerd_core::php_settings::render_cover_ini`), and atomically writes the
+  result to `{data}/php-ext/php-<ver>/cover.ini`. This read-render-write happens
+  on **every** invocation - `cover.ini` is never cached or diffed against the
+  last run, so it can't drift out of sync with `php-cli.ini` (whose contents
+  change whenever a PHP setting is edited). It then `exec`s PHP with `PHPRC`
+  set to that path, followed by the caller's own args. `exec` replaces the
+  process, so on success it never returns; a missing binary, missing
+  `pcov.so`, or a write failure prints a `yerd:` diagnostic and returns
   `ExitCode::FAILURE`.
+
+`PHPRC` rather than `-d` flags is deliberate: `-d` only affects the exec'd
+process itself, but `PHPRC` is an environment variable, so it's inherited by
+any PHP process that process spawns in turn (e.g. `php artisan test`'s child
+PHPUnit/Pest/paratest run, launched via `PHP_BINARY` by a Symfony `Process`
+that inherits the parent's environment) - which is what actually needs pcov
+loaded to produce a coverage report. Setting `PHPRC` on the `Command` overrides
+that one key and leaves the rest of the environment inherited (no
+`env_clear()` is called), so if the caller's shell already has its own `PHPRC`
+(for example from the `yerd path install` rc-block, which points the plain
+`php` shim at `{data}/php-cli.ini`), the cover shim's value wins for the
+exec'd process - intentional, not a conflict to resolve.
 
 ::: info Unix-only
 The `dispatch()` call is `#[cfg(unix)]` and the cover symlinks are only ever

--- a/docs/guide/code-coverage.md
+++ b/docs/guide/code-coverage.md
@@ -30,9 +30,11 @@ phpcover vendor/bin/phpunit --coverage-text
 php8.4cover vendor/bin/pest --coverage
 ```
 
-Each cover shim runs the matching PHP CLI with pcov enabled
-(`-d extension=<pcov.so> -d pcov.enabled=1`), then hands off to your script. Your
-tooling sees a PHP with a working coverage driver and reports as usual.
+Each cover shim points `PHPRC` at a pcov-enabled copy of Yerd's CLI ini, then
+hands off to your script. Because `PHPRC` is an environment variable rather
+than a CLI flag, it's inherited by any PHP process your script spawns in
+turn - which is what makes `artisan test`'s child PHPUnit/Pest/paratest run
+see a working coverage driver too, not just the top-level `artisan` process.
 
 ::: tip Add the shim dir to your PATH
 The cover shims sit in the same `{data}/bin` directory as `php` (Yerd prints the
@@ -76,9 +78,10 @@ The `yerd` binary is a **multi-call** binary: before it parses any CLI arguments
 it checks the name it was invoked as. The `phpcover` and `php<version>cover`
 entries in `{data}/bin` are symlinks back to `yerd` itself; when `yerd` sees one
 of those names, it resolves the right PHP CLI binary plus that version's
-`pcov.so` and `exec`s PHP with coverage enabled. Invoked under any other name it
-falls through to the normal CLI, so the clean `php`/`php<version>` shims are
-untouched.
+`pcov.so`, writes a copy of Yerd's CLI ini with pcov's `extension`/
+`pcov.enabled` directives appended, and `exec`s PHP with `PHPRC` pointing at
+that copy. Invoked under any other name it falls through to the normal CLI, so
+the clean `php`/`php<version>` shims are untouched.
 
 ## See also
 

--- a/docs/php-ext/architecture.md
+++ b/docs/php-ext/architecture.md
@@ -253,9 +253,11 @@ The fetch loop is shared, but the two extensions are gated and loaded differentl
   As an optimization the fetch **skips the network entirely** when every installed
   version already has a `pcov.so` on disk (a warm/offline start does no manifest GET).
   `pcov` is **not** loaded into normal `php` or PHP-FPM; it is consumed only by the CLI
-  **cover shims** (`phpcover` / `php<ver>cover`), which load it at exec time via
-  `-d extension=<pcov.so> -d pcov.enabled=1`. That keeps coverage instrumentation out
-  of day-to-day serving - **zero coverage overhead** unless you invoke a cover shim.
+  **cover shims** (`phpcover` / `php<ver>cover`), which load it at exec time by pointing
+  `PHPRC` at a pcov-augmented copy of Yerd's CLI ini (an environment variable, not a
+  `-d` flag, so it's inherited by any PHP process the exec'd one spawns in turn). That
+  keeps coverage instrumentation out of day-to-day serving - **zero coverage overhead**
+  unless you invoke a cover shim.
 
 ## 6. Out of scope
 - Windows (Yerd's PHP is macOS/Linux today).


### PR DESCRIPTION
## What does this PR do?

phpcover/php<ver>cover now enable pcov via a PHPRC environment override instead of -d flags, so coverage survives into child PHP processes such as artisan test's spawned PHPUnit/Pest/paratest run, which previously failed with "No code coverage driver available".

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coverage shims now enable pcov by writing a temporary PHP config and launching PHP with `PHPRC` set, so child PHP processes inherit coverage settings.
  * Added support for generating the coverage-enabled PHP config used by the shims.

* **Bug Fixes**
  * Improved handling of coverage configuration so it is written atomically and reused across re-execed child processes.
  * Added coverage for the shim behavior to verify `PHPRC` persists through a grandchild process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->