### PR TITLE
[Fix] Linux titlebar not triggering actions

### DIFF
--- a/apps/yerd-gui/src/components/TitleBar.vue
+++ b/apps/yerd-gui/src/components/TitleBar.vue
@@ -185,7 +185,7 @@ function controlButtonClass(kind: ControlKind): string {
         type="button"
         :aria-label="controlLabel(kind)"
         :class="controlButtonClass(kind)"
-        @click="controlAction(kind)"
+        @click="controlAction(kind)()"
       >
         <component :is="controlIcon(kind)" :class="controlIconClass(kind)" />
       </button>
@@ -209,7 +209,7 @@ function controlButtonClass(kind: ControlKind): string {
         type="button"
         :aria-label="controlLabel(kind)"
         :class="controlButtonClass(kind)"
-        @click="controlAction(kind)"
+        @click="controlAction(kind)()"
       >
         <component :is="controlIcon(kind)" :class="controlIconClass(kind)" />
       </button>

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -289,9 +289,15 @@ const emptyEnvironment = computed(
         </div>
 
         <Card class="relative overflow-hidden">
-          <!-- A soft brand wash - the only place indigo gets a hero surface. -->
+          <!-- A soft brand wash - the only place indigo gets a hero surface.
+               A gradient fade rather than a blurred circle: `filter: blur()`
+               forces this element onto its own GPU compositing layer, which on
+               WebKitGTK (Linux) can make the window's software rounded-corner
+               clip (`#app`'s `overflow: hidden`, since the window itself has
+               no native corner mask) briefly fail to reapply on an unrelated
+               repaint elsewhere in the tree, punching a hole to the desktop. -->
           <div
-            class="pointer-events-none absolute -right-20 -top-20 size-56 rounded-full bg-brand/5 blur-2xl"
+            class="pointer-events-none absolute -right-24 -top-24 size-72 rounded-full bg-[radial-gradient(circle,hsl(var(--brand)/0.08)_0%,transparent_70%)]"
             aria-hidden="true"
           />
 


### PR DESCRIPTION
## What does this PR do?

Linux title bar actions were not triggering - for example, close, minimise, etc. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the window control buttons so close, minimize, and maximize actions now trigger reliably on Linux-style title bars.
* **Style**
  * Updated the serving console card’s background decoration with a smoother, more polished visual effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->