### PR TITLE
[Fix] Onboarding Auto Install

### DIFF
--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -19,6 +19,7 @@
 
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri_plugin_autostart::ManagerExt as _;
 
@@ -639,6 +640,20 @@ fn nudge_if_requires_approval() {
 
 #[cfg(target_os = "macos")]
 static DAEMON_REG_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Set while `setup_app`'s macOS launch-time self-repair thread is actively
+/// inside `ensure_daemon_registration`, so the frontend can show the
+/// Install/Start button as busy instead of idle. Not cfg-gated: it stays
+/// `false` forever on Linux, where nothing ever mutates it - a cheap,
+/// cross-platform-safe getter beats cfg-gating the command itself. Purely a UX
+/// signal; `DAEMON_REG_LOCK` is what actually serializes daemon mutation.
+pub(crate) static DAEMON_SELF_REPAIR_BUSY: AtomicBool = AtomicBool::new(false);
+
+/// Tauri command backing the frontend's `daemonSelfRepairBusy()`.
+#[tauri::command]
+pub fn daemon_self_repair_busy() -> bool {
+    DAEMON_SELF_REPAIR_BUSY.load(Ordering::SeqCst)
+}
 
 /// This GUI's version (= the bundled `yerdd` version; both `version.workspace`).
 #[cfg(target_os = "macos")]
@@ -1435,10 +1450,12 @@ pub fn set_title_bar_style(style: TitleBarStyle) -> Result<(), GuiError> {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::{
-        decide, reg_action, reg_plan, Decision, GuiSettings, RegAction, StartPhase, TitleBarStyle,
+        daemon_self_repair_busy, decide, reg_action, reg_plan, Decision, GuiSettings, RegAction,
+        StartPhase, TitleBarStyle, DAEMON_SELF_REPAIR_BUSY,
     };
     use crate::tray::TrayIconVariant;
     use semver::Version;
+    use std::sync::atomic::Ordering;
 
     fn v(s: &str) -> Version {
         Version::parse(s).unwrap()
@@ -1478,6 +1495,18 @@ mod tests {
             serde_json::to_string(&TitleBarStyle::Windows).unwrap(),
             "\"windows\""
         );
+    }
+
+    /// `daemon_self_repair_busy` round-trips the flag it reads; false by
+    /// default. Restores the shared static to `false` afterwards since it's a
+    /// process-wide static shared across the test binary.
+    #[test]
+    fn daemon_self_repair_busy_round_trips_the_flag() {
+        assert!(!daemon_self_repair_busy());
+        DAEMON_SELF_REPAIR_BUSY.store(true, Ordering::SeqCst);
+        assert!(daemon_self_repair_busy());
+        DAEMON_SELF_REPAIR_BUSY.store(false, Ordering::SeqCst);
+        assert!(!daemon_self_repair_busy());
     }
 
     #[test]

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -168,6 +168,7 @@ fn main() {
             autostart::setup_state,
             autostart::mark_onboarded,
             autostart::daemon_version_conflict,
+            autostart::daemon_self_repair_busy,
             logging::gui_log,
             logging::get_gui_logs,
             logging::get_diagnostics,
@@ -225,10 +226,20 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     tray::spawn_launch_update_check(app.handle().clone());
     show_initial_window(app);
     #[cfg(target_os = "macos")]
-    std::thread::spawn(|| {
-        autostart::migrate_gui_login_if_needed();
-        let _ = autostart::ensure_daemon_registration();
-    });
+    {
+        let app_handle = app.handle().clone();
+        std::thread::spawn(move || {
+            use std::sync::atomic::Ordering;
+            use tauri::Emitter;
+
+            autostart::migrate_gui_login_if_needed();
+            autostart::DAEMON_SELF_REPAIR_BUSY.store(true, Ordering::SeqCst);
+            let _ = app_handle.emit("daemon-self-repair", true);
+            let _ = autostart::ensure_daemon_registration();
+            autostart::DAEMON_SELF_REPAIR_BUSY.store(false, Ordering::SeqCst);
+            let _ = app_handle.emit("daemon-self-repair", false);
+        });
+    }
     Ok(())
 }
 

--- a/apps/yerd-gui/src/composables/useDaemonStart.test.ts
+++ b/apps/yerd-gui/src/composables/useDaemonStart.test.ts
@@ -9,7 +9,13 @@ const mocks = vi.hoisted(() => ({
   statusImpl: vi.fn(),
   startDaemon: vi.fn(),
   daemonDiagnostics: vi.fn(),
+  daemonSelfRepairBusy: vi.fn(),
 }));
+
+// Captures the callback each `listen(name, cb)` call registers, keyed by event
+// name, so tests can fire `daemon-start-phase` / `daemon-self-repair` events
+// independently (the previous single shared mock couldn't distinguish them).
+const listeners = vi.hoisted(() => new Map<string, (event: { payload: unknown }) => void>());
 
 vi.mock("@/ipc/client", () => {
   class IpcError extends Error {
@@ -24,17 +30,31 @@ vi.mock("@/ipc/client", () => {
     IpcError,
     startDaemon: mocks.startDaemon,
     daemonDiagnostics: mocks.daemonDiagnostics,
+    daemonSelfRepairBusy: mocks.daemonSelfRepairBusy,
     status: (...args: unknown[]) => mocks.statusImpl(...args),
   };
 });
 
-vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (name: string, cb: (event: { payload: unknown }) => void) => {
+    listeners.set(name, cb);
+    return () => {};
+  }),
+}));
 vi.mock("@/lib/log", () => ({
   log: { info() {}, debug() {}, warn() {}, error() {} },
 }));
 
+/** Flush the microtask queue - fake timers only stub `setTimeout`/`setInterval`,
+ * not native promise resolution, so this settles `ensureListener`'s awaited
+ * `listen()`/seed chain without advancing any timers. */
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
 import { IpcError } from "@/ipc/client";
-import { useDaemonStart } from "./useDaemonStart";
 
 // POLL_MS / RUNNING_CEILING_MS are module-private in useDaemonStart.ts; mirror
 // them here so the ceiling assertions stay pinned to the same granularity.
@@ -43,7 +63,16 @@ const RUNNING_CEILING_MS = 30_000;
 
 let activeWrapper: ReturnType<typeof mount> | null = null;
 
-function mountComposable() {
+/**
+ * Mount a fresh instance of the composable. `phase`/`backgroundBusy`/
+ * `listenerStarted` are module-level singletons in `useDaemonStart.ts`, so a
+ * static top-level import would only ever register `listen()` once for the
+ * whole file - later tests could never observe their own `daemon-self-repair`
+ * callback. `vi.resetModules()` (in `beforeEach` below) plus a dynamic import
+ * here gives every test its own fresh singleton, matching one real app launch.
+ */
+async function mountComposable() {
+  const { useDaemonStart } = await import("./useDaemonStart");
   let api!: ReturnType<typeof useDaemonStart>;
   const Comp = defineComponent({
     setup() {
@@ -52,6 +81,7 @@ function mountComposable() {
     },
   });
   activeWrapper = mount(Comp);
+  await flushMicrotasks();
   return { wrapper: activeWrapper, api };
 }
 
@@ -73,9 +103,12 @@ const diag = {
 };
 
 beforeEach(() => {
+  vi.resetModules();
   vi.clearAllMocks();
+  listeners.clear();
   mocks.startDaemon.mockResolvedValue(undefined);
   mocks.daemonDiagnostics.mockResolvedValue(diag);
+  mocks.daemonSelfRepairBusy.mockResolvedValue(false);
   vi.useFakeTimers();
 });
 
@@ -88,7 +121,7 @@ afterEach(() => {
 describe("useDaemonStart readiness wait", () => {
   it("connects before the ceiling and shows no diagnostics panel", async () => {
     mocks.statusImpl.mockResolvedValue({});
-    const { api } = mountComposable();
+    const { api } = await mountComposable();
 
     await api.start();
 
@@ -99,7 +132,7 @@ describe("useDaemonStart readiness wait", () => {
 
   it("only surfaces diagnostics after the 30s ceiling, not before", async () => {
     mocks.statusImpl.mockRejectedValue(new IpcError("down", "unreachable"));
-    const { api } = mountComposable();
+    const { api } = await mountComposable();
 
     void api.start();
     // One poll short of the ceiling: still waiting, no diagnostics yet.
@@ -112,5 +145,56 @@ describe("useDaemonStart readiness wait", () => {
     expect(mocks.daemonDiagnostics).toHaveBeenCalledOnce();
     expect(api.diagnostics.value).not.toBeNull();
     expect(api.phase.value).toBe("idle");
+  });
+});
+
+describe("useDaemonStart background self-repair signal", () => {
+  it("daemon-self-repair true shows busy/Preparing Daemon; false clears it", async () => {
+    mocks.statusImpl.mockResolvedValue({});
+    const { api } = await mountComposable();
+
+    listeners.get("daemon-self-repair")?.({ payload: true });
+    expect(api.starting.value).toBe(true);
+    expect(api.activeLabel.value).toBe("Preparing Daemon");
+
+    listeners.get("daemon-self-repair")?.({ payload: false });
+    expect(api.starting.value).toBe(false);
+    expect(api.activeLabel.value).toBeNull();
+  });
+
+  it("a late-resolving seed can't clobber a since-arrived event (seed race guard)", async () => {
+    let resolveSeed!: (busy: boolean) => void;
+    mocks.daemonSelfRepairBusy.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSeed = resolve;
+        }),
+    );
+    const { api } = await mountComposable();
+
+    // The thread finishes and emits its terminal `false` before the seed IPC
+    // (still in flight) resolves.
+    listeners.get("daemon-self-repair")?.({ payload: false });
+    expect(api.starting.value).toBe(false);
+
+    // The seed now resolves late with a stale `true` sampled before the thread
+    // finished. Without the `backgroundBusySeen` guard this would incorrectly
+    // flip `starting` back to true with no further event to correct it.
+    resolveSeed(true);
+    await flushMicrotasks();
+
+    expect(api.starting.value).toBe(false);
+    expect(api.activeLabel.value).toBeNull();
+  });
+
+  it("start() is gated on phase alone - a same-tick self-repair doesn't block it", async () => {
+    mocks.statusImpl.mockResolvedValue({});
+    const { api } = await mountComposable();
+
+    listeners.get("daemon-self-repair")?.({ payload: true });
+    expect(api.starting.value).toBe(true);
+
+    await api.start();
+    expect(mocks.startDaemon).toHaveBeenCalledOnce();
   });
 });

--- a/apps/yerd-gui/src/composables/useDaemonStart.ts
+++ b/apps/yerd-gui/src/composables/useDaemonStart.ts
@@ -3,7 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 
 import { useDaemon } from "@/composables/useDaemon";
 import { useOperations } from "@/composables/useOperations";
-import { daemonDiagnostics, IpcError, startDaemon } from "@/ipc/client";
+import { daemonDiagnostics, daemonSelfRepairBusy, IpcError, startDaemon } from "@/ipc/client";
 import type { DaemonDiagnostics } from "@/ipc/types";
 import { log } from "@/lib/log";
 
@@ -75,11 +75,21 @@ function labelFor(p: StartPhase): string | null {
 const { connected, refresh } = useDaemon();
 const operations = useOperations();
 
-// `phase` is the single source of truth; `starting` is derived so the existing
-// `:disabled` / spinner bindings keep working unchanged.
+// `phase` is the single source of truth for the click-driven flow; `starting`
+// is derived so the existing `:disabled` / spinner bindings keep working
+// unchanged. `backgroundBusy` is a second, independent signal for macOS's
+// launch-time self-repair thread (`setup_app`), which can re-register/kickstart
+// the daemon outside any click - see the `daemon-self-repair` listener below.
+// It ORs into `starting` (so the button still shows busy) but deliberately
+// stays out of `start()`'s re-entrancy guard, which must keep reading `phase`
+// alone: `App.vue`'s auto-start calls `start()` once per mount, and it must
+// not be silently swallowed by a same-tick self-repair no-op.
 const phase = ref<StartPhase>("idle");
-const starting = computed(() => phase.value !== "idle");
-const activeLabel = computed(() => labelFor(phase.value));
+const backgroundBusy = ref(false);
+const starting = computed(() => phase.value !== "idle" || backgroundBusy.value);
+const activeLabel = computed(() =>
+  phase.value === "idle" && backgroundBusy.value ? "Preparing Daemon" : labelFor(phase.value),
+);
 const pendingApproval = ref(false);
 const diagnostics = ref<DaemonDiagnostics | null>(null);
 
@@ -176,18 +186,21 @@ function beginPolling(startError?: string): void {
 
 /**
  * Begin the daemon-start flow (singleton). A second call while one is already in
- * flight is a no-op: the in-flight guard stops two callers interleaving and
- * clearing each other's shared state. `phase` goes to "starting" synchronously so
- * the spinner shows on click (the macOS plan can spend seconds probing launchctl
- * before the first phase event). Once `startDaemon` returns, `acceptRustPhases` is
- * dropped so a straggler phase event can't flip the label after the frontend owns
- * running/idle; a launch throw (missing sidecar, translocation refusal, register
- * failure) diagnoses immediately. `nudge` defaults to true (open Login Items on a
- * pending approval); only onboarding passes false. A throwing `beforeProbe` is
- * treated as not-pending-approval.
+ * flight is a no-op: the in-flight guard (on `phase`, not the OR'd `starting` -
+ * see the field comment above) stops two callers interleaving and clearing each
+ * other's shared state, while still letting `App.vue`'s auto-start run through a
+ * same-tick `backgroundBusy` window instead of being silently dropped. `phase`
+ * goes to "starting" synchronously so the spinner shows on click (the macOS plan
+ * can spend seconds probing launchctl before the first phase event). Once
+ * `startDaemon` returns, `acceptRustPhases` is dropped so a straggler phase event
+ * can't flip the label after the frontend owns running/idle; a launch throw
+ * (missing sidecar, translocation refusal, register failure) diagnoses
+ * immediately. `nudge` defaults to true (open Login Items on a pending
+ * approval); only onboarding passes false. A throwing `beforeProbe` is treated
+ * as not-pending-approval.
  */
 async function start(opts: StartOptions = {}): Promise<void> {
-  if (starting.value) return;
+  if (phase.value !== "idle") return;
   reset();
   phase.value = "starting";
   acceptRustPhases = true;
@@ -242,10 +255,20 @@ watch(connected, (c) => {
  * singleton lives for the app's lifetime, so the unlisten handle is intentionally
  * dropped; if events are unavailable (non-Tauri/test context) the listener flag is
  * reset so phases simply won't update.
+ *
+ * Also registers the `daemon-self-repair` listener (macOS launch-time self-repair
+ * thread) and seeds `backgroundBusy` from the current flag right after, in case
+ * the thread was already mid-flight before this listener attached. The seed is
+ * guarded by `backgroundBusySeen`: once any event has arrived, it wins outright -
+ * without that, the seed's IPC round-trip could sample the flag while still
+ * `true`, race with the thread's own terminal `false` event arriving first, and
+ * then overwrite `backgroundBusy` back to `true` with no further event ever
+ * coming to correct it.
  */
 async function ensureListener(): Promise<void> {
   if (listenerStarted) return;
   listenerStarted = true;
+  let backgroundBusySeen = false;
   try {
     await listen<string>("daemon-start-phase", (e) => {
       if (!acceptRustPhases) return;
@@ -255,8 +278,20 @@ async function ensureListener(): Promise<void> {
         log.debug(`daemon start phase: ${p}`);
       }
     });
+    await listen<boolean>("daemon-self-repair", (e) => {
+      backgroundBusySeen = true;
+      backgroundBusy.value = e.payload;
+      log.debug(`daemon self-repair: ${e.payload ? "busy" : "idle"}`);
+    });
   } catch {
     listenerStarted = false;
+    return;
+  }
+  try {
+    const busy = await daemonSelfRepairBusy();
+    if (!backgroundBusySeen) backgroundBusy.value = busy;
+  } catch {
+    /* non-fatal: non-macOS or IPC unavailable - backgroundBusy stays false */
   }
 }
 

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -836,6 +836,15 @@ export async function openLoginItems(): Promise<void> {
   await call<void>("open_login_items");
 }
 
+/**
+ * macOS: whether the launch-time daemon self-repair thread (`setup_app`) is
+ * currently re-registering/kickstarting the daemon. Always false elsewhere -
+ * no such thread runs on other OSes.
+ */
+export async function daemonSelfRepairBusy(): Promise<boolean> {
+  return call<boolean>("daemon_self_repair_busy");
+}
+
 // ── dumps (Laravel telemetry) ────────────────────────────────────────────────
 
 /** Page buffered dump events newer than `since` (0 = all). */

--- a/docs/developer/gui.md
+++ b/docs/developer/gui.md
@@ -140,10 +140,11 @@ Three commands are **host-only helpers** with no daemon IPC:
 | `host_platform` | `&'static str` (`std::env::consts::OS`) | `"linux"` / `"macos"` / `"windows"` to gate platform UI |
 | `elevate` / `unelevate` | `()` | run `yerd elevate <target>` / `yerd unelevate <target>` under OS elevation (see below) |
 
-The Settings page (route `/general`) adds further host-only commands (no daemon IPC) for daemon lifecycle and autostart - `daemon_installed`, `start_daemon`, `stop_daemon`, `cli_path_status`, `install_cli_to_path`, `remove_cli_from_path`, `open_login_items`, `get_autostart`, `set_autostart_daemon`, `set_autostart_gui`, `set_gui_minimized` - implemented in `daemon.rs` (resolve the bundled binaries, start/stop, install the `yerd` CLI on PATH) and `autostart.rs` (per-user service + run-at-login; macOS uses `smappservice.rs`). The daemon is **bundled** in the app, so there's no download/install command.
+The Settings page (route `/general`) adds further host-only commands (no daemon IPC) for daemon lifecycle and autostart - `daemon_installed`, `start_daemon`, `stop_daemon`, `cli_path_status`, `install_cli_to_path`, `remove_cli_from_path`, `open_login_items`, `get_autostart`, `set_autostart_daemon`, `set_autostart_gui`, `set_gui_minimized`, `daemon_self_repair_busy` - implemented in `daemon.rs` (resolve the bundled binaries, start/stop, install the `yerd` CLI on PATH) and `autostart.rs` (per-user service + run-at-login; macOS uses `smappservice.rs`). The daemon is **bundled** in the app, so there's no download/install command.
 
 On macOS, `autostart.rs` also self-repairs the daemon's SMAppService registration
-on every launch (`ensure_daemon_registration`). It folds the GUI/daemon version
+on every launch (`ensure_daemon_registration`, run from a background thread in
+`setup_app`). It folds the GUI/daemon version
 comparison (`decide`) and a phantom-job check into a `RegAction`: `Refuse` when
 the registered daemon is newer than this GUI (a downgrade guard - the running
 daemon is left alone and the version conflict is surfaced on the Overview
@@ -157,6 +158,18 @@ from since there's no job to kick. Every branch logs to
 `{cache}/yerd-gui-repair.log`, which `daemon_diagnostics`/"Copy diagnostics"
 surfaces - the first place to check when a daemon doesn't come back after an
 update.
+
+Because this thread runs unconditionally on every launch - including when
+onboarding is still showing (a prior "Install" click can leave a registration
+behind even if the journey wasn't finished) - it can be doing real,
+multi-second work (or opening Login Items) with no user click involved. The
+thread brackets its call to `ensure_daemon_registration` with a
+`DAEMON_SELF_REPAIR_BUSY` atomic flag and a `daemon-self-repair` Tauri event
+(`true` before, `false` after), which `useDaemonStart.ts`'s `backgroundBusy`
+signal (below) ORs into the Install/Start button's busy state, so the button
+never sits idle while this is happening. `DAEMON_REG_LOCK` is what actually
+serializes registration/kickstart calls against a concurrent manual start; the
+flag/event are purely a UX signal layered on top, not a correctness mechanism.
 
 ::: tip No `Request` is ever built in the frontend
 The `Request` enum is intentionally **not** mirrored into TypeScript. The
@@ -437,6 +450,7 @@ and `elevate` (the `elevate` command above), typed to the
 | Composable | Role |
 | --- | --- |
 | `useDaemon` | **Singleton** daemon store. One poller for the whole app (connection pill, views) so the daemon isn't hit by N independent `status` loops. `status` doubles as the liveness probe; only a genuine **unreachable** error flips `connected` to `false` - a typed daemon error still means the daemon is up. Started/stopped from `App.vue`. |
+| `useDaemonStart` | **Singleton** "start the daemon, wait for it to connect, diagnose on failure" flow shared by onboarding step 1, `DaemonDownHero`, and Doctor. `phase` (click-driven, fed by the Rust `daemon-start-phase` event) and `backgroundBusy` (fed by macOS's launch-time self-repair thread's `daemon-self-repair` event, see above) both OR into `starting`/`activeLabel` so every consumer's button reflects either kind of in-flight work - but `start()`'s own re-entrancy guard reads `phase` alone, so a same-tick self-repair no-op can never suppress `App.vue`'s automatic start. |
 | `usePoll` | Generic mount-scoped poller. Never overlaps in-flight calls, **pauses while the document is hidden** (background tab / tray), refreshes on becoming visible, and clears its timer on unmount. Default cadence 4s; callers should not go below ~3s for `status`. |
 | `useToast` | Module-level toast store rendered by the single `<Toaster>` in `App.vue`. Errors linger (8s), success/info auto-dismiss (4s). |
 


### PR DESCRIPTION
## What does this PR do?

On MacOS, the onboarding journey attempts to automatically install/repair the daemon, but this was not reflected in the UI, this fix ensures that it is reflected in the UI on first load. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer startup status for macOS, including a “Preparing Daemon” state while background repair work runs.
  * Exposed a new app-side status check so the UI can reflect daemon self-repair activity in real time.

* **Bug Fixes**
  * Improved startup behavior so background repair no longer blocks or hides normal daemon launch actions.
  * Added more reliable handling for startup state updates during edge cases and rapid transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->