### PR TITLE
[Feat] Fedora .rpm package and self-update support

### DIFF
--- a/.github/workflows/build-cdn.yml
+++ b/.github/workflows/build-cdn.yml
@@ -23,6 +23,14 @@ on:
         description: "Arch Linux x86_64 — .pkg.tar.zst"
         type: boolean
         default: false
+      fedora_x64:
+        description: "Fedora x86_64 — .rpm"
+        type: boolean
+        default: false
+      fedora_arm64:
+        description: "Fedora arm64 — .rpm"
+        type: boolean
+        default: false
       folder:
         description: "Override the builds/<folder> name (default: UTC YYYY-MM-DD_HH-MM-<run>). Must match ^[A-Za-z0-9][A-Za-z0-9._-]*$."
         type: string
@@ -60,6 +68,8 @@ jobs:
           IN_LINUX_X64: ${{ inputs.linux_x64 }}
           IN_LINUX_ARM64: ${{ inputs.linux_arm64 }}
           IN_ARCH: ${{ inputs.arch }}
+          IN_FEDORA_X64: ${{ inputs.fedora_x64 }}
+          IN_FEDORA_ARM64: ${{ inputs.fedora_arm64 }}
           IN_FOLDER: ${{ inputs.folder }}
         run: |
           set -euo pipefail
@@ -78,6 +88,12 @@ jobs:
           fi
           if [ "$IN_ARCH" = "true" ]; then
             add '{"id":"arch-x86_64","runner":"ubuntu-22.04","container":"archlinux:base-devel","kind":"arch"}'
+          fi
+          if [ "$IN_FEDORA_X64" = "true" ]; then
+            add '{"id":"fedora-x86_64","runner":"ubuntu-22.04","container":"","kind":"fedora"}'
+          fi
+          if [ "$IN_FEDORA_ARM64" = "true" ]; then
+            add '{"id":"fedora-arm64","runner":"ubuntu-22.04-arm","container":"","kind":"fedora"}'
           fi
           [ "$(printf '%s' "$targets" | jq 'length')" -gt 0 ] \
             || { echo "::error::select at least one target"; exit 1; }
@@ -140,7 +156,7 @@ jobs:
         run: |
           set -euo pipefail
           find . -mindepth 2 -type f \
-            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' \) \
+            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' -o -name '*.rpm' \) \
             -exec mv -t . {} +
           find . -mindepth 1 -type d -exec rm -rf {} +
           ver="v${VERSION}"
@@ -151,6 +167,7 @@ jobs:
               *.pkg.tar.zst) ext="pkg.tar.zst"; os="Linux" ;;
               *.dmg)         ext="dmg";         os="MacOS" ;;
               *.deb)         ext="deb";         os="Linux" ;;
+              *.rpm)         ext="rpm";         os="Linux" ;;
               *) continue ;;
             esac
             case "$f" in
@@ -166,7 +183,7 @@ jobs:
         working-directory: dist
         run: |
           find . -maxdepth 1 -type f \
-            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' \) \
+            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' -o -name '*.rpm' \) \
             -printf '%P\n' | sort | xargs -r sha256sum > SHA256SUMS
           cat SHA256SUMS
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,12 @@ jobs:
       # No authenticated git op in the GUI build (npm ci / cargo / tauri), so
       # don't leave the token in .git/config where third-party build code runs.
       - uses: actions/checkout@v4
-        if: matrix.kind == 'gui'
+        if: matrix.kind == 'gui' || matrix.kind == 'fedora'
         with:
           persist-credentials: false
 
       - name: Install Linux GUI build deps
-        if: matrix.kind == 'gui' && runner.os == 'Linux'
+        if: (matrix.kind == 'gui' || matrix.kind == 'fedora') && runner.os == 'Linux'
         working-directory: .
         run: |
           sudo apt-get update
@@ -73,16 +73,16 @@ jobs:
             libdbus-1-dev libxdo-dev librsvg2-dev
 
       - uses: actions/setup-node@v4
-        if: matrix.kind == 'gui'
+        if: matrix.kind == 'gui' || matrix.kind == 'fedora'
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: apps/yerd-gui/package-lock.json
       - uses: Swatinem/rust-cache@v2
-        if: matrix.kind == 'gui'
+        if: matrix.kind == 'gui' || matrix.kind == 'fedora'
 
       - name: Install frontend deps
-        if: matrix.kind == 'gui'
+        if: matrix.kind == 'gui' || matrix.kind == 'fedora'
         run: npm ci
 
       # macOS: import the Developer ID cert into an ephemeral keychain and stage
@@ -485,11 +485,82 @@ jobs:
           # relabels it to Yerd_Linux_x86_64_v<ver>.pkg.tar.zst.
           cp "$PKG" "$GITHUB_WORKSPACE/arch-out/Yerd_${YERD_PKGVER}_x86_64.pkg.tar.zst"
 
+      # ─────────────────────────────── Fedora target ─────────────────────────────
+      # Native Fedora .rpm via Tauri's built-in (pure-Rust) rpm bundler. Unlike the
+      # Arch leg no container is needed - the bundler runs on Ubuntu. The daemon is
+      # built with the `rpm` self-update feature; the gate below proves it took. The
+      # rpm's real-Fedora validation (deps resolve, %post runs) is the blocking
+      # smoke job in release.yml. These steps keep the GUI leg's default
+      # working-directory (apps/yerd-gui) for the tauri build, and set an explicit
+      # repo-root working-directory for the cargo/staging steps.
+      - name: Stage embedded binaries with the rpm feature (externalBin)
+        if: matrix.kind == 'fedora'
+        working-directory: .
+        run: |
+          set -euo pipefail
+          cargo build --release --features yerdd/rpm -p yerd -p yerdd -p yerd-helper
+          # Symmetric guard to the deb (:137-139) and arch (:473-475) legs: the
+          # bundled daemon MUST be rpm-format, else the .rpm would ship a daemon
+          # that self-updates via the wrong package manager.
+          fmt=$(./target/release/yerdd --pkg-format)
+          [ "$fmt" = "rpm" ] \
+            || { echo "::error::fedora yerdd --pkg-format=$fmt (expected rpm); the rpm feature did not take"; exit 1; }
+          mkdir -p apps/yerd-gui/src-tauri/binaries
+          if [ "$(uname -m)" = "aarch64" ]; then
+            triple=aarch64-unknown-linux-gnu
+          else
+            triple=x86_64-unknown-linux-gnu
+          fi
+          for b in yerd yerdd yerd-helper; do
+            cp "target/release/$b" "apps/yerd-gui/src-tauri/binaries/$b-$triple"
+          done
+
+      - name: Build the Fedora .rpm (Tauri rpm bundler)
+        if: matrix.kind == 'fedora'
+        run: npm run tauri build -- --config src-tauri/tauri.bundle-linux-rpm.conf.json
+
+      - name: Stage the .rpm with a Yerd_* name for the rename step
+        if: matrix.kind == 'fedora'
+        working-directory: .
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          rpms=(target/release/bundle/rpm/*.rpm \
+                apps/yerd-gui/src-tauri/target/release/bundle/rpm/*.rpm)
+          [ "${#rpms[@]}" -gt 0 ] || { echo "::error::no .rpm produced"; exit 1; }
+          rpm="${rpms[0]}"
+          # Tauri names the file Yerd-<ver>-1.<arch>.rpm (hyphen), which the publish
+          # `Yerd_*` rename glob would miss - so stage a `Yerd_*` copy with an
+          # arch token so the rename loop yields Yerd_Linux_x86_64_v<ver>.rpm /
+          # Yerd_Linux_Arm64_v<ver>.rpm (mirrors the arch leg's staging).
+          if [ "$(uname -m)" = "aarch64" ]; then arch=arm64; else arch=x86_64; fi
+          mkdir -p "$GITHUB_WORKSPACE/fedora-out"
+          cp "$rpm" "$GITHUB_WORKSPACE/fedora-out/Yerd_${arch}.rpm"
+
+      - name: Assert .rpm contents + %post scriptlet
+        if: matrix.kind == 'fedora'
+        working-directory: .
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rpm
+          pkg=$(ls "$GITHUB_WORKSPACE"/fedora-out/*.rpm | head -n1)
+          list=$(rpm -qlp "$pkg")
+          for b in yerd yerdd yerd-helper yerd-gui; do
+            printf '%s\n' "$list" | grep -Eq "^/usr/bin/$b\$" \
+              || { echo "::error::.rpm missing /usr/bin/$b"; exit 1; }
+          done
+          # The %post scriptlet (setcap) must be present.
+          rpm -qp --scripts "$pkg" | grep -qi "postinstall" \
+            || { echo "::error::.rpm has no %post scriptlet"; exit 1; }
+          echo "Fedora .rpm OK: $pkg (pkg-format=rpm)"
+
       # ──────────────────────────────── Upload ──────────────────────────────────
-      # One upload for either kind: on a GUI leg the bundle globs match and
-      # arch-out is absent; on the Arch leg only arch-out matches. `if-no-files-
-      # found: error` fires only if the whole union is empty. Paths are resolved
-      # relative to the workspace (upload-artifact ignores the run default).
+      # One upload for any kind: on a GUI leg the bundle globs match and arch-out /
+      # fedora-out are absent; on the Arch leg only arch-out matches; on the Fedora
+      # leg only fedora-out matches. `if-no-files-found: error` fires only if the
+      # whole union is empty. Paths are resolved relative to the workspace
+      # (upload-artifact ignores the run default).
       - uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.id }}
@@ -501,3 +572,4 @@ jobs:
             apps/yerd-gui/src-tauri/target/release/bundle/**/*.dmg
             apps/yerd-gui/src-tauri/target/release/bundle/updater/*.app.tar.gz
             arch-out/*.pkg.tar.zst
+            fedora-out/*.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,30 @@ jobs:
             --all-targets -- -D warnings
           cargo test -p yerdd -p yerd-update --features yerdd/pacman
 
+      # The Fedora package builds the daemon with `--features yerdd/rpm`, which
+      # default `--workspace` never exercises (the `PkgFormat::Rpm` selection arm +
+      # the cfg-gated stage_update fixtures). Mirrors the pacman step above; both
+      # matrix arches run it, so the aarch64 selection arm is covered too.
+      - name: Clippy + test (rpm feature)
+        if: runner.os == 'Linux'
+        run: |
+          cargo clippy -p yerdd -p yerd-update --features yerdd/rpm \
+            --all-targets -- -D warnings
+          cargo test -p yerdd -p yerd-update --features yerdd/rpm
+
+      # The `pacman` and `rpm` self-update features are mutually exclusive; enabling
+      # both must fail to compile (the `compile_error!` guard in yerd-update). An
+      # explicit guard, not a bare `! cargo build` (which `set -e` ignores unless it
+      # is the block's terminal command).
+      - name: Assert pacman + rpm features are mutually exclusive
+        if: runner.os == 'Linux'
+        run: |
+          if cargo build -p yerdd --features yerdd/pacman,yerdd/rpm 2>/dev/null; then
+            echo "::error::yerdd with both pacman and rpm features must not compile"
+            exit 1
+          fi
+          echo "OK: pacman+rpm correctly refuses to compile"
+
   # Frontend unit/component tests + production build (type-check via vue-tsc).
   frontend:
     name: frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,16 +51,54 @@ jobs:
           {"id":"linux-x86_64","runner":"ubuntu-22.04","container":"","kind":"gui"},
           {"id":"linux-arm64","runner":"ubuntu-22.04-arm","container":"","kind":"gui"},
           {"id":"macos","runner":"macos-14","container":"","kind":"gui"},
-          {"id":"arch-x86_64","runner":"ubuntu-22.04","container":"archlinux:base-devel","kind":"arch"}
+          {"id":"arch-x86_64","runner":"ubuntu-22.04","container":"archlinux:base-devel","kind":"arch"},
+          {"id":"fedora-x86_64","runner":"ubuntu-22.04","container":"","kind":"fedora"},
+          {"id":"fedora-arm64","runner":"ubuntu-22.04-arm","container":"","kind":"fedora"}
         ]
     secrets: inherit
+
+  # Real-Fedora validation of the freshly-built .rpm — the ONLY place its `depends`
+  # names and %post scriptlet run on an actual rpm stack (the bundler itself runs on
+  # Ubuntu). Blocking: `publish` needs it, so a broken rpm can't ship. x86_64 only;
+  # both arches share one depends list + one %post, so this still catches a typo'd
+  # dependency name or a broken scriptlet.
+  smoke:
+    name: fedora-smoke
+    needs: build
+    runs-on: ubuntu-22.04
+    container: fedora:latest
+    steps:
+      # findutils isn't in the minimal fedora image; dnf is. Install it before the
+      # `find` below (libcap/getcap arrive as an rpm dependency of the package).
+      - name: Install smoke prereqs
+        run: dnf -y install findutils
+      - name: Download the fedora x86_64 build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-fedora-x86_64
+          path: rpm
+      - name: dnf install + assert pkg-format
+        run: |
+          set -euo pipefail
+          pkg=$(find rpm -name '*.rpm' | head -n1)
+          [ -n "$pkg" ] || { echo "::error::no .rpm in the fedora artifact"; exit 1; }
+          # Proves every Requires resolves against Fedora repos, and runs %post.
+          dnf install -y "$pkg"
+          # Blocking: the shipped daemon must self-update via rpm.
+          fmt=$(yerdd --pkg-format)
+          [ "$fmt" = "rpm" ] \
+            || { echo "::error::installed yerdd --pkg-format=$fmt (expected rpm)"; exit 1; }
+          # Advisory: file caps often can't persist on a container's overlayfs.
+          getcap /usr/bin/yerdd | grep -q cap_net_bind_service \
+            || echo "::warning::setcap did not persist in the container (expected on overlayfs)"
+          echo "Fedora smoke OK: $pkg installs, deps resolve, pkg-format=rpm"
 
   # The ONLY job that touches the release. Assemble everything, create it as a
   # hidden draft with all files + checksums attached, then flip it public —
   # so nobody can ever see a release missing its artifacts.
   publish:
     name: publish
-    needs: build
+    needs: [build, smoke]
     runs-on: ubuntu-22.04
     # Checkout is needed so the trust-anchor gate can read the embedded
     # UPDATE_PUBLIC_KEY from source at the tagged commit. GH_REPO is kept explicit
@@ -90,7 +128,7 @@ jobs:
         run: |
           set -euo pipefail
           find . -mindepth 2 -type f \
-            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' \) \
+            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' -o -name '*.rpm' \) \
             -exec mv -t . {} +
           # Drop the now-redundant nested dirs so `dist/*` is files-only.
           find . -mindepth 1 -type d -exec rm -rf {} +
@@ -111,6 +149,7 @@ jobs:
               *.pkg.tar.zst) ext="pkg.tar.zst"; os="Linux" ;;
               *.dmg)         ext="dmg";         os="MacOS" ;;
               *.deb)         ext="deb";         os="Linux" ;;
+              *.rpm)         ext="rpm";         os="Linux" ;;
               *) continue ;;
             esac
             case "$f" in
@@ -151,7 +190,7 @@ jobs:
           trap 'rm -f "$RUNNER_TEMP/minisign.key"' EXIT
           umask 077; printf '%s\n' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/minisign.key"
           shopt -s nullglob
-          for f in *.app.tar.gz *.deb *.pkg.tar.zst; do
+          for f in *.app.tar.gz *.deb *.pkg.tar.zst *.rpm; do
             minisign -S -H -s "$RUNNER_TEMP/minisign.key" -m "$f" -x "$f.sig"
             echo "signed $f -> $f.sig"
           done
@@ -174,7 +213,7 @@ jobs:
             exit 1
           fi
           shopt -s nullglob
-          for f in *.app.tar.gz *.deb *.pkg.tar.zst; do
+          for f in *.app.tar.gz *.deb *.pkg.tar.zst *.rpm; do
             minisign -V -H -P "$KEY" -m "$f" -x "$f.sig" \
               || { echo "::error::embedded UPDATE_PUBLIC_KEY does not verify $f.sig (key/secret mismatch)"; exit 1; }
             echo "verified $f against embedded key"
@@ -184,7 +223,7 @@ jobs:
         working-directory: dist
         run: |
           find . -maxdepth 1 -type f \
-            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' \) \
+            \( -name '*.deb' -o -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.pkg.tar.zst' -o -name '*.rpm' \) \
             -printf '%P\n' | sort | xargs -r sha256sum > SHA256SUMS
           echo "Artifacts:" && cat SHA256SUMS
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,10 @@ jobs:
     name: fedora-smoke
     needs: build
     runs-on: ubuntu-22.04
-    container: fedora:latest
+    # Pinned to a fixed Fedora release (not the mutable `latest`) so a release run
+    # always validates against the same rpm environment. Bump deliberately; tighten
+    # to an `@sha256:` digest if fully-reproducible smoke runs are needed.
+    container: fedora:42
     steps:
       # findutils isn't in the minimal fedora image; dnf is. Install it before the
       # `find` below (libcap/getcap arrive as an rpm dependency of the package).

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ runtime). Grab the latest **stable release** from the
 | Linux · Debian/Ubuntu (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
 | Linux · Debian/Ubuntu (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
 | Linux · Arch (x86-64) | `Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` | `sudo pacman -U ./Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` |
+| Linux · Fedora (x86-64) | `Yerd_Linux_x86_64_v<ver>.rpm` | `sudo dnf install ./Yerd_Linux_x86_64_v<ver>.rpm` |
+| Linux · Fedora (arm64) | `Yerd_Linux_Arm64_v<ver>.rpm` | `sudo dnf install ./Yerd_Linux_Arm64_v<ver>.rpm` |
 
 > **Arch note.** If you have a leftover `/usr/bin/yerd` from the old v1 (Go)
 > project, remove it first - pacman refuses to install over a file it doesn't

--- a/apps/yerd-gui/src-tauri/deb/postrm.sh
+++ b/apps/yerd-gui/src-tauri/deb/postrm.sh
@@ -5,14 +5,19 @@
 # on upgrade (the new package's postinst recreates them). In the normal layout
 # Tauri ships the real binaries in /usr/bin (dpkg removes those itself); postinst
 # only creates symlinks in the /usr/lib fallback path. dpkg does not track
-# maintainer-script-created symlinks, so this is the only cleanup. The -L guard
-# means real, dpkg-owned files (and files another package owns) are left alone.
+# maintainer-script-created symlinks, so this is the only cleanup. We remove a
+# symlink only if it still points into the /usr/lib fallback dir (the exact target
+# shape postinst creates) - so real dpkg-owned files and foreign symlinks another
+# package repointed are left alone, mirroring postinst's refuse-to-clobber guard.
 set -e
 
 case "$1" in
   remove|purge)
     for b in yerd yerdd yerd-helper; do
-      [ -L "/usr/bin/$b" ] && rm -f "/usr/bin/$b"
+      [ -L "/usr/bin/$b" ] || continue
+      case "$(readlink "/usr/bin/$b")" in
+        /usr/lib/*/"$b") rm -f "/usr/bin/$b" ;;
+      esac
     done
     ;;
 esac

--- a/apps/yerd-gui/src-tauri/rpm/postinst.sh
+++ b/apps/yerd-gui/src-tauri/rpm/postinst.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Yerd GUI .rpm %post scriptlet.
+#
+# Tauri's rpm bundler installs the GUI **and** its externalBin sidecars (yerd,
+# yerdd, yerd-helper) side-by-side into /usr/bin - so they are already on PATH and
+# already siblings of /usr/bin/yerd-gui. No symlinking is needed in that (normal)
+# layout; the only post-install work is granting the daemon permission to bind
+# privileged ports (80/443). If setcap fails (overlayfs/NFS/noxattr mounts can't
+# hold file capabilities) the daemon falls back to 8080/8443.
+#
+# Unlike a deb postinst (which receives the `configure` verb as $1), an rpm %post
+# receives $1 = the post-transaction count of packages with this name: 1 on a
+# fresh install, 2 during an upgrade. We want to (re)apply setcap in both cases
+# (rpm wipes file caps on upgrade), so there is no verb to switch on. A
+# /usr/lib/<product>/ fallback is kept for resilience with foreign layouts that
+# stage the sidecars there instead of /usr/bin.
+set -e
+
+# Locate the daemon: /usr/bin (normal) or a single /usr/lib/<dir>/ fallback we
+# symlink onto PATH. Fail closed (below) only if it's absent from both.
+yerdd=""
+if [ -x /usr/bin/yerdd ] && [ -x /usr/bin/yerd ] && [ -x /usr/bin/yerd-helper ]; then
+  yerdd=/usr/bin/yerdd
+else
+  # Locate the single embedded dir holding all three binaries; refuse on an
+  # ambiguous match (a stale/foreign tree) before touching /usr/bin.
+  dir=""
+  for cand in /usr/lib/*/yerdd; do
+    [ -f "$cand" ] || continue
+    d=$(dirname "$cand")
+    [ -f "$d/yerd" ] && [ -f "$d/yerd-helper" ] || continue
+    if [ -n "$dir" ] && [ "$dir" != "$d" ]; then
+      echo "yerd: multiple embedded binary dirs ($dir and $d); refusing to symlink" >&2
+      exit 1
+    fi
+    dir="$d"
+  done
+  if [ -n "$dir" ]; then
+    # Co-locate on PATH; refuse to clobber a real file or a foreign symlink at
+    # /usr/bin/$b - that would steal a path owned by another package.
+    for b in yerd yerdd yerd-helper; do
+      src="$dir/$b"
+      dst="/usr/bin/$b"
+      if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+        echo "yerd: $dst exists and is not a symlink; refusing to overwrite" >&2
+        exit 1
+      fi
+      if [ -L "$dst" ] && [ "$(readlink "$dst")" != "$src" ]; then
+        echo "yerd: $dst points elsewhere; refusing to overwrite foreign symlink" >&2
+        exit 1
+      fi
+      ln -sfn "$src" "$dst"
+    done
+    yerdd="$dir/yerdd"
+  fi
+fi
+if [ -z "$yerdd" ]; then
+  echo "yerd: could not locate the yerdd binary in /usr/bin or /usr/lib" >&2
+  exit 1
+fi
+
+# Privileged-port capability on the REAL daemon binary; best-effort.
+if command -v setcap >/dev/null 2>&1; then
+  setcap 'cap_net_bind_service=+ep' "$yerdd" \
+    || echo "yerd: setcap failed; the daemon will use ports 8080/8443" >&2
+else
+  echo "yerd: setcap not found (install libcap); the daemon will use 8080/8443" >&2
+fi
+
+exit 0

--- a/apps/yerd-gui/src-tauri/rpm/postrm.sh
+++ b/apps/yerd-gui/src-tauri/rpm/postrm.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Yerd GUI .rpm %postun scriptlet.
+#
+# Remove any /usr/bin symlinks %post created - but ONLY on real erase, never on
+# upgrade (the new package's %post recreates them). In the normal layout Tauri
+# ships the real binaries in /usr/bin (rpm removes those itself); %post only
+# creates symlinks in the /usr/lib fallback path. rpm does not track
+# scriptlet-created symlinks, so this is the only cleanup. The -L guard means
+# real, rpm-owned files (and files another package owns) are left alone.
+#
+# Unlike a deb postrm (which switches on a remove/purge/upgrade verb), an rpm
+# %postun receives $1 = the count of this package's versions remaining after the
+# transaction: 0 on a final erase, 1 during an upgrade. Clean up only when it hits
+# 0, so an upgrade (whose new %post will recreate the symlinks) is left untouched.
+set -e
+
+if [ "$1" = 0 ]; then
+  for b in yerd yerdd yerd-helper; do
+    [ -L "/usr/bin/$b" ] && rm -f "/usr/bin/$b"
+  done
+fi
+
+exit 0

--- a/apps/yerd-gui/src-tauri/rpm/postrm.sh
+++ b/apps/yerd-gui/src-tauri/rpm/postrm.sh
@@ -5,8 +5,10 @@
 # upgrade (the new package's %post recreates them). In the normal layout Tauri
 # ships the real binaries in /usr/bin (rpm removes those itself); %post only
 # creates symlinks in the /usr/lib fallback path. rpm does not track
-# scriptlet-created symlinks, so this is the only cleanup. The -L guard means
-# real, rpm-owned files (and files another package owns) are left alone.
+# scriptlet-created symlinks, so this is the only cleanup. We remove a symlink
+# only if it still points into the /usr/lib fallback dir (the exact target shape
+# %post creates) - so real rpm-owned files and foreign symlinks another package
+# repointed are left alone, mirroring %post's refuse-to-clobber guard.
 #
 # Unlike a deb postrm (which switches on a remove/purge/upgrade verb), an rpm
 # %postun receives $1 = the count of this package's versions remaining after the
@@ -16,7 +18,10 @@ set -e
 
 if [ "$1" = 0 ]; then
   for b in yerd yerdd yerd-helper; do
-    [ -L "/usr/bin/$b" ] && rm -f "/usr/bin/$b"
+    [ -L "/usr/bin/$b" ] || continue
+    case "$(readlink "/usr/bin/$b")" in
+      /usr/lib/*/"$b") rm -f "/usr/bin/$b" ;;
+    esac
   done
 fi
 

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -230,6 +230,7 @@ pub async fn apply_update(app: tauri::AppHandle, channel: Option<String>) -> Res
         yerd_ipc::StagedArtifact::AppTarGz => "app_tar_gz",
         yerd_ipc::StagedArtifact::Deb => "deb",
         yerd_ipc::StagedArtifact::Pacman => "pacman",
+        yerd_ipc::StagedArtifact::Rpm => "rpm",
         _ => {
             return Err(GuiError::internal(
                 "unknown staged artifact kind from the daemon",

--- a/apps/yerd-gui/src-tauri/tauri.bundle-linux-rpm.conf.json
+++ b/apps/yerd-gui/src-tauri/tauri.bundle-linux-rpm.conf.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": ["rpm"],
+    "externalBin": ["binaries/yerd", "binaries/yerdd", "binaries/yerd-helper"],
+    "linux": {
+      "rpm": {
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3",
+          "libayatana-appindicator-gtk3",
+          "librsvg2",
+          "libcap",
+          "libxcrypt-compat"
+        ],
+        "postInstallScript": "rpm/postinst.sh"
+      }
+    }
+  }
+}

--- a/apps/yerd-gui/src-tauri/tauri.bundle-linux-rpm.conf.json
+++ b/apps/yerd-gui/src-tauri/tauri.bundle-linux-rpm.conf.json
@@ -13,7 +13,8 @@
           "libcap",
           "libxcrypt-compat"
         ],
-        "postInstallScript": "rpm/postinst.sh"
+        "postInstallScript": "rpm/postinst.sh",
+        "postRemoveScript": "rpm/postrm.sh"
       }
     }
   }

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -602,9 +602,12 @@ fn apply_linux_rpm(staged: &Path, relaunch_gui: bool) -> Result<(), String> {
 /// `rpm -U`s that copy - closing the verify→re-read TOCTOU on the user-writable
 /// staged path. The package's `%post` scriptlet reapplies setcap.
 ///
-/// `rpm -U --oldpackage` installs the file regardless of version (so an
-/// edge-to-stable downgrade works, like `dpkg -i`); `rpm` is non-interactive by
-/// default. Unlike `dnf`, `rpm -U` does not *resolve* dependencies, but it does
+/// `rpm -U --oldpackage --replacepkgs` installs the file regardless of version (so
+/// an edge-to-stable downgrade works, like `dpkg -i`); `--replacepkgs` also lets a
+/// same-version reinstall succeed, so a retry after a partial/interrupted attempt
+/// is idempotent (plain `rpm -U` would abort with "already installed"). `rpm` is
+/// non-interactive by default. Unlike `dnf`, `rpm -U` does not *resolve*
+/// dependencies, but it does
 /// *check* them: it aborts on an unmet `Requires`, so the packaged `depends` list
 /// must not gain a new entry between releases (an existing install would have the
 /// old deps only). It also fails if PackageKit/dnf holds the rpmdb lock. rpm's
@@ -636,6 +639,7 @@ fn elevated_install_rpm(staged: &Path) -> Result<(), String> {
         let out = Command::new("rpm")
             .arg("-U")
             .arg("--oldpackage")
+            .arg("--replacepkgs")
             .arg(&pkg)
             .output()
             .map_err(|e| format!("spawning rpm: {e}"))?;

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -45,7 +45,7 @@ use yerd_update::{verify_minisign, UPDATE_PUBLIC_KEY};
 pub const APPLY_ENV: &str = "YERD_APPLY_UPDATE";
 /// Env var carrying the staged artifact path.
 pub const APPLY_PATH_ENV: &str = "YERD_APPLY_PATH";
-/// Env var carrying the artifact kind: `"deb"`, `"pacman"`, or `"app_tar_gz"`.
+/// Env var carrying the artifact kind: `"deb"`, `"pacman"`, `"rpm"`, or `"app_tar_gz"`.
 pub const APPLY_KIND_ENV: &str = "YERD_APPLY_KIND";
 /// Env var: `"1"` to relaunch the GUI after the install.
 pub const APPLY_RELAUNCH_GUI_ENV: &str = "YERD_APPLY_RELAUNCH_GUI";
@@ -57,6 +57,10 @@ pub const INSTALL_DEB_ARG: &str = "__yerd-install-deb";
 /// argv sentinel for the elevated Arch pacman-install re-exec. Mirrors
 /// [`INSTALL_DEB_ARG`] for the `.pkg.tar.zst` install path.
 pub const INSTALL_PACMAN_ARG: &str = "__yerd-install-pacman";
+
+/// argv sentinel for the elevated Fedora rpm-install re-exec. Mirrors
+/// [`INSTALL_DEB_ARG`] for the `.rpm` install path.
+pub const INSTALL_RPM_ARG: &str = "__yerd-install-rpm";
 
 /// If invoked as the elevated deb installer (`yerd __yerd-install-deb <path>`),
 /// run it and return the exit code; otherwise `None` (normal dispatch proceeds).
@@ -88,6 +92,22 @@ pub fn run_install_pacman_from_args() -> Option<ExitCode> {
         return Some(ExitCode::from(2));
     };
     Some(install_pacman_entry(Path::new(&path)))
+}
+
+/// If invoked as the elevated rpm installer (`yerd __yerd-install-rpm <path>`),
+/// run it and return the exit code; otherwise `None`. The rpm counterpart of
+/// [`run_install_deb_from_args`].
+#[must_use]
+pub fn run_install_rpm_from_args() -> Option<ExitCode> {
+    let mut args = std::env::args_os().skip(1);
+    if args.next()?.to_str() != Some(INSTALL_RPM_ARG) {
+        return None;
+    }
+    let Some(path) = args.next() else {
+        eprintln!("yerd: {INSTALL_RPM_ARG} requires a path");
+        return Some(ExitCode::from(2));
+    };
+    Some(install_rpm_entry(Path::new(&path)))
 }
 
 /// Run the elevated deb install (Linux). The cfg split lives in a helper with a
@@ -127,6 +147,24 @@ fn install_pacman_entry(_path: &Path) -> ExitCode {
     ExitCode::from(1)
 }
 
+/// Run the elevated rpm install (Linux). Mirror of [`install_deb_entry`].
+#[cfg(target_os = "linux")]
+fn install_rpm_entry(path: &Path) -> ExitCode {
+    match elevated_install_rpm(path) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("yerd: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn install_rpm_entry(_path: &Path) -> ExitCode {
+    eprintln!("yerd: elevated rpm install is Linux-only");
+    ExitCode::from(1)
+}
+
 /// If invoked in applier mode (the [`APPLY_ENV`] var is set), run the apply and
 /// return its exit code; otherwise `None` (normal CLI dispatch proceeds). All
 /// inputs travel via env vars so nothing leaks into the argv-driven help.
@@ -140,10 +178,11 @@ pub fn run_from_env() -> Option<ExitCode> {
     let kind = match std::env::var(APPLY_KIND_ENV).as_deref() {
         Ok("deb") => StagedArtifact::Deb,
         Ok("pacman") => StagedArtifact::Pacman,
+        Ok("rpm") => StagedArtifact::Rpm,
         Ok("app_tar_gz") => StagedArtifact::AppTarGz,
         other => {
             eprintln!(
-                "yerd: invalid {APPLY_KIND_ENV}={other:?} (expected \"deb\", \"pacman\" or \"app_tar_gz\")"
+                "yerd: invalid {APPLY_KIND_ENV}={other:?} (expected \"deb\", \"pacman\", \"rpm\" or \"app_tar_gz\")"
             );
             return Some(ExitCode::from(2));
         }
@@ -165,6 +204,7 @@ pub fn run(staged: &Path, kind: StagedArtifact, relaunch_gui: bool) -> ExitCode 
         StagedArtifact::AppTarGz => apply_macos(staged, relaunch_gui),
         StagedArtifact::Deb => apply_linux(staged, relaunch_gui),
         StagedArtifact::Pacman => apply_linux_pacman(staged, relaunch_gui),
+        StagedArtifact::Rpm => apply_linux_rpm(staged, relaunch_gui),
         _ => Err("unknown staged artifact kind from the daemon".to_owned()),
     };
     match result {
@@ -535,6 +575,90 @@ fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
     install
 }
 
+// ── Linux (Fedora): reinstall the .rpm ───────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn apply_linux_rpm(staged: &Path, relaunch_gui: bool) -> Result<(), String> {
+    if nix::unistd::geteuid().is_root() {
+        return elevated_install_rpm(staged);
+    }
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let status = Command::new("pkexec")
+        .arg(&exe)
+        .arg(INSTALL_RPM_ARG)
+        .arg(staged)
+        .status()
+        .map_err(|e| format!("spawning pkexec: {e}"))?;
+    if !status.success() {
+        return Err("privileged install (pkexec) failed or was cancelled".to_owned());
+    }
+    restart_services(relaunch_gui);
+    Ok(())
+}
+
+/// Elevated installer (runs as root via the `pkexec` re-exec). Mirror of
+/// [`elevated_install_deb`] for the Fedora package: reads + verifies the staged
+/// `.rpm` **once**, copies the verified bytes into a root-owned 0700 dir, and
+/// `rpm -U`s that copy - closing the verify→re-read TOCTOU on the user-writable
+/// staged path. The package's `%post` scriptlet reapplies setcap.
+///
+/// `rpm -U --oldpackage` installs the file regardless of version (so an
+/// edge-to-stable downgrade works, like `dpkg -i`); `rpm` is non-interactive by
+/// default. Unlike `dnf`, `rpm -U` does not *resolve* dependencies, but it does
+/// *check* them: it aborts on an unmet `Requires`, so the packaged `depends` list
+/// must not gain a new entry between releases (an existing install would have the
+/// old deps only). It also fails if PackageKit/dnf holds the rpmdb lock. rpm's
+/// output (stderr, then stdout) is surfaced in the error so unmet-dep / db-lock
+/// failures are legible rather than a generic "failed". The copy keeps a `.rpm`
+/// suffix for clarity; the package name itself comes from the embedded header.
+#[cfg(target_os = "linux")]
+fn elevated_install_rpm(staged: &Path) -> Result<(), String> {
+    use std::os::unix::fs::{DirBuilderExt as _, PermissionsExt as _};
+
+    if !nix::unistd::geteuid().is_root() {
+        return Err("the elevated installer must run as root".to_owned());
+    }
+    let bytes = std::fs::read(staged).map_err(|e| format!("reading staged .rpm: {e}"))?;
+    let sig_path = sibling_sig(staged);
+    let sig = std::fs::read_to_string(&sig_path)
+        .map_err(|e| format!("reading signature {}: {e}", sig_path.display()))?;
+    verify_minisign(UPDATE_PUBLIC_KEY, &sig, &bytes).map_err(|e| e.to_string())?;
+
+    let dir = std::env::temp_dir().join(format!("yerd-update-{}", unique_suffix()));
+    std::fs::DirBuilder::new()
+        .mode(0o700)
+        .create(&dir)
+        .map_err(|e| format!("creating secure install dir: {e}"))?;
+    let pkg = dir.join("update.rpm");
+    let install = (|| -> Result<(), String> {
+        std::fs::write(&pkg, &bytes).map_err(|e| format!("writing verified .rpm: {e}"))?;
+        let _ = std::fs::set_permissions(&pkg, std::fs::Permissions::from_mode(0o600));
+        let out = Command::new("rpm")
+            .arg("-U")
+            .arg("--oldpackage")
+            .arg(&pkg)
+            .output()
+            .map_err(|e| format!("spawning rpm: {e}"))?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let detail = if stderr.trim().is_empty() {
+                String::from_utf8_lossy(&out.stdout).trim().to_owned()
+            } else {
+                stderr.trim().to_owned()
+            };
+            if detail.is_empty() {
+                Err("rpm failed to install the new package".to_owned())
+            } else {
+                Err(format!("rpm failed to install the new package: {detail}"))
+            }
+        }
+    })();
+    let _ = std::fs::remove_dir_all(&dir);
+    install
+}
+
 #[cfg(target_os = "linux")]
 fn relaunch_gui_app() {
     use std::os::unix::process::CommandExt as _;
@@ -571,6 +695,11 @@ fn apply_linux(_staged: &Path, _relaunch_gui: bool) -> Result<(), String> {
 #[cfg(not(target_os = "linux"))]
 fn apply_linux_pacman(_staged: &Path, _relaunch_gui: bool) -> Result<(), String> {
     Err("an Arch .pkg.tar.zst cannot be installed on this platform".to_owned())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn apply_linux_rpm(_staged: &Path, _relaunch_gui: bool) -> Result<(), String> {
+    Err("a Fedora .rpm cannot be installed on this platform".to_owned())
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]

--- a/bin/yerd/src/main.rs
+++ b/bin/yerd/src/main.rs
@@ -29,6 +29,9 @@ fn main() -> ExitCode {
     if let Some(code) = yerd::apply::run_install_pacman_from_args() {
         return code;
     }
+    if let Some(code) = yerd::apply::run_install_rpm_from_args() {
+        return code;
+    }
 
     let cli = Cli::parse();
     let runtime = match tokio::runtime::Builder::new_current_thread()

--- a/bin/yerdd/Cargo.toml
+++ b/bin/yerdd/Cargo.toml
@@ -12,6 +12,10 @@ description            = "Yerd unprivileged daemon — wires every Phase-1 libra
 # to `Pacman` so self-update selects the `.pkg.tar.zst` and installs via `pacman -U`.
 # Enabled ONLY by the Arch CI build (`--features yerdd/pacman`); default off → `.deb`.
 pacman = ["yerd-update/pacman"]
+# Build the daemon for the Fedora package: flips `PkgFormat::current()` to `Rpm` so
+# self-update selects the `.rpm` and installs via `rpm -U`. Enabled ONLY by the
+# Fedora CI build (`--features yerdd/rpm`); mutually exclusive with `pacman`.
+rpm = ["yerd-update/rpm"]
 
 [[bin]]
 name = "yerdd"

--- a/bin/yerdd/src/args.rs
+++ b/bin/yerdd/src/args.rs
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 #[derive(clap::Parser, Debug)]
 #[command(name = "yerdd", version, about = "Yerd daemon")]
 pub struct Cli {
-    /// Print the build's self-update package format (`deb`/`pacman`) and exit.
+    /// Print the build's self-update package format (`deb`/`pacman`/`rpm`) and exit.
     ///
-    /// Hidden diagnostic: the release pipeline runs this on the freshly-built
-    /// Arch `yerdd` to assert it was compiled with the `pacman` feature, so a
-    /// forgotten `--features` flag fails the release instead of shipping a
-    /// `.deb`-format updater inside the `.pkg.tar.zst`. Handled in `main` before
-    /// the daemon starts.
+    /// Hidden diagnostic: the release pipeline runs this on the freshly-built Arch
+    /// and Fedora `yerdd` to assert it was compiled with the matching
+    /// `pacman`/`rpm` feature, so a forgotten `--features` flag fails the release
+    /// instead of shipping a `.deb`-format updater inside the `.pkg.tar.zst` or
+    /// `.rpm`. Handled in `main` before the daemon starts.
     #[arg(long, hide = true)]
     pub pkg_format: bool,
     /// Subcommand to run; defaults to `Serve` with default args when omitted.

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -3377,6 +3377,8 @@ Subject: Captured\r\n\r\nhi\r\n";
         let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
         let pkg = "Yerd_Linux_x86_64_v99-0-1.pkg.tar.zst";
         let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
+        let rpm = "Yerd_Linux_x86_64_v99-0-1.rpm";
+        let rpm_arm = "Yerd_Linux_Arm64_v99-0-1.rpm";
         let releases = format!(
             r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
@@ -3389,11 +3391,17 @@ Subject: Captured\r\n\r\nhi\r\n";
                 {{"name":"{pkg}.sig","browser_download_url":"https://h/{pkg}.sig","size":1}},
                 {{"name":"{pkg_arm}","browser_download_url":"https://h/{pkg_arm}","size":4}},
                 {{"name":"{pkg_arm}.sig","browser_download_url":"https://h/{pkg_arm}.sig","size":1}},
+                {{"name":"{rpm}","browser_download_url":"https://h/{rpm}","size":4}},
+                {{"name":"{rpm}.sig","browser_download_url":"https://h/{rpm}.sig","size":1}},
+                {{"name":"{rpm_arm}","browser_download_url":"https://h/{rpm_arm}","size":4}},
+                {{"name":"{rpm_arm}.sig","browser_download_url":"https://h/{rpm_arm}.sig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
             ]}}]"#
         );
         let h = yerd_update::sha256_hex(b"test");
-        let sums = format!("{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n{h}  {pkg}\n{h}  {pkg_arm}\n");
+        let sums = format!(
+            "{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n{h}  {pkg}\n{h}  {pkg_arm}\n{h}  {rpm}\n{h}  {rpm_arm}\n"
+        );
         let dl = StageDl { releases, sums };
 
         let resp = crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await;
@@ -3425,6 +3433,12 @@ Subject: Captured\r\n\r\nhi\r\n";
                     }
                     (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Pacman) => {
                         (yerd_ipc::StagedArtifact::Pacman, pkg_arm)
+                    }
+                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Rpm) => {
+                        (yerd_ipc::StagedArtifact::Rpm, rpm)
+                    }
+                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Rpm) => {
+                        (yerd_ipc::StagedArtifact::Rpm, rpm_arm)
                     }
                     (other, _) => panic!("unexpected platform for fixture: {other:?}"),
                 };

--- a/bin/yerdd/src/main.rs
+++ b/bin/yerdd/src/main.rs
@@ -57,11 +57,13 @@ fn main() -> ExitCode {
 }
 
 /// The build's self-update package format as a stable lowercase string
-/// (`"pacman"` when compiled with the `pacman` feature, else `"deb"`). Used by the
-/// hidden `--pkg-format` diagnostic the release pipeline asserts on.
+/// (`"pacman"` under the `pacman` feature, `"rpm"` under the `rpm` feature, else
+/// `"deb"`). Used by the hidden `--pkg-format` diagnostic the release pipeline
+/// asserts on.
 fn pkg_format_str() -> &'static str {
     match yerd_update::PkgFormat::current() {
         yerd_update::PkgFormat::Pacman => "pacman",
+        yerd_update::PkgFormat::Rpm => "rpm",
         yerd_update::PkgFormat::Deb => "deb",
     }
 }

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -430,6 +430,7 @@ pub async fn stage_update(
         ArtifactKind::AppTarGz => StagedArtifact::AppTarGz,
         ArtifactKind::Deb => StagedArtifact::Deb,
         ArtifactKind::Pacman => StagedArtifact::Pacman,
+        ArtifactKind::Rpm => StagedArtifact::Rpm,
     };
     tracing::info!(version = %target_ver, path = %path.display(), "staged verified update artifact");
     Response::Staged {

--- a/crates/yerd-ipc/src/update.rs
+++ b/crates/yerd-ipc/src/update.rs
@@ -46,4 +46,6 @@ pub enum StagedArtifact {
     Deb,
     /// Arch `.pkg.tar.zst` - the applier reinstalls via `pacman -U`.
     Pacman,
+    /// Linux `.rpm` - the applier reinstalls via `rpm -U`.
+    Rpm,
 }

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -1763,6 +1763,14 @@ fn staged_artifact_each_variant_byte_shape() {
         serde_json::from_str::<StagedArtifact>(r#""pacman""#).unwrap(),
         StagedArtifact::Pacman
     );
+    assert_eq!(
+        serde_json::to_string(&StagedArtifact::Rpm).unwrap(),
+        r#""rpm""#
+    );
+    assert_eq!(
+        serde_json::from_str::<StagedArtifact>(r#""rpm""#).unwrap(),
+        StagedArtifact::Rpm
+    );
 }
 
 #[test]

--- a/crates/yerd-update/Cargo.toml
+++ b/crates/yerd-update/Cargo.toml
@@ -14,11 +14,14 @@ minisign-verify = { workspace = true }
 hex             = { workspace = true }
 
 [features]
-# Build-time package-format tiebreak. A release ships BOTH a `.deb` and a
-# `.pkg.tar.zst` for the same Linux arch; the running binary must pick the one
+# Build-time package-format tiebreak. A release ships a `.deb`, a `.pkg.tar.zst`,
+# and a `.rpm` for the same Linux arch; the running binary must pick the one
 # matching how it was installed. Enabling `pacman` (the Arch package build only)
-# flips `PkgFormat::current()` to `Pacman`. Default off → `Deb`. See `PkgFormat`.
+# flips `PkgFormat::current()` to `Pacman`; `rpm` (the Fedora package build only)
+# flips it to `Rpm`. The two distro features are mutually exclusive. Default off →
+# `Deb`. See `PkgFormat`.
 pacman = []
+rpm = []
 
 [lints]
 workspace = true

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -78,35 +78,52 @@ pub enum ArtifactKind {
     Deb,
     /// An Arch package (reinstalled via `pacman -U`).
     Pacman,
+    /// A Red Hat package (reinstalled via `rpm -U`).
+    Rpm,
 }
 
 /// The Linux package format a build self-updates with.
 ///
-/// A release ships BOTH a `.deb` and a `.pkg.tar.zst` for the same arch, so a
-/// running Linux binary cannot tell which to install from [`Platform`] alone
+/// A release ships a `.deb`, a `.pkg.tar.zst`, and a `.rpm` for the same arch, so
+/// a running Linux binary cannot tell which to install from [`Platform`] alone
 /// (that only knows OS + arch, not distro). Instead the format is fixed at build
 /// time: [`PkgFormat::current`] returns [`PkgFormat::Pacman`] when compiled with
-/// the `pacman` feature (the Arch package build) and [`PkgFormat::Deb`] otherwise.
-/// macOS selection ignores it. This is decoupled from `cfg!` in the type so
-/// selection stays testable for either format from any build.
+/// the `pacman` feature (the Arch package build), [`PkgFormat::Rpm`] with the
+/// `rpm` feature (the Fedora package build), and [`PkgFormat::Deb`] otherwise. The
+/// two distro features are mutually exclusive. macOS selection ignores it. This is
+/// decoupled from `cfg!` in the type so selection stays testable for any format
+/// from any build.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PkgFormat {
     /// Debian `.deb` (installed via `dpkg -i`). The default build.
     Deb,
     /// Arch `.pkg.tar.zst` (installed via `pacman -U`).
     Pacman,
+    /// Red Hat `.rpm` (installed via `rpm -U`).
+    Rpm,
 }
 
+// The `pacman` and `rpm` features both fix the self-update format at build time;
+// enabling both is contradictory and would make `current()` ambiguous, so refuse
+// to compile that combination outright.
+#[cfg(all(feature = "pacman", feature = "rpm"))]
+compile_error!("the `pacman` and `rpm` features are mutually exclusive");
+
 impl PkgFormat {
-    /// The package format this binary was built for: [`PkgFormat::Pacman`] when
-    /// compiled with the `pacman` feature, else [`PkgFormat::Deb`].
+    /// The package format this binary was built for: [`PkgFormat::Pacman`] under
+    /// the `pacman` feature, [`PkgFormat::Rpm`] under the `rpm` feature, else
+    /// [`PkgFormat::Deb`].
     #[must_use]
     pub fn current() -> Self {
         #[cfg(feature = "pacman")]
         {
             Self::Pacman
         }
-        #[cfg(not(feature = "pacman"))]
+        #[cfg(feature = "rpm")]
+        {
+            Self::Rpm
+        }
+        #[cfg(not(any(feature = "pacman", feature = "rpm")))]
         {
             Self::Deb
         }
@@ -157,11 +174,12 @@ impl std::error::Error for AssetError {}
 ///
 /// Selection is by filename convention (the names the release workflow emits):
 /// the macOS artifact ends `.app.tar.gz` and is arch-tagged; the Linux artifact
-/// ends `.deb` (Debian) or `.pkg.tar.zst` (Arch) per `format` and is arch-tagged
-/// (`x86_64` or `arm64`); the signature is `<artifact>.sig`; the manifest is named
-/// `SHA256SUMS`. `format` resolves the deb-vs-pacman ambiguity on Linux (a release
-/// carries both) and is ignored on macOS. Intel macOS / unsupported platforms
-/// return [`AssetError::NoArtifactForPlatform`] rather than mis-selecting.
+/// ends `.deb` (Debian), `.pkg.tar.zst` (Arch), or `.rpm` (Fedora) per `format`
+/// and is arch-tagged (`x86_64` or `arm64`); the signature is `<artifact>.sig`;
+/// the manifest is named `SHA256SUMS`. `format` resolves the deb-vs-pacman-vs-rpm
+/// ambiguity on Linux (a release carries all three) and is ignored on macOS. Intel
+/// macOS / unsupported platforms return [`AssetError::NoArtifactForPlatform`]
+/// rather than mis-selecting.
 pub fn select_asset(
     release: &ReleaseMeta,
     platform: Platform,
@@ -177,6 +195,8 @@ pub fn select_asset(
         (Platform::LinuxAarch64, PkgFormat::Pacman) => {
             (ArtifactKind::Pacman, is_linux_aarch64_pacman)
         }
+        (Platform::LinuxX86_64, PkgFormat::Rpm) => (ArtifactKind::Rpm, is_linux_x86_64_rpm),
+        (Platform::LinuxAarch64, PkgFormat::Rpm) => (ArtifactKind::Rpm, is_linux_aarch64_rpm),
         (p @ (Platform::MacOsX86_64 | Platform::Unsupported), _) => {
             return Err(AssetError::NoArtifactForPlatform(p));
         }
@@ -244,6 +264,21 @@ fn is_linux_x86_64_pacman(name: &str) -> bool {
 fn is_linux_aarch64_pacman(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     lower.ends_with(".pkg.tar.zst") && (lower.contains("aarch64") || lower.contains("arm64"))
+}
+
+// The Fedora package is named `Yerd_Linux_x86_64_*.rpm`. The `.rpm` suffix is disjoint
+// from `.deb` and `.pkg.tar.zst`, so the rpm matchers never collide with the others.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn is_linux_x86_64_rpm(name: &str) -> bool {
+    name.ends_with(".rpm") && (name.contains("x86_64") || name.contains("amd64"))
+}
+
+// The arm64 Fedora asset is `Yerd_Linux_Arm64_*.rpm` (capital "Arm64"), so match
+// case-insensitively for the `Arm64`/`aarch64` token, mirroring `is_linux_aarch64_artifact`.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn is_linux_aarch64_rpm(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.ends_with(".rpm") && (lower.contains("aarch64") || lower.contains("arm64"))
 }
 
 /// Why verification failed.
@@ -422,12 +457,39 @@ mod tests {
     }
 
     #[test]
+    fn selects_linux_x86_64_rpm() {
+        let r = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.rpm",
+            "Yerd_Linux_x86_64_v2-0-2.rpm.sig",
+            "SHA256SUMS",
+        ]);
+        let sel = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Rpm).unwrap();
+        assert_eq!(sel.kind, ArtifactKind::Rpm);
+        assert!(sel.artifact.name.ends_with(".rpm"));
+        assert!(sel.signature.name.ends_with(".rpm.sig"));
+    }
+
+    #[test]
+    fn selects_linux_aarch64_rpm() {
+        let r = release_with(&[
+            "Yerd_Linux_Arm64_v2-0-2.rpm",
+            "Yerd_Linux_Arm64_v2-0-2.rpm.sig",
+            "SHA256SUMS",
+        ]);
+        let sel = select_asset(&r, Platform::LinuxAarch64, PkgFormat::Rpm).unwrap();
+        assert_eq!(sel.kind, ArtifactKind::Rpm);
+        assert_eq!(sel.artifact.name, "Yerd_Linux_Arm64_v2-0-2.rpm");
+    }
+
+    #[test]
     fn both_artifacts_present_resolves_per_format() {
         let r = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
             "Yerd_Linux_x86_64_v2-0-2.deb.sig",
             "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
             "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
+            "Yerd_Linux_x86_64_v2-0-2.rpm",
+            "Yerd_Linux_x86_64_v2-0-2.rpm.sig",
             "SHA256SUMS",
         ]);
         let deb = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb).unwrap();
@@ -436,6 +498,9 @@ mod tests {
         let pac = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Pacman).unwrap();
         assert_eq!(pac.kind, ArtifactKind::Pacman);
         assert!(pac.artifact.name.ends_with(".pkg.tar.zst"));
+        let rpm = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Rpm).unwrap();
+        assert_eq!(rpm.kind, ArtifactKind::Rpm);
+        assert!(rpm.artifact.name.ends_with(".rpm"));
     }
 
     #[test]
@@ -488,6 +553,39 @@ mod tests {
         assert_eq!(
             select_asset(&only_arm_pac, Platform::LinuxX86_64, PkgFormat::Pacman),
             Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+    }
+
+    #[test]
+    fn rpm_matchers_are_disjoint_from_deb_pacman_and_across_arch() {
+        // An rpm-only release resolves under Rpm but not Deb/Pacman.
+        let only_rpm = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.rpm",
+            "Yerd_Linux_x86_64_v2-0-2.rpm.sig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&only_rpm, Platform::LinuxX86_64, PkgFormat::Deb),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+        assert_eq!(
+            select_asset(&only_rpm, Platform::LinuxX86_64, PkgFormat::Pacman),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+        // A deb-only release does not resolve under Rpm.
+        let only_deb = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.deb",
+            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&only_deb, Platform::LinuxX86_64, PkgFormat::Rpm),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxX86_64))
+        );
+        // rpm matchers are arch-disjoint (an x86_64-only rpm release has no arm64 artifact).
+        assert_eq!(
+            select_asset(&only_rpm, Platform::LinuxAarch64, PkgFormat::Rpm),
+            Err(AssetError::NoArtifactForPlatform(Platform::LinuxAarch64))
         );
     }
 

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -430,7 +430,8 @@ cargo xtask version-check v2.0.2 # release gate: assert a tag matches the manife
 ```
 
 The shipped artifacts are the **GUI bundle** (`.dmg` on macOS, `.deb` on Linux),
-**plus a native Arch package** (`.pkg.tar.zst`, x86-64). The three binaries
+**plus a native Arch package** (`.pkg.tar.zst`, x86-64) **and a Fedora package**
+(`.rpm`, x86-64 and arm64). The three binaries
 (`yerd`/`yerdd`/`yerd-helper`) are embedded via Tauri `externalBin`
 (per-platform overlays in `apps/yerd-gui/src-tauri/`). Tauri builds the `.app`
 (macOS) and `.deb` (Linux) directly; the macOS `.dmg` is built as a separate
@@ -468,18 +469,40 @@ users should keep their system current. It also requires the default
 (Yerd verifies it itself with the embedded update key), so a hardened
 `LocalFileSigLevel = Required` rejects the local install.
 
-**The `pacman` feature / `PkgFormat` tiebreak.** A release carries *both* a `.deb`
-and a `.pkg.tar.zst` for x86-64, so a running Linux binary can't tell which to
-self-update from `Platform` (OS + arch) alone. The format is fixed at **build
-time**: `yerd_update::PkgFormat::current()` returns `Pacman` only when compiled
-with the `pacman` Cargo feature. The `arch` job builds the daemon with
-`--features yerdd/pacman` (→ `yerd-update/pacman`), so its `yerdd` selects the
-`.pkg.tar.zst` and the applier installs it via `pacman -U`; every other build
-defaults to `Deb`/`dpkg -i`. **This only works because the Arch package is built
-in a separate job (its own cargo invocation/target dir)** - within one cargo
-build, the feature would unify across the whole graph. The release gate proves
-the flag took by running the freshly-built `yerdd --pkg-format` and asserting it
-prints `pacman`. arm64 Arch is not built for v1.
+### The Fedora package (`.rpm`)
+
+Unlike pacman, Tauri v2 **does** have an rpm bundler (pure-Rust, no `rpmbuild`),
+so the `.rpm` reuses the normal Tauri bundle machinery rather than a hand-written
+spec. The `fedora` jobs in
+[`build.yml`](https://github.com/forjedio/yerd/blob/main/.github/workflows/build.yml)
+run on the Ubuntu runners (x86-64 and arm64), build the sidecars with
+`--features yerdd/rpm`, and run `tauri build` with the
+`tauri.bundle-linux-rpm.conf.json` overlay (rpm `depends` + an `rpm/postinst.sh`
+`%post` that `setcap`s `/usr/bin/yerdd`, mirroring the deb postinst). Because the
+bundler runs on Ubuntu, a **blocking** `fedora:latest` smoke job in `release.yml`
+`dnf install`s the produced `.rpm` (proving every `Requires` resolves) and asserts
+`yerdd --pkg-format` before the release can publish.
+
+In-app `yerd update` on Fedora runs `rpm -U --oldpackage` on the downloaded,
+minisign-verified `.rpm`. Like `dpkg -i`/`pacman -U` it does no dependency
+*resolution*, but it does *check* dependencies, so the packaged `depends` list must
+stay stable across releases (a newly-added `Requires` would abort an existing
+user's self-update); Yerd surfaces rpm's message on failure.
+
+**The `pacman`/`rpm` feature / `PkgFormat` tiebreak.** A release carries a `.deb`,
+a `.pkg.tar.zst`, and a `.rpm` for the same arch, so a running Linux binary can't
+tell which to self-update from `Platform` (OS + arch) alone. The format is fixed at
+**build time**: `yerd_update::PkgFormat::current()` returns `Pacman` only when
+compiled with the `pacman` Cargo feature and `Rpm` only with the `rpm` feature
+(the two are mutually exclusive - enabling both is a `compile_error!`). The `arch`
+job builds the daemon with `--features yerdd/pacman`, the `fedora` job with
+`--features yerdd/rpm`, so each `yerdd` selects its own package and the applier
+installs it via `pacman -U` / `rpm -U --oldpackage`; every other build defaults to
+`Deb`/`dpkg -i`. **This only works because each distro package is built in a
+separate job (its own cargo invocation/target dir)** - within one cargo build, the
+feature would unify across the whole graph. The release gate proves the flag took by
+running the freshly-built `yerdd --pkg-format` and asserting it prints
+`pacman`/`rpm`.
 
 **`tauri/custom-protocol` is required too.** `PKGBUILD`'s `build()` builds the
 GUI binary with a raw `cargo build`, not `tauri build`/`npm run tauri build` -

--- a/docs/developer/gui.md
+++ b/docs/developer/gui.md
@@ -303,7 +303,10 @@ Arch package (`.pkg.tar.zst`) is **not** a Tauri bundle target (Tauri has no
 pacman bundler) - it's built separately from
 [`packaging/arch/PKGBUILD`](https://github.com/forjedio/yerd/blob/main/packaging/arch)
 in the release workflow's `arch` job, with a `.install` scriptlet doing the same
-`setcap`. See [Packaging and releasing](./building#the-arch-package-pkg-tar-zst).
+`setcap`. The Fedora `.rpm`, by contrast, **is** a Tauri bundle target (Tauri v2
+has an rpm bundler): the `fedora` jobs run `tauri build` with the
+`tauri.bundle-linux-rpm.conf.json` overlay and an `rpm/postinst.sh` `%post` doing
+the same `setcap`. See [Packaging and releasing](./building#the-arch-package-pkg-tar-zst).
 
 ::: info Three windows, one bundle
 The app is no longer single-window. `tauri.conf.json` declares **three** windows,

--- a/docs/developer/gui.md
+++ b/docs/developer/gui.md
@@ -306,7 +306,7 @@ in the release workflow's `arch` job, with a `.install` scriptlet doing the same
 `setcap`. The Fedora `.rpm`, by contrast, **is** a Tauri bundle target (Tauri v2
 has an rpm bundler): the `fedora` jobs run `tauri build` with the
 `tauri.bundle-linux-rpm.conf.json` overlay and an `rpm/postinst.sh` `%post` doing
-the same `setcap`. See [Packaging and releasing](./building#the-arch-package-pkg-tar-zst).
+the same `setcap`. See [Packaging and releasing](./building#the-fedora-package-rpm).
 
 ::: info Three windows, one bundle
 The app is no longer single-window. `tauri.conf.json` declares **three** windows,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,13 +10,14 @@ GUI-first way to run Yerd.
 
 Yerd runs entirely **as your user**. `sudo` shows up in exactly two
 non-ongoing places: installing the system package (standard for any
-`.deb`/`.pkg.tar.zst`), and a single, optional, **one-time** privileged setup
-step that the app walks you through. Day-to-day use never touches root.
+`.deb`/`.pkg.tar.zst`/`.rpm`), and a single, optional, **one-time** privileged
+setup step that the app walks you through. Day-to-day use never touches root.
 
 ::: info Supported platforms
 Yerd ships a single desktop app for **macOS** (Apple Silicon) and **Linux**
-(Debian/Ubuntu `.deb` for x86-64 and arm64, plus an Arch `.pkg.tar.zst` for
-x86-64). The daemon, the `yerd` CLI, and the privileged
+(Debian/Ubuntu `.deb` for x86-64 and arm64, an Arch `.pkg.tar.zst` for x86-64,
+and a Fedora `.rpm` for x86-64 and arm64). The daemon, the `yerd` CLI, and the
+privileged
 helper are all bundled inside it - there is nothing else to install. PHP itself is
 **not** bundled - Yerd downloads prebuilt static PHP builds on demand once you
 pick a version, so the install stays tiny and fast.
@@ -38,6 +39,8 @@ Grab the latest **stable release** from the
 | Linux · Debian/Ubuntu (x86-64) | `Yerd_Linux_x86_64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_x86_64_v<ver>.deb` |
 | Linux · Debian/Ubuntu (arm64) | `Yerd_Linux_Arm64_v<ver>.deb` | `sudo apt install ./Yerd_Linux_Arm64_v<ver>.deb` |
 | Linux · Arch (x86-64) | `Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` | `sudo pacman -U ./Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` |
+| Linux · Fedora (x86-64) | `Yerd_Linux_x86_64_v<ver>.rpm` | `sudo dnf install ./Yerd_Linux_x86_64_v<ver>.rpm` |
+| Linux · Fedora (arm64) | `Yerd_Linux_Arm64_v<ver>.rpm` | `sudo dnf install ./Yerd_Linux_Arm64_v<ver>.rpm` |
 
 ::: tip Arch Linux
 Remove any leftover `/usr/bin/yerd` from the old v1 (Go) project first - pacman

--- a/docs/reference/cli/uninstall.md
+++ b/docs/reference/cli/uninstall.md
@@ -27,7 +27,7 @@ It removes, in order:
 2. **The daemon** - stops and disables the per-user service (systemd `--user` / launchd) and reaps the running `yerdd` (which in turn stops its PHP-FPM pools and any managed services).
 3. **The PATH entry** - removes the yerd block from your shell startup files (the same block [`yerd path`](./tooling) manages).
 4. **Config, data, and cache** - the `yerd.toml` config, installed PHP versions, dev tools, downloads, the local CA, and the runtime socket directory.
-5. **The binaries** - `yerd`, `yerdd`, and `yerd-helper`. A package install is left for your package manager instead (`sudo apt purge yerd` on Debian/Ubuntu, `sudo pacman -R yerd` on Arch) - yerd never `rm`s package-managed files.
+5. **The binaries** - `yerd`, `yerdd`, and `yerd-helper`. A package install is left for your package manager instead (`sudo apt purge yerd` on Debian/Ubuntu, `sudo pacman -R yerd` on Arch, `sudo dnf remove yerd` on Fedora) - yerd never `rm`s package-managed files.
 
 When something can't be removed automatically, it's listed at the end as a leftover to handle manually.
 
@@ -48,7 +48,7 @@ You'll be asked to confirm before anything is removed. Pass `--yes` (`-y`) to sk
 
 ## Platform support
 
-Full uninstall is supported on **macOS** and **Linux**. The desktop app itself (the `.app` / `.deb` / `.pkg.tar.zst`) is removed the usual way for your platform - drag to Trash on macOS, or `sudo apt purge yerd` (Debian/Ubuntu) / `sudo pacman -R yerd` (Arch) on Linux.
+Full uninstall is supported on **macOS** and **Linux**. The desktop app itself (the `.app` / `.deb` / `.pkg.tar.zst` / `.rpm`) is removed the usual way for your platform - drag to Trash on macOS, or `sudo apt purge yerd` (Debian/Ubuntu) / `sudo pacman -R yerd` (Arch) / `sudo dnf remove yerd` (Fedora) on Linux.
 
 ## See also
 

--- a/docs/reference/cli/update.md
+++ b/docs/reference/cli/update.md
@@ -46,7 +46,7 @@ automated downgrade isn't implemented yet - it currently just says so.
    nothing is available, it reports and exits `0` - no download happens.
 3. Otherwise asks the daemon to download and verify the target release's
    artifact (`Request::StageUpdate`): the daemon fetches the platform-specific
-   asset (macOS `.app.tar.gz`, Linux `.deb`/`.pkg.tar.zst`), checks its
+   asset (macOS `.app.tar.gz`, Linux `.deb`/`.pkg.tar.zst`/`.rpm`), checks its
    SHA-256 against the release's `SHA256SUMS` manifest, and verifies a
    detached minisign signature against an embedded public key.
 4. Re-verifies the signature a second time locally (closing the window
@@ -70,6 +70,7 @@ silently failing.
 | macOS (Apple Silicon) | Extracts the `.app.tar.gz`, swaps it into `/Applications`, restarts the daemon via `launchctl kickstart -k`. |
 | Linux (`.deb` build) | Reinstalls via `dpkg -i`, elevated with `pkexec` if needed; restarts the daemon via `systemctl --user restart` (or a stop/start fallback with no systemd user instance). |
 | Linux (Arch `.pkg.tar.zst` build) | Reinstalls via `pacman -U`, same elevation and restart path as the `.deb` build. |
+| Linux (Fedora `.rpm` build) | Reinstalls via `rpm -U --oldpackage`, same elevation and restart path as the `.deb` build. |
 | Intel macOS, other platforms | No self-update artifact is published; `yerd update` reports nothing available. |
 
 ## See also


### PR DESCRIPTION
## What does this PR do?

Adds a Fedora .rpm (x86_64 and arm64) built via Tauri's rpm bundler, wired end-to-end through the existing minisign-verified self-updater so Fedora installs update in place via rpm -U, mirroring the Debian and Arch packaging paths.

## Related issues

Closes #109 

## Type of change

- [x] New feature
- [x] Build / CI / tooling

## Platforms tested

- [x] Linux

## Checklist

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets` is clean
- [ ] `cargo test` passes
- [ ] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [ ] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fedora RPM support for downloads, builds, installs, and self-updates.
  * Added Fedora x86_64 and arm64 package options to the release and install flows.
* **Bug Fixes**
  * Improved Linux package selection so the correct artifact is chosen for RPM-based systems.
  * Added validation and smoke testing to help catch packaging issues before release.
* **Documentation**
  * Updated installation, update, uninstall, and developer docs with Fedora RPM instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->