### PR TITLE
[Fix] Resolve zend extension load error

### DIFF
--- a/crates/yerd-php/src/pure/ext_probe.rs
+++ b/crates/yerd-php/src/pure/ext_probe.rs
@@ -53,7 +53,10 @@ pub fn interpret_probe(exit_ok: bool, diagnostics: &str) -> Result<(), ExtLoadEr
     if s.contains("valid zend extension") {
         return Err(ExtLoadError::NotZend);
     }
-    if s.contains("as it is a zend extension") || s.contains("is a zend extension and") {
+    if s.contains("as it is a zend extension")
+        || s.contains("is a zend extension and")
+        || s.contains("must be loaded as a zend extension")
+    {
         return Err(ExtLoadError::IsZend);
     }
     if s.contains("module api")
@@ -118,6 +121,17 @@ mod tests {
         );
         assert_eq!(
             interpret_probe(true, "Cannot load xdebug - it as it is a Zend extension"),
+            Err(ExtLoadError::IsZend)
+        );
+    }
+
+    #[test]
+    fn zend_extension_custom_guard_is_iszend() {
+        assert_eq!(
+            interpret_probe(
+                true,
+                "PHP Warning: Xdebug MUST be loaded as a Zend extension in Unknown on line 0"
+            ),
             Err(ExtLoadError::IsZend)
         );
     }


### PR DESCRIPTION
## What does this PR do?

it was possible to register a zend extension as a standard extension. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed

@coderabbitai ignore