### PR TITLE
[Fix] Open email links in the browser

### DIFF
--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { openableHrefForTarget, resolveExternalHref } from "./mailLinks";
+import { resolveExternalHref, resolveFrameLink } from "./mailLinks";
 
 describe("resolveExternalHref", () => {
   it("returns absolute http(s) URLs to open", () => {
@@ -40,7 +40,7 @@ describe("resolveExternalHref", () => {
   });
 });
 
-describe("openableHrefForTarget", () => {
+describe("resolveFrameLink", () => {
   // Build the anchor inside a real iframe's document, so `target` comes from a
   // different realm than this module - exactly the production shape (clicks
   // originate in the email frame). A same-realm `document.createElement` anchor
@@ -62,27 +62,38 @@ describe("openableHrefForTarget", () => {
     return a;
   }
 
-  it("resolves the URL when the click lands on the anchor itself", () => {
-    const a = anchorWith("https://example.com");
-    expect(openableHrefForTarget(a)).toBe("https://example.com/");
+  it("opens an external link when the click lands on the anchor itself", () => {
+    expect(resolveFrameLink(anchorWith("https://example.com"))).toEqual({
+      kind: "open",
+      url: "https://example.com/",
+    });
   });
 
   it("walks up from nested content (e.g. an image inside the link)", () => {
     const a = anchorWith("https://example.com", "<img alt='logo'>");
-    const img = a.querySelector("img");
-    expect(openableHrefForTarget(img)).toBe("https://example.com/");
+    expect(resolveFrameLink(a.querySelector("img"))).toEqual({
+      kind: "open",
+      url: "https://example.com/",
+    });
   });
 
-  it("returns null for a non-openable anchor so the click is left alone", () => {
-    expect(openableHrefForTarget(anchorWith("#section"))).toBeNull();
-    expect(openableHrefForTarget(anchorWith("javascript:alert(1)"))).toBeNull();
+  it("lets same-document `#` anchors scroll", () => {
+    expect(resolveFrameLink(anchorWith("#section"))).toEqual({ kind: "scroll" });
+    expect(resolveFrameLink(anchorWith("#"))).toEqual({ kind: "scroll" });
+  });
+
+  it("blocks in-frame navigation for relative and same-origin links", () => {
+    expect(resolveFrameLink(anchorWith("/dashboard"))).toEqual({ kind: "block" });
+    expect(resolveFrameLink(anchorWith("../up"))).toEqual({ kind: "block" });
+    expect(resolveFrameLink(anchorWith(""))).toEqual({ kind: "block" });
+    expect(resolveFrameLink(anchorWith("javascript:alert(1)"))).toEqual({ kind: "block" });
   });
 
   it("returns null when the click isn't on a link", () => {
     const doc = frameDoc();
     const p = doc.createElement("p");
     doc.body.append(p);
-    expect(openableHrefForTarget(p)).toBeNull();
-    expect(openableHrefForTarget(null)).toBeNull();
+    expect(resolveFrameLink(p)).toBeNull();
+    expect(resolveFrameLink(null)).toBeNull();
   });
 });

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { openableHrefForTarget, resolveExternalHref } from "./mailLinks";
+
+describe("resolveExternalHref", () => {
+  it("returns absolute http(s) URLs to open", () => {
+    expect(resolveExternalHref("http://example.com")).toBe("http://example.com/");
+    expect(resolveExternalHref("https://example.com/path?q=1#frag")).toBe(
+      "https://example.com/path?q=1#frag",
+    );
+  });
+
+  it("honours mailto and tel links", () => {
+    expect(resolveExternalHref("mailto:hi@example.com")).toBe("mailto:hi@example.com");
+    expect(resolveExternalHref("tel:+15551234567")).toBe("tel:+15551234567");
+  });
+
+  it("normalises scheme case and trims surrounding whitespace", () => {
+    expect(resolveExternalHref("  HTTPS://Example.com  ")).toBe("https://example.com/");
+  });
+
+  it("ignores relative, protocol-relative, and in-page anchor links", () => {
+    expect(resolveExternalHref("/dashboard")).toBeNull();
+    expect(resolveExternalHref("../up")).toBeNull();
+    expect(resolveExternalHref("//example.com")).toBeNull();
+    expect(resolveExternalHref("#section")).toBeNull();
+  });
+
+  it("ignores unsupported and dangerous schemes", () => {
+    expect(resolveExternalHref("javascript:alert(1)")).toBeNull();
+    expect(resolveExternalHref("data:text/html,<h1>hi</h1>")).toBeNull();
+    expect(resolveExternalHref("file:///etc/passwd")).toBeNull();
+  });
+
+  it("ignores empty, whitespace, and nullish input", () => {
+    expect(resolveExternalHref("")).toBeNull();
+    expect(resolveExternalHref("   ")).toBeNull();
+    expect(resolveExternalHref(null)).toBeNull();
+    expect(resolveExternalHref(undefined)).toBeNull();
+  });
+});
+
+describe("openableHrefForTarget", () => {
+  // Build the anchor inside a real iframe's document, so `target` comes from a
+  // different realm than this module - exactly the production shape (clicks
+  // originate in the email frame). A same-realm `document.createElement` anchor
+  // would not exercise the cross-realm path where `instanceof Element` fails.
+  function frameDoc(): Document {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    const doc = iframe.contentDocument;
+    if (!doc) throw new Error("no iframe contentDocument");
+    return doc;
+  }
+
+  function anchorWith(href: string, child?: string): Element {
+    const doc = frameDoc();
+    const a = doc.createElement("a");
+    a.setAttribute("href", href);
+    if (child) a.innerHTML = child;
+    doc.body.append(a);
+    return a;
+  }
+
+  it("resolves the URL when the click lands on the anchor itself", () => {
+    const a = anchorWith("https://example.com");
+    expect(openableHrefForTarget(a)).toBe("https://example.com/");
+  });
+
+  it("walks up from nested content (e.g. an image inside the link)", () => {
+    const a = anchorWith("https://example.com", "<img alt='logo'>");
+    const img = a.querySelector("img");
+    expect(openableHrefForTarget(img)).toBe("https://example.com/");
+  });
+
+  it("returns null for a non-openable anchor so the click is left alone", () => {
+    expect(openableHrefForTarget(anchorWith("#section"))).toBeNull();
+    expect(openableHrefForTarget(anchorWith("javascript:alert(1)"))).toBeNull();
+  });
+
+  it("returns null when the click isn't on a link", () => {
+    const doc = frameDoc();
+    const p = doc.createElement("p");
+    doc.body.append(p);
+    expect(openableHrefForTarget(p)).toBeNull();
+    expect(openableHrefForTarget(null)).toBeNull();
+  });
+});

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -27,19 +27,39 @@ export function resolveExternalHref(rawHref: string | null | undefined): string 
   return OPENABLE_SCHEMES.has(url.protocol) ? url.href : null;
 }
 
+/** What to do with a click on an `<a href>` inside the email frame: `open` it in
+ *  the OS browser, let a same-document `#` anchor `scroll`, or `block` an
+ *  in-frame navigation the preview must never perform (relative/same-origin
+ *  links would otherwise load app content over the email). */
+export type FrameLinkAction =
+  | { kind: "open"; url: string }
+  | { kind: "scroll" }
+  | { kind: "block" };
+
+/** True for an in-page fragment link (`#`, `#section`): activating it only
+ *  scrolls the current document, so the handler must let it proceed. */
+function isInPageFragment(rawHref: string | null): boolean {
+  return (rawHref?.trim() ?? "").startsWith("#");
+}
+
 /**
- * The external URL to open for a click that landed on `target` inside an email
- * body, or `null` when the click isn't on an openable link. Walks up to the
- * nearest `<a href>` so clicks on nested content (e.g. `<a><img></a>`) resolve,
- * then classifies its href via {@link resolveExternalHref}. Returning `null`
- * lets the caller leave the click alone, so same-document `#` anchors still
- * scroll instead of becoming inert.
+ * Classify a click that landed on `target` inside an email body. Returns `null`
+ * when the click isn't on a link (leave it alone); otherwise a
+ * {@link FrameLinkAction}: openable schemes go to the OS browser, same-document
+ * `#` anchors are left to scroll, and everything else (relative, same-origin,
+ * `javascript:`) is blocked so the sandboxed frame can't navigate itself away
+ * from the email. Walks up to the nearest `<a href>` so clicks on nested content
+ * (e.g. `<a><img></a>`) resolve.
  *
  * The target comes from the iframe's own realm, whose `Element` differs from
  * this module's, so `instanceof Element` would always be false. We duck-type on
  * `closest` instead (absent on `document`/`window` targets) to stay realm-safe.
  */
-export function openableHrefForTarget(target: EventTarget | null): string | null {
+export function resolveFrameLink(target: EventTarget | null): FrameLinkAction | null {
   const anchor = (target as Element | null)?.closest?.("a[href]");
-  return anchor ? resolveExternalHref(anchor.getAttribute("href")) : null;
+  if (!anchor) return null;
+  const href = anchor.getAttribute("href");
+  const url = resolveExternalHref(href);
+  if (url) return { kind: "open", url };
+  return isInPageFragment(href) ? { kind: "scroll" } : { kind: "block" };
 }

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -1,0 +1,45 @@
+/** Schemes a captured email may link to that we route to the OS browser (or the
+ *  OS handler, for mailto/tel). Everything else - relative paths, in-page `#`
+ *  anchors, `javascript:`, `data:`, `file:` - is ignored so a message can never
+ *  drive navigation anywhere but a real external target the user chose. */
+const OPENABLE_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+/**
+ * Decide what a clicked link in an email body should open. Returns the absolute
+ * URL to hand to the OS (via the opener plugin), or `null` when the link should
+ * be ignored.
+ *
+ * Only absolute URLs in {@link OPENABLE_SCHEMES} are honoured. Relative hrefs,
+ * bare `#` anchors, and malformed values all fail `new URL()` (we pass no base
+ * on purpose, so nothing resolves against the app's own origin) and return
+ * `null`; `javascript:`/`data:`/`file:` parse but are not openable schemes.
+ */
+export function resolveExternalHref(rawHref: string | null | undefined): string | null {
+  if (!rawHref) return null;
+  const href = rawHref.trim();
+  if (!href) return null;
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  return OPENABLE_SCHEMES.has(url.protocol) ? url.href : null;
+}
+
+/**
+ * The external URL to open for a click that landed on `target` inside an email
+ * body, or `null` when the click isn't on an openable link. Walks up to the
+ * nearest `<a href>` so clicks on nested content (e.g. `<a><img></a>`) resolve,
+ * then classifies its href via {@link resolveExternalHref}. Returning `null`
+ * lets the caller leave the click alone, so same-document `#` anchors still
+ * scroll instead of becoming inert.
+ *
+ * The target comes from the iframe's own realm, whose `Element` differs from
+ * this module's, so `instanceof Element` would always be false. We duck-type on
+ * `closest` instead (absent on `document`/`window` targets) to stay realm-safe.
+ */
+export function openableHrefForTarget(target: EventTarget | null): string | null {
+  const anchor = (target as Element | null)?.closest?.("a[href]");
+  return anchor ? resolveExternalHref(anchor.getAttribute("href")) : null;
+}

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -18,14 +18,19 @@ import {
   IpcError,
   listMails,
   markMailsRead,
+  openInBrowser,
 } from "@/ipc/client";
+import { openableHrefForTarget } from "@/lib/mailLinks";
 import type { MailDetail, MailSummary } from "@/ipc/types";
 
-// The rendered HTML email is sandboxed: no scripts, no same-origin. The child CSP
-// keeps `default-src 'none'` (so nothing executes), but allows images over
-// data:/http/https so emails render with their inline AND remote images (logos
-// etc.). Note: like any mail client, this means remote images can load when you
-// open a message.
+// The rendered HTML email runs no scripts: the sandbox withholds `allow-scripts`
+// and the child CSP keeps `default-src 'none'`, so nothing in a message executes.
+// `allow-same-origin` is granted only so the host can attach a click listener to
+// the frame and route link clicks to the OS browser (see `interceptFrameLinks`);
+// with scripts still disabled a message can't abuse that same-origin access. The
+// CSP allows images over data:/http/https so emails render their inline AND
+// remote images (logos etc.) - like any mail client, opening a message can load
+// remote images.
 const CHILD_CSP =
   "default-src 'none'; img-src data: http: https:; style-src 'unsafe-inline'";
 
@@ -184,6 +189,32 @@ function frameSrcdoc(html: string): string {
   return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${CHILD_CSP}"></head><body>${html}</body></html>`;
 }
 
+// Frame documents that already have the link-click listener, so a repeated
+// `@load` for the same document can't stack listeners (which would open a link
+// twice). Keyed weakly so entries vanish with their document.
+const linkedDocs = new WeakSet<Document>();
+
+/**
+ * Route link clicks inside the email frame to the OS browser. The sandbox blocks
+ * the frame from navigating itself, so without this an external link is inert
+ * (the bug this fixes). On each `@load` we attach a click listener to the frame
+ * document; for an openable link it cancels the (blocked) in-frame navigation
+ * and hands the URL to the opener plugin. Non-openable clicks (relative, `#`,
+ * `javascript:`) fall through untouched, so same-document `#` anchors still
+ * scroll.
+ */
+function interceptFrameLinks(e: Event): void {
+  const doc = (e.target as HTMLIFrameElement).contentDocument;
+  if (!doc || linkedDocs.has(doc)) return;
+  linkedDocs.add(doc);
+  doc.addEventListener("click", (ev) => {
+    const url = openableHrefForTarget(ev.target);
+    if (!url) return;
+    ev.preventDefault();
+    void openInBrowser(url).catch(() => toast.error("Couldn't open link"));
+  });
+}
+
 function formatDate(epoch: number): string {
   if (!epoch) return "-";
   return new Date(epoch * 1000).toLocaleString();
@@ -284,9 +315,10 @@ function formatDate(epoch: number): string {
           <iframe
             v-if="detail.html_body"
             :srcdoc="frameSrcdoc(detail.html_body)"
-            sandbox=""
+            sandbox="allow-same-origin"
             class="min-h-0 flex-1 bg-white"
             title="Email body"
+            @load="interceptFrameLinks"
           />
           <pre
             v-else

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -20,7 +20,7 @@ import {
   markMailsRead,
   openInBrowser,
 } from "@/ipc/client";
-import { openableHrefForTarget } from "@/lib/mailLinks";
+import { resolveFrameLink } from "@/lib/mailLinks";
 import type { MailDetail, MailSummary } from "@/ipc/types";
 
 // The rendered HTML email runs no scripts: the sandbox withholds `allow-scripts`
@@ -195,23 +195,24 @@ function frameSrcdoc(html: string): string {
 const linkedDocs = new WeakSet<Document>();
 
 /**
- * Route link clicks inside the email frame to the OS browser. The sandbox blocks
- * the frame from navigating itself, so without this an external link is inert
- * (the bug this fixes). On each `@load` we attach a click listener to the frame
- * document; for an openable link it cancels the (blocked) in-frame navigation
- * and hands the URL to the opener plugin. Non-openable clicks (relative, `#`,
- * `javascript:`) fall through untouched, so same-document `#` anchors still
- * scroll.
+ * Route link clicks inside the email frame. On each `@load` we attach one click
+ * listener to the frame document; it classifies the click via `resolveFrameLink`
+ * and either hands an openable URL to the opener plugin, leaves a same-document
+ * `#` anchor to scroll, or blocks anything else so a relative/same-origin link
+ * can't navigate the sandboxed frame away from the email onto app content. A
+ * click that isn't on a link is left alone.
  */
 function interceptFrameLinks(e: Event): void {
   const doc = (e.target as HTMLIFrameElement).contentDocument;
   if (!doc || linkedDocs.has(doc)) return;
   linkedDocs.add(doc);
   doc.addEventListener("click", (ev) => {
-    const url = openableHrefForTarget(ev.target);
-    if (!url) return;
+    const action = resolveFrameLink(ev.target);
+    if (!action || action.kind === "scroll") return;
     ev.preventDefault();
-    void openInBrowser(url).catch(() => toast.error("Couldn't open link"));
+    if (action.kind === "open") {
+      void openInBrowser(action.url).catch(() => toast.error("Couldn't open link"));
+    }
   });
 }
 


### PR DESCRIPTION
## What does this PR do?

Detects clicks on rendered email previews and opens the default browser with the URL

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail preview link handling now classifies clicks to either open allowed external URLs (web, email, phone), scroll within the message for hash links, or block unsafe/non-openable links.
  * Clicks anywhere inside an anchor (including nested elements) now resolve to the correct link target.
* **Bug Fixes**
  * Unsupported schemes and malformed/empty hrefs are ignored to prevent navigation from the preview frame.
* **Tests**
  * Added automated coverage for external href and frame link resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->