### PR TITLE
[Fix] Resolve wordpress install OOM error

### DIFF
--- a/bin/yerd/src/shim.rs
+++ b/bin/yerd/src/shim.rs
@@ -157,7 +157,7 @@ mod tests {
         std::fs::write(&base, "; base\n").unwrap();
         assert_eq!(cli_phprc(&dirs, "8.4"), Some(base.clone()));
 
-        let per_version = cli_ini_path(&dirs, "8.4");
+        let per_version = dirs.data.join("php-cli-8.4.ini");
         std::fs::write(&per_version, "; per-version\n").unwrap();
         assert_eq!(cli_phprc(&dirs, "8.4"), Some(per_version));
     }

--- a/bin/yerd/src/shim.rs
+++ b/bin/yerd/src/shim.rs
@@ -126,6 +126,7 @@ pub(crate) fn fail(msg: String) -> ExitCode {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -136,5 +137,28 @@ mod tests {
             Some("8.4")
         );
         assert_eq!(minor_from_php_path(Path::new("/d/bin/php")), None);
+    }
+
+    #[test]
+    fn cli_phprc_prefers_per_version_then_base_then_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = PlatformDirs {
+            config: tmp.path().join("c"),
+            data: tmp.path().join("d"),
+            state: tmp.path().join("s"),
+            cache: tmp.path().join("ca"),
+            runtime: tmp.path().join("r"),
+        };
+        std::fs::create_dir_all(&dirs.data).unwrap();
+
+        assert_eq!(cli_phprc(&dirs, "8.4"), None);
+
+        let base = dirs.data.join("php-cli.ini");
+        std::fs::write(&base, "; base\n").unwrap();
+        assert_eq!(cli_phprc(&dirs, "8.4"), Some(base.clone()));
+
+        let per_version = cli_ini_path(&dirs, "8.4");
+        std::fs::write(&per_version, "; per-version\n").unwrap();
+        assert_eq!(cli_phprc(&dirs, "8.4"), Some(per_version));
     }
 }

--- a/bin/yerd/src/wp_shim.rs
+++ b/bin/yerd/src/wp_shim.rs
@@ -27,7 +27,7 @@ use yerd_core::PhpVersion;
 use yerd_ipc::{Request, Response};
 use yerd_platform::{ActivePaths, Paths, PlatformDirs};
 
-use crate::shim::{cli_binary, fail, resolve_default_php};
+use crate::shim::{cli_binary, cli_phprc, fail, resolve_default_php};
 use crate::transport;
 
 /// How long to wait for the daemon to answer `ListSites` before giving up and
@@ -52,16 +52,22 @@ const QUIET_DEPRECATIONS: [&str; 2] = ["-d", "error_reporting=E_ALL & ~E_DEPRECA
 /// tiny drop-in ini applying the same suppression, in a directory added to
 /// `PHP_INI_SCAN_DIR` (see [`quiet_deprecations_scan_dir_env`]) - unlike a CLI
 /// flag, an env var is inherited by any child process, so it still applies
-/// after a `launch_self()` re-exec. Idempotent (safe to call on every
-/// invocation). Kept in sync with the identical function in
-/// `bin/yerdd/src/tools/wp_cli.rs` - see [`QUIET_DEPRECATIONS`]'s doc comment
+/// after a `launch_self()` re-exec.
+///
+/// It also pins `display_errors = stderr`: this shim now sets `PHPRC` to the
+/// generated CLI ini (so `memory_limit` etc. apply), and that ini carries the
+/// user's `display_errors`, defaulting to `On` - which would route PHP warnings
+/// to *stdout* and corrupt `wp ... --format=json` output. Scanned after the
+/// main ini, this drop-in wins and forces errors back to stderr. Idempotent
+/// (safe to call on every invocation). Kept in sync with the identical function
+/// in `bin/yerdd/src/tools/wp_cli.rs` - see [`QUIET_DEPRECATIONS`]'s doc comment
 /// for why this is duplicated rather than shared.
 fn ensure_quiet_deprecations_scan_dir(dirs: &PlatformDirs) -> std::io::Result<PathBuf> {
     let dir = dirs.data.join("wp-cli-quiet.d");
     std::fs::create_dir_all(&dir)?;
     std::fs::write(
         dir.join("quiet-deprecations.ini"),
-        "error_reporting = E_ALL & ~E_DEPRECATED\n",
+        "error_reporting = E_ALL & ~E_DEPRECATED\ndisplay_errors = stderr\n",
     )?;
     Ok(dir)
 }
@@ -100,8 +106,8 @@ fn run() -> ExitCode {
         Some(cwd) => site_scope(&dirs, cwd),
         None => ScopeResolution::NoScope,
     };
-    let (php_bin, scope) = match resolution {
-        ScopeResolution::Scoped(s) => (s.php_bin.clone(), Some(s)),
+    let (php_bin, minor, scope) = match resolution {
+        ScopeResolution::Scoped(s) => (s.php_bin.clone(), s.php_minor.clone(), Some(s)),
         ScopeResolution::MatchedPhpMissing { php_version } => {
             return fail(format!(
                 "this site is pinned to PHP {php_version}, which is not installed — run \
@@ -109,7 +115,7 @@ fn run() -> ExitCode {
             ));
         }
         ScopeResolution::NoScope => match resolve_default_php(&dirs) {
-            Some((php, _minor)) => (php, None),
+            Some((php, minor)) => (php, minor, None),
             None => return fail("no PHP installed — run `yerd install php <version>`".to_owned()),
         },
     };
@@ -141,6 +147,9 @@ fn run() -> ExitCode {
         .current_dir(boot_dir);
     if let Ok(dir) = ensure_quiet_deprecations_scan_dir(&dirs) {
         cmd.env("PHP_INI_SCAN_DIR", quiet_deprecations_scan_dir_env(&dir));
+    }
+    if let Some(phprc) = cli_phprc(&dirs, &minor) {
+        cmd.env("PHPRC", phprc);
     }
     if let Some(s) = &scope {
         cmd.arg(format!("--path={}", s.served_root.display()));
@@ -184,6 +193,10 @@ fn split_boot_fs(boot_fs: &Path) -> Option<(&Path, &std::ffi::OsStr)> {
 pub struct SiteScope {
     /// The PHP CLI binary pinned to the matched site.
     pub php_bin: PathBuf,
+    /// The matched site's pinned PHP version as `"major.minor"` - the
+    /// [`cli_phprc`] key for pointing `PHPRC` at that version's generated CLI
+    /// ini.
+    pub php_minor: String,
     /// The matched site's (canonicalized) served root - `document_root`
     /// joined with `web_subpath` - i.e. where `WordPress` actually lives, not
     /// necessarily the site's project root. Passed to `wp` as `--path=`.
@@ -233,10 +246,12 @@ pub fn site_scope(dirs: &PlatformDirs, cwd: &Path) -> ScopeResolution {
     let Some((root, php_version)) = match_site(cwd, &candidates) else {
         return ScopeResolution::NoScope;
     };
-    let php_bin = cli_binary(dirs, &php_version.to_string());
+    let minor = php_version.to_string();
+    let php_bin = cli_binary(dirs, &minor);
     if php_bin.is_file() {
         ScopeResolution::Scoped(SiteScope {
             php_bin,
+            php_minor: minor,
             served_root: root,
         })
     } else {
@@ -307,6 +322,7 @@ mod tests {
         let ini = std::fs::read_to_string(dir.join("quiet-deprecations.ini")).unwrap();
         assert!(ini.contains("error_reporting"));
         assert!(ini.contains("~E_DEPRECATED"));
+        assert!(ini.contains("display_errors = stderr"));
         assert!(ensure_quiet_deprecations_scan_dir(&dirs).is_ok());
     }
 

--- a/bin/yerdd/src/create_site/laravel.rs
+++ b/bin/yerdd/src/create_site/laravel.rs
@@ -114,6 +114,7 @@ pub(super) async fn run(
         &spec.parent_dir,
         Some(&path_env),
         Some(&composer_home),
+        None,
         false,
         None,
         state,

--- a/bin/yerdd/src/create_site/mod.rs
+++ b/bin/yerdd/src/create_site/mod.rs
@@ -240,6 +240,7 @@ async fn run_streamed(
     cwd: &Path,
     path_env: Option<&std::ffi::OsString>,
     composer_home: Option<&Path>,
+    phprc: Option<&Path>,
     quiet_wp_cli_deprecations: bool,
     stdin_data: Option<&str>,
     state: &Arc<DaemonState>,
@@ -265,6 +266,9 @@ async fn run_streamed(
     if let Some(home) = composer_home {
         cmd.env("COMPOSER_HOME", home)
             .env("COMPOSER_NO_INTERACTION", "1");
+    }
+    if let Some(phprc) = phprc {
+        cmd.env("PHPRC", phprc);
     }
     if quiet_wp_cli_deprecations {
         if let Ok(dir) = crate::tools::wp_cli::ensure_quiet_deprecations_scan_dir(&state.dirs) {

--- a/bin/yerdd/src/create_site/wordpress.rs
+++ b/bin/yerdd/src/create_site/wordpress.rs
@@ -40,6 +40,7 @@ pub(super) async fn run(
             spec.php.major, spec.php.minor
         ));
     }
+    let phprc = crate::php_install::cli_phprc(dirs, spec.php);
     if let Err(e) = validate_admin_credentials(options) {
         return Outcome::Failed(format!("invalid WordPress admin account: {e}"));
     }
@@ -101,6 +102,7 @@ pub(super) async fn run(
         &boot_fs,
         &download_args,
         &project_dir,
+        phprc.as_deref(),
         None,
         state,
         &mut cancel_rx,
@@ -130,6 +132,7 @@ pub(super) async fn run(
         &boot_fs,
         &config_args,
         &project_dir,
+        phprc.as_deref(),
         None,
         state,
         &mut cancel_rx,
@@ -160,6 +163,7 @@ pub(super) async fn run(
         &boot_fs,
         &install_args,
         &project_dir,
+        phprc.as_deref(),
         Some(options.admin_password.as_str()),
         state,
         &mut cancel_rx,
@@ -177,7 +181,16 @@ pub(super) async fn run(
         }
     }
 
-    if apply_permalink_structure(id, &php_cli, &boot_fs, &project_dir, state, &mut cancel_rx).await
+    if apply_permalink_structure(
+        id,
+        &php_cli,
+        &boot_fs,
+        &project_dir,
+        phprc.as_deref(),
+        state,
+        &mut cancel_rx,
+    )
+    .await
         == PermalinkOutcome::Cancelled
     {
         rollback(&project_dir, db_created, service, &db_name, state).await;
@@ -238,6 +251,7 @@ async fn apply_permalink_structure(
     php_cli: &Path,
     boot_fs: &Path,
     project_dir: &Path,
+    phprc: Option<&Path>,
     state: &Arc<DaemonState>,
     cancel_rx: &mut watch::Receiver<bool>,
 ) -> PermalinkOutcome {
@@ -252,6 +266,7 @@ async fn apply_permalink_structure(
         boot_fs,
         &permalink_args,
         project_dir,
+        phprc,
         None,
         state,
         cancel_rx,
@@ -315,6 +330,7 @@ async fn run_wp_step(
     boot_fs: &Path,
     args: &[String],
     project_dir: &Path,
+    phprc: Option<&Path>,
     stdin_data: Option<&str>,
     state: &Arc<DaemonState>,
     cancel_rx: &mut watch::Receiver<bool>,
@@ -329,8 +345,8 @@ async fn run_wp_step(
         .map(|s| (*s).to_owned())
         .collect();
     super::run_streamed(
-        id, php_cli, &php_flags, &boot_name, &full_args, &boot_dir, None, None, true, stdin_data,
-        state, cancel_rx,
+        id, php_cli, &php_flags, &boot_name, &full_args, &boot_dir, None, None, phprc, true,
+        stdin_data, state, cancel_rx,
     )
     .await
 }

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -500,6 +500,26 @@ pub fn cli_binary_path(dirs: &PlatformDirs, version: PhpVersion) -> PathBuf {
     p
 }
 
+/// The `PHPRC` target for a version's CLI: its per-version ini
+/// (`data/php-cli-<major>.<minor>.ini`) if present, else the base
+/// `data/php-cli.ini` if present, else `None` (leave `PHPRC` unset). Mirrors
+/// `bin/yerd/src/shim.rs::cli_phprc` - the two binaries can't share code across
+/// the boundary, so the filename shape here is kept byte-for-byte in step with
+/// what [`write_cli_ini`] emits. Pointing a wp-cli launch at this ini is what
+/// gets the user's global CLI settings (`memory_limit`, ...) applied; without
+/// it, wp-cli runs under PHP's compiled-in defaults.
+#[must_use]
+pub fn cli_phprc(dirs: &PlatformDirs, version: PhpVersion) -> Option<PathBuf> {
+    let per_version = dirs
+        .data
+        .join(format!("php-cli-{}.{}.ini", version.major, version.minor));
+    if per_version.is_file() {
+        return Some(per_version);
+    }
+    let base = dirs.data.join("php-cli.ini");
+    base.is_file().then_some(base)
+}
+
 /// The directory users add to PATH for the managed `php` shim (`data/bin`).
 #[must_use]
 pub fn shim_dir(dirs: &PlatformDirs) -> PathBuf {
@@ -954,6 +974,30 @@ mod tests {
             cli_binary_path(&dirs, PhpVersion::new(8, 5)),
             PathBuf::from("/d/php/php-8.5/bin/php")
         );
+    }
+
+    #[test]
+    fn cli_phprc_prefers_per_version_then_base_then_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = PlatformDirs {
+            config: tmp.path().join("c"),
+            data: tmp.path().join("d"),
+            state: tmp.path().join("s"),
+            cache: tmp.path().join("ca"),
+            runtime: tmp.path().join("r"),
+        };
+        std::fs::create_dir_all(&dirs.data).unwrap();
+        let v = PhpVersion::new(8, 5);
+
+        assert_eq!(cli_phprc(&dirs, v), None);
+
+        let base = dirs.data.join("php-cli.ini");
+        std::fs::write(&base, "; base\n").unwrap();
+        assert_eq!(cli_phprc(&dirs, v), Some(base.clone()));
+
+        let per_version = dirs.data.join("php-cli-8.5.ini");
+        std::fs::write(&per_version, "; per-version\n").unwrap();
+        assert_eq!(cli_phprc(&dirs, v), Some(per_version));
     }
 
     #[cfg(unix)]

--- a/bin/yerdd/src/tools/wp_cli.rs
+++ b/bin/yerdd/src/tools/wp_cli.rs
@@ -49,14 +49,23 @@ pub(crate) const QUIET_DEPRECATIONS: [&str; 2] = ["-d", "error_reporting=E_ALL &
 /// tiny drop-in ini applying the same suppression, in a directory meant to be
 /// added to `PHP_INI_SCAN_DIR` (see [`quiet_deprecations_scan_dir_env`]) -
 /// unlike a CLI flag, an env var is inherited by any child process, so it
-/// still applies after a `launch_self()` re-exec. Idempotent (safe to call on
+/// still applies after a `launch_self()` re-exec.
+///
+/// It also pins `display_errors = stderr`. Every wp-cli launch now sets `PHPRC`
+/// to the generated CLI ini (so `memory_limit` and friends apply), and that ini
+/// carries the user's `display_errors` setting, defaulting to `On` - which on
+/// the CLI SAPI would route PHP warnings to *stdout* and corrupt machine-read
+/// output (`wp ... --format=json`, and this crate's own `wp user list` JSON
+/// parse). Scanned after the main ini, this drop-in wins, forcing errors back
+/// to stderr where wp-cli expects them; the plain `php` shim never adds this
+/// scan dir, so its `display_errors` is untouched. Idempotent (safe to call on
 /// every invocation).
 pub(crate) fn ensure_quiet_deprecations_scan_dir(dirs: &PlatformDirs) -> std::io::Result<PathBuf> {
     let dir = dirs.data.join("wp-cli-quiet.d");
     std::fs::create_dir_all(&dir)?;
     std::fs::write(
         dir.join("quiet-deprecations.ini"),
-        "error_reporting = E_ALL & ~E_DEPRECATED\n",
+        "error_reporting = E_ALL & ~E_DEPRECATED\ndisplay_errors = stderr\n",
     )?;
     Ok(dir)
 }
@@ -211,6 +220,7 @@ mod tests {
         let ini = std::fs::read_to_string(dir.join("quiet-deprecations.ini")).unwrap();
         assert!(ini.contains("error_reporting"));
         assert!(ini.contains("~E_DEPRECATED"));
+        assert!(ini.contains("display_errors = stderr"));
 
         // Idempotent: calling it again doesn't fail on the already-existing dir/file.
         assert!(ensure_quiet_deprecations_scan_dir(&dirs).is_ok());

--- a/bin/yerdd/src/wordpress_url_sync.rs
+++ b/bin/yerdd/src/wordpress_url_sync.rs
@@ -14,7 +14,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
-use yerd_core::Site;
+use yerd_core::{PhpVersion, Site};
 
 use crate::state::DaemonState;
 
@@ -47,8 +47,16 @@ pub async fn sync_site_url(site: &Site, state: &DaemonState) {
     let url = target_url(&host, site.secure());
 
     for option in ["siteurl", "home"] {
-        if let Err(e) =
-            run_option_update(&php_cli, &boot_fs, &served_root, option, &url, &state.dirs).await
+        if let Err(e) = run_option_update(
+            &php_cli,
+            site.php(),
+            &boot_fs,
+            &served_root,
+            option,
+            &url,
+            &state.dirs,
+        )
+        .await
         {
             tracing::warn!(
                 site = %site.name(),
@@ -99,6 +107,7 @@ fn option_update_invocation(
 
 async fn run_option_update(
     php_cli: &Path,
+    php: PhpVersion,
     boot_fs: &Path,
     served_root: &Path,
     option: &str,
@@ -118,6 +127,9 @@ async fn run_option_update(
         .env("NO_COLOR", "1")
         .stdin(Stdio::null())
         .kill_on_drop(true);
+    if let Some(phprc) = crate::php_install::cli_phprc(dirs, php) {
+        cmd.env("PHPRC", phprc);
+    }
     if let Ok(dir) = crate::tools::wp_cli::ensure_quiet_deprecations_scan_dir(dirs) {
         cmd.env(
             "PHP_INI_SCAN_DIR",

--- a/bin/yerdd/src/wordpress_users.rs
+++ b/bin/yerdd/src/wordpress_users.rs
@@ -7,6 +7,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+use yerd_core::PhpVersion;
 use yerd_ipc::{ErrorCode, Response, WordPressAdminUser};
 
 use crate::state::DaemonState;
@@ -59,7 +60,7 @@ pub async fn admin_users(site: &str, state: &DaemonState) -> Response {
         };
     }
 
-    match run_user_list(&php_cli, &boot_fs, &served_root, &state.dirs).await {
+    match run_user_list(&php_cli, php, &boot_fs, &served_root, &state.dirs).await {
         Ok(users) => Response::WordpressAdminUsers { users },
         Err(e) => Response::Error {
             code: ErrorCode::Internal,
@@ -99,6 +100,7 @@ struct WpCliUser {
 
 async fn run_user_list(
     php_cli: &Path,
+    php: PhpVersion,
     boot_fs: &Path,
     served_root: &Path,
     dirs: &yerd_platform::PlatformDirs,
@@ -108,12 +110,16 @@ async fn run_user_list(
     };
     let mut cmd = tokio::process::Command::new(php_cli);
     cmd.args(crate::tools::wp_cli::QUIET_DEPRECATIONS)
+        .args(["-d", "display_errors=stderr"])
         .arg(&boot_name)
         .args(&args)
         .current_dir(&boot_dir)
         .env("NO_COLOR", "1")
         .stdin(Stdio::null())
         .kill_on_drop(true);
+    if let Some(phprc) = crate::php_install::cli_phprc(dirs, php) {
+        cmd.env("PHPRC", phprc);
+    }
     if let Ok(dir) = crate::tools::wp_cli::ensure_quiet_deprecations_scan_dir(dirs) {
         cmd.env(
             "PHP_INI_SCAN_DIR",


### PR DESCRIPTION
## What does this PR do?

Resolve an OOM error when installing WP due to low php memory limit via the CLI. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WordPress and site setup flows now automatically use the most appropriate PHP CLI configuration when available, improving consistency across commands.

* **Bug Fixes**
  * Improved WP-CLI output handling by routing errors to stderr, which helps keep JSON-based output cleaner.
  * Deprecation notices are now suppressed more reliably during CLI operations.
  * WordPress URL and user-management actions now respect the site’s PHP version when running CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->