### PR TITLE
[Fix] Arch Linux mysql install crash

### DIFF
--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -481,7 +481,10 @@ where
     /// Guarded by an [`InitGroupReaper`]: if the owning task is dropped mid-init
     /// (daemon shutdown), the init tool's whole process group is killed so a
     /// grandchild it forked (e.g. `mariadb-install-db`'s bootstrap server) can't
-    /// leak - `kill_on_drop` alone only reaps the direct child.
+    /// leak - `kill_on_drop` alone only reaps the direct child. The reaper is
+    /// bound after `child`, so on a drop mid-`wait()` reverse-declaration order
+    /// runs the reaper's `killpg` while the PID is still valid, then
+    /// `kill_on_drop` reaps the direct child.
     async fn run_init(
         &self,
         service: Service,
@@ -531,10 +534,6 @@ where
                 datadir: datadir.to_path_buf(),
                 detail: format!("spawn {}: {source}", init_bin.display()),
             })?;
-        // `child` is declared before `reaper`, so if this task is dropped while
-        // awaiting `wait()` the reaper runs first (reverse-declaration drop) and
-        // SIGKILLs the init group while the PID is still valid, then
-        // `kill_on_drop` reaps the direct child.
         let mut reaper = InitGroupReaper::arm(child.id());
         let waited = child.wait().await;
         if waited.is_ok() {
@@ -1160,14 +1159,15 @@ mod tests {
         );
     }
 
+    /// `arm` stores the PID and `disarm` clears it. The values are captured
+    /// before asserting so a failing assertion can't drop a still-armed reaper
+    /// and fire a real `killpg`.
     #[test]
     fn init_group_reaper_disarm_clears_the_pid() {
         let mut reaper = InitGroupReaper::arm(4242);
         let armed = reaper.0;
         reaper.disarm();
         let disarmed = reaper.0;
-        // Assert only after disarming, so a failing assertion can't drop an armed
-        // reaper and fire a real `killpg`.
         assert_eq!(armed, Some(4242));
         assert_eq!(disarmed, None);
     }

--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -1172,6 +1172,56 @@ mod tests {
         assert_eq!(disarmed, None);
     }
 
+    /// End-to-end guard for the actual fix: `run_init` must spawn the datadir-init
+    /// tool into its **own** process group, or a group-directed signal from a
+    /// shell-script init tool (`mariadb-install-db`) reaches and kills the daemon.
+    /// Drives the real `run_init` with a fake init binary that reports its PID and
+    /// process-group id; `run_init` redirects the child's stdout to the log file,
+    /// so we read it back and assert the child leads its own group (`pid == pgid`).
+    /// Deleting the `set_own_process_group` call from `run_init` fails this.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_init_spawns_the_init_tool_in_its_own_process_group() {
+        use std::os::unix::fs::PermissionsExt;
+        use yerd_supervise::{SystemClock, TokioProcessSpawner};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let init_bin = tmp.path().join("fake-init.sh");
+        std::fs::write(
+            &init_bin,
+            "#!/bin/sh\nprintf '%s %s' \"$$\" \"$(ps -o pgid= -p $$)\"\nexit 0\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&init_bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let log = tmp.path().join("init.log");
+        let mgr = ServiceManager::new(
+            TokioProcessSpawner,
+            SystemClock,
+            crate::health::ServiceProbes::new(),
+            dirs_in(tmp.path()),
+            ActivePortBinder::new(),
+        );
+        mgr.run_init(
+            Service::MySql,
+            &init_bin,
+            &tmp.path().join("staging"),
+            &tmp.path().join("datadir"),
+            &log,
+        )
+        .await
+        .expect("fake init exits 0");
+
+        let out = std::fs::read_to_string(&log).unwrap();
+        let mut fields = out.split_whitespace();
+        let child_pid: i32 = fields.next().unwrap().parse().unwrap();
+        let group: i32 = fields.next().unwrap().parse().unwrap();
+        assert_eq!(
+            child_pid, group,
+            "run_init must put the init tool in its own group; got pid {child_pid} pgid {group}"
+        );
+    }
+
     /// The Postgres arm opens the log file for stderr capture, creating it.
     #[test]
     fn build_cmd_postgres_opens_log_and_sets_datadir_args() {

--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -477,6 +477,11 @@ where
     /// require a clean `exit 0`. Init output goes to the service log so a
     /// failure is diagnosable via `yerd service logs`. `datadir` is the FINAL
     /// path, used only for error reporting.
+    ///
+    /// Guarded by an [`InitGroupReaper`]: if the owning task is dropped mid-init
+    /// (daemon shutdown), the init tool's whole process group is killed so a
+    /// grandchild it forked (e.g. `mariadb-install-db`'s bootstrap server) can't
+    /// leak - `kill_on_drop` alone only reaps the direct child.
     async fn run_init(
         &self,
         service: Service,
@@ -506,6 +511,7 @@ where
             }
             Service::Redis => return Ok(()),
         }
+        set_own_process_group(&mut cmd);
         if let Ok(f) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -525,7 +531,16 @@ where
                 datadir: datadir.to_path_buf(),
                 detail: format!("spawn {}: {source}", init_bin.display()),
             })?;
-        let reason = child.wait().await.map_err(|source| ServiceError::Init {
+        // `child` is declared before `reaper`, so if this task is dropped while
+        // awaiting `wait()` the reaper runs first (reverse-declaration drop) and
+        // SIGKILLs the init group while the PID is still valid, then
+        // `kill_on_drop` reaps the direct child.
+        let mut reaper = InitGroupReaper::arm(child.id());
+        let waited = child.wait().await;
+        if waited.is_ok() {
+            reaper.disarm();
+        }
+        let reason = waited.map_err(|source| ServiceError::Init {
             service,
             datadir: datadir.to_path_buf(),
             detail: format!("wait for init: {source}"),
@@ -805,6 +820,47 @@ async fn wait_after_kill<Ch: ChildHandle>(
     }
 }
 
+/// Put `cmd` in its own process group at spawn time (Unix) so a signal it or any
+/// descendant raises can never reach the daemon, and so the supervisor's
+/// `killpg(pid, ..)` targets exactly this subtree. Both the long-running server
+/// ([`build_cmd`]) and the one-shot datadir init ([`ServiceManager::run_init`])
+/// route through here; the [`yerd_supervise::ChildHandle`] contract requires it.
+fn set_own_process_group(cmd: &mut StdCommand) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    #[cfg(not(unix))]
+    let _ = cmd;
+}
+
+/// Drop guard that sends SIGKILL to the process group led by a spawned init tool
+/// unless [`disarm`](Self::disarm)ed. Armed with the child's PID after spawn and
+/// disarmed once `wait()` returns (the group is then gone, and the reaped PID
+/// could otherwise be reused); so it only fires when the task is dropped
+/// mid-init. Relies on the init command being spawned into its own group via
+/// [`set_own_process_group`], so its PID is the group id.
+struct InitGroupReaper(Option<u32>);
+
+impl InitGroupReaper {
+    fn arm(leader_pid: u32) -> Self {
+        Self(Some(leader_pid))
+    }
+
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for InitGroupReaper {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0 {
+            yerd_supervise::kill_process_group(pid);
+        }
+    }
+}
+
 /// Build the server command per engine, forcing foreground operation and (on
 /// Unix) its own process group so the supervisor's `killpg` reaps any children
 /// with it. Fallible because the Postgres arm opens the log file for stderr
@@ -847,11 +903,7 @@ fn build_cmd(
             cmd.stderr(std::process::Stdio::from(f));
         }
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        cmd.process_group(0);
-    }
+    set_own_process_group(&mut cmd);
     Ok(cmd)
 }
 
@@ -1067,6 +1119,57 @@ mod tests {
         assert_eq!(args.len(), 1);
         assert!(args[0].starts_with("--defaults-file="), "got: {args:?}");
         assert!(args[0].contains("my.cnf"));
+    }
+
+    /// The datadir-init tool and the long-running server both spawn through
+    /// [`set_own_process_group`], which must land the child in its **own**
+    /// process group. A regression here (an init tool left in the daemon's
+    /// group) lets a group-directed signal from a shell-script init tool like
+    /// `mariadb-install-db` reach and kill the daemon. `process_group` can't be
+    /// read back off `std::process::Command`, so this asserts the behaviour by
+    /// actually spawning: an isolated child leads its own group (`pid == pgid`),
+    /// an un-isolated one inherits the parent's group and is not the leader.
+    #[cfg(unix)]
+    #[test]
+    fn set_own_process_group_makes_child_its_own_group_leader() {
+        fn own_pid_and_group(isolate: bool) -> (i32, i32) {
+            let mut cmd = StdCommand::new("sh");
+            cmd.arg("-c")
+                .arg("printf '%s %s' \"$$\" \"$(ps -o pgid= -p $$)\"");
+            if isolate {
+                set_own_process_group(&mut cmd);
+            }
+            let out = cmd.output().expect("spawn sh");
+            let text = String::from_utf8_lossy(&out.stdout);
+            let mut fields = text.split_whitespace();
+            let child_pid = fields.next().unwrap().parse().unwrap();
+            let group = fields.next().unwrap().parse().unwrap();
+            (child_pid, group)
+        }
+
+        let (child_pid, group) = own_pid_and_group(true);
+        assert_eq!(
+            child_pid, group,
+            "isolated child must lead its own process group"
+        );
+
+        let (child_pid, group) = own_pid_and_group(false);
+        assert_ne!(
+            child_pid, group,
+            "un-isolated child inherits the daemon's group, so it is not the leader"
+        );
+    }
+
+    #[test]
+    fn init_group_reaper_disarm_clears_the_pid() {
+        let mut reaper = InitGroupReaper::arm(4242);
+        let armed = reaper.0;
+        reaper.disarm();
+        let disarmed = reaper.0;
+        // Assert only after disarming, so a failing assertion can't drop an armed
+        // reaper and fire a real `killpg`.
+        assert_eq!(armed, Some(4242));
+        assert_eq!(disarmed, None);
     }
 
     /// The Postgres arm opens the log file for stderr capture, creating it.

--- a/crates/yerd-supervise/src/lib.rs
+++ b/crates/yerd-supervise/src/lib.rs
@@ -27,7 +27,7 @@ pub mod traits;
 
 pub use error::{DownloadError, ExitReason, SpawnFailureReason};
 pub use listen::Listen;
-pub use real::{SystemClock, TokioChild, TokioProcessSpawner};
+pub use real::{kill_process_group, SystemClock, TokioChild, TokioProcessSpawner};
 pub use supervisor::{
     backoff_for, transition, Action, Elapsed, ErrorTag, Event, KillSignal, PoolState, StopProtocol,
     SupervisorPolicy,

--- a/crates/yerd-supervise/src/real.rs
+++ b/crates/yerd-supervise/src/real.rs
@@ -29,13 +29,28 @@ impl Clock for SystemClock {
 /// whole subtree. Requires the leader to have been spawned into its own process
 /// group (`process_group(0)`), so its PID doubles as the group id. No-op off
 /// Unix (Windows worker teardown is a Phase 2 job-object ticket, as for `kill`).
+///
+/// A `leader_pid` of 0 is ignored: `killpg(0, ..)` targets the *caller's* own
+/// process group, so it would signal the daemon itself. A real spawned child PID
+/// is never 0; this only guards a future or mistaken caller.
 #[cfg(unix)]
 pub fn kill_process_group(leader_pid: u32) {
     use nix::sys::signal::{killpg, Signal};
     use nix::unistd::Pid;
-    if let Ok(pid) = i32::try_from(leader_pid) {
+    if let Some(pid) = group_signal_target(leader_pid) {
         let _ = killpg(Pid::from_raw(pid), Signal::SIGKILL);
     }
+}
+
+/// The `i32` PID to hand `killpg`, or `None` when the group must not be signalled:
+/// a `leader_pid` of 0 (`killpg(0, ..)` hits the caller's own group) or one that
+/// overflows `i32`. Pure, so the 0-guard is tested without issuing a real signal.
+#[cfg(unix)]
+fn group_signal_target(leader_pid: u32) -> Option<i32> {
+    if leader_pid == 0 {
+        return None;
+    }
+    i32::try_from(leader_pid).ok()
 }
 
 #[cfg(not(unix))]
@@ -100,5 +115,21 @@ impl ChildHandle for TokioChild {
             let _ = (signal, protocol);
             self.inner.kill().await
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::group_signal_target;
+
+    #[test]
+    fn group_signal_target_rejects_zero_and_overflow() {
+        assert_eq!(group_signal_target(0), None);
+        assert_eq!(group_signal_target(1234), Some(1234));
+        assert_eq!(
+            group_signal_target(u32::MAX),
+            None,
+            "a PID that overflows i32 must not be signalled"
+        );
     }
 }

--- a/crates/yerd-supervise/src/real.rs
+++ b/crates/yerd-supervise/src/real.rs
@@ -53,6 +53,8 @@ fn group_signal_target(leader_pid: u32) -> Option<i32> {
     i32::try_from(leader_pid).ok()
 }
 
+/// Non-Unix stub: process-group reaping is a Phase 2 job-object ticket, so this
+/// is a no-op (see the Unix impl for the semantics).
 #[cfg(not(unix))]
 pub fn kill_process_group(_leader_pid: u32) {}
 

--- a/crates/yerd-supervise/src/real.rs
+++ b/crates/yerd-supervise/src/real.rs
@@ -20,6 +20,27 @@ impl Clock for SystemClock {
     }
 }
 
+/// Best-effort SIGKILL to the entire process group led by `leader_pid`.
+///
+/// A spawned leader's `kill_on_drop(true)` only SIGKILLs the **direct** child,
+/// so any grandchild it forked (e.g. the bootstrap server a `mariadb-install-db`
+/// script launches) survives. When a task owning such a leader is dropped before
+/// it can `wait()` - a daemon shutting down mid-init - call this to reap the
+/// whole subtree. Requires the leader to have been spawned into its own process
+/// group (`process_group(0)`), so its PID doubles as the group id. No-op off
+/// Unix (Windows worker teardown is a Phase 2 job-object ticket, as for `kill`).
+#[cfg(unix)]
+pub fn kill_process_group(leader_pid: u32) {
+    use nix::sys::signal::{killpg, Signal};
+    use nix::unistd::Pid;
+    if let Ok(pid) = i32::try_from(leader_pid) {
+        let _ = killpg(Pid::from_raw(pid), Signal::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+pub fn kill_process_group(_leader_pid: u32) {}
+
 /// Spawns commands via `tokio::process::Command`, sets `kill_on_drop(true)` so
 /// unexpected crashes of the daemon take the child down with them.
 pub struct TokioProcessSpawner;


### PR DESCRIPTION
## What does this PR do?

Resolves an Arch linux mysql isntallation daemon crash noticed during testing of the WordPress functionality. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup so interrupted startup steps don’t leave background processes running.
  * Added safer isolation for launched commands, helping prevent accidental termination of unrelated processes.
  * Long-running services now use a shared process-isolation approach for more consistent behavior.

* **Tests**
  * Added coverage for process-group handling and cleanup behavior on Unix systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->