### PR TITLE
[Feat] PostgreSQL PostGIS (full) variant support

### DIFF
--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -186,7 +186,18 @@ where
             }
         })?;
 
-        let cmd_builder = || build_cmd(service, &binary, &config_path, &datadir, &log_path);
+        let install_dir = version::install_dir(&self.dirs, service, &version);
+        let geo_env = geo_data_env(service, &install_dir, &version);
+        let cmd_builder = || {
+            build_cmd(
+                service,
+                &binary,
+                &config_path,
+                &datadir,
+                &log_path,
+                &geo_env,
+            )
+        };
 
         let initial_since = self.clock.now();
         let result = self
@@ -859,16 +870,22 @@ impl Drop for InitGroupReaper {
 
 /// Build the server command per engine, forcing foreground operation and (on
 /// Unix) its own process group so the supervisor's `killpg` reaps any children
-/// with it. Fallible because the Postgres arm opens the log file for stderr
-/// capture.
+/// with it. `env` is added on top of the inherited environment (services are not
+/// env-scrubbed); it carries `PROJ_DATA` / `GDAL_DATA` for `PostGIS` postgres
+/// variants and is empty otherwise. Fallible because the Postgres arm opens the
+/// log file for stderr capture.
 fn build_cmd(
     service: Service,
     binary: &std::path::Path,
     config_path: &std::path::Path,
     datadir: &std::path::Path,
     log_path: &std::path::Path,
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
 ) -> Result<StdCommand, ServiceError> {
     let mut cmd = StdCommand::new(binary);
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
     match service {
         Service::Redis => {
             cmd.arg(config_path);
@@ -901,6 +918,71 @@ fn build_cmd(
     }
     set_own_process_group(&mut cmd);
     Ok(cmd)
+}
+
+/// Environment to inject into the postmaster for a `PostGIS`-bearing postgres
+/// variant install: `PROJ_DATA` / `GDAL_DATA`, probed from the install tree so
+/// `ST_Transform` and raster reprojection can find their runtime data. Empty for
+/// the base build, any non-variant label, and every non-postgres service - only a
+/// variant install is probed, and each var is set only when its file is found.
+fn geo_data_env(
+    service: Service,
+    install_dir: &std::path::Path,
+    version: &ServiceVersion,
+) -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    if service != Service::Postgres || !version.has_variant() {
+        return Vec::new();
+    }
+    let (proj, gdal) = find_geo_data_dirs(install_dir);
+    let mut env = Vec::new();
+    if let Some(dir) = proj {
+        env.push(("PROJ_DATA".into(), dir.into_os_string()));
+    }
+    if let Some(dir) = gdal {
+        env.push(("GDAL_DATA".into(), dir.into_os_string()));
+    }
+    env
+}
+
+/// Depth-first search of `root` for the parent directories of `proj.db` (PROJ) and
+/// `gdalvrt.xsd` (GDAL), short-circuiting once both are found. First match wins if
+/// a name appears more than once (walk order). Unreadable directories and errored
+/// entries are skipped. `DirEntry::file_type()` does not follow symlinks, so a
+/// symlinked directory is not recursed (no loop risk) and a symlinked target file
+/// is skipped - acceptable because yerd controls the published tarball layout.
+fn find_geo_data_dirs(
+    root: &std::path::Path,
+) -> (Option<std::path::PathBuf>, Option<std::path::PathBuf>) {
+    let mut proj = None;
+    let mut gdal = None;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                match entry.file_name().to_str() {
+                    Some("proj.db") if proj.is_none() => {
+                        proj = entry.path().parent().map(std::path::Path::to_path_buf);
+                    }
+                    Some("gdalvrt.xsd") if gdal.is_none() => {
+                        gdal = entry.path().parent().map(std::path::Path::to_path_buf);
+                    }
+                    _ => {}
+                }
+            }
+            if proj.is_some() && gdal.is_some() {
+                return (proj, gdal);
+            }
+        }
+    }
+    (proj, gdal)
 }
 
 /// Arguments for an engine's one-shot datadir init tool. `staging` is the fresh
@@ -1069,6 +1151,17 @@ mod tests {
         assert!(check_pg_major(tmp.path(), &v("16.4")).is_ok());
     }
 
+    /// A variant label (`17-full`) shares the base's numeric major, so it must
+    /// open a datadir initialised by the base build - this is what lets a user
+    /// switch base to variant without a cross-major rejection.
+    #[test]
+    fn check_pg_major_accepts_a_variant_of_the_same_major() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("PG_VERSION"), b"17\n").unwrap();
+        assert!(check_pg_major(tmp.path(), &v("17-full")).is_ok());
+        assert!(check_pg_major(tmp.path(), &v("17.10-full")).is_ok());
+    }
+
     #[test]
     fn check_pg_major_rejects_cross_major_datadir() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1133,7 +1226,7 @@ mod tests {
         let config = tmp.path().join("redis.conf");
         let datadir = tmp.path().join("data");
         let log = tmp.path().join("redis.log");
-        let cmd = build_cmd(Service::Redis, &binary, &config, &datadir, &log).unwrap();
+        let cmd = build_cmd(Service::Redis, &binary, &config, &datadir, &log, &[]).unwrap();
         assert_eq!(cmd.get_program(), binary.as_os_str());
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args, vec![config.as_os_str()]);
@@ -1146,7 +1239,7 @@ mod tests {
         let config = tmp.path().join("my.cnf");
         let datadir = tmp.path().join("data");
         let log = tmp.path().join("mysql.log");
-        let cmd = build_cmd(Service::MySql, &binary, &config, &datadir, &log).unwrap();
+        let cmd = build_cmd(Service::MySql, &binary, &config, &datadir, &log, &[]).unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
@@ -1313,7 +1406,7 @@ mod tests {
         let config = tmp.path().join("postgresql.conf");
         let datadir = tmp.path().join("data");
         let log = tmp.path().join("pg.log");
-        let cmd = build_cmd(Service::Postgres, &binary, &config, &datadir, &log).unwrap();
+        let cmd = build_cmd(Service::Postgres, &binary, &config, &datadir, &log, &[]).unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
@@ -1332,7 +1425,7 @@ mod tests {
         let config = tmp.path().join("postgresql.conf");
         let datadir = tmp.path().join("data");
         let log = tmp.path().join("missing").join("pg.log");
-        let err = build_cmd(Service::Postgres, &binary, &config, &datadir, &log).unwrap_err();
+        let err = build_cmd(Service::Postgres, &binary, &config, &datadir, &log, &[]).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -1343,6 +1436,97 @@ mod tests {
             ),
             "got: {err:?}"
         );
+    }
+
+    /// `build_cmd` layers the supplied env pairs onto the command (on top of the
+    /// inherited environment, which the services path never scrubs).
+    #[test]
+    fn build_cmd_sets_supplied_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let binary = tmp.path().join("postgres");
+        let config = tmp.path().join("postgresql.conf");
+        let datadir = tmp.path().join("data");
+        let log = tmp.path().join("pg.log");
+        let env = vec![
+            (
+                std::ffi::OsString::from("PROJ_DATA"),
+                std::ffi::OsString::from("/i/share/proj"),
+            ),
+            (
+                std::ffi::OsString::from("GDAL_DATA"),
+                std::ffi::OsString::from("/i/share/gdal"),
+            ),
+        ];
+        let cmd = build_cmd(Service::Postgres, &binary, &config, &datadir, &log, &env).unwrap();
+        let got: std::collections::BTreeMap<_, _> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| v.map(|v| (k.to_owned(), v.to_owned())))
+            .collect();
+        assert_eq!(
+            got.get(std::ffi::OsStr::new("PROJ_DATA"))
+                .map(std::ffi::OsString::as_os_str),
+            Some(std::ffi::OsStr::new("/i/share/proj"))
+        );
+        assert_eq!(
+            got.get(std::ffi::OsStr::new("GDAL_DATA"))
+                .map(std::ffi::OsString::as_os_str),
+            Some(std::ffi::OsStr::new("/i/share/gdal"))
+        );
+    }
+
+    /// A staged install tree with the two geo-data files under `share/`.
+    fn stage_geo_install(root: &std::path::Path, proj: bool, gdal: bool) {
+        if proj {
+            let dir = root.join("share").join("proj");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("proj.db"), b"").unwrap();
+        }
+        if gdal {
+            let dir = root.join("share").join("gdal");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("gdalvrt.xsd"), b"").unwrap();
+        }
+    }
+
+    #[test]
+    fn geo_data_env_empty_for_base_label() {
+        let tmp = tempfile::tempdir().unwrap();
+        stage_geo_install(tmp.path(), true, true);
+        assert!(geo_data_env(Service::Postgres, tmp.path(), &v("17")).is_empty());
+    }
+
+    #[test]
+    fn geo_data_env_empty_for_non_postgres_variant() {
+        let tmp = tempfile::tempdir().unwrap();
+        stage_geo_install(tmp.path(), true, true);
+        assert!(geo_data_env(Service::MySql, tmp.path(), &v("9.7-full")).is_empty());
+    }
+
+    #[test]
+    fn geo_data_env_sets_both_when_probed() {
+        let tmp = tempfile::tempdir().unwrap();
+        stage_geo_install(tmp.path(), true, true);
+        let env = geo_data_env(Service::Postgres, tmp.path(), &v("17-full"));
+        let map: std::collections::BTreeMap<_, _> = env.into_iter().collect();
+        assert_eq!(
+            map.get(std::ffi::OsStr::new("PROJ_DATA"))
+                .map(std::ffi::OsString::as_os_str),
+            Some(tmp.path().join("share").join("proj").as_os_str())
+        );
+        assert_eq!(
+            map.get(std::ffi::OsStr::new("GDAL_DATA"))
+                .map(std::ffi::OsString::as_os_str),
+            Some(tmp.path().join("share").join("gdal").as_os_str())
+        );
+    }
+
+    #[test]
+    fn geo_data_env_sets_only_the_found_var() {
+        let tmp = tempfile::tempdir().unwrap();
+        stage_geo_install(tmp.path(), true, false);
+        let env = geo_data_env(Service::Postgres, tmp.path(), &v("17-full"));
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, std::ffi::OsString::from("PROJ_DATA"));
     }
 
     /// Regression for the `mariadb-install-db` "Could not find

--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -944,15 +944,23 @@ fn geo_data_env(
     env
 }
 
-/// Depth-first search of `root` for the parent directories of `proj.db` (PROJ) and
-/// `gdalvrt.xsd` (GDAL), short-circuiting once both are found. First match wins if
-/// a name appears more than once (walk order). Unreadable directories and errored
-/// entries are skipped. `DirEntry::file_type()` does not follow symlinks, so a
-/// symlinked directory is not recursed (no loop risk) and a symlinked target file
-/// is skipped - acceptable because yerd controls the published tarball layout.
+/// The directories holding `proj.db` (PROJ) and `gdalvrt.xsd` (GDAL) inside a
+/// variant install. Fast path: the published Unix layout puts them at
+/// `share/proj` / `share/gdal`, so probe those directly first. Otherwise fall back
+/// to a depth-first walk of `root`, short-circuiting once both are found (first
+/// match wins if a name recurs). Unreadable directories and errored entries are
+/// skipped. `DirEntry::file_type()` does not follow symlinks, so a symlinked
+/// directory is not recursed (no loop risk) and a symlinked target file is skipped
+/// - acceptable because yerd controls the published tarball layout.
 fn find_geo_data_dirs(
     root: &std::path::Path,
 ) -> (Option<std::path::PathBuf>, Option<std::path::PathBuf>) {
+    let proj_dir = root.join("share").join("proj");
+    let gdal_dir = root.join("share").join("gdal");
+    if proj_dir.join("proj.db").is_file() && gdal_dir.join("gdalvrt.xsd").is_file() {
+        return (Some(proj_dir), Some(gdal_dir));
+    }
+
     let mut proj = None;
     let mut gdal = None;
     let mut stack = vec![root.to_path_buf()];
@@ -1527,6 +1535,23 @@ mod tests {
         let env = geo_data_env(Service::Postgres, tmp.path(), &v("17-full"));
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, std::ffi::OsString::from("PROJ_DATA"));
+    }
+
+    /// When the data lives outside the `share/proj` + `share/gdal` fast-path
+    /// locations, the fallback walk still finds both and returns their real dirs.
+    #[test]
+    fn find_geo_data_dirs_falls_back_to_walk_for_nonstandard_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj_dir = tmp.path().join("lib").join("proj9");
+        let gdal_dir = tmp.path().join("share").join("contrib").join("gdal");
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        std::fs::create_dir_all(&gdal_dir).unwrap();
+        std::fs::write(proj_dir.join("proj.db"), b"").unwrap();
+        std::fs::write(gdal_dir.join("gdalvrt.xsd"), b"").unwrap();
+        assert_eq!(
+            find_geo_data_dirs(tmp.path()),
+            (Some(proj_dir), Some(gdal_dir))
+        );
     }
 
     /// Regression for the `mariadb-install-db` "Could not find

--- a/crates/yerd-services/src/version.rs
+++ b/crates/yerd-services/src/version.rs
@@ -110,11 +110,12 @@ impl ServiceVersion {
         &self.0
     }
 
-    /// The numeric major component: the leading run before the first `.` or `-`,
-    /// used to pin datadirs for engines whose on-disk format is major-incompatible.
-    /// A variant suffix (`<version>-<variant>`, e.g. the `PostGIS` `full` build) is
-    /// ignored, so `"17-full"` / `"17.10-full"` share the numeric major `17` with
-    /// the base `"17"` / `"17.10"` builds - and thus the same datadir.
+    /// The major component: the leading run before the first `.` or `-`, used to
+    /// pin datadirs for engines whose on-disk format is major-incompatible. A
+    /// variant suffix (`<version>-<variant>`, e.g. the `PostGIS` `full` build) is
+    /// ignored, so `"17-full"` / `"17.10-full"` share the major `17` with the base
+    /// `"17"` / `"17.10"` builds - and thus the same datadir. Always non-empty: a
+    /// valid label starts with an ASCII alphanumeric (see [`Self::is_valid`]).
     #[must_use]
     pub fn major(&self) -> &str {
         self.0.split(['.', '-']).next().unwrap_or(&self.0)
@@ -127,10 +128,13 @@ impl ServiceVersion {
         self.0.contains('-')
     }
 
+    /// A label is a safe single path component and yields a non-empty [`major`]:
+    /// it must start with an ASCII alphanumeric (so no leading `.`/`-`/`_`, and no
+    /// `.`/`..`) and contain only ASCII alphanumerics plus `.`, `_`, `-`.
+    ///
+    /// [`major`]: Self::major
     fn is_valid(s: &str) -> bool {
-        !s.is_empty()
-            && s != "."
-            && s != ".."
+        s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
             && s.chars()
                 .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
     }
@@ -323,6 +327,8 @@ mod tests {
         assert!(ServiceVersion::from_str("..").is_err());
         assert!(ServiceVersion::from_str("a/b").is_err());
         assert!(ServiceVersion::from_str("a b").is_err());
+        assert!(ServiceVersion::from_str("-full").is_err());
+        assert!(ServiceVersion::from_str(".17").is_err());
     }
 
     #[test]

--- a/crates/yerd-services/src/version.rs
+++ b/crates/yerd-services/src/version.rs
@@ -110,11 +110,21 @@ impl ServiceVersion {
         &self.0
     }
 
-    /// The major component (the substring before the first `.`), used to pin
-    /// datadirs for engines whose on-disk format is major-incompatible.
+    /// The numeric major component: the leading run before the first `.` or `-`,
+    /// used to pin datadirs for engines whose on-disk format is major-incompatible.
+    /// A variant suffix (`<version>-<variant>`, e.g. the `PostGIS` `full` build) is
+    /// ignored, so `"17-full"` / `"17.10-full"` share the numeric major `17` with
+    /// the base `"17"` / `"17.10"` builds - and thus the same datadir.
     #[must_use]
     pub fn major(&self) -> &str {
-        self.0.split('.').next().unwrap_or(&self.0)
+        self.0.split(['.', '-']).next().unwrap_or(&self.0)
+    }
+
+    /// Whether this label carries a variant suffix (`"17-full"` yes, `"17.10"` no).
+    /// The numeric version part never contains a hyphen, so a hyphen marks a variant.
+    #[must_use]
+    pub fn has_variant(&self) -> bool {
+        self.0.contains('-')
     }
 
     fn is_valid(s: &str) -> bool {
@@ -363,6 +373,29 @@ mod tests {
         assert_eq!(ServiceVersion::from_str("16").unwrap().major(), "16");
     }
 
+    /// A variant suffix (`-full` or any other) is ignored by `major()`, so a
+    /// variant shares the numeric major - and thus the datadir - of its base.
+    #[test]
+    fn major_ignores_variant_suffix() {
+        assert_eq!(ServiceVersion::from_str("17-full").unwrap().major(), "17");
+        assert_eq!(
+            ServiceVersion::from_str("17.10-full").unwrap().major(),
+            "17"
+        );
+        assert_eq!(ServiceVersion::from_str("17-foo").unwrap().major(), "17");
+    }
+
+    #[test]
+    fn has_variant_keys_on_a_hyphen() {
+        assert!(ServiceVersion::from_str("17-full").unwrap().has_variant());
+        assert!(ServiceVersion::from_str("16.10-full")
+            .unwrap()
+            .has_variant());
+        assert!(!ServiceVersion::from_str("17").unwrap().has_variant());
+        assert!(!ServiceVersion::from_str("8.4").unwrap().has_variant());
+        assert!(!ServiceVersion::from_str("full").unwrap().has_variant());
+    }
+
     #[test]
     fn datadir_pins_postgres_to_major_only() {
         let dirs = dirs_in(std::path::Path::new("/tmp/x"));
@@ -376,6 +409,22 @@ mod tests {
             datadir(&dirs, Service::MySql, &v8),
             PathBuf::from("/tmp/x/d/services/mysql/data")
         );
+    }
+
+    /// Base and any variant of the same major resolve to one shared datadir, so a
+    /// `change-version` between base and variant keeps the databases in place.
+    #[test]
+    fn datadir_is_shared_across_base_and_variant() {
+        let dirs = dirs_in(std::path::Path::new("/tmp/x"));
+        let shared = PathBuf::from("/tmp/x/d/services/postgres/data-17");
+        for label in ["17", "17.10", "17.10-full", "17-full"] {
+            let v = ServiceVersion::from_str(label).unwrap();
+            assert_eq!(
+                datadir(&dirs, Service::Postgres, &v),
+                shared,
+                "label {label}"
+            );
+        }
     }
 
     #[test]

--- a/docs/developer/crates/yerd-services.md
+++ b/docs/developer/crates/yerd-services.md
@@ -138,11 +138,25 @@ checksum sidecar for service builds).
 ## `version.rs` - layout & discovery
 
 `ServiceVersion` is an opaque, validated version label (services don't share PHP's
-major.minor shape). The on-disk layout under `PlatformDirs`:
+major.minor shape). Labels may carry a **variant suffix** after a hyphen -
+Postgres publishes both a lean base (`17`) and a PostGIS `17-full` under the same
+service. The label is treated as opaque end to end: `release.rs` reads each
+`version` string straight from the `services.json` listing (it never splits a
+filename), so a hyphen in the label is safe by construction. Ordering
+compares component-by-component and ranks a **plain** build above a suffixed one
+at the same number (`"17.10" > "17.10-full"`), so `full` is never mistaken for the
+"latest" build when resolving the newest version. `ServiceVersion::major()` ignores
+the variant suffix (it splits on the first `.` or `-`), so a base and any variant of
+the same major **share one datadir** (`data-<major>`) - which is what lets a
+`change-version` between base and `full` preserve databases. For a variant install,
+`manager.rs` also probes the install tree for `proj.db` / `gdalvrt.xsd` and, when
+found, exports `PROJ_DATA` / `GDAL_DATA` into the postmaster environment (base
+installs get neither) - what lets `PostGIS` `ST_Transform` / raster reprojection
+resolve their runtime data. The on-disk layout under `PlatformDirs`:
 
 ```text
-{data}/services/<id>/<version>/bin/<server_binary>   # the install
-{data}/services/<id>/<version>/data        (or data-<major> for Postgres)
+{data}/services/<id>/<version>/bin/<server_binary>   # the install (per version/label)
+{data}/services/<id>/data                  (or data-<major> for Postgres) # shared datadir
 {state}/services/<id>/<id>.conf            # rendered config
 {state}/services/<id>/<id>.log             # captured stdout/stderr
 {runtime}/services/<id>/<id>.sock          # Unix socket (MySQL/MariaDB)

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -40,10 +40,10 @@ The `php.json` manifest is signed with a dedicated minisign key whose public hal
 Yerd's builds ship the **bulk** extension set, so a real-world Laravel app has
 what it needs out of the box - highlights include **`intl`** (ICU, required by
 Laravel's `Number` helper), **`sodium`**, **`mysqli`**, **`gd`**, **`imagick`**,
-**`redis`**, **`opcache`**, and **`swoole`**. Database access is covered by
-**`pdo_mysql`** plus PDO's built-in `mysql`, `pgsql`, and `sqlite` drivers (so
-`PDO::getAvailableDrivers()` returns all three) and the native `mysqli`, `pgsql`,
-and `sqlite3` extensions. Coverage is provided separately by `pcov` - see
+**`redis`**, **`opcache`**, and **`swoole`**. Database access is covered by the
+**`pdo_mysql`**, **`pdo_pgsql`**, and **`pdo_sqlite`** PDO drivers (so
+`PDO::getAvailableDrivers()` returns all three) alongside the native `mysqli`,
+`pgsql`, and `sqlite3` extensions. Coverage is provided separately by `pcov` - see
 [Code Coverage](./code-coverage).
 
 The authoritative list for any install is `php -m` (via the
@@ -93,7 +93,9 @@ on 8.4, as noted.
 | `pcre` | *(core)* Perl-compatible regular expressions, i.e. the `preg_*` functions. |
 | `PDO` | *(core)* The database-access abstraction layer; the bundled drivers cover MySQL, PostgreSQL, and SQLite. |
 | `pdo_mysql` | PDO driver for MySQL/MariaDB. |
-| `pgsql` | Native PostgreSQL client library (also backs PDO's `pgsql` driver). |
+| `pdo_pgsql` | PDO driver for PostgreSQL. |
+| `pdo_sqlite` | PDO driver for SQLite. |
+| `pgsql` | Native PostgreSQL client library (libpq-backed `pg_*` functions). |
 | `Phar` | *(core)* PHP Archive support: bundle a whole application into one distributable file. |
 | `posix` | POSIX system-call bindings (users, groups, process info) on Unix. |
 | `protobuf` | Google Protocol Buffers runtime for compact, fast binary (de)serialization. |

--- a/docs/guide/services.md
+++ b/docs/guide/services.md
@@ -73,9 +73,10 @@ Each installed engine's `⋯` menu offers:
 ### Managing services
 
 ```sh
-yerd service available          # versions installable for your platform
-yerd service install redis 8    # download, install, and start
-yerd services                   # list everything: version, state, port
+yerd service available            # versions installable for your platform
+yerd service install redis 8      # download, install, and start
+yerd service install postgres 17-full  # PostGIS build (see below)
+yerd services                     # list everything: version, state, port
 
 yerd service start redis        # start it now
 yerd service stop redis         # stop for this session (returns on next daemon start)
@@ -141,6 +142,70 @@ Only one can listen on `3306` at a time. If both are installed, whichever binds
 first wins and the other logs a non-fatal "port in use" and stays down. Run a
 single SQL engine, or give one a different `port`.
 :::
+
+## PostgreSQL: base and PostGIS (`full`) builds
+
+PostgreSQL ships in **two flavours**, and you choose which one you install by its
+version label. `full` is the PostGIS variant, appended to the version as a
+`<version>-full` label:
+
+| Label | What you get | Compressed size | License |
+|---|---|---|---|
+| `17` | The lean base build. | ≈ 6.5 MB | 100% PostgreSQL License (permissive) |
+| `17-full` | The base plus **PostGIS** and its geospatial stack. | ≈ 60-64 MB | GPL-encumbered (see below) |
+
+```sh
+yerd service install postgres 17        # lean base
+yerd service install postgres 17-full   # PostGIS build
+```
+
+Both show up as distinct installable versions in `yerd service available` and in
+the desktop app's version picker. The build is downloaded once per install and
+cached.
+
+### What each build bundles
+
+Both builds ship the standard contrib extensions - `pg_stat_statements`,
+`pg_trgm`, `citext`, `unaccent`, `hstore`, `ltree`, `btree_gin`, `btree_gist`,
+`fuzzystrmatch`, `tablefunc`, `intarray`, `cube`, `earthdistance`,
+`postgres_fdw`, `dblink`, `pageinspect`, `amcheck`, `pgstattuple`,
+`pg_buffercache` - plus **`pgvector`** (Linux and macOS).
+
+The **`full`** build adds the geospatial and crypto stack on top:
+
+- **PostGIS** with raster and topology: `postgis`, `postgis_raster`,
+  `postgis_topology`, `postgis_tiger_geocoder`, `address_standardizer`.
+- `pgcrypto`, `uuid-ossp`, `sslinfo`, and `xml2`.
+
+### Base and `full` share one datadir - switch between them freely
+
+`17` and `17-full` are separate *installs* but **share a single data directory**
+(Postgres datadirs are pinned to the major version, and the `full` variant maps to
+the same major). So you can install the base build, create databases, then switch
+with `yerd service change-version postgres 17-full` (or back) **without losing your
+data** - the databases carry across the switch.
+
+One caveat: PostGIS objects created while running `full` need the PostGIS `.so` to
+be *used*. The base build still starts against the shared datadir and your regular
+tables are fine, but queries that touch PostGIS types or functions only work while
+`full` is running - so enable `full` before you start using PostGIS.
+
+Uninstalling with `--purge` deletes the shared datadir, so `yerd service uninstall
+postgres <label> --purge` removes the databases for **both** flavours of that major.
+
+::: warning `full` is GPL-encumbered
+The base build stays **100% PostgreSQL License** (permissive). The `full` build
+bundles GPL/LGPL components - **PostGIS** is GPLv2 and **GEOS** is LGPL-2.1 (PROJ,
+GDAL, json-c, and protobuf-c are permissive). Install `full` only if that
+licensing suits your project. Each component's notice ships inside the downloaded
+tarball (`LICENSE-postgis`, `LICENSE-geos`, `LICENSE-proj`, `LICENSE-gdal`, and
+friends).
+:::
+
+Backup and restore are unchanged - both builds ship the same `pg_dump` /
+`pg_restore` / `psql` tools, so [`yerd db backup` / `restore`](../reference/cli/db)
+work identically. A dump that uses PostGIS objects only restores into a `full`
+target, because those objects need the PostGIS `.so`.
 
 ## Windows and Redis licensing
 

--- a/docs/reference/cli/services.md
+++ b/docs/reference/cli/services.md
@@ -47,10 +47,10 @@ there is no undo.
 
 ::: info PostgreSQL has a `full` (PostGIS) variant
 `postgres` publishes two builds per major: the lean base (`17`) and a PostGIS
-build (`17-full`). Install either by its label, e.g. `yerd service install
-postgres 17-full`. The two are separate installs that **share one data directory**
-(pinned to the numeric major), so `change-version` between them preserves your
-databases; see
+build (`17-full`). Install either by its label, e.g.
+`yerd service install postgres 17-full`. The two are separate installs that
+**share one data directory** (pinned to the numeric major), so `change-version`
+between them preserves your databases; see
 [PostgreSQL: base and PostGIS builds](../../guide/services#postgresql-base-and-postgis-full-builds)
 for the extension lists, the shared-datadir behaviour, and the GPL posture of
 `full`.

--- a/docs/reference/cli/services.md
+++ b/docs/reference/cli/services.md
@@ -45,6 +45,17 @@ picks up where you left off. With `--purge` the engine's stored data is deleted 
 there is no undo.
 :::
 
+::: info PostgreSQL has a `full` (PostGIS) variant
+`postgres` publishes two builds per major: the lean base (`17`) and a PostGIS
+build (`17-full`). Install either by its label, e.g. `yerd service install
+postgres 17-full`. The two are separate installs that **share one data directory**
+(pinned to the numeric major), so `change-version` between them preserves your
+databases; see
+[PostgreSQL: base and PostGIS builds](../../guide/services#postgresql-base-and-postgis-full-builds)
+for the extension lists, the shared-datadir behaviour, and the GPL posture of
+`full`.
+:::
+
 ## Lifecycle
 
 | Command | Description |


### PR DESCRIPTION
## What does this PR do?

Adds PROJ_DATA/GDAL_DATA probing for PostGIS-bearing PostgreSQL variant installs and makes base and variant builds of the same major share one datadir, so you can change-version between them without losing databases.  Updates docs for both this and some other PHP and service changes.

## Related issues

closes #131

## Type of change

- [x] Bug fix
- [x] Documentation

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for hyphenated Postgres variant labels (e.g., `17-full`) and sharing the same major-pinned datadir between base and variant.
  - Postgres variant installs now automatically configure geospatial data paths in the service environment (when the required files are present).

- **Bug Fixes**
  - Improved Postgres initialization/version parsing so variant and base labels resolve to the same numeric major.
  - Updated PHP PDO bundled-extension documentation to reflect the correct bundled driver list.

- **Documentation**
  - Expanded guides and CLI reference for Postgres base vs `full`, shared datadir behavior, purge/backup considerations, and licensing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->