### PR TITLE
[Feat] Add yerd coverage command

### DIFF
--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -228,6 +228,21 @@ pub enum Command {
         #[command(subcommand)]
         action: PathAction,
     },
+    /// Run a script under the default PHP version with pcov coverage enabled -
+    /// the discoverable front door to the `phpcover` shim. Everything after
+    /// `coverage` is passed straight through to PHP. To pin a specific version,
+    /// use the `php<version>cover` shim (e.g. `php8.4cover`) instead. Local -
+    /// execs PHP directly and does not talk to the daemon. (Unix only.)
+    Coverage {
+        /// Arguments forwarded verbatim to PHP, e.g. `artisan test --coverage`.
+        #[arg(
+            trailing_var_arg = true,
+            allow_hyphen_values = true,
+            num_args = 0..,
+            value_name = "ARGS"
+        )]
+        args: Vec<std::ffi::OsString>,
+    },
 }
 
 /// A binary on/off toggle argument (e.g. `yerd front-controller <name> on`).

--- a/bin/yerd/src/cover_shim.rs
+++ b/bin/yerd/src/cover_shim.rs
@@ -11,6 +11,7 @@
 //! stays enabled across that hop too. Unix-only: cover shims are never created
 //! on other platforms.
 
+use std::ffi::OsString;
 use std::io::Write as _;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -37,7 +38,16 @@ pub fn dispatch() -> Option<ExitCode> {
     let arg0 = std::env::args_os().next()?;
     let name = Path::new(&arg0).file_name()?.to_str()?;
     let spec = parse_cover_name(name)?;
-    Some(run(&spec))
+    let forward: Vec<OsString> = std::env::args_os().skip(1).collect();
+    Some(run(&spec, &forward))
+}
+
+/// Front door for `yerd coverage <args…>`: run the default PHP version with pcov
+/// enabled, forwarding `args` to PHP (same effect as the `phpcover` shim). On
+/// success `exec` replaces the process and never returns.
+#[must_use]
+pub fn run_coverage(args: &[OsString]) -> ExitCode {
+    run(&CoverSpec::Default, args)
 }
 
 /// Parse a cover-alias basename. Matches `phpcover` and `php<MAJOR>.<MINOR>cover`
@@ -58,7 +68,7 @@ fn parse_cover_name(name: &str) -> Option<CoverSpec> {
     Some(CoverSpec::Version(major, minor))
 }
 
-fn run(spec: &CoverSpec) -> ExitCode {
+fn run(spec: &CoverSpec, forward: &[OsString]) -> ExitCode {
     let dirs = match ActivePaths::new().resolve() {
         Ok(d) => d,
         Err(e) => return fail(format!("cannot resolve yerd directories: {e}")),
@@ -96,7 +106,7 @@ fn run(spec: &CoverSpec) -> ExitCode {
 
     let err = Command::new(&php_bin)
         .env("PHPRC", &cover_ini_path)
-        .args(std::env::args_os().skip(1))
+        .args(forward)
         .exec();
     if err.kind() == std::io::ErrorKind::NotFound {
         return fail(format!(

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -45,6 +45,18 @@ pub async fn run(cli: Cli) -> ExitCode {
         Command::Elevate { target } => return elevate::run_elevate(*target, false).await,
         Command::Unelevate { target } => return elevate::run_elevate(*target, true).await,
         Command::Path { action } => return path_cmd::run(*action),
+        #[cfg_attr(not(unix), allow(unused_variables))]
+        Command::Coverage { args } => {
+            #[cfg(unix)]
+            {
+                return cover_shim::run_coverage(args);
+            }
+            #[cfg(not(unix))]
+            {
+                eprintln!("yerd: coverage is only available on macOS and Linux");
+                return ExitCode::from(2);
+            }
+        }
         Command::Domain {
             action: crate::cli::DomainAction::List { site },
         } => return run_domain_list(site.as_deref(), cli.json).await,

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -195,6 +195,11 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
                 "path is handled locally, not over IPC".to_owned(),
             ));
         }
+        Command::Coverage { .. } => {
+            return Err(ClientError::Usage(
+                "coverage is handled locally, not over IPC".to_owned(),
+            ));
+        }
         Command::Link { .. } => {
             return Err(ClientError::Usage(
                 "link is handled locally, not over IPC".to_owned(),
@@ -2722,6 +2727,7 @@ mod tests {
             Command::Path {
                 action: crate::cli::PathAction::Install,
             },
+            Command::Coverage { args: vec![] },
             Command::Link {
                 name_or_path: None,
                 path: None,

--- a/bin/yerd/tests/cover_shim_e2e.rs
+++ b/bin/yerd/tests/cover_shim_e2e.rs
@@ -1,11 +1,13 @@
-//! End-to-end: prove that `PHPRC`, set by the `phpcover`/`php<ver>cover` shim on
-//! the process it `exec`s, is inherited by a subsequent process that one
-//! re-execs itself - the actual mechanism that lets coverage survive `artisan
-//! test`'s child PHPUnit/Pest/paratest hop. Spawns the real built `yerd`
-//! binary under a `php8.4cover` name against a fully faked `PlatformDirs`
-//! layout (a stub shell script standing in for the PHP interpreter), rather
-//! than calling `cover_shim::dispatch()` in-process, because it resolves
-//! `ActivePaths::new().resolve()` internally with no dirs-injection seam.
+//! End-to-end: prove that `PHPRC`, set by the cover launcher on the process it
+//! `exec`s, is inherited by a subsequent process that one re-execs itself - the
+//! actual mechanism that lets coverage survive `artisan test`'s child
+//! PHPUnit/Pest/paratest hop. Covers both front doors that reach the same
+//! cover-shim logic: the `php<ver>cover` argv[0] shim and the `yerd coverage`
+//! subcommand. Spawns the real built `yerd` binary against a fully faked
+//! `PlatformDirs` layout (a stub shell script standing in for the PHP
+//! interpreter), rather than calling `cover_shim::dispatch()` in-process,
+//! because it resolves `ActivePaths::new().resolve()` internally with no
+//! dirs-injection seam.
 
 #![allow(
     clippy::unwrap_used,
@@ -33,8 +35,10 @@ mod tests {
         esac\n\
         exec \"$0\" --grandchild\n";
 
-    #[test]
-    fn phprc_survives_a_re_exec_grandchild_hop() {
+    /// Build a faked `PlatformDirs` layout under a fresh tempdir: a stub PHP 8.4
+    /// CLI binary and a stub `pcov.so`. Returns `(tempdir, home, expected cover.ini)`;
+    /// the tempdir is kept alive by the caller.
+    fn faked_php_8_4_layout() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let home = tmp.path().join("home");
         fs::create_dir_all(&home).expect("mkdir home");
@@ -50,36 +54,72 @@ mod tests {
         fs::create_dir_all(&ext_dir).expect("mkdir php-ext");
         fs::write(ext_dir.join("pcov.so"), b"").expect("write stub pcov.so");
 
-        let cover_shim_bin = tmp.path().join("php8.4cover");
-        symlink(env!("CARGO_BIN_EXE_yerd"), &cover_shim_bin).expect("symlink cover shim");
+        let expected_phprc = ext_dir.join("cover.ini");
+        (tmp, home, expected_phprc)
+    }
 
-        let output = Command::new(&cover_shim_bin)
+    /// Invoke `program` with `args` under the faked home's XDG environment and
+    /// return its captured output.
+    fn run_in_home(
+        program: &std::path::Path,
+        args: &[&str],
+        home: &std::path::Path,
+    ) -> std::process::Output {
+        Command::new(program)
+            .args(args)
             .env_clear()
-            .env("HOME", &home)
+            .env("HOME", home)
             .env("XDG_DATA_HOME", home.join(".local").join("share"))
             .env("XDG_CONFIG_HOME", home.join(".config"))
             .env("XDG_STATE_HOME", home.join(".local").join("state"))
             .env("XDG_CACHE_HOME", home.join(".cache"))
             .output()
-            .expect("run php8.4cover");
+            .expect("run yerd")
+    }
 
+    /// Assert the stub PHP printed the expected `PHPRC` on both the top-level
+    /// process and its re-exec'd grandchild, and that the cover ini was written.
+    fn assert_phprc_hop(output: &std::process::Output, expected_phprc: &std::path::Path) {
         assert!(
             output.status.success(),
-            "php8.4cover failed: {}",
+            "cover run failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
-
-        let expected_phprc = ext_dir.join("cover.ini");
         let stdout = String::from_utf8_lossy(&output.stdout);
         let lines: Vec<&str> = stdout.lines().collect();
+        let want = expected_phprc.to_str().expect("utf8 path");
         assert_eq!(
             lines,
-            vec![
-                expected_phprc.to_str().expect("utf8 path"),
-                expected_phprc.to_str().expect("utf8 path"),
-            ],
+            vec![want, want],
             "PHPRC must be identical across the re-exec hop (top-level process and its grandchild)"
         );
         assert!(expected_phprc.is_file(), "cover.ini must have been written");
+    }
+
+    #[test]
+    fn phprc_survives_a_re_exec_grandchild_hop() {
+        let (tmp, home, expected_phprc) = faked_php_8_4_layout();
+
+        let cover_shim_bin = tmp.path().join("php8.4cover");
+        symlink(env!("CARGO_BIN_EXE_yerd"), &cover_shim_bin).expect("symlink cover shim");
+
+        let output = run_in_home(&cover_shim_bin, &[], &home);
+        assert_phprc_hop(&output, &expected_phprc);
+    }
+
+    /// The `yerd coverage` subcommand front door reaches the same cover-shim
+    /// logic as the `phpcover` argv[0] shim: invoked as the real `yerd` binary,
+    /// it resolves the default PHP (8.4, the only installed version) and enables
+    /// pcov via `PHPRC`, which survives the grandchild hop identically.
+    #[test]
+    fn coverage_subcommand_enables_pcov_like_phpcover() {
+        let (_tmp, home, expected_phprc) = faked_php_8_4_layout();
+
+        let output = run_in_home(
+            std::path::Path::new(env!("CARGO_BIN_EXE_yerd")),
+            &["coverage"],
+            &home,
+        );
+        assert_phprc_hop(&output, &expected_phprc);
     }
 }

--- a/bin/yerd/tests/cover_shim_e2e.rs
+++ b/bin/yerd/tests/cover_shim_e2e.rs
@@ -24,15 +24,20 @@ mod tests {
 
     use yerd_platform::PlatformDirs;
 
-    /// A `#!/bin/sh` stand-in for the PHP CLI binary: prints `$PHPRC`, then
-    /// re-execs itself once with `--grandchild` appended (the actual hop under
-    /// test - a plain re-exec inherits the parent's environment, same as
-    /// Symfony `Process` spawning `PHPUnit` via `PHP_BINARY`), then exits.
+    /// A `#!/bin/sh` stand-in for the PHP CLI binary. On every process it prints
+    /// `phprc=$PHPRC`; on the top-level pass (before the hop) it also prints
+    /// `args=$*` so a test can assert the launcher forwarded the caller's
+    /// arguments verbatim. It then re-execs itself once with `--grandchild`
+    /// (the actual hop under test - a plain re-exec inherits the parent's
+    /// environment, same as Symfony `Process` spawning `PHPUnit` via
+    /// `PHP_BINARY`) and exits. The grandchild deliberately carries only
+    /// `--grandchild`, so it exercises `PHPRC` inheritance, not arg forwarding.
     const STUB_PHP: &str = "#!/bin/sh\n\
-        printf '%s\\n' \"$PHPRC\"\n\
+        printf 'phprc=%s\\n' \"$PHPRC\"\n\
         case \"$1\" in\n\
         --grandchild) exit 0 ;;\n\
         esac\n\
+        printf 'args=%s\\n' \"$*\"\n\
         exec \"$0\" --grandchild\n";
 
     /// Build a faked `PlatformDirs` layout under a fresh tempdir: a stub PHP 8.4
@@ -77,21 +82,40 @@ mod tests {
             .expect("run yerd")
     }
 
-    /// Assert the stub PHP printed the expected `PHPRC` on both the top-level
-    /// process and its re-exec'd grandchild, and that the cover ini was written.
-    fn assert_phprc_hop(output: &std::process::Output, expected_phprc: &std::path::Path) {
+    /// Assert the stub PHP saw `PHPRC` pointing at the cover ini on both the
+    /// top-level process and its re-exec'd grandchild (coverage surviving the
+    /// hop), that the cover ini was written, and that `expected_args` reached the
+    /// top-level PHP verbatim - i.e. the launcher forwarded the caller's args and
+    /// leaked no shim or subcommand name into them.
+    fn assert_cover_run(
+        output: &std::process::Output,
+        expected_phprc: &std::path::Path,
+        expected_args: &str,
+    ) {
         assert!(
             output.status.success(),
             "cover run failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let lines: Vec<&str> = stdout.lines().collect();
-        let want = expected_phprc.to_str().expect("utf8 path");
+        let want_phprc = expected_phprc.to_str().expect("utf8 path");
+        let phprc: Vec<&str> = stdout
+            .lines()
+            .filter_map(|l| l.strip_prefix("phprc="))
+            .collect();
         assert_eq!(
-            lines,
-            vec![want, want],
+            phprc,
+            vec![want_phprc, want_phprc],
             "PHPRC must be identical across the re-exec hop (top-level process and its grandchild)"
+        );
+        let args: Vec<&str> = stdout
+            .lines()
+            .filter_map(|l| l.strip_prefix("args="))
+            .collect();
+        assert_eq!(
+            args,
+            vec![expected_args],
+            "forwarded args must reach PHP verbatim with no shim/subcommand name leaked"
         );
         assert!(expected_phprc.is_file(), "cover.ini must have been written");
     }
@@ -103,23 +127,25 @@ mod tests {
         let cover_shim_bin = tmp.path().join("php8.4cover");
         symlink(env!("CARGO_BIN_EXE_yerd"), &cover_shim_bin).expect("symlink cover shim");
 
-        let output = run_in_home(&cover_shim_bin, &[], &home);
-        assert_phprc_hop(&output, &expected_phprc);
+        let output = run_in_home(&cover_shim_bin, &["artisan", "test", "--coverage"], &home);
+        assert_cover_run(&output, &expected_phprc, "artisan test --coverage");
     }
 
     /// The `yerd coverage` subcommand front door reaches the same cover-shim
     /// logic as the `phpcover` argv[0] shim: invoked as the real `yerd` binary,
     /// it resolves the default PHP (8.4, the only installed version) and enables
-    /// pcov via `PHPRC`, which survives the grandchild hop identically.
+    /// pcov via `PHPRC`, which survives the grandchild hop identically. The args
+    /// after `coverage` are forwarded to PHP verbatim - the subcommand name must
+    /// not leak into them.
     #[test]
     fn coverage_subcommand_enables_pcov_like_phpcover() {
         let (_tmp, home, expected_phprc) = faked_php_8_4_layout();
 
         let output = run_in_home(
             std::path::Path::new(env!("CARGO_BIN_EXE_yerd")),
-            &["coverage"],
+            &["coverage", "artisan", "test", "--coverage"],
             &home,
         );
-        assert_phprc_hop(&output, &expected_phprc);
+        assert_cover_run(&output, &expected_phprc, "artisan test --coverage");
     }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -180,6 +180,7 @@ export default withMermaid({
             { text: 'Domains', link: '/reference/cli/domains' },
             { text: 'HTTPS', link: '/reference/cli/https' },
             { text: 'PHP', link: '/reference/cli/php' },
+            { text: 'Coverage', link: '/reference/cli/coverage' },
             { text: 'Tooling', link: '/reference/cli/tooling' },
             { text: 'Services', link: '/reference/cli/services' },
             { text: 'Databases', link: '/reference/cli/db' },

--- a/docs/developer/binaries/yerd.md
+++ b/docs/developer/binaries/yerd.md
@@ -160,6 +160,15 @@ that one key and leaves the rest of the environment inherited (no
 `php` shim at `{data}/php-cli.ini`), the cover shim's value wins for the
 exec'd process - intentional, not a conflict to resolve.
 
+The same logic also backs the `yerd coverage <args…>` **subcommand**, which
+reaches it from the other direction. Rather than being keyed on `argv[0]`,
+`lib.rs::run` intercepts `Command::Coverage` locally (like `elevate`/`path`,
+before the daemon round-trip) and calls `cover_shim::run_coverage`, which is just
+`run(&CoverSpec::Default, args)` with the clap-captured passthrough args. So the
+subcommand and the `phpcover` shim share one implementation and one code path;
+the only difference is where the forwarded args come from (`argv[0]` dispatch
+forwards `env::args_os().skip(1)`, the subcommand forwards its `Vec<OsString>`).
+
 ::: info Unix-only
 The `dispatch()` call is `#[cfg(unix)]` and the cover symlinks are only ever
 created on Unix - on other platforms `yerd` is always just the CLI. PHP itself

--- a/docs/guide/code-coverage.md
+++ b/docs/guide/code-coverage.md
@@ -6,10 +6,10 @@ coverage (PHPUnit, Pest, `artisan test --coverage`) without installing or
 configuring an extension yourself.
 
 The friendliest way in is the **`yerd coverage`** subcommand: it runs your
-**default** PHP version with pcov enabled and forwards everything after the first
-argument straight to PHP - the same coverage mechanism as the `phpcover` shim,
-but discoverable from `yerd --help` without needing the shim directory on your
-`PATH`.
+**default** PHP version with pcov enabled and forwards everything after the
+`coverage` subcommand straight to PHP - the same coverage mechanism as the
+`phpcover` shim, but discoverable from `yerd --help` without needing the shim
+directory on your `PATH`.
 
 Under the hood, coverage is exposed through dedicated **cover shims**: `phpcover`
 for your default PHP version, and `php<version>cover` (for example `php8.4cover`)
@@ -42,8 +42,8 @@ php8.4cover vendor/bin/pest --coverage
 ```
 
 ::: tip `yerd coverage` is a passthrough
-Everything after the first argument is handed verbatim to PHP, so flags like
-`--coverage` belong to your test runner, not to `yerd`. Two small edges: a
+Everything after the `coverage` subcommand is handed verbatim to PHP, so flags
+like `--coverage` belong to your test runner, not to `yerd`. Two small edges: a
 leading `yerd coverage --help` prints `yerd`'s own help for the command (put
 `--help` after your script to forward it, e.g. `yerd coverage artisan --help`),
 and the global `--json` flag has no effect here - it, like every other flag, is

--- a/docs/guide/code-coverage.md
+++ b/docs/guide/code-coverage.md
@@ -5,10 +5,18 @@ driver, with every PHP version it installs - so you can run your test suite with
 coverage (PHPUnit, Pest, `artisan test --coverage`) without installing or
 configuring an extension yourself.
 
-Coverage is exposed through dedicated **cover shims**: `phpcover` for your
-default PHP version, and `php<version>cover` (for example `php8.4cover`) for a
-specific one. They live in the same `{data}/bin` directory as the regular `php`
-shim.
+The friendliest way in is the **`yerd coverage`** subcommand: it runs your
+**default** PHP version with pcov enabled and forwards everything after the first
+argument straight to PHP - the same coverage mechanism as the `phpcover` shim,
+but discoverable from `yerd --help` without needing the shim directory on your
+`PATH`.
+
+Under the hood, coverage is exposed through dedicated **cover shims**: `phpcover`
+for your default PHP version, and `php<version>cover` (for example `php8.4cover`)
+for a specific one. They live in the same `{data}/bin` directory as the regular
+`php` shim. `yerd coverage` runs the same coverage mechanism as `phpcover`
+(default PHP + pcov); use a `php<version>cover` shim when you need to pin coverage
+to a specific version.
 
 ::: info Zero overhead by default
 The plain `php` and `php<version>` shims **never** load pcov, so normal CLI
@@ -19,16 +27,28 @@ per command.
 
 ## Running tests with coverage
 
-Use a cover shim anywhere you'd normally use `php`:
+Use `yerd coverage` (or a cover shim) anywhere you'd normally use `php`:
 
 ```sh
-# Default PHP version, Pest or PHPUnit
-phpcover artisan test --coverage
-phpcover vendor/bin/phpunit --coverage-text
+# Default PHP version, via the subcommand - args pass straight through to PHP
+yerd coverage artisan test --coverage
+yerd coverage vendor/bin/phpunit --coverage-text
 
-# Pin coverage to a specific PHP version
+# The same coverage mechanism, via the shim
+phpcover artisan test --coverage
+
+# Pin coverage to a specific PHP version with a versioned shim
 php8.4cover vendor/bin/pest --coverage
 ```
+
+::: tip `yerd coverage` is a passthrough
+Everything after the first argument is handed verbatim to PHP, so flags like
+`--coverage` belong to your test runner, not to `yerd`. Two small edges: a
+leading `yerd coverage --help` prints `yerd`'s own help for the command (put
+`--help` after your script to forward it, e.g. `yerd coverage artisan --help`),
+and the global `--json` flag has no effect here - it, like every other flag, is
+passed to PHP rather than producing a JSON response.
+:::
 
 Each cover shim points `PHPRC` at a pcov-enabled copy of Yerd's CLI ini, then
 hands off to your script. Because `PHPRC` is an environment variable rather
@@ -82,6 +102,11 @@ of those names, it resolves the right PHP CLI binary plus that version's
 `pcov.enabled` directives appended, and `exec`s PHP with `PHPRC` pointing at
 that copy. Invoked under any other name it falls through to the normal CLI, so
 the clean `php`/`php<version>` shims are untouched.
+
+`yerd coverage` reaches that **same** code path from the other direction: rather
+than being keyed on the invoked name, the subcommand hands its forwarded
+arguments to the identical cover-shim logic for the default version. So the two
+front doors, subcommand and shim, share one implementation.
 
 ## See also
 

--- a/docs/reference/cli/coverage.md
+++ b/docs/reference/cli/coverage.md
@@ -1,0 +1,67 @@
+# Coverage
+
+`yerd coverage` runs your **default** PHP version with the bundled
+[pcov](../../guide/code-coverage) line-coverage driver enabled, then forwards
+everything after the first argument verbatim to PHP. It is the discoverable front
+door to the `phpcover` shim - the same coverage mechanism, but reachable from
+`yerd --help` without the shim directory on your `PATH`.
+
+Like `elevate`/`path`, it does **not** map to an IPC request: it `exec`s PHP
+directly in your terminal (inheriting your stdin/stdout/stderr, arguments, and
+exit code) rather than asking the daemon to do anything. (Attempting to route it
+over IPC is an explicit usage error.)
+
+```sh
+yerd coverage [ARGS...]
+```
+
+| Command | Description |
+| --- | --- |
+| `yerd coverage [ARGS...]` | Run the default PHP version with pcov enabled, passing `ARGS` to PHP. |
+
+```sh
+yerd coverage artisan test --coverage         # Laravel / Pest / PHPUnit
+yerd coverage vendor/bin/phpunit --coverage-text
+yerd coverage -r 'var_dump(extension_loaded("pcov"));'   # prints bool(true)
+```
+
+The process exit code is PHP's own, so `yerd coverage` composes in CI exactly
+like the interpreter it wraps.
+
+## Pinning a version
+
+`yerd coverage` always tracks your [global default](../../guide/php-versions#the-global-default)
+version. To pin coverage to a specific version, use that version's cover shim
+directly instead:
+
+```sh
+php8.4cover vendor/bin/pest --coverage
+php8.5cover artisan test --coverage
+```
+
+## Passthrough behaviour
+
+Everything after the first argument is handed straight to PHP, so flags belong to
+your script or test runner, not to `yerd`:
+
+- A **leading** `yerd coverage --help` (or `-h`) prints `yerd`'s own help for the
+  command, because `--help` is `yerd`'s built-in flag. To forward `--help` to your
+  script, put it after the script name: `yerd coverage artisan --help`.
+- Every other flag - including `--version` and the global `--json` - is passed
+  through to PHP. `yerd coverage` therefore produces PHP's output, never a JSON
+  daemon response, and `--json` has no effect. This is the one command where the
+  "`--json` on every command" note in the [overview](./) does not apply.
+
+## Failure modes
+
+- If the resolved default version has no published pcov build for your OS and
+  architecture yet, `yerd coverage` reports that pcov isn't installed for that
+  version rather than running without coverage. The background fetch is
+  best-effort and never blocks a PHP install.
+- **Unix only.** Coverage is available on macOS and Linux; it is not generated on
+  other platforms.
+
+## See also
+
+- [Code Coverage guide](../../guide/code-coverage) - how pcov is bundled and how the cover shims work.
+- [PHP](./php) - installing versions and setting the global default that `yerd coverage` tracks.

--- a/docs/reference/cli/coverage.md
+++ b/docs/reference/cli/coverage.md
@@ -2,9 +2,9 @@
 
 `yerd coverage` runs your **default** PHP version with the bundled
 [pcov](../../guide/code-coverage) line-coverage driver enabled, then forwards
-everything after the first argument verbatim to PHP. It is the discoverable front
-door to the `phpcover` shim - the same coverage mechanism, but reachable from
-`yerd --help` without the shim directory on your `PATH`.
+everything after the `coverage` subcommand verbatim to PHP. It is the discoverable
+front door to the `phpcover` shim - the same coverage mechanism, but reachable
+from `yerd --help` without the shim directory on your `PATH`.
 
 Like `elevate`/`path`, it does **not** map to an IPC request: it `exec`s PHP
 directly in your terminal (inheriting your stdin/stdout/stderr, arguments, and
@@ -41,8 +41,8 @@ php8.5cover artisan test --coverage
 
 ## Passthrough behaviour
 
-Everything after the first argument is handed straight to PHP, so flags belong to
-your script or test runner, not to `yerd`:
+Everything after the `coverage` subcommand is handed straight to PHP, so flags
+belong to your script or test runner, not to `yerd`:
 
 - A **leading** `yerd coverage --help` (or `-h`) prints `yerd`'s own help for the
   command, because `--help` is `yerd`'s built-in flag. To forward `--help` to your

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -18,11 +18,11 @@ yerd [--json] <COMMAND> [ARGS...]
 
 | Flag | Description |
 | --- | --- |
-| `--json` | Emit machine-readable JSON instead of human-readable text. Available on every command. |
+| `--json` | Emit machine-readable JSON instead of human-readable text. Available on every command except [`coverage`](./coverage), which forwards everything after it (including `--json`) to PHP. |
 | `--help`, `-h` | Print help for the command. |
 | `--version`, `-V` | Print the `yerd` version. |
 
-`--json` is a global flag, so you can place it before or after the subcommand: `yerd --json status` and `yerd status --json` are equivalent. In JSON mode the entire daemon response is printed as pretty JSON; the process exit code still reflects success or failure (see [Exit codes](#exit-codes)).
+`--json` is a global flag, so you can place it before or after the subcommand: `yerd --json status` and `yerd status --json` are equivalent. In JSON mode the entire daemon response is printed as pretty JSON; the process exit code still reflects success or failure (see [Exit codes](#exit-codes)). The one exception is [`coverage`](./coverage), which is a passthrough to PHP: anything after `coverage` - `--json` included - goes to PHP rather than to `yerd`.
 
 ::: info
 `yerd` is the command-line front end. The daemon (`yerdd`) does the real work: running the proxy, DNS responder, PHP-FPM pools, and certificate authority. See [The Daemon](../../guide/daemon) for how it runs, and the [IPC Protocol](../../developer/ipc-protocol) for the request/response wire format.
@@ -35,7 +35,7 @@ yerd [--json] <COMMAND> [ARGS...]
 | [Sites](./sites) | `sites`, `park`, `unpark`, `link`, `unlink`, `root` |
 | [Domains](./domains) | `domain list`, `domain add`, `domain remove`, `domain primary`, `domain reset` |
 | [HTTPS](./https) | `secure`, `unsecure` |
-| [PHP](./php) | `use`, `install php`, `uninstall php`, `update php`, `restart php`, `list php`, `list parked`, `set php`, `unset php`, `php ext add`/`remove`/`list` |
+| [PHP](./php) | `use`, `install php`, `uninstall php`, `update php`, `restart php`, `list php`, `list parked`, `set php`, `unset php`, `php ext add`/`remove`/`list`, [`coverage`](./coverage) |
 | [Tooling](./tooling) | `tools`, `install tool`, `uninstall tool`, `path install`, `path uninstall`, `path print` |
 | [Services](./services) | `services`, `service available`, `service install`, `service change-version`, `service uninstall`, `service start`, `service stop`, `service restart`, `service set-port`, `service logs` |
 | [Databases](./db) | `db list`, `db create`, `db drop`, `db backup`, `db restore` |


### PR DESCRIPTION
## What does this PR do?

Adds a yerd coverage command that wraps around phpcover

## Related issues

closes #113 

## Type of change

- [x] New feature
- [x] Documentation

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `yerd coverage` to run the default PHP with pcov line coverage enabled.
  * Forwards arguments directly to PHP (including values after `coverage`) and preserves PHP output and exit codes.
  * Coverage is limited to macOS and Linux; `--json` is not handled by `yerd` for this command.

* **Documentation**
  * Added CLI reference for `yerd coverage`, updated the coverage guide, and updated the CLI reference sidebar and global `--json` behavior.

* **Tests**
  * Refreshed coverage end-to-end tests to validate PHPRC inheritance and exact argument passthrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->