### PR TITLE
[Feat] Manage proxies using the Yerd CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6587,6 +6587,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "webpki-roots 0.26.11",
  "yerd-config",
  "yerd-core",
  "yerd-depcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ http-body-util     = "0.1"
 bytes              = "1"
 tokio-rustls       = "0.26"
 rustls             = "0.23"
+# Mozilla trust anchors for the daemon's reverse-proxy client verifier (public
+# https upstreams). Kept out of yerd-proxy's runtime graph (see its
+# no_runtime_deps guard); the daemon builds the ClientConfig and injects it.
+webpki-roots       = "0.26"
 tracing            = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "registry"] }
 tracing-appender   = { version = "0.2", default-features = false }

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -209,6 +209,13 @@ pub enum Command {
         #[command(subcommand)]
         action: DomainAction,
     },
+    /// Manage reverse proxies: a whole-host proxy (`reverb.test` → a running
+    /// service) or a path rule on an existing site (`app.test/app` → a service).
+    Proxy {
+        /// What to do.
+        #[command(subcommand)]
+        action: ProxyAction,
+    },
     /// Grant yerd OS-level privileges (run via `sudo`). No subcommand = all.
     Elevate {
         /// Which privilege to grant; omit to grant all.
@@ -256,6 +263,33 @@ pub enum PathAction {
     Uninstall,
     /// Print the shell snippet without modifying any file (for manual `eval`).
     Print,
+}
+
+/// Action of `yerd proxy`.
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum ProxyAction {
+    /// Add a proxy. Two arguments create a whole-host proxy
+    /// (`yerd proxy add reverb http://localhost:8080`); three attach a path rule
+    /// to an existing site (`yerd proxy add myapp /app http://127.0.0.1:8080`).
+    Add {
+        /// A proxy name (whole-host) or a site name (path rule).
+        first: String,
+        /// The upstream URL (whole-host), or the path prefix (path rule).
+        second: String,
+        /// The upstream URL, when the second argument is a path prefix.
+        third: Option<String>,
+    },
+    /// Remove a proxy. One argument removes a whole-host proxy
+    /// (`yerd proxy remove reverb`); two remove a site's path rule
+    /// (`yerd proxy remove myapp /app`).
+    Remove {
+        /// A whole-host proxy name, or a site name (with a path prefix).
+        target: String,
+        /// The path prefix, when removing a site's path rule.
+        prefix: Option<String>,
+    },
+    /// List whole-host proxies and per-site path rules.
+    List,
 }
 
 /// Action of `yerd domain`.

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -145,6 +145,7 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
         Command::Services => Request::ListServices,
         Command::Service { action } => service_request(action),
         Command::Domain { action } => domain_request(action)?,
+        Command::Proxy { action } => proxy_request(action)?,
         Command::Tunnel { action } => tunnel_request(action),
         Command::Db { action } => db_request(action),
         Command::Mail { action } => match action {
@@ -285,6 +286,62 @@ fn domain_request(action: &crate::cli::DomainAction) -> Result<Request, ClientEr
             Request::ResetDomains { name: site.clone() }
         }
     })
+}
+
+/// Map a `yerd proxy <action>` to its wire request. Arity distinguishes a
+/// whole-host proxy from a path rule (see [`crate::cli::ProxyAction`]). The
+/// upstream URL is validated by the daemon (authoritative); the client only
+/// checks the site/proxy name and, for a rule, that the prefix is absolute.
+fn proxy_request(action: &crate::cli::ProxyAction) -> Result<Request, ClientError> {
+    use crate::cli::ProxyAction;
+    Ok(match action {
+        ProxyAction::List => Request::ListProxies,
+        ProxyAction::Add {
+            first,
+            second,
+            third,
+        } => {
+            validate_name(first)?;
+            if let Some(url) = third {
+                validate_prefix(second)?;
+                Request::AddProxyRule {
+                    site: first.clone(),
+                    prefix: second.clone(),
+                    url: url.clone(),
+                }
+            } else {
+                Request::AddProxy {
+                    name: first.clone(),
+                    url: second.clone(),
+                }
+            }
+        }
+        ProxyAction::Remove { target, prefix } => {
+            validate_name(target)?;
+            if let Some(prefix) = prefix {
+                validate_prefix(prefix)?;
+                Request::RemoveProxyRule {
+                    site: target.clone(),
+                    prefix: prefix.clone(),
+                }
+            } else {
+                Request::RemoveProxy {
+                    name: target.clone(),
+                }
+            }
+        }
+    })
+}
+
+/// Client-side check that a proxy rule prefix is an absolute path, for a clean
+/// exit-2 error before connecting. The daemon is authoritative.
+fn validate_prefix(prefix: &str) -> Result<(), ClientError> {
+    if !prefix.starts_with('/') {
+        return Err(ClientError::Usage(format!(
+            "invalid path prefix {prefix:?}: must begin with '/'"
+        )));
+    }
+    Ok(())
 }
 
 /// Light client-side shape check for a domain FQDN, for a clean exit-2 error
@@ -722,8 +779,35 @@ pub fn render(resp: &Response, json: bool) -> Rendered {
             *ahead_of_stable,
             *source,
         )),
+        Response::Proxies { proxies, rules } => Rendered::ok(format_proxies(proxies, rules)),
         _ => Rendered::err("unexpected response from daemon".to_owned()),
     }
+}
+
+/// Render `yerd proxy list`: whole-host proxies then per-site path rules.
+fn format_proxies(proxies: &[yerd_ipc::ProxyEntry], rules: &[yerd_ipc::ProxyRuleEntry]) -> String {
+    use std::fmt::Write as _;
+    if proxies.is_empty() && rules.is_empty() {
+        return "no proxies configured".to_owned();
+    }
+    let mut out = String::new();
+    if !proxies.is_empty() {
+        out.push_str("Whole-host proxies:\n");
+        for p in proxies {
+            let scheme = if p.secure { "https" } else { "http" };
+            let _ = writeln!(out, "  {} ({scheme}) -> {}", p.name, p.target);
+        }
+    }
+    if !rules.is_empty() {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("Path rules:\n");
+        for r in rules {
+            let _ = writeln!(out, "  {} {} -> {}", r.site, r.prefix, r.target);
+        }
+    }
+    out.trim_end().to_owned()
 }
 
 /// Process exit code for a response: `1` for an error or any `Fail`-severity
@@ -2377,6 +2461,80 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&err.stdout).unwrap();
         assert_eq!(v["type"], "error");
         assert_eq!(err.code, 1);
+    }
+
+    #[test]
+    fn maps_proxy_command() {
+        use crate::cli::ProxyAction;
+        assert_eq!(
+            to_request(&Command::Proxy {
+                action: ProxyAction::Add {
+                    first: "reverb".into(),
+                    second: "http://localhost:8080".into(),
+                    third: None,
+                },
+            })
+            .unwrap(),
+            Request::AddProxy {
+                name: "reverb".into(),
+                url: "http://localhost:8080".into(),
+            }
+        );
+        assert_eq!(
+            to_request(&Command::Proxy {
+                action: ProxyAction::Add {
+                    first: "myapp".into(),
+                    second: "/app".into(),
+                    third: Some("http://127.0.0.1:8080".into()),
+                },
+            })
+            .unwrap(),
+            Request::AddProxyRule {
+                site: "myapp".into(),
+                prefix: "/app".into(),
+                url: "http://127.0.0.1:8080".into(),
+            }
+        );
+        assert_eq!(
+            to_request(&Command::Proxy {
+                action: ProxyAction::Remove {
+                    target: "reverb".into(),
+                    prefix: None,
+                },
+            })
+            .unwrap(),
+            Request::RemoveProxy {
+                name: "reverb".into(),
+            }
+        );
+        assert_eq!(
+            to_request(&Command::Proxy {
+                action: ProxyAction::Remove {
+                    target: "myapp".into(),
+                    prefix: Some("/app".into()),
+                },
+            })
+            .unwrap(),
+            Request::RemoveProxyRule {
+                site: "myapp".into(),
+                prefix: "/app".into(),
+            }
+        );
+        assert_eq!(
+            to_request(&Command::Proxy {
+                action: ProxyAction::List,
+            })
+            .unwrap(),
+            Request::ListProxies
+        );
+        assert!(to_request(&Command::Proxy {
+            action: ProxyAction::Add {
+                first: "myapp".into(),
+                second: "app".into(),
+                third: Some("http://127.0.0.1:8080".into()),
+            },
+        })
+        .is_err());
     }
 
     #[test]

--- a/bin/yerdd/Cargo.toml
+++ b/bin/yerdd/Cargo.toml
@@ -57,6 +57,7 @@ interprocess   = { workspace = true }
 fs4            = { workspace = true }
 rustls         = { workspace = true, features = ["ring"] }
 rustls-pki-types = { workspace = true, features = ["alloc", "std"] }
+webpki-roots   = { workspace = true }
 time           = { workspace = true }
 # PHP install path: fetch (rustls, no OpenSSL) + unpack prebuilt builds.
 reqwest        = { workspace = true }

--- a/bin/yerdd/src/error.rs
+++ b/bin/yerdd/src/error.rs
@@ -27,6 +27,10 @@ pub enum DaemonError {
     /// Proxy server failure.
     #[error("proxy: {0}")]
     Proxy(#[from] yerd_proxy::ProxyError),
+
+    /// rustls client-config build failure (proxy upstream TLS trust anchors).
+    #[error("client tls: {0}")]
+    ClientTls(#[from] rustls::Error),
     /// PHP-FPM supervisor failure.
     #[error("php: {0}")]
     Php(#[from] yerd_php::PhpError),
@@ -63,7 +67,7 @@ pub fn exit_code(e: &DaemonError) -> u8 {
         DaemonError::AlreadyRunning { .. } => 75,
         DaemonError::Config(_) | DaemonError::Core(_) => 78,
         DaemonError::Io { .. } => 74,
-        DaemonError::Platform(_) | DaemonError::Tls(_) => 71,
+        DaemonError::Platform(_) | DaemonError::Tls(_) | DaemonError::ClientTls(_) => 71,
         _ => 70,
     }
 }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -2066,9 +2066,14 @@ fn is_self_forward(url: &str, bound_ports: &[u16]) -> bool {
 }
 
 /// Reply to [`Request::ListProxies`]: whole-host proxies plus every per-site
-/// path-prefix rule (linked keyed by name, parked by document-root).
+/// path-prefix rule. Linked rules key by site name already; parked rules key by
+/// document-root, which is resolved through the live router to the current site
+/// name (mirroring `ListSites`) so the output round-trips through
+/// `yerd proxy remove <site> <prefix>`. A parked docroot with no current site
+/// falls back to the raw key.
 async fn list_proxies(state: &DaemonState) -> Response {
     let cfg = state.config.lock().await;
+    let router = state.router.read().await;
     let proxies = cfg
         .proxies
         .iter()
@@ -2079,15 +2084,23 @@ async fn list_proxies(state: &DaemonState) -> Response {
         })
         .collect();
     let mut rules = Vec::new();
-    for (site, site_rules) in cfg
-        .proxy_rules
-        .linked
-        .iter()
-        .chain(cfg.proxy_rules.parked.iter())
-    {
+    for (site, site_rules) in &cfg.proxy_rules.linked {
         for r in site_rules {
             rules.push(yerd_ipc::ProxyRuleEntry {
                 site: site.clone(),
+                prefix: r.prefix().to_owned(),
+                target: r.target().to_string(),
+            });
+        }
+    }
+    for (docroot, site_rules) in &cfg.proxy_rules.parked {
+        let site_name = router
+            .iter()
+            .find(|s| s.document_root().to_string_lossy().as_ref() == docroot.as_str())
+            .map_or_else(|| docroot.clone(), |s| s.name().to_owned());
+        for r in site_rules {
+            rules.push(yerd_ipc::ProxyRuleEntry {
+                site: site_name.clone(),
                 prefix: r.prefix().to_owned(),
                 target: r.target().to_string(),
             });

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -161,7 +161,21 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         | Request::AddDomain { .. }
         | Request::RemoveDomain { .. }
         | Request::SetPrimaryDomain { .. }
-        | Request::ResetDomains { .. } => handle_mutation(req, state).await,
+        | Request::ResetDomains { .. }
+        | Request::RemoveProxy { .. }
+        | Request::RemoveProxyRule { .. } => handle_mutation(req, state).await,
+        Request::AddProxy { ref url, .. } | Request::AddProxyRule { ref url, .. } => {
+            if is_self_forward(url, &[state.http.bound, state.https.bound]) {
+                Response::Error {
+                    code: ErrorCode::InvalidPath,
+                    message: "proxy target points at yerd's own listening port (routing loop)"
+                        .to_owned(),
+                }
+            } else {
+                handle_mutation(req, state).await
+            }
+        }
+        Request::ListProxies => list_proxies(state).await,
         Request::ListGroups => {
             let cfg = state.config.lock().await;
             Response::Groups {
@@ -2034,6 +2048,54 @@ fn site_needing_url_sync(
     candidate.get(&name.to_ascii_lowercase()).cloned()
 }
 
+/// Whether `url` is a loopback target on one of Yerd's **actively bound** proxy
+/// ports - a request to such a proxy would forward straight back into Yerd,
+/// re-resolve, and loop. Checked here rather than in the pure config layer
+/// because the bound port is a runtime fact. A malformed URL returns `false` so
+/// the mutation handler surfaces the precise parse error instead.
+fn is_self_forward(url: &str, bound_ports: &[u16]) -> bool {
+    let Ok(target) = yerd_core::UpstreamTarget::from_url_str(url) else {
+        return false;
+    };
+    let loopback = target.host() == "localhost"
+        || target
+            .host()
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback());
+    loopback && bound_ports.contains(&target.port())
+}
+
+/// Reply to [`Request::ListProxies`]: whole-host proxies plus every per-site
+/// path-prefix rule (linked keyed by name, parked by document-root).
+async fn list_proxies(state: &DaemonState) -> Response {
+    let cfg = state.config.lock().await;
+    let proxies = cfg
+        .proxies
+        .iter()
+        .map(|p| yerd_ipc::ProxyEntry {
+            name: p.name().to_owned(),
+            target: p.target().to_string(),
+            secure: p.secure(),
+        })
+        .collect();
+    let mut rules = Vec::new();
+    for (site, site_rules) in cfg
+        .proxy_rules
+        .linked
+        .iter()
+        .chain(cfg.proxy_rules.parked.iter())
+    {
+        for r in site_rules {
+            rules.push(yerd_ipc::ProxyRuleEntry {
+                site: site.clone(),
+                prefix: r.prefix().to_owned(),
+                target: r.target().to_string(),
+            });
+        }
+    }
+    Response::Proxies { proxies, rules }
+}
+
 /// Apply a group mutation (create/delete/reorder/assign). Groups are a
 /// config-only organisational overlay that never affects routing, so this uses
 /// the lighter clone → apply → validate → save → commit path (like
@@ -2222,6 +2284,18 @@ mod tests {
     use yerd_platform::PlatformDirs;
 
     use crate::test_support::state_in;
+
+    #[test]
+    fn self_forward_matches_only_loopback_on_bound_ports() {
+        let bound = [8080, 8443];
+        assert!(is_self_forward("http://127.0.0.1:8080", &bound));
+        assert!(is_self_forward("https://localhost:8443", &bound));
+        assert!(is_self_forward("http://[::1]:8080", &bound));
+        assert!(!is_self_forward("http://127.0.0.1:3000", &bound));
+        assert!(!is_self_forward("http://192.168.1.5:8080", &bound));
+        assert!(!is_self_forward("http://example.com:8080", &bound));
+        assert!(!is_self_forward("not-a-url", &bound));
+    }
 
     #[test]
     fn bundle_contains_ca_matches_embedded_ca() {

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -68,6 +68,32 @@ pub enum Outcome {
     Restart,
 }
 
+/// Build the reverse-proxy client-TLS bundle injected into the proxy: a
+/// no-verify config for local/`.test` upstreams (self-signed dev backends), and
+/// a public verifier over the bundled Mozilla roots for genuine public hosts.
+///
+/// This crate owns `webpki-roots` (banned in `yerd-proxy`); both configs are
+/// built with an explicit `ring` provider so they don't depend on the
+/// process-default `CryptoProvider` install order.
+fn build_proxy_client_tls() -> Result<Arc<yerd_proxy::ProxyClientTls>, rustls::Error> {
+    use rustls::crypto::ring::default_provider;
+    use rustls::{ClientConfig, RootCertStore};
+
+    let local = yerd_proxy::ProxyClientTls::no_verify_config()?;
+
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let public = ClientConfig::builder_with_provider(Arc::new(default_provider()))
+        .with_safe_default_protocol_versions()?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    Ok(Arc::new(yerd_proxy::ProxyClientTls::new(
+        local,
+        Arc::new(public),
+    )))
+}
+
 /// Run the daemon to completion (until a shutdown signal or restart request).
 ///
 /// `main` calls this inside a tokio runtime; integration tests call
@@ -137,6 +163,7 @@ async fn run_until_shutdown(
         let login_tokens = daemon.state.wordpress_login_tokens.clone();
         let login_prepend_script = daemon.state.wordpress_login_prepend_script.clone();
         let symlink_protection = daemon.state.symlink_protection.clone();
+        let client_tls = build_proxy_client_tls()?;
         Some(tokio::spawn(yerd_proxy::ProxyServer::serve(
             http_listener,
             Some(https),
@@ -145,6 +172,7 @@ async fn run_until_shutdown(
             login_tokens,
             login_prepend_script,
             symlink_protection,
+            client_tls,
             async move {
                 let _ = rx.changed().await;
             },

--- a/bin/yerdd/src/mutate.rs
+++ b/bin/yerdd/src/mutate.rs
@@ -18,7 +18,9 @@
 use std::path::PathBuf;
 
 use yerd_config::{Config, DomainDelta};
-use yerd_core::{Domain, PhpVersion, Site, SiteRouter};
+use yerd_core::{
+    Domain, PhpVersion, ProxyRule, ProxySite, Site, SiteKind, SiteRouter, UpstreamTarget,
+};
 use yerd_ipc::{ErrorCode, Request};
 
 /// A mutation that could not be applied. The inner string is a
@@ -94,6 +96,14 @@ pub fn apply(
             apply_set_primary_domain(cfg, router, name, domain)
         }
         Request::ResetDomains { name } => apply_reset_domains(cfg, router, name),
+        Request::AddProxy { name, url } => apply_add_proxy(cfg, router, name, url),
+        Request::RemoveProxy { name } => apply_remove_proxy(cfg, name),
+        Request::AddProxyRule { site, prefix, url } => {
+            apply_add_proxy_rule(cfg, router, site, prefix, url)
+        }
+        Request::RemoveProxyRule { site, prefix } => {
+            apply_remove_proxy_rule(cfg, router, site, prefix)
+        }
         Request::CreateGroup { name } => apply_create_group(cfg, name),
         Request::DeleteGroup { name } => Ok(apply_delete_group(cfg, name)),
         Request::SetGroupOrder { order } => apply_set_group_order(cfg, order),
@@ -138,6 +148,9 @@ fn apply_link(
     if let Some(delta) = cfg.domains.parked.remove(&docroot_key) {
         cfg.domains.linked.insert(name_lc.clone(), delta);
     }
+    if let Some(rules) = cfg.proxy_rules.parked.remove(&docroot_key) {
+        cfg.proxy_rules.linked.insert(name_lc.clone(), rules);
+    }
     cfg.linked.push(site);
     Ok(Applied {
         summary: format!("linked {name_lc}"),
@@ -153,6 +166,9 @@ fn apply_link(
 fn apply_unpark(cfg: &mut Config, path: &str) -> Applied {
     let removed = cfg.parked.paths.remove(path);
     cfg.domains
+        .parked
+        .retain(|docroot, _| !is_under_root(docroot, path));
+    cfg.proxy_rules
         .parked
         .retain(|docroot, _| !is_under_root(docroot, path));
     Applied {
@@ -198,7 +214,12 @@ fn apply_unlink(cfg: &mut Config, router: &SiteRouter, name: &str) -> Result<App
     cfg.linked.retain(|s| s.name() != name_lc);
     if let Some(delta) = cfg.domains.linked.remove(&name_lc) {
         if reparks {
-            cfg.domains.parked.insert(docroot_key, delta);
+            cfg.domains.parked.insert(docroot_key.clone(), delta);
+        }
+    }
+    if let Some(rules) = cfg.proxy_rules.linked.remove(&name_lc) {
+        if reparks {
+            cfg.proxy_rules.parked.insert(docroot_key, rules);
         }
     }
     Ok(Applied {
@@ -258,9 +279,161 @@ fn apply_set_secure(
         Ok(Applied {
             summary: format!("{name_lc} secure={secure}"),
         })
+    } else if let Some(proxy) = cfg.proxies.iter_mut().find(|p| p.name() == name_lc) {
+        proxy.set_secure(secure);
+        Ok(Applied {
+            summary: format!("proxy {name_lc} secure={secure}"),
+        })
     } else {
         Err(MutateError::NotFound(format!("no site named {name_lc}")))
     }
+}
+
+/// Reject a proxy/rule target that would loop back into Yerd via a `.tld` host.
+///
+/// The loopback-on-own-*port* loop (a target like `127.0.0.1:<bound-port>`) is
+/// checked separately in [`crate::ipc_server`], where the *actively bound* proxy
+/// port is known - a runtime fact this pure layer can't see.
+fn reject_loop_target(cfg: &Config, target: &UpstreamTarget) -> Result<(), MutateError> {
+    let host = target.host();
+    let dotted = format!(".{}", cfg.tld.as_str());
+    if host == cfg.tld.as_str() || host.ends_with(&dotted) {
+        return Err(MutateError::Invalid(format!(
+            "proxy target must not be a .{} host (routing loop)",
+            cfg.tld.as_str()
+        )));
+    }
+    Ok(())
+}
+
+/// Normalise a rule prefix's trailing slash the same way
+/// [`yerd_core::ProxyRule::new`] does, so removal matches a stored rule.
+fn normalize_prefix(prefix: &str) -> String {
+    let mut p = prefix.to_owned();
+    while p.len() > 1 && p.ends_with('/') {
+        p.pop();
+    }
+    p
+}
+
+/// Register a whole-host proxy. Rejects a name that collides with a linked site,
+/// a parked site (via the pre-mutation `router`), or an existing proxy, and a
+/// looping target.
+fn apply_add_proxy(
+    cfg: &mut Config,
+    router: &SiteRouter,
+    name: &str,
+    url: &str,
+) -> Result<Applied, MutateError> {
+    let target = UpstreamTarget::from_url_str(url)
+        .map_err(|e| MutateError::Invalid(format!("invalid proxy target: {e}")))?;
+    reject_loop_target(cfg, &target)?;
+    let proxy = ProxySite::new(name, target)
+        .map_err(|e| MutateError::Invalid(format!("invalid proxy name: {e}")))?;
+    let name_lc = proxy.name().to_owned();
+    if router.get(&name_lc).is_some() || cfg.proxies.iter().any(|p| p.name() == name_lc) {
+        return Err(MutateError::AlreadyExists(format!(
+            "a site or proxy named {name_lc} already exists"
+        )));
+    }
+    cfg.proxies.push(proxy);
+    Ok(Applied {
+        summary: format!("added proxy {name_lc} -> {url}"),
+    })
+}
+
+/// Remove a whole-host proxy by name.
+fn apply_remove_proxy(cfg: &mut Config, name: &str) -> Result<Applied, MutateError> {
+    let name_lc = name.to_ascii_lowercase();
+    let before = cfg.proxies.len();
+    cfg.proxies.retain(|p| p.name() != name_lc);
+    if cfg.proxies.len() == before {
+        return Err(MutateError::NotFound(format!("no proxy named {name_lc}")));
+    }
+    Ok(Applied {
+        summary: format!("removed proxy {name_lc}"),
+    })
+}
+
+/// The `proxy_rules` storage key for a site: linked sites key by name, parked
+/// sites by document-root (matching `[[overrides]]`). Returns `None` if the site
+/// is unknown to the pre-mutation router.
+fn proxy_rule_key(router: &SiteRouter, name_lc: &str) -> Option<(bool, String)> {
+    let site = router.get(name_lc)?;
+    match site.kind() {
+        SiteKind::Linked => Some((true, name_lc.to_owned())),
+        SiteKind::Parked => Some((false, override_key(site))),
+    }
+}
+
+/// Add a path-prefix proxy rule to an existing site.
+fn apply_add_proxy_rule(
+    cfg: &mut Config,
+    router: &SiteRouter,
+    site: &str,
+    prefix: &str,
+    url: &str,
+) -> Result<Applied, MutateError> {
+    let name_lc = site.to_ascii_lowercase();
+    let target = UpstreamTarget::from_url_str(url)
+        .map_err(|e| MutateError::Invalid(format!("invalid proxy target: {e}")))?;
+    reject_loop_target(cfg, &target)?;
+    let rule = ProxyRule::new(prefix, target)
+        .map_err(|e| MutateError::Invalid(format!("invalid rule prefix: {e}")))?;
+    let (linked, key) = proxy_rule_key(router, &name_lc)
+        .ok_or_else(|| MutateError::NotFound(format!("no site named {name_lc}")))?;
+    let map = if linked {
+        &mut cfg.proxy_rules.linked
+    } else {
+        &mut cfg.proxy_rules.parked
+    };
+    let rules = map.entry(key).or_default();
+    if rules.iter().any(|r| r.prefix() == rule.prefix()) {
+        return Err(MutateError::AlreadyExists(format!(
+            "site {name_lc} already has a proxy rule for {}",
+            rule.prefix()
+        )));
+    }
+    let summary = format!("added proxy rule {name_lc}{} -> {url}", rule.prefix());
+    rules.push(rule);
+    Ok(Applied { summary })
+}
+
+/// Remove a path-prefix proxy rule from a site, pruning the site's entry when
+/// its last rule goes so the config round-trips to a byte-identical state.
+fn apply_remove_proxy_rule(
+    cfg: &mut Config,
+    router: &SiteRouter,
+    site: &str,
+    prefix: &str,
+) -> Result<Applied, MutateError> {
+    let name_lc = site.to_ascii_lowercase();
+    let wanted = normalize_prefix(prefix);
+    let (linked, key) = proxy_rule_key(router, &name_lc)
+        .ok_or_else(|| MutateError::NotFound(format!("no site named {name_lc}")))?;
+    let map = if linked {
+        &mut cfg.proxy_rules.linked
+    } else {
+        &mut cfg.proxy_rules.parked
+    };
+    let Some(rules) = map.get_mut(&key) else {
+        return Err(MutateError::NotFound(format!(
+            "site {name_lc} has no proxy rule for {wanted}"
+        )));
+    };
+    let before = rules.len();
+    rules.retain(|r| r.prefix() != wanted);
+    if rules.len() == before {
+        return Err(MutateError::NotFound(format!(
+            "site {name_lc} has no proxy rule for {wanted}"
+        )));
+    }
+    if rules.is_empty() {
+        map.remove(&key);
+    }
+    Ok(Applied {
+        summary: format!("removed proxy rule {name_lc}{wanted}"),
+    })
 }
 
 fn apply_set_wordpress_auto_login(
@@ -732,6 +905,239 @@ mod tests {
         r.insert(Site::parked(name, root, v(8, 3)).unwrap())
             .unwrap();
         r
+    }
+
+    #[test]
+    fn add_proxy_registers_rejects_dup_and_loops() {
+        let mut cfg = Config::default();
+        let r = empty_router();
+        apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxy {
+                name: "Reverb".into(),
+                url: "http://localhost:3000".into(),
+            },
+            None,
+            v(8, 3),
+        )
+        .unwrap();
+        assert_eq!(cfg.proxies.len(), 1);
+        assert_eq!(cfg.proxies[0].name(), "reverb");
+
+        let dup = apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxy {
+                name: "reverb".into(),
+                url: "http://localhost:3001".into(),
+            },
+            None,
+            v(8, 3),
+        );
+        assert!(matches!(dup, Err(MutateError::AlreadyExists(_))));
+
+        let tld_loop = apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxy {
+                name: "x".into(),
+                url: "http://foo.test".into(),
+            },
+            None,
+            v(8, 3),
+        );
+        assert!(matches!(tld_loop, Err(MutateError::Invalid(_))));
+    }
+
+    #[test]
+    fn add_proxy_rejects_site_name_collision() {
+        let mut cfg = Config::default();
+        let r = router_with_parked("blog", "/srv/blog");
+        let res = apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxy {
+                name: "blog".into(),
+                url: "http://localhost:3000".into(),
+            },
+            None,
+            v(8, 3),
+        );
+        assert!(matches!(res, Err(MutateError::AlreadyExists(_))));
+    }
+
+    #[test]
+    fn remove_proxy_reports_not_found() {
+        let mut cfg = Config::default();
+        let r = empty_router();
+        assert!(matches!(
+            apply(
+                &mut cfg,
+                &r,
+                &Request::RemoveProxy {
+                    name: "nope".into()
+                },
+                None,
+                v(8, 3),
+            ),
+            Err(MutateError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn add_and_remove_parked_proxy_rule_prunes_key() {
+        let mut cfg = Config::default();
+        let r = router_with_parked("blog", "/srv/blog");
+        apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxyRule {
+                site: "blog".into(),
+                prefix: "/ws".into(),
+                url: "http://127.0.0.1:3000".into(),
+            },
+            None,
+            v(8, 3),
+        )
+        .unwrap();
+        assert_eq!(cfg.proxy_rules.parked.get("/srv/blog").unwrap().len(), 1);
+
+        let dup = apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxyRule {
+                site: "blog".into(),
+                prefix: "/ws/".into(),
+                url: "http://127.0.0.1:3001".into(),
+            },
+            None,
+            v(8, 3),
+        );
+        assert!(matches!(dup, Err(MutateError::AlreadyExists(_))));
+
+        apply(
+            &mut cfg,
+            &r,
+            &Request::RemoveProxyRule {
+                site: "blog".into(),
+                prefix: "/ws".into(),
+            },
+            None,
+            v(8, 3),
+        )
+        .unwrap();
+        assert!(!cfg.proxy_rules.parked.contains_key("/srv/blog"));
+
+        let unknown = apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxyRule {
+                site: "nope".into(),
+                prefix: "/x".into(),
+                url: "http://127.0.0.1:3000".into(),
+            },
+            None,
+            v(8, 3),
+        );
+        assert!(matches!(unknown, Err(MutateError::NotFound(_))));
+    }
+
+    #[test]
+    fn link_and_unlink_migrate_proxy_rules() {
+        let mut cfg = Config::default();
+        cfg.parked.paths.insert("/srv".to_string());
+        let rule = yerd_core::ProxyRule::new(
+            "/ws",
+            yerd_core::UpstreamTarget::from_url_str("http://127.0.0.1:3000").unwrap(),
+        )
+        .unwrap();
+        cfg.proxy_rules
+            .parked
+            .insert("/srv/app".to_string(), vec![rule]);
+
+        apply(
+            &mut cfg,
+            &empty_router(),
+            &Request::Link {
+                name: "app".into(),
+                path: PathBuf::from("/ignored"),
+            },
+            Some(PathBuf::from("/srv/app")),
+            v(8, 3),
+        )
+        .unwrap();
+        assert!(cfg.proxy_rules.parked.is_empty());
+        assert_eq!(cfg.proxy_rules.linked.get("app").unwrap().len(), 1);
+
+        let mut router = empty_router();
+        router
+            .insert(Site::linked("app", "/srv/app", v(8, 3)).unwrap())
+            .unwrap();
+        apply(
+            &mut cfg,
+            &router,
+            &Request::Unlink { name: "app".into() },
+            None,
+            v(8, 3),
+        )
+        .unwrap();
+        assert!(cfg.proxy_rules.linked.is_empty());
+        assert_eq!(cfg.proxy_rules.parked.get("/srv/app").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn unpark_drops_proxy_rules_under_root() {
+        let mut cfg = Config::default();
+        let rule = yerd_core::ProxyRule::new(
+            "/ws",
+            yerd_core::UpstreamTarget::from_url_str("http://127.0.0.1:3000").unwrap(),
+        )
+        .unwrap();
+        cfg.parked.paths.insert("/srv".to_string());
+        cfg.proxy_rules
+            .parked
+            .insert("/srv/app".to_string(), vec![rule]);
+        apply(
+            &mut cfg,
+            &empty_router(),
+            &Request::Unpark {
+                path: "/srv".into(),
+            },
+            None,
+            v(8, 3),
+        )
+        .unwrap();
+        assert!(cfg.proxy_rules.parked.is_empty());
+    }
+
+    #[test]
+    fn secure_toggles_whole_host_proxy() {
+        let mut cfg = Config::default();
+        let r = empty_router();
+        apply(
+            &mut cfg,
+            &r,
+            &Request::AddProxy {
+                name: "reverb".into(),
+                url: "http://localhost:3000".into(),
+            },
+            None,
+            v(8, 3),
+        )
+        .unwrap();
+        apply(
+            &mut cfg,
+            &r,
+            &Request::SetSecure {
+                name: "reverb".into(),
+                secure: true,
+            },
+            None,
+            v(8, 3),
+        )
+        .unwrap();
+        assert!(cfg.proxies[0].secure());
     }
 
     #[test]

--- a/bin/yerdd/src/site_domains.rs
+++ b/bin/yerdd/src/site_domains.rs
@@ -28,6 +28,13 @@ use yerd_core::{choose_primary, effective_domains, Domain, RouterConfig, Site, S
 /// `insert_with_domains` error arm is unreachable in practice; it logs and drops
 /// the site rather than panicking, so a latent bug degrades gracefully instead of
 /// bricking boot.
+///
+/// Whole-host proxies are inserted after sites, so a real site's apex always
+/// wins the exact index: a proxy that collides with a site (or another proxy)
+/// fails `insert_proxy` and is dropped with a log. Each site's path-prefix rules
+/// are then attached (linked keyed by name, parked by document-root); a rule set
+/// for a dropped/absent site is harmless, as it is only ever consulted for a
+/// site the router actually resolved.
 #[must_use]
 pub(crate) fn build(cfg: &Config, sites: Vec<Site>) -> SiteRouter {
     let plans = plan_sites(cfg, sites);
@@ -44,6 +51,25 @@ pub(crate) fn build(cfg: &Config, sites: Vec<Site>) -> SiteRouter {
         let primary = choose_primary(plan.site.name(), &won, Some(&plan.primary));
         if let Err(e) = router.insert_with_domains(plan.site.clone(), won, primary) {
             tracing::error!(site = plan.site.name(), error = %e, "dropping site: router insert failed");
+        }
+    }
+
+    for proxy in &cfg.proxies {
+        if let Err(e) = router.insert_proxy(proxy.clone()) {
+            tracing::error!(proxy = proxy.name(), error = %e, "dropping proxy: router insert failed (name/apex taken)");
+        }
+    }
+
+    for plan in &plans {
+        let rules = match plan.site.kind() {
+            yerd_core::SiteKind::Linked => cfg.proxy_rules.linked.get(plan.site.name()),
+            yerd_core::SiteKind::Parked => cfg
+                .proxy_rules
+                .parked
+                .get(&plan.site.document_root().to_string_lossy().into_owned()),
+        };
+        if let Some(rules) = rules {
+            router.set_proxy_rules(plan.site.name(), rules.clone());
         }
     }
     router
@@ -64,7 +90,9 @@ pub(crate) struct DomainCollision {
 
 /// Detect domains wanted by more than one site, using the same effective-set and
 /// claim rules as [`build`]. Empty for a well-formed config where every domain
-/// has a single claimant.
+/// has a single claimant. A whole-host proxy whose apex is already claimed by a
+/// site is reported too (loser `proxy:<name>`), so the doctor can flag the
+/// shadow.
 #[must_use]
 pub(crate) fn collisions(cfg: &Config, sites: Vec<Site>) -> Vec<DomainCollision> {
     let plans = plan_sites(cfg, sites);
@@ -97,6 +125,17 @@ pub(crate) fn collisions(cfg: &Config, sites: Vec<Site>) -> Vec<DomainCollision>
             continue;
         }
         out.push(DomainCollision { winner, losers });
+    }
+
+    for proxy in &cfg.proxies {
+        if let Some(&winner_idx) = claims.get(proxy.name()) {
+            if let Some(winner) = plans.get(winner_idx).map(|p| p.site.name().to_owned()) {
+                out.push(DomainCollision {
+                    winner,
+                    losers: vec![format!("proxy:{}", proxy.name())],
+                });
+            }
+        }
     }
     out
 }
@@ -208,6 +247,45 @@ mod tests {
         let r = build(&cfg, vec![linked("foo", "/srv/foo")]);
         assert_eq!(r.resolve("foo.test").map(Site::name), Some("foo"));
         assert_eq!(r.resolve("api.foo.test"), None);
+    }
+
+    fn target(url: &str) -> yerd_core::UpstreamTarget {
+        yerd_core::UpstreamTarget::from_url_str(url).unwrap()
+    }
+
+    #[test]
+    fn proxies_and_rules_fold_into_router() {
+        let mut cfg = cfg_with_tld("test");
+        cfg.proxies
+            .push(yerd_core::ProxySite::new("reverb", target("http://127.0.0.1:3000")).unwrap());
+        cfg.proxy_rules.linked.insert(
+            "foo".into(),
+            vec![yerd_core::ProxyRule::new("/ws", target("http://127.0.0.1:3001")).unwrap()],
+        );
+        let r = build(&cfg, vec![linked("foo", "/srv/foo")]);
+        assert!(matches!(
+            r.resolve_route("reverb.test"),
+            Some(yerd_core::Route::Proxy(_))
+        ));
+        assert_eq!(r.resolve("foo.test").map(Site::name), Some("foo"));
+        assert_eq!(r.rules_for("foo").len(), 1);
+        assert!(yerd_core::match_rule(r.rules_for("foo"), "/ws/x").is_some());
+    }
+
+    #[test]
+    fn real_site_beats_a_same_named_proxy() {
+        let mut cfg = cfg_with_tld("test");
+        cfg.proxies
+            .push(yerd_core::ProxySite::new("app", target("http://127.0.0.1:3000")).unwrap());
+        let r = build(&cfg, vec![linked("app", "/srv/app")]);
+        assert!(matches!(
+            r.resolve_route("app.test"),
+            Some(yerd_core::Route::Php(_))
+        ));
+        let cols = collisions(&cfg, vec![linked("app", "/srv/app")]);
+        assert!(cols
+            .iter()
+            .any(|c| c.winner == "app" && c.losers.iter().any(|l| l == "proxy:app")));
     }
 
     #[test]

--- a/bin/yerdd/tests/lifecycle.rs
+++ b/bin/yerdd/tests/lifecycle.rs
@@ -291,6 +291,10 @@ mod tests {
                 login_tokens,
                 login_prepend_script,
                 daemon.state.symlink_protection.clone(),
+                std::sync::Arc::new(yerd_proxy::ProxyClientTls::new(
+                    yerd_proxy::ProxyClientTls::no_verify_config().unwrap(),
+                    yerd_proxy::ProxyClientTls::no_verify_config().unwrap(),
+                )),
                 async move {
                     let _ = rx.changed().await;
                 },

--- a/crates/yerd-config/src/error.rs
+++ b/crates/yerd-config/src/error.rs
@@ -160,6 +160,13 @@ pub enum ValidateErrorReason {
     /// A `[domains]` delta named a wildcard as its `primary` (a primary must be a
     /// concrete, exact domain).
     DomainPrimaryWildcard,
+    /// A `[[proxies]]` name collides with a linked site or another proxy.
+    ProxyNameCollision,
+    /// Two `[proxy_rules]` entries for the same site share a path prefix.
+    ProxyRuleDuplicatePrefix,
+    /// A proxy/rule target points back at a `.tld` host (a routing loop into
+    /// Yerd itself); targets must address the backing service directly.
+    ProxyTargetLoop,
 }
 
 impl fmt::Display for ValidateErrorReason {
@@ -205,6 +212,9 @@ impl fmt::Display for ValidateErrorReason {
             Self::DomainPrimaryWildcard => {
                 "a domains primary must be an exact (non-wildcard) domain"
             }
+            Self::ProxyNameCollision => "a proxy name collides with a linked site or another proxy",
+            Self::ProxyRuleDuplicatePrefix => "two proxy rules for one site share a path prefix",
+            Self::ProxyTargetLoop => "a proxy target must not point at a .test host",
         };
         f.write_str(msg)
     }
@@ -284,6 +294,9 @@ mod tests {
             ValidateErrorReason::DomainAddedDuplicate,
             ValidateErrorReason::DomainAddedSuppressedOverlap,
             ValidateErrorReason::DomainPrimaryWildcard,
+            ValidateErrorReason::ProxyNameCollision,
+            ValidateErrorReason::ProxyRuleDuplicatePrefix,
+            ValidateErrorReason::ProxyTargetLoop,
         ] {
             assert!(!r.to_string().is_empty());
             let _ = format!("{r:?}");

--- a/crates/yerd-config/src/error.rs
+++ b/crates/yerd-config/src/error.rs
@@ -167,6 +167,10 @@ pub enum ValidateErrorReason {
     /// A proxy/rule target points back at a `.tld` host (a routing loop into
     /// Yerd itself); targets must address the backing service directly.
     ProxyTargetLoop,
+    /// A `[proxy_rules.linked.<name>]` key names a linked site that does not
+    /// exist (a typo or a casing mismatch against the site's normalized name);
+    /// the rule would silently never apply.
+    ProxyRuleUnknownSite,
 }
 
 impl fmt::Display for ValidateErrorReason {
@@ -214,7 +218,12 @@ impl fmt::Display for ValidateErrorReason {
             }
             Self::ProxyNameCollision => "a proxy name collides with a linked site or another proxy",
             Self::ProxyRuleDuplicatePrefix => "two proxy rules for one site share a path prefix",
-            Self::ProxyTargetLoop => "a proxy target must not point at a .test host",
+            Self::ProxyTargetLoop => {
+                "a proxy target must not point at a host under the configured TLD (routing loop)"
+            }
+            Self::ProxyRuleUnknownSite => {
+                "a proxy rule references a linked site that does not exist"
+            }
         };
         f.write_str(msg)
     }
@@ -297,6 +306,7 @@ mod tests {
             ValidateErrorReason::ProxyNameCollision,
             ValidateErrorReason::ProxyRuleDuplicatePrefix,
             ValidateErrorReason::ProxyTargetLoop,
+            ValidateErrorReason::ProxyRuleUnknownSite,
         ] {
             assert!(!r.to_string().is_empty());
             let _ = format!("{r:?}");

--- a/crates/yerd-config/src/lib.rs
+++ b/crates/yerd-config/src/lib.rs
@@ -73,4 +73,4 @@ pub use schema::{
 /// key inside `[[linked]]` and `[[overrides]]` for the per-site
 /// front-controller-vs-direct-execution toggle (defaults to auto when absent).
 /// Both v11→v12 and v12→v13 are bare version bumps.
-pub const CURRENT_VERSION: u32 = 13;
+pub const CURRENT_VERSION: u32 = 14;

--- a/crates/yerd-config/src/migrate.rs
+++ b/crates/yerd-config/src/migrate.rs
@@ -19,7 +19,7 @@ pub(crate) type MigrationStep = fn(&mut Value) -> Result<(), ConfigError>;
 /// Forward-migration steps, indexed so that **`STEPS[N]` walks `vN → v(N+1)`**.
 /// This matches [`up`], which indexes `STEPS[current]` (== the version being
 /// migrated *from*). Example: a v1 file is migrated by `STEPS[1]`. When
-/// `CURRENT_VERSION == 13`, `STEPS = [v0→v1, …, v11→v12, v12→v13]`, length 13.
+/// `CURRENT_VERSION == 14`, `STEPS = [v0→v1, …, v12→v13, v13→v14]`, length 14.
 ///
 /// `STEPS[0]` (v0→v1) is only reachable via a hand-crafted `version = 0` file -
 /// v0 was never written to disk - but it must exist so that `STEPS[1]` does.
@@ -37,6 +37,7 @@ pub(crate) const STEPS: &[MigrationStep] = &[
     migrate_v10_to_v11,
     migrate_v11_to_v12,
     migrate_v12_to_v13,
+    migrate_v13_to_v14,
 ];
 
 /// `v0 → v1`: bump the version. v0 predates any shipped config, so there is no
@@ -146,6 +147,13 @@ fn migrate_v12_to_v13(value: &mut Value) -> Result<(), ConfigError> {
     set_version(value, 13)
 }
 
+/// `v13 → v14`: bump the version. v14 added the optional `[[proxies]]` array and
+/// `[proxy_rules]` table, both of which default to empty when absent, so an
+/// in-place version bump is the entire migration.
+fn migrate_v13_to_v14(value: &mut Value) -> Result<(), ConfigError> {
+    set_version(value, 14)
+}
+
 /// Set the top-level `version` key, erroring if the root is not a table.
 fn set_version(value: &mut Value, n: i64) -> Result<(), ConfigError> {
     let table = value.as_table_mut().ok_or(ConfigError::Migration {
@@ -215,7 +223,14 @@ mod tests {
 
     #[test]
     fn current_version_pinned() {
-        assert_eq!(crate::CURRENT_VERSION, 13);
+        assert_eq!(crate::CURRENT_VERSION, 14);
+    }
+
+    #[test]
+    fn v13_to_v14_is_a_bare_version_bump() {
+        let mut v: Value = toml::from_str("version = 13\n").unwrap();
+        migrate_v13_to_v14(&mut v).unwrap();
+        assert_eq!(read_version(&v).unwrap(), 14);
     }
 
     #[test]

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -76,6 +76,45 @@ struct Wire {
     // `ConfigError::Core`.
     #[serde(default)]
     domains: DomainsSectionWire,
+    // v14: optional `[[proxies]]` array; absent in v13 and earlier → empty.
+    // `target` strings are validated into `yerd_core::UpstreamTarget` in
+    // `TryFrom`, so a bad URL surfaces as `ConfigError::Core`.
+    #[serde(default)]
+    proxies: Vec<ProxyWire>,
+    // v14: optional `[proxy_rules]` table; absent in v13 and earlier → empty.
+    #[serde(default)]
+    proxy_rules: ProxyRulesSectionWire,
+}
+
+/// One `[[proxies]]` table: a whole-host proxy's name, upstream, and HTTPS flag.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProxyWire {
+    name: String,
+    target: String,
+    #[serde(default)]
+    secure: bool,
+}
+
+/// The `[proxy_rules]` table. Both maps default to empty, so an absent table
+/// parses to [`crate::schema::ProxyRulesSection::default`].
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProxyRulesSectionWire {
+    #[serde(default)]
+    linked: BTreeMap<String, Vec<ProxyRuleWire>>,
+    #[serde(default)]
+    parked: BTreeMap<String, Vec<ProxyRuleWire>>,
+}
+
+/// One `[[proxy_rules.linked.<name>]]` / `[[proxy_rules.parked."<docroot>"]]`
+/// rule: a path prefix plus an upstream (validated into `UpstreamTarget` in
+/// `TryFrom`).
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProxyRuleWire {
+    prefix: String,
+    target: String,
 }
 
 /// The `[domains]` table. Both maps default to empty, so an absent table parses
@@ -440,6 +479,11 @@ impl TryFrom<Wire> for Config {
             linked: convert_domain_deltas(w.domains.linked)?,
             parked: convert_domain_deltas(w.domains.parked)?,
         };
+        let proxies = convert_proxies(w.proxies)?;
+        let proxy_rules = crate::schema::ProxyRulesSection {
+            linked: convert_proxy_rules(w.proxy_rules.linked)?,
+            parked: convert_proxy_rules(w.proxy_rules.parked)?,
+        };
         Ok(Config {
             version: crate::CURRENT_VERSION,
             tld,
@@ -457,8 +501,42 @@ impl TryFrom<Wire> for Config {
             tunnel,
             groups,
             domains,
+            proxies,
+            proxy_rules,
         })
     }
+}
+
+/// Convert `[[proxies]]` wire tables into validated [`yerd_core::ProxySite`]s.
+/// A bad name or URL surfaces as [`ConfigError::Core`].
+fn convert_proxies(wire: Vec<ProxyWire>) -> Result<Vec<yerd_core::ProxySite>, ConfigError> {
+    wire.into_iter()
+        .map(|p| {
+            let target = yerd_core::UpstreamTarget::from_url_str(&p.target)?;
+            let mut proxy = yerd_core::ProxySite::new(&p.name, target)?;
+            proxy.set_secure(p.secure);
+            Ok(proxy)
+        })
+        .collect()
+}
+
+/// Convert a `[proxy_rules.*]` wire map into validated [`yerd_core::ProxyRule`]
+/// lists. A bad prefix or URL surfaces as [`ConfigError::Core`].
+fn convert_proxy_rules(
+    wire: BTreeMap<String, Vec<ProxyRuleWire>>,
+) -> Result<BTreeMap<String, Vec<yerd_core::ProxyRule>>, ConfigError> {
+    wire.into_iter()
+        .map(|(key, rules)| {
+            let rules = rules
+                .into_iter()
+                .map(|r| {
+                    let target = yerd_core::UpstreamTarget::from_url_str(&r.target)?;
+                    Ok(yerd_core::ProxyRule::new(&r.prefix, target)?)
+                })
+                .collect::<Result<Vec<_>, ConfigError>>()?;
+            Ok((key, rules))
+        })
+        .collect()
 }
 
 /// Convert a raw `[domains.*]` delta map into typed [`crate::schema::DomainDelta`]
@@ -558,6 +636,53 @@ pub(crate) fn validate(c: &Config) -> Result<(), ConfigError> {
     validate_tunnel(c)?;
     validate_groups(c)?;
     validate_domains(c)?;
+    validate_proxies(c)?;
+    Ok(())
+}
+
+/// `[[proxies]]` / `[proxy_rules]` invariants visible to this pure crate: proxy
+/// names are unique among proxies and don't collide with a linked site; each
+/// site's rule prefixes are unique; and no target points at a `.tld` host (a
+/// routing loop into Yerd). Name/URL *shape* is already enforced by
+/// `ProxySite::new` / `UpstreamTarget::from_url_str` during wire conversion.
+///
+/// The `.tld`-host loop guard is enforced here so a hand-edited config can't slip
+/// that self-forwarding target past load. The loopback-on-own-*port* loop is the
+/// daemon's job (it needs the actively bound port, a runtime fact invisible
+/// here), as are collisions with **parked** sites - mirroring `[domains]`/`[tunnel]`.
+fn validate_proxies(c: &Config) -> Result<(), ConfigError> {
+    let dotted_tld = format!(".{}", c.tld.as_str());
+    let targets_loop = |t: &yerd_core::UpstreamTarget| {
+        t.host() == c.tld.as_str() || t.host().ends_with(&dotted_tld)
+    };
+
+    let linked_names: BTreeSet<&str> = c.linked.iter().map(yerd_core::Site::name).collect();
+    let mut seen_proxy: BTreeSet<&str> = BTreeSet::new();
+    for p in &c.proxies {
+        if linked_names.contains(p.name()) || !seen_proxy.insert(p.name()) {
+            return Err(ve(ValidateErrorReason::ProxyNameCollision));
+        }
+        if targets_loop(p.target()) {
+            return Err(ve(ValidateErrorReason::ProxyTargetLoop));
+        }
+    }
+
+    for rules in c
+        .proxy_rules
+        .linked
+        .values()
+        .chain(c.proxy_rules.parked.values())
+    {
+        let mut seen_prefix: BTreeSet<&str> = BTreeSet::new();
+        for r in rules {
+            if !seen_prefix.insert(r.prefix()) {
+                return Err(ve(ValidateErrorReason::ProxyRuleDuplicatePrefix));
+            }
+            if targets_loop(r.target()) {
+                return Err(ve(ValidateErrorReason::ProxyTargetLoop));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -898,7 +1023,7 @@ mod tests {
         match Config::from_toml("version = 99\n") {
             Err(ConfigError::UnsupportedVersion {
                 found: 99,
-                current: 13,
+                current: 14,
             }) => {}
             other => panic!("expected UnsupportedVersion, got {other:?}"),
         }
@@ -1458,6 +1583,92 @@ php = "not-a-version"
     #[test]
     fn validate_accepts_default() {
         Config::default().validate().unwrap();
+    }
+
+    fn upstream(url: &str) -> yerd_core::UpstreamTarget {
+        yerd_core::UpstreamTarget::from_url_str(url).unwrap()
+    }
+
+    #[test]
+    fn proxies_and_rules_round_trip() {
+        let mut c = Config::default();
+        let mut p = yerd_core::ProxySite::new("reverb", upstream("http://127.0.0.1:3000")).unwrap();
+        p.set_secure(true);
+        c.proxies.push(p);
+        c.proxy_rules.linked.insert(
+            "app".to_owned(),
+            vec![yerd_core::ProxyRule::new("/ws", upstream("https://127.0.0.1:3443")).unwrap()],
+        );
+        c.proxy_rules.parked.insert(
+            "/srv/blog".to_owned(),
+            vec![yerd_core::ProxyRule::new("/api", upstream("http://127.0.0.1:9000")).unwrap()],
+        );
+        let toml = c.to_toml().unwrap();
+        let back = Config::from_toml(&toml).unwrap();
+        assert_eq!(c, back);
+        assert_eq!(back.to_toml().unwrap(), toml);
+    }
+
+    #[test]
+    fn removing_last_proxy_rule_returns_to_byte_identical_default() {
+        let mut c = Config::default();
+        c.proxy_rules.linked.insert("app".to_owned(), Vec::new());
+        assert_eq!(c.to_toml().unwrap(), Config::default().to_toml().unwrap());
+    }
+
+    #[test]
+    fn default_config_emits_no_proxy_tables() {
+        let s = Config::default().to_toml().unwrap();
+        assert!(!s.contains("[[proxies]]"), "got: {s}");
+        assert!(!s.contains("[proxy_rules"), "got: {s}");
+    }
+
+    #[test]
+    fn validate_rejects_proxy_name_collision_with_linked() {
+        let mut c = Config::default();
+        c.linked.push(
+            yerd_core::Site::linked("reverb", "/srv/reverb", yerd_core::PhpVersion::new(8, 3))
+                .unwrap(),
+        );
+        c.proxies
+            .push(yerd_core::ProxySite::new("reverb", upstream("http://127.0.0.1:3000")).unwrap());
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::ProxyNameCollision,
+            }) => {}
+            other => panic!("expected ProxyNameCollision, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_rule_prefix() {
+        let mut c = Config::default();
+        c.proxy_rules.linked.insert(
+            "app".to_owned(),
+            vec![
+                yerd_core::ProxyRule::new("/ws", upstream("http://127.0.0.1:3000")).unwrap(),
+                yerd_core::ProxyRule::new("/ws/", upstream("http://127.0.0.1:3001")).unwrap(),
+            ],
+        );
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::ProxyRuleDuplicatePrefix,
+            }) => {}
+            other => panic!("expected ProxyRuleDuplicatePrefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_tld_target() {
+        let mut c = Config::default();
+        c.proxies
+            .push(yerd_core::ProxySite::new("loop", upstream("http://other.test")).unwrap());
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::ProxyTargetLoop,
+            }) => {}
+            other => panic!("expected ProxyTargetLoop, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -646,6 +646,11 @@ pub(crate) fn validate(c: &Config) -> Result<(), ConfigError> {
 /// routing loop into Yerd). Name/URL *shape* is already enforced by
 /// `ProxySite::new` / `UpstreamTarget::from_url_str` during wire conversion.
 ///
+/// Every `[proxy_rules.linked.<name>]` key must match a `[[linked]]` site by its
+/// normalized name (so a typo'd or mis-cased key that would silently never apply
+/// is rejected at load). Parked rules key by document-root and can't be checked
+/// here (parked sites are directory-derived), matching `[domains]`.
+///
 /// The `.tld`-host loop guard is enforced here so a hand-edited config can't slip
 /// that self-forwarding target past load. The loopback-on-own-*port* loop is the
 /// daemon's job (it needs the actively bound port, a runtime fact invisible
@@ -667,20 +672,31 @@ fn validate_proxies(c: &Config) -> Result<(), ConfigError> {
         }
     }
 
-    for rules in c
-        .proxy_rules
-        .linked
-        .values()
-        .chain(c.proxy_rules.parked.values())
-    {
-        let mut seen_prefix: BTreeSet<&str> = BTreeSet::new();
-        for r in rules {
-            if !seen_prefix.insert(r.prefix()) {
-                return Err(ve(ValidateErrorReason::ProxyRuleDuplicatePrefix));
-            }
-            if targets_loop(r.target()) {
-                return Err(ve(ValidateErrorReason::ProxyTargetLoop));
-            }
+    for (site, rules) in &c.proxy_rules.linked {
+        if !linked_names.contains(site.as_str()) {
+            return Err(ve(ValidateErrorReason::ProxyRuleUnknownSite));
+        }
+        validate_rule_set(rules, &targets_loop)?;
+    }
+    for rules in c.proxy_rules.parked.values() {
+        validate_rule_set(rules, &targets_loop)?;
+    }
+    Ok(())
+}
+
+/// Per-site rule-list invariants shared by linked and parked rules: prefixes are
+/// unique within the site, and no target loops back into Yerd.
+fn validate_rule_set(
+    rules: &[yerd_core::ProxyRule],
+    targets_loop: &impl Fn(&yerd_core::UpstreamTarget) -> bool,
+) -> Result<(), ConfigError> {
+    let mut seen_prefix: BTreeSet<&str> = BTreeSet::new();
+    for r in rules {
+        if !seen_prefix.insert(r.prefix()) {
+            return Err(ve(ValidateErrorReason::ProxyRuleDuplicatePrefix));
+        }
+        if targets_loop(r.target()) {
+            return Err(ve(ValidateErrorReason::ProxyTargetLoop));
         }
     }
     Ok(())
@@ -1589,9 +1605,14 @@ php = "not-a-version"
         yerd_core::UpstreamTarget::from_url_str(url).unwrap()
     }
 
+    fn linked_site(name: &str, root: &str) -> yerd_core::Site {
+        yerd_core::Site::linked(name, root, yerd_core::PhpVersion::new(8, 3)).unwrap()
+    }
+
     #[test]
     fn proxies_and_rules_round_trip() {
         let mut c = Config::default();
+        c.linked.push(linked_site("app", "/srv/app"));
         let mut p = yerd_core::ProxySite::new("reverb", upstream("http://127.0.0.1:3000")).unwrap();
         p.set_secure(true);
         c.proxies.push(p);
@@ -1643,6 +1664,7 @@ php = "not-a-version"
     #[test]
     fn validate_rejects_duplicate_rule_prefix() {
         let mut c = Config::default();
+        c.linked.push(linked_site("app", "/srv/app"));
         c.proxy_rules.linked.insert(
             "app".to_owned(),
             vec![
@@ -1655,6 +1677,37 @@ php = "not-a-version"
                 reason: ValidateErrorReason::ProxyRuleDuplicatePrefix,
             }) => {}
             other => panic!("expected ProxyRuleDuplicatePrefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_proxy_rule_dangling_linked_site() {
+        let mut c = Config::default();
+        c.proxy_rules.linked.insert(
+            "ghost".to_owned(),
+            vec![yerd_core::ProxyRule::new("/ws", upstream("http://127.0.0.1:3000")).unwrap()],
+        );
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::ProxyRuleUnknownSite,
+            }) => {}
+            other => panic!("expected ProxyRuleUnknownSite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_proxy_rule_miscased_linked_site() {
+        let mut c = Config::default();
+        c.linked.push(linked_site("myapp", "/srv/myapp"));
+        c.proxy_rules.linked.insert(
+            "MyApp".to_owned(),
+            vec![yerd_core::ProxyRule::new("/ws", upstream("http://127.0.0.1:3000")).unwrap()],
+        );
+        match c.validate() {
+            Err(ConfigError::Validate {
+                reason: ValidateErrorReason::ProxyRuleUnknownSite,
+            }) => {}
+            other => panic!("expected ProxyRuleUnknownSite, got {other:?}"),
         }
     }
 

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -125,11 +125,16 @@ pub struct ProxyRulesSection {
 }
 
 impl ProxyRulesSection {
-    /// True when there are no linked and no parked rules, letting the serialiser
-    /// omit the `[proxy_rules]` table so a default config stays byte-stable.
+    /// True when neither side holds any non-empty rule list - matching the
+    /// serialiser, which prunes empty-vector entries, so a section whose only
+    /// entries are empty rule lists round-trips as absent (the `[proxy_rules]`
+    /// table is omitted and a default config stays byte-stable).
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.linked.is_empty() && self.parked.is_empty()
+        self.linked
+            .values()
+            .chain(self.parked.values())
+            .all(Vec::is_empty)
     }
 }
 

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use yerd_core::{Domain, PhpVersion, Site, Tld};
+use yerd_core::{Domain, PhpVersion, ProxyRule, ProxySite, Site, Tld};
 
 /// Top-level on-disk config.
 ///
@@ -75,6 +75,12 @@ pub struct Config {
     /// Per-site routable-domain customisations (added/suppressed domains and a
     /// chosen primary), split by site class. Empty by default.
     pub domains: DomainsSection,
+    /// Whole-host reverse proxies (`reverb.test` → `http(s)://host:port`). Order
+    /// is preserved on round-trip. Empty by default.
+    pub proxies: Vec<ProxySite>,
+    /// Per-site path-prefix reverse-proxy rules (`app.test/app` → upstream),
+    /// split by site class. Empty by default.
+    pub proxy_rules: ProxyRulesSection,
 }
 
 impl Default for Config {
@@ -96,7 +102,34 @@ impl Default for Config {
             tunnel: TunnelSection::default(),
             groups: GroupsSection::default(),
             domains: DomainsSection::default(),
+            proxies: Vec::new(),
+            proxy_rules: ProxyRulesSection::default(),
         }
+    }
+}
+
+/// Per-site path-prefix reverse-proxy rules (see [`Config::proxy_rules`]).
+///
+/// Split by site class exactly like [`DomainsSection`]: **linked** rules key by
+/// site name; **parked** rules key by document-root string (byte-exact, never
+/// canonicalised - see [`SiteOverride`]). A site with no rules has no entry, so
+/// an uncustomised config omits the whole section. The daemon applies these onto
+/// [`yerd_core::SiteRouter`] at build time.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProxyRulesSection {
+    /// Linked-site rules, keyed by site name. `BTreeMap` for stable order.
+    pub linked: BTreeMap<String, Vec<ProxyRule>>,
+    /// Parked-site rules, keyed by document-root string. `BTreeMap` for stable
+    /// order.
+    pub parked: BTreeMap<String, Vec<ProxyRule>>,
+}
+
+impl ProxyRulesSection {
+    /// True when there are no linked and no parked rules, letting the serialiser
+    /// omit the `[proxy_rules]` table so a default config stays byte-stable.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.linked.is_empty() && self.parked.is_empty()
     }
 }
 

--- a/crates/yerd-config/src/serialize.rs
+++ b/crates/yerd-config/src/serialize.rs
@@ -67,6 +67,39 @@ struct WireSer<'a> {
     // `[domains]` region, keeping the byte-shape goldens intact.
     #[serde(skip_serializing_if = "Option::is_none")]
     domains: Option<DomainsSectionSer<'a>>,
+    // v14: optional `[[proxies]]` array - a trailing sub-table region. Skipped
+    // when empty so a default config emits no `[[proxies]]`, keeping the
+    // byte-shape goldens intact.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    proxies: Vec<ProxySer<'a>>,
+    // v14: optional `[proxy_rules]` table - a trailing sub-table region. `None`
+    // (skipped) when both maps are empty, so a default config emits no
+    // `[proxy_rules]` region.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proxy_rules: Option<ProxyRulesSectionSer<'a>>,
+}
+
+#[derive(Serialize)]
+struct ProxySer<'a> {
+    name: &'a str,
+    target: String,
+    // A default (off) `secure` still emits, since every `[[proxies]]` entry
+    // already emits a table; keeping the field present makes the flag visible.
+    secure: bool,
+}
+
+#[derive(Serialize)]
+struct ProxyRulesSectionSer<'a> {
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    linked: BTreeMap<&'a str, Vec<ProxyRuleSer<'a>>>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    parked: BTreeMap<&'a str, Vec<ProxyRuleSer<'a>>>,
+}
+
+#[derive(Serialize)]
+struct ProxyRuleSer<'a> {
+    prefix: &'a str,
+    target: String,
 }
 
 #[derive(Serialize)]
@@ -321,8 +354,49 @@ pub(crate) fn to_toml(c: &Config) -> Result<String, ConfigError> {
                 parked: domain_delta_map(&c.domains.parked),
             })
         },
+        proxies: c
+            .proxies
+            .iter()
+            .map(|p| ProxySer {
+                name: p.name(),
+                target: p.target().to_string(),
+                secure: p.secure(),
+            })
+            .collect(),
+        proxy_rules: {
+            let linked = proxy_rule_map(&c.proxy_rules.linked);
+            let parked = proxy_rule_map(&c.proxy_rules.parked);
+            if linked.is_empty() && parked.is_empty() {
+                None
+            } else {
+                Some(ProxyRulesSectionSer { linked, parked })
+            }
+        },
     };
     toml::to_string_pretty(&w).map_err(Into::into)
+}
+
+/// Build a borrowed `[proxy_rules.*]` map, pruning any site whose rule list is
+/// empty (an empty list is equivalent to no entry and must not emit `key = []`,
+/// so removing a site's last rule round-trips to a byte-identical config).
+fn proxy_rule_map(
+    src: &BTreeMap<String, Vec<yerd_core::ProxyRule>>,
+) -> BTreeMap<&str, Vec<ProxyRuleSer<'_>>> {
+    src.iter()
+        .filter(|(_, rules)| !rules.is_empty())
+        .map(|(k, rules)| {
+            (
+                k.as_str(),
+                rules
+                    .iter()
+                    .map(|r| ProxyRuleSer {
+                        prefix: r.prefix(),
+                        target: r.target().to_string(),
+                    })
+                    .collect(),
+            )
+        })
+        .collect()
 }
 
 /// Build a borrowed `[domains.*]` delta map, pruning any all-empty delta (an
@@ -359,8 +433,8 @@ mod tests {
     fn default_to_toml_starts_with_version_line() {
         let s = to_toml(&Config::default()).unwrap();
         assert!(
-            s.starts_with("version = 13\n"),
-            "expected `version = 13` first line; got: {s}"
+            s.starts_with("version = 14\n"),
+            "expected `version = 14` first line; got: {s}"
         );
     }
 

--- a/crates/yerd-config/tests/toml_byte_shape.rs
+++ b/crates/yerd-config/tests/toml_byte_shape.rs
@@ -59,8 +59,8 @@ fn populated() -> Config {
 fn default_config_starts_with_version_line() {
     let s = Config::default().to_toml().unwrap();
     assert!(
-        s.starts_with("version = 13\n"),
-        "expected first line `version = 13`; got: {s}"
+        s.starts_with("version = 14\n"),
+        "expected first line `version = 14`; got: {s}"
     );
 }
 

--- a/crates/yerd-core/src/error.rs
+++ b/crates/yerd-core/src/error.rs
@@ -74,6 +74,90 @@ pub enum CoreError {
         /// The colliding domain sub-part (e.g. `"api.foo"` or `"*.foo"`).
         domain: String,
     },
+
+    /// A string failed to parse as an
+    /// [`UpstreamTarget`](crate::UpstreamTarget).
+    #[error("invalid proxy target {input:?}: {reason}")]
+    InvalidUpstreamTarget {
+        /// The raw input that failed to parse.
+        input: String,
+        /// Why it failed.
+        reason: UpstreamTargetErrorReason,
+    },
+
+    /// A string failed to validate as a [`ProxyRule`](crate::ProxyRule) prefix.
+    #[error("invalid proxy rule prefix {input:?}: {reason}")]
+    InvalidProxyRule {
+        /// The raw prefix that failed validation.
+        input: String,
+        /// Why it failed.
+        reason: ProxyRuleErrorReason,
+    },
+}
+
+/// Specific failure modes for [`UpstreamTarget`](crate::UpstreamTarget) parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UpstreamTargetErrorReason {
+    /// Input was empty.
+    Empty,
+    /// Input had no `scheme://` separator.
+    MissingScheme,
+    /// Scheme was neither `http` nor `https`.
+    UnsupportedScheme,
+    /// Input carried `user:pass@` credentials.
+    HasCredentials,
+    /// Input carried a path, query, or fragment.
+    HasPathOrQuery,
+    /// The host was empty.
+    MissingHost,
+    /// The host was not an IP address or a plain DNS hostname (or an
+    /// unbracketed IPv6 literal).
+    InvalidHost,
+    /// The port was absent-but-colon, non-numeric, zero, or out of `u16` range.
+    InvalidPort,
+}
+
+impl fmt::Display for UpstreamTargetErrorReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            Self::Empty => "target must not be empty",
+            Self::MissingScheme => "target must start with http:// or https://",
+            Self::UnsupportedScheme => "target scheme must be http or https",
+            Self::HasCredentials => "target must not contain credentials",
+            Self::HasPathOrQuery => "target must not contain a path, query, or fragment",
+            Self::MissingHost => "target host must not be empty",
+            Self::InvalidHost => "target host is not a valid IP or hostname",
+            Self::InvalidPort => "target port must be a number in 1..=65535",
+        };
+        f.write_str(msg)
+    }
+}
+
+/// Specific failure modes for [`ProxyRule`](crate::ProxyRule) prefix validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProxyRuleErrorReason {
+    /// Prefix was empty.
+    Empty,
+    /// Prefix did not begin with `/`.
+    NotAbsolute,
+    /// Prefix contained a `..` path component.
+    ContainsDotDot,
+    /// Prefix contained an ASCII/Unicode control character.
+    ContainsControl,
+}
+
+impl fmt::Display for ProxyRuleErrorReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            Self::Empty => "prefix must not be empty",
+            Self::NotAbsolute => "prefix must begin with '/'",
+            Self::ContainsDotDot => "prefix must not contain a '..' component",
+            Self::ContainsControl => "prefix must not contain control characters",
+        };
+        f.write_str(msg)
+    }
 }
 
 /// Specific failure modes for [`PhpVersion`](crate::PhpVersion) parsing.

--- a/crates/yerd-core/src/lib.rs
+++ b/crates/yerd-core/src/lib.rs
@@ -14,6 +14,7 @@ mod host;
 mod php;
 pub mod php_extensions;
 pub mod php_settings;
+mod proxy;
 mod router;
 mod site;
 mod tld;
@@ -41,11 +42,13 @@ pub const CA_COMMON_NAME: &str = "Yerd Local CA";
 pub use detect::{detect, Detection, ProjectSignals};
 pub use domain::{choose_primary, effective_domains, Domain};
 pub use error::{
-    CoreError, DomainErrorReason, PhpVersionErrorReason, SiteNameErrorReason, TldErrorReason,
+    CoreError, DomainErrorReason, PhpVersionErrorReason, ProxyRuleErrorReason, SiteNameErrorReason,
+    TldErrorReason, UpstreamTargetErrorReason,
 };
 pub use php::PhpVersion;
 pub use php_extensions::{ExtError, NameErrorReason, PathErrorReason};
 pub use php_settings::{PhpSettingError, ValueErrorReason};
-pub use router::{RouterConfig, SiteRouter};
+pub use proxy::{match_rule, ProxyRule, ProxySite, UpstreamTarget};
+pub use router::{Route, RouterConfig, SiteRouter};
 pub use site::{slugify_site_name, Site, SiteKind};
 pub use tld::Tld;

--- a/crates/yerd-core/src/proxy.rs
+++ b/crates/yerd-core/src/proxy.rs
@@ -1,0 +1,464 @@
+//! Pure reverse-proxy domain types.
+//!
+//! [`UpstreamTarget`] is a validated `http[s]://host:port` forwarding target;
+//! [`ProxyRule`] is a path-prefix rule attached to a PHP site (`/app` →
+//! upstream); [`ProxySite`] is a whole-host proxy (`reverb.test` → upstream).
+//!
+//! These types are pure data: they carry no serde impls (the `yerd-config`
+//! crate owns the string↔typed conversion on the wire) and do no I/O. The
+//! forwarder in `yerd-proxy` consumes [`UpstreamTarget::is_local`] to pick a
+//! client-TLS policy and [`UpstreamTarget::server_name`] to seed the upstream
+//! TLS SNI.
+
+use std::net::IpAddr;
+
+use crate::error::{CoreError, ProxyRuleErrorReason, UpstreamTargetErrorReason};
+use crate::site::validate_and_lowercase_name;
+
+/// A validated reverse-proxy upstream: scheme (`http`/`https`), host, port.
+///
+/// Parsed from a URL string via [`Self::from_url_str`]. A path, query,
+/// fragment, or credentials in the URL are rejected: the forwarder passes the
+/// original request path verbatim, so a target path would be ambiguous.
+///
+/// IPv6 hosts are stored **without** brackets (so [`Self::server_name`] feeds
+/// `rustls`'s `ServerName::try_from`, which accepts `::1` but not `[::1]`);
+/// [`std::fmt::Display`] re-adds them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamTarget {
+    secure: bool,
+    host: String,
+    port: u16,
+}
+
+impl UpstreamTarget {
+    /// Parses `http[s]://host[:port]`. Port defaults to 80 (http) / 443 (https).
+    pub fn from_url_str(input: &str) -> Result<Self, CoreError> {
+        let raw = input.trim();
+        let reason = |r: UpstreamTargetErrorReason| CoreError::InvalidUpstreamTarget {
+            input: input.to_owned(),
+            reason: r,
+        };
+        if raw.is_empty() {
+            return Err(reason(UpstreamTargetErrorReason::Empty));
+        }
+        let (scheme, rest) = raw
+            .split_once("://")
+            .ok_or_else(|| reason(UpstreamTargetErrorReason::MissingScheme))?;
+        let secure = match scheme.to_ascii_lowercase().as_str() {
+            "http" => false,
+            "https" => true,
+            _ => return Err(reason(UpstreamTargetErrorReason::UnsupportedScheme)),
+        };
+        if rest.contains('@') {
+            return Err(reason(UpstreamTargetErrorReason::HasCredentials));
+        }
+        if rest.contains('/') || rest.contains('?') || rest.contains('#') {
+            return Err(reason(UpstreamTargetErrorReason::HasPathOrQuery));
+        }
+        let default_port = if secure { 443 } else { 80 };
+        let (host, port) = split_host_port(rest, default_port)
+            .ok_or_else(|| reason(UpstreamTargetErrorReason::InvalidPort))?;
+        if host.is_empty() {
+            return Err(reason(UpstreamTargetErrorReason::MissingHost));
+        }
+        if !is_valid_host(host) {
+            return Err(reason(UpstreamTargetErrorReason::InvalidHost));
+        }
+        if port == 0 {
+            return Err(reason(UpstreamTargetErrorReason::InvalidPort));
+        }
+        Ok(Self {
+            secure,
+            host: host.to_ascii_lowercase(),
+            port,
+        })
+    }
+
+    /// Whether the upstream is reached over TLS (`https://`).
+    #[must_use]
+    pub fn secure(&self) -> bool {
+        self.secure
+    }
+
+    /// The upstream host, unbracketed even for IPv6.
+    #[must_use]
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// The upstream port.
+    #[must_use]
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// The value to seed the upstream TLS SNI / `ServerName` with: the host,
+    /// unbracketed. **Never** the client `Host` header.
+    #[must_use]
+    pub fn server_name(&self) -> &str {
+        &self.host
+    }
+
+    /// Whether the host is loopback, a private/link-local IP, `localhost`, or a
+    /// name under the given `tld`. The forwarder skips certificate verification
+    /// for such upstreams (self-signed local dev backends are the norm) and
+    /// verifies public hosts normally.
+    #[must_use]
+    pub fn is_local(&self, tld: &str) -> bool {
+        if self.host == "localhost" {
+            return true;
+        }
+        if self.host == tld || self.host.ends_with(&format!(".{tld}")) {
+            return true;
+        }
+        match self.host.parse::<IpAddr>() {
+            Ok(IpAddr::V4(v4)) => v4.is_loopback() || v4.is_private() || v4.is_link_local(),
+            Ok(IpAddr::V6(v6)) => {
+                if v6.is_loopback() {
+                    return true;
+                }
+                let seg0 = v6.segments().first().copied().unwrap_or(0);
+                let unique_local = (seg0 & 0xfe00) == 0xfc00;
+                let link_local = (seg0 & 0xffc0) == 0xfe80;
+                unique_local || link_local
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+impl std::fmt::Display for UpstreamTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let scheme = if self.secure { "https" } else { "http" };
+        if self.host.contains(':') {
+            write!(f, "{scheme}://[{}]:{}", self.host, self.port)
+        } else {
+            write!(f, "{scheme}://{}:{}", self.host, self.port)
+        }
+    }
+}
+
+/// Splits `host[:port]` (bracketed IPv6 allowed) into an unbracketed host and a
+/// port, defaulting the port. Returns `None` when the port is malformed, or for
+/// an unbracketed multi-colon host (an IPv6 literal that must be bracketed).
+fn split_host_port(rest: &str, default_port: u16) -> Option<(&str, u16)> {
+    if let Some(inner) = rest.strip_prefix('[') {
+        let (host, after) = inner.split_once(']')?;
+        let port = if after.is_empty() {
+            default_port
+        } else {
+            after.strip_prefix(':')?.parse().ok()?
+        };
+        return Some((host, port));
+    }
+    match rest.matches(':').count() {
+        0 => Some((rest, default_port)),
+        1 => {
+            let (host, p) = rest.rsplit_once(':')?;
+            Some((host, p.parse().ok()?))
+        }
+        _ => None,
+    }
+}
+
+/// A host is valid if it parses as an IP address, or is a plain hostname (ASCII
+/// `[a-z0-9._-]`, non-empty, no leading/trailing dot). `_` is allowed for
+/// container/service names (e.g. `my_service` from a docker-compose network),
+/// which aren't strict DNS but resolve fine on a local dev network.
+fn is_valid_host(host: &str) -> bool {
+    if host.parse::<IpAddr>().is_ok() {
+        return true;
+    }
+    if host.is_empty() || host.starts_with('.') || host.ends_with('.') {
+        return false;
+    }
+    host.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'.' || b == b'_')
+}
+
+/// A path-prefix reverse-proxy rule attached to an existing PHP site: requests
+/// whose path is under [`Self::prefix`] are forwarded to [`Self::target`]; every
+/// other path is served by PHP as usual.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyRule {
+    prefix: String,
+    target: UpstreamTarget,
+}
+
+impl ProxyRule {
+    /// Validates `prefix` (absolute; no `..` component; no control chars, space,
+    /// `?`, or `#` - none of which can appear in `uri.path()`, so such a prefix
+    /// would be a silently dead rule) and normalizes a trailing slash away
+    /// (`/app/` → `/app`; root stays `/`).
+    pub fn new(prefix: &str, target: UpstreamTarget) -> Result<Self, CoreError> {
+        let reason = |r: ProxyRuleErrorReason| CoreError::InvalidProxyRule {
+            input: prefix.to_owned(),
+            reason: r,
+        };
+        if prefix.is_empty() {
+            return Err(reason(ProxyRuleErrorReason::Empty));
+        }
+        if !prefix.starts_with('/') {
+            return Err(reason(ProxyRuleErrorReason::NotAbsolute));
+        }
+        if prefix
+            .chars()
+            .any(|c| c.is_control() || c == ' ' || c == '?' || c == '#')
+        {
+            return Err(reason(ProxyRuleErrorReason::ContainsControl));
+        }
+        if prefix.split('/').any(|seg| seg == "..") {
+            return Err(reason(ProxyRuleErrorReason::ContainsDotDot));
+        }
+        let mut normalized = prefix.to_owned();
+        while normalized.len() > 1 && normalized.ends_with('/') {
+            normalized.pop();
+        }
+        Ok(Self {
+            prefix: normalized,
+            target,
+        })
+    }
+
+    /// The normalized path prefix (e.g. `/app`; root is `/`).
+    #[must_use]
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// The upstream this rule forwards to.
+    #[must_use]
+    pub fn target(&self) -> &UpstreamTarget {
+        &self.target
+    }
+
+    /// Whether this rule matches `path`. Boundary-correct: `/app` matches `/app`
+    /// and `/app/x` but not `/apple`. Root (`/`) is a catch-all.
+    #[must_use]
+    pub fn matches_path(&self, path: &str) -> bool {
+        if self.prefix == "/" {
+            return path.starts_with('/');
+        }
+        path == self.prefix || path.starts_with(&format!("{}/", self.prefix))
+    }
+}
+
+/// Longest-prefix match of `path` against `rules`. Returns the rule with the
+/// longest matching prefix, or `None` if none match. Callers pass the raw,
+/// case-sensitive, percent-encoded `uri.path()` (no normalization) — an
+/// under-match (an encoded path not matching) is acceptable for a dev tool; the
+/// matcher never over-matches.
+#[must_use]
+pub fn match_rule<'a>(rules: &'a [ProxyRule], path: &str) -> Option<&'a ProxyRule> {
+    rules
+        .iter()
+        .filter(|r| r.matches_path(path))
+        .max_by_key(|r| r.prefix.len())
+}
+
+/// A whole-host reverse proxy: a `{name}.{tld}` host forwarded wholesale to
+/// [`Self::target`], with no PHP/document-root. The router routes it alongside
+/// PHP sites; the daemon forwards it without ever entering PHP-FPM resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxySite {
+    name: String,
+    target: UpstreamTarget,
+    secure: bool,
+}
+
+impl ProxySite {
+    /// Constructs a proxy site. Validates and lowercases `name` as a DNS label.
+    /// Initialises `secure = false` (promote via [`Self::set_secure`]).
+    pub fn new(name: &str, target: UpstreamTarget) -> Result<Self, CoreError> {
+        let name = validate_and_lowercase_name(name)?;
+        Ok(Self {
+            name,
+            target,
+            secure: false,
+        })
+    }
+
+    /// The validated, lowercased DNS-label name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The upstream this proxy forwards to.
+    #[must_use]
+    pub fn target(&self) -> &UpstreamTarget {
+        &self.target
+    }
+
+    /// Whether the proxy is served over HTTPS.
+    #[must_use]
+    pub fn secure(&self) -> bool {
+        self.secure
+    }
+
+    /// Toggles the HTTPS flag.
+    pub fn set_secure(&mut self, secure: bool) {
+        self.secure = secure;
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    fn target(url: &str) -> UpstreamTarget {
+        UpstreamTarget::from_url_str(url).unwrap()
+    }
+
+    #[test]
+    fn parses_http_default_port() {
+        let t = target("http://localhost");
+        assert!(!t.secure());
+        assert_eq!(t.host(), "localhost");
+        assert_eq!(t.port(), 80);
+    }
+
+    #[test]
+    fn parses_https_default_port() {
+        let t = target("https://api.example.com");
+        assert!(t.secure());
+        assert_eq!(t.port(), 443);
+    }
+
+    #[test]
+    fn parses_explicit_port() {
+        let t = target("http://127.0.0.1:8080");
+        assert_eq!(t.host(), "127.0.0.1");
+        assert_eq!(t.port(), 8080);
+    }
+
+    #[test]
+    fn parses_bracketed_ipv6() {
+        let t = target("http://[::1]:8080");
+        assert_eq!(t.host(), "::1");
+        assert_eq!(t.port(), 8080);
+        assert_eq!(t.server_name(), "::1");
+        assert_eq!(t.to_string(), "http://[::1]:8080");
+    }
+
+    #[test]
+    fn parses_bracketed_ipv6_default_port() {
+        let t = target("https://[fe80::1]");
+        assert_eq!(t.host(), "fe80::1");
+        assert_eq!(t.port(), 443);
+    }
+
+    #[test]
+    fn display_round_trips_through_parse() {
+        for url in [
+            "http://localhost:80",
+            "https://example.com:443",
+            "http://[::1]:9000",
+        ] {
+            let t = target(url);
+            let reparsed = UpstreamTarget::from_url_str(&t.to_string()).unwrap();
+            assert_eq!(t, reparsed);
+        }
+    }
+
+    #[test]
+    fn rejects_bad_targets() {
+        for bad in [
+            "",
+            "localhost:8080",
+            "ftp://localhost",
+            "http://user:pass@host",
+            "http://host/path",
+            "http://host?q=1",
+            "http://host:0",
+            "http://host:99999",
+            "http://host:",
+            "http://::1:8080",
+            "http://",
+        ] {
+            assert!(
+                UpstreamTarget::from_url_str(bad).is_err(),
+                "expected error for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_local_classifies_hosts() {
+        assert!(target("http://localhost").is_local("test"));
+        assert!(target("http://127.0.0.1").is_local("test"));
+        assert!(target("http://10.1.2.3").is_local("test"));
+        assert!(target("http://192.168.1.1").is_local("test"));
+        assert!(target("http://169.254.1.1").is_local("test"));
+        assert!(target("http://[::1]").is_local("test"));
+        assert!(target("http://[fc00::1]").is_local("test"));
+        assert!(target("http://[fe80::1]").is_local("test"));
+        assert!(target("http://myapp.test").is_local("test"));
+        assert!(!target("http://api.example.com").is_local("test"));
+        assert!(!target("http://8.8.8.8").is_local("test"));
+        assert!(!target("http://[2606:4700::1]").is_local("test"));
+    }
+
+    #[test]
+    fn rule_normalizes_and_matches() {
+        let r = ProxyRule::new("/app/", target("http://127.0.0.1:8080")).unwrap();
+        assert_eq!(r.prefix(), "/app");
+        assert!(r.matches_path("/app"));
+        assert!(r.matches_path("/app/foo"));
+        assert!(!r.matches_path("/apple"));
+        assert!(!r.matches_path("/"));
+    }
+
+    #[test]
+    fn root_rule_is_catch_all() {
+        let r = ProxyRule::new("/", target("http://127.0.0.1:8080")).unwrap();
+        assert_eq!(r.prefix(), "/");
+        assert!(r.matches_path("/"));
+        assert!(r.matches_path("/anything"));
+    }
+
+    #[test]
+    fn rejects_bad_prefixes() {
+        for bad in ["", "app", "/a/../b", "/x\ty"] {
+            assert!(
+                ProxyRule::new(bad, target("http://127.0.0.1:8080")).is_err(),
+                "expected error for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn match_rule_picks_longest_prefix() {
+        let rules = vec![
+            ProxyRule::new("/app", target("http://127.0.0.1:8080")).unwrap(),
+            ProxyRule::new("/app/admin", target("http://127.0.0.1:9090")).unwrap(),
+        ];
+        let hit = match_rule(&rules, "/app/admin/x").unwrap();
+        assert_eq!(hit.prefix(), "/app/admin");
+        let hit = match_rule(&rules, "/app/other").unwrap();
+        assert_eq!(hit.prefix(), "/app");
+        assert!(match_rule(&rules, "/nope").is_none());
+    }
+
+    #[test]
+    fn proxysite_validates_name() {
+        let p = ProxySite::new("Reverb", target("http://localhost:8080")).unwrap();
+        assert_eq!(p.name(), "reverb");
+        assert!(!p.secure());
+        assert!(ProxySite::new("bad.name", target("http://localhost:8080")).is_err());
+    }
+
+    #[test]
+    fn proxysite_secure_toggles() {
+        let mut p = ProxySite::new("reverb", target("http://localhost:8080")).unwrap();
+        p.set_secure(true);
+        assert!(p.secure());
+    }
+}

--- a/crates/yerd-core/src/proxy.rs
+++ b/crates/yerd-core/src/proxy.rs
@@ -109,7 +109,12 @@ impl UpstreamTarget {
         if self.host == "localhost" {
             return true;
         }
-        if self.host == tld || self.host.ends_with(&format!(".{tld}")) {
+        if self.host == tld
+            || self
+                .host
+                .strip_suffix(tld)
+                .is_some_and(|prefix| prefix.ends_with('.'))
+        {
             return true;
         }
         match self.host.parse::<IpAddr>() {
@@ -240,7 +245,10 @@ impl ProxyRule {
         if self.prefix == "/" {
             return path.starts_with('/');
         }
-        path == self.prefix || path.starts_with(&format!("{}/", self.prefix))
+        path == self.prefix
+            || path
+                .strip_prefix(self.prefix.as_str())
+                .is_some_and(|rest| rest.starts_with('/'))
     }
 }
 

--- a/crates/yerd-core/src/proxy.rs
+++ b/crates/yerd-core/src/proxy.rs
@@ -254,7 +254,7 @@ impl ProxyRule {
 
 /// Longest-prefix match of `path` against `rules`. Returns the rule with the
 /// longest matching prefix, or `None` if none match. Callers pass the raw,
-/// case-sensitive, percent-encoded `uri.path()` (no normalization) — an
+/// case-sensitive, percent-encoded `uri.path()` (no normalization): an
 /// under-match (an encoded path not matching) is acceptable for a dev tool; the
 /// matcher never over-matches.
 #[must_use]

--- a/crates/yerd-core/src/router.rs
+++ b/crates/yerd-core/src/router.rs
@@ -186,7 +186,7 @@ impl SiteRouter {
         effective: Vec<Domain>,
         primary: Domain,
     ) -> Result<(), CoreError> {
-        if self.sites.contains_key(site.name()) {
+        if self.sites.contains_key(site.name()) || self.proxy_sites.contains_key(site.name()) {
             return Err(CoreError::DuplicateSite {
                 name: site.name().to_owned(),
             });
@@ -240,6 +240,7 @@ impl SiteRouter {
             }
         }
         self.primaries.remove(name);
+        self.proxy_rules.remove(name);
         Ok(site)
     }
 

--- a/crates/yerd-core/src/router.rs
+++ b/crates/yerd-core/src/router.rs
@@ -20,6 +20,7 @@ use std::collections::{BTreeMap, HashMap};
 use crate::domain::Domain;
 use crate::error::CoreError;
 use crate::host::{self, HostKind};
+use crate::proxy::{ProxyRule, ProxySite};
 use crate::site::Site;
 use crate::tld::Tld;
 
@@ -99,6 +100,20 @@ impl<'de> serde::Deserialize<'de> for RouterConfig {
     }
 }
 
+/// What a host resolves to: a PHP [`Site`] or a whole-host [`ProxySite`].
+///
+/// Returned by [`SiteRouter::resolve_route`]. The dispatcher forwards a
+/// `Proxy` host straight to its upstream (never touching PHP-FPM), and serves a
+/// `Php` host as today (subject to any per-site path rule; see
+/// [`SiteRouter::rules_for`]).
+#[derive(Debug)]
+pub enum Route<'a> {
+    /// A PHP-served site.
+    Php(&'a Site),
+    /// A whole-host reverse proxy.
+    Proxy(&'a ProxySite),
+}
+
 /// Host→site router.
 ///
 /// `Default` is deliberately not derived - callers should pass a
@@ -111,6 +126,13 @@ pub struct SiteRouter {
     primaries: BTreeMap<String, Domain>,
     exact: HashMap<String, String>,
     wildcards: HashMap<String, String>,
+    /// Whole-host proxies, keyed by name (like [`Self::sites`]). Their apexes
+    /// are indexed into [`Self::exact`] so [`Self::resolve_route`] finds them and
+    /// insertion detects collisions with PHP sites.
+    proxy_sites: BTreeMap<String, ProxySite>,
+    /// Per-site path-prefix proxy rules, keyed by PHP-site name (like
+    /// [`Self::domains`]). Populated by the daemon at build time from config.
+    proxy_rules: BTreeMap<String, Vec<ProxyRule>>,
 }
 
 impl SiteRouter {
@@ -124,6 +146,8 @@ impl SiteRouter {
             primaries: BTreeMap::new(),
             exact: HashMap::new(),
             wildcards: HashMap::new(),
+            proxy_sites: BTreeMap::new(),
+            proxy_rules: BTreeMap::new(),
         }
     }
 
@@ -302,13 +326,27 @@ impl SiteRouter {
         &self.config
     }
 
-    /// Resolves a `Host:` header value to a site.
+    /// Resolves a `Host:` header value to a PHP site.
+    ///
+    /// A thin Php-only wrapper over [`Self::resolve_route`]: a host that routes
+    /// to a whole-host proxy returns `None` here. Existing callers that only
+    /// serve PHP (`WordPress` shadow lookups, tunnel origin) keep this shape.
+    #[must_use]
+    pub fn resolve(&self, host: &str) -> Option<&Site> {
+        match self.resolve_route(host)? {
+            Route::Php(site) => Some(site),
+            Route::Proxy(_) => None,
+        }
+    }
+
+    /// Resolves a `Host:` header value to a [`Route`] (PHP site or whole-host
+    /// proxy).
     ///
     /// Exact domain match first; then a single-label wildcard match (the host
     /// with its leftmost label replaced by `*`). No implicit catch-all: a host
     /// with no matching exact or wildcard domain is unresolved.
     #[must_use]
-    pub fn resolve(&self, host: &str) -> Option<&Site> {
+    pub fn resolve_route(&self, host: &str) -> Option<Route<'_>> {
         let host = match host::normalise(host) {
             HostKind::Hostname(c) => c,
             HostKind::Unroutable => return None,
@@ -326,7 +364,7 @@ impl SiteRouter {
         }
 
         if let Some(name) = self.exact.get(sub) {
-            return self.sites.get(name);
+            return self.route_for(name);
         }
 
         if let Some((_, rest)) = sub.split_once('.') {
@@ -334,10 +372,83 @@ impl SiteRouter {
             key.push_str("*.");
             key.push_str(rest);
             if let Some(name) = self.wildcards.get(&key) {
-                return self.sites.get(name);
+                return self.route_for(name);
             }
         }
         None
+    }
+
+    /// Maps an already-resolved routing key to its `Route`. A key indexes at
+    /// most one of `sites`/`proxy_sites` (insertion rejects cross-namespace
+    /// collisions), so PHP is tried first, then proxy.
+    fn route_for(&self, name: &str) -> Option<Route<'_>> {
+        if let Some(site) = self.sites.get(name) {
+            return Some(Route::Php(site));
+        }
+        self.proxy_sites.get(name).map(Route::Proxy)
+    }
+
+    /// Inserts a whole-host proxy, indexing its apex into the exact map.
+    ///
+    /// Errors with [`CoreError::DuplicateSite`] if the name is already taken by a
+    /// site or another proxy, or [`CoreError::DuplicateDomain`] if the apex is
+    /// already claimed. No partial state is left on error. The daemon
+    /// pre-de-conflicts at build time, so these are safety nets.
+    pub fn insert_proxy(&mut self, proxy: ProxySite) -> Result<(), CoreError> {
+        let name = proxy.name().to_owned();
+        if self.sites.contains_key(&name) || self.proxy_sites.contains_key(&name) {
+            return Err(CoreError::DuplicateSite { name });
+        }
+        let apex = Domain::apex(&name);
+        if self.exact.contains_key(apex.as_str()) {
+            return Err(CoreError::DuplicateDomain {
+                domain: apex.as_str().to_owned(),
+            });
+        }
+        self.exact.insert(apex.as_str().to_owned(), name.clone());
+        self.proxy_sites.insert(name, proxy);
+        Ok(())
+    }
+
+    /// Removes a whole-host proxy by name, together with its apex index entry.
+    /// Errors with [`CoreError::SiteNotFound`] if missing.
+    pub fn remove_proxy(&mut self, name: &str) -> Result<ProxySite, CoreError> {
+        let proxy = self
+            .proxy_sites
+            .remove(name)
+            .ok_or_else(|| CoreError::SiteNotFound {
+                name: name.to_owned(),
+            })?;
+        let apex = Domain::apex(name);
+        if self
+            .exact
+            .get(apex.as_str())
+            .is_some_and(|owner| owner == name)
+        {
+            self.exact.remove(apex.as_str());
+        }
+        Ok(proxy)
+    }
+
+    /// Iterates whole-host proxies in lexicographic name order.
+    pub fn proxy_iter(&self) -> impl Iterator<Item = &ProxySite> + '_ {
+        self.proxy_sites.values()
+    }
+
+    /// The path-prefix proxy rules attached to `site` (empty slice if none).
+    #[must_use]
+    pub fn rules_for(&self, site: &str) -> &[ProxyRule] {
+        self.proxy_rules.get(site).map_or(&[], Vec::as_slice)
+    }
+
+    /// Sets (or clears, when `rules` is empty) the path-prefix proxy rules for a
+    /// PHP site. Called by the daemon while building the router from config.
+    pub fn set_proxy_rules(&mut self, site: &str, rules: Vec<ProxyRule>) {
+        if rules.is_empty() {
+            self.proxy_rules.remove(site);
+        } else {
+            self.proxy_rules.insert(site.to_owned(), rules);
+        }
     }
 }
 
@@ -384,6 +495,65 @@ mod tests {
             r.insert(parked(n)).unwrap();
         }
         r
+    }
+
+    fn proxy(name: &str) -> crate::proxy::ProxySite {
+        let target = crate::proxy::UpstreamTarget::from_url_str("http://127.0.0.1:8080").unwrap();
+        crate::proxy::ProxySite::new(name, target).unwrap()
+    }
+
+    #[test]
+    fn resolve_route_distinguishes_php_and_proxy() {
+        let mut r = router_with("test", &["app"]);
+        r.insert_proxy(proxy("reverb")).unwrap();
+        assert!(matches!(r.resolve_route("app.test"), Some(Route::Php(s)) if s.name() == "app"));
+        assert!(
+            matches!(r.resolve_route("reverb.test"), Some(Route::Proxy(p)) if p.name() == "reverb")
+        );
+        assert!(r.resolve("reverb.test").is_none());
+        assert!(r.resolve_route("nope.test").is_none());
+    }
+
+    #[test]
+    fn insert_proxy_rejects_name_and_apex_collisions() {
+        let mut r = router_with("test", &["app"]);
+        assert!(matches!(
+            r.insert_proxy(proxy("app")),
+            Err(CoreError::DuplicateSite { .. })
+        ));
+        r.insert_proxy(proxy("reverb")).unwrap();
+        assert!(matches!(
+            r.insert_proxy(proxy("reverb")),
+            Err(CoreError::DuplicateSite { .. })
+        ));
+    }
+
+    #[test]
+    fn remove_proxy_clears_apex_index() {
+        let mut r = router_with("test", &[]);
+        r.insert_proxy(proxy("reverb")).unwrap();
+        assert!(r.resolve_route("reverb.test").is_some());
+        let removed = r.remove_proxy("reverb").unwrap();
+        assert_eq!(removed.name(), "reverb");
+        assert!(r.resolve_route("reverb.test").is_none());
+        r.insert_proxy(proxy("reverb")).unwrap();
+        assert!(matches!(
+            r.remove_proxy("missing"),
+            Err(CoreError::SiteNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn proxy_rules_set_get_and_clear() {
+        let mut r = router_with("test", &["app"]);
+        assert!(r.rules_for("app").is_empty());
+        let target = crate::proxy::UpstreamTarget::from_url_str("http://127.0.0.1:8080").unwrap();
+        let rule = crate::proxy::ProxyRule::new("/ws", target).unwrap();
+        r.set_proxy_rules("app", vec![rule]);
+        assert_eq!(r.rules_for("app").len(), 1);
+        assert_eq!(r.rules_for("app")[0].prefix(), "/ws");
+        r.set_proxy_rules("app", vec![]);
+        assert!(r.rules_for("app").is_empty());
     }
 
     /// Default (apex-only) resolution: exact apex resolves, subdomains do not.

--- a/crates/yerd-core/src/site.rs
+++ b/crates/yerd-core/src/site.rs
@@ -243,7 +243,7 @@ impl Site {
 }
 
 /// Validates and lowercases a site name. Checks run in a fixed, pinned order.
-fn validate_and_lowercase_name(raw: &str) -> Result<String, CoreError> {
+pub(crate) fn validate_and_lowercase_name(raw: &str) -> Result<String, CoreError> {
     if raw.is_empty() {
         return Err(err(raw, SiteNameErrorReason::Empty));
     }

--- a/crates/yerd-ipc/src/lib.rs
+++ b/crates/yerd-ipc/src/lib.rs
@@ -46,7 +46,10 @@ pub use error::{FrameError, IpcError, IpcErrorKind};
 pub use frame::{encode_frame, FrameDecoder, DEFAULT_MAX_FRAME};
 pub use message::{decode_message, encode_message};
 pub use request::Request;
-pub use response::{ErrorCode, PhpExtInfo, PhpUpdate, Response, SiteEntry, WordPressAdminUser};
+pub use response::{
+    ErrorCode, PhpExtInfo, PhpUpdate, ProxyEntry, ProxyRuleEntry, Response, SiteEntry,
+    WordPressAdminUser,
+};
 pub use status::{
     CaStatus, CloudflaredSource, CloudflaredStatus, DatabaseSummary, Diagnosis, DiagnosisCode,
     DomainShadow, FixReport, FixResult, MailDetail, MailHeader, MailStatus, MailSummary,

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -115,6 +115,37 @@ pub enum Request {
         /// The site name.
         name: String,
     },
+    /// Register a whole-host reverse proxy (`name.test` → `url`).
+    AddProxy {
+        /// The proxy name (a single DNS label).
+        name: String,
+        /// The upstream URL, e.g. `http://localhost:8080` (validated by the daemon).
+        url: String,
+    },
+    /// Remove a whole-host reverse proxy by name.
+    RemoveProxy {
+        /// The proxy name to remove.
+        name: String,
+    },
+    /// Add a path-prefix reverse-proxy rule to an existing site
+    /// (`site.test/prefix` → `url`), leaving all other paths served by PHP.
+    AddProxyRule {
+        /// The site the rule attaches to.
+        site: String,
+        /// The path prefix, e.g. `/app` (must begin with `/`).
+        prefix: String,
+        /// The upstream URL (validated by the daemon).
+        url: String,
+    },
+    /// Remove a path-prefix reverse-proxy rule from a site.
+    RemoveProxyRule {
+        /// The site the rule is on.
+        site: String,
+        /// The path prefix to remove.
+        prefix: String,
+    },
+    /// Enumerate whole-host proxies and per-site path-prefix rules.
+    ListProxies,
     /// Fetch read-only daemon runtime facts (DNS address, TLD, CA path +
     /// fingerprint). Used by `yerd elevate` to drive the privileged helper.
     DaemonInfo,
@@ -752,6 +783,11 @@ mod variant_name_pinning {
             Request::RenameGroup { .. } => {}
             Request::SetSymlinkProtection { .. } => {}
             Request::SetFrontController { .. } => {}
+            Request::AddProxy { .. } => {}
+            Request::RemoveProxy { .. } => {}
+            Request::AddProxyRule { .. } => {}
+            Request::RemoveProxyRule { .. } => {}
+            Request::ListProxies => {}
         }
     }
 
@@ -1007,6 +1043,23 @@ mod variant_name_pinning {
             name: "blog".to_owned(),
             enabled: true,
         });
+        pin(Request::AddProxy {
+            name: "reverb".to_owned(),
+            url: "http://localhost:8080".to_owned(),
+        });
+        pin(Request::RemoveProxy {
+            name: "reverb".to_owned(),
+        });
+        pin(Request::AddProxyRule {
+            site: "app".to_owned(),
+            prefix: "/app".to_owned(),
+            url: "http://127.0.0.1:8080".to_owned(),
+        });
+        pin(Request::RemoveProxyRule {
+            site: "app".to_owned(),
+            prefix: "/app".to_owned(),
+        });
+        pin(Request::ListProxies);
     }
 
     fn laravel_options_fixture() -> crate::LaravelOptions {

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -40,6 +40,14 @@ pub enum Response {
     /// [`crate::Request::Unlink`], [`crate::Request::SetPhp`],
     /// [`crate::Request::SetSecure`]).
     Ok,
+    /// Reply to [`crate::Request::ListProxies`] - whole-host proxies and
+    /// per-site path-prefix rules.
+    Proxies {
+        /// Whole-host proxies, in config order.
+        proxies: Vec<ProxyEntry>,
+        /// Per-site path-prefix rules.
+        rules: Vec<ProxyRuleEntry>,
+    },
     /// A request failed. `code` is machine-readable; `message` is for
     /// human display.
     Error {
@@ -390,6 +398,30 @@ pub struct SiteEntry {
     pub uses_front_controller: bool,
 }
 
+/// One whole-host reverse proxy (reply element of [`Response::Proxies`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxyEntry {
+    /// The proxy name (its `{name}.{tld}` host).
+    pub name: String,
+    /// The upstream URL (`http[s]://host:port`).
+    pub target: String,
+    /// Whether the proxy is served over HTTPS.
+    pub secure: bool,
+}
+
+/// One per-site path-prefix reverse-proxy rule (reply element of
+/// [`Response::Proxies`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxyRuleEntry {
+    /// The site the rule attaches to (a linked site name or a parked
+    /// document-root display label).
+    pub site: String,
+    /// The path prefix (e.g. `/app`).
+    pub prefix: String,
+    /// The upstream URL (`http[s]://host:port`).
+    pub target: String,
+}
+
 /// One `WordPress` administrator account, for the auto-login user picker -
 /// see [`Response::WordpressAdminUsers`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -489,6 +521,7 @@ mod variant_name_pinning {
             Response::Tunnels { .. } => {}
             Response::NamedTunnels { .. } => {}
             Response::Groups { .. } => {}
+            Response::Proxies { .. } => {}
         }
     }
 
@@ -736,6 +769,18 @@ mod variant_name_pinning {
         pin_response(Response::Groups {
             order: vec!["Blog".into(), "Shop".into()],
             members: BTreeMap::from([("app".into(), "Blog".into())]),
+        });
+        pin_response(Response::Proxies {
+            proxies: vec![ProxyEntry {
+                name: "reverb".into(),
+                target: "http://127.0.0.1:8080".into(),
+                secure: false,
+            }],
+            rules: vec![ProxyRuleEntry {
+                site: "app".into(),
+                prefix: "/app".into(),
+                target: "http://127.0.0.1:8080".into(),
+            }],
         });
         for c in [
             ErrorCode::NotFound,

--- a/crates/yerd-proxy/src/client_tls.rs
+++ b/crates/yerd-proxy/src/client_tls.rs
@@ -1,0 +1,134 @@
+//! Client-side TLS configuration for forwarding to `https://` upstreams.
+//!
+//! [`ProxyClientTls`] bundles two prebuilt `rustls::ClientConfig`s: a **public**
+//! verifier (trust anchors supplied by the daemon, which owns `webpki-roots` -
+//! this crate must not) and a **local no-verify** verifier for
+//! loopback/private/`.test` upstreams, where self-signed dev backends are the
+//! norm. [`ProxyClientTls::config_for`] picks between them by
+//! [`yerd_core::UpstreamTarget::is_local`].
+//!
+//! Both configs are built with an explicit `ring` provider
+//! ([`rustls::ClientConfig::builder_with_provider`]) so they never depend on the
+//! process-default `CryptoProvider` install order (which, in the daemon, only
+//! happens later, inside the spawned proxy task).
+
+use std::sync::Arc;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::ring::default_provider;
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, Error as TlsError, SignatureScheme};
+use yerd_core::UpstreamTarget;
+
+/// Client TLS policy for reverse-proxy upstreams.
+#[derive(Debug, Clone)]
+pub struct ProxyClientTls {
+    local: Arc<ClientConfig>,
+    public: Arc<ClientConfig>,
+}
+
+impl ProxyClientTls {
+    /// Bundles a `local` no-verify config (see [`Self::no_verify_config`]) and a
+    /// daemon-supplied `public` config whose trust anchors verify genuine public
+    /// hosts.
+    #[must_use]
+    pub fn new(local: Arc<ClientConfig>, public: Arc<ClientConfig>) -> Self {
+        Self { local, public }
+    }
+
+    /// The client config to use for `target` under `tld`: the no-verify config
+    /// for a local host, the public verifier otherwise.
+    #[must_use]
+    pub fn config_for(&self, target: &UpstreamTarget, tld: &str) -> Arc<ClientConfig> {
+        if target.is_local(tld) {
+            self.local.clone()
+        } else {
+            self.public.clone()
+        }
+    }
+
+    /// A rustls client config that accepts any server certificate. Only ever
+    /// applied to local upstreams by [`Self::config_for`]. Errors only on an
+    /// inconsistent crypto provider (never for `ring`).
+    pub fn no_verify_config() -> Result<Arc<ClientConfig>, TlsError> {
+        let cfg = ClientConfig::builder_with_provider(Arc::new(default_provider()))
+            .with_safe_default_protocol_versions()?
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerify))
+            .with_no_client_auth();
+        Ok(Arc::new(cfg))
+    }
+}
+
+/// A `ServerCertVerifier` that accepts any certificate. Scoped to local
+/// upstreams only. Must implement the signature-verification methods (not just
+/// `verify_server_cert`), or rustls 0.23 fails the handshake regardless.
+#[derive(Debug)]
+struct NoVerify;
+
+impl ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, TlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_verify_config_builds() {
+        assert!(ProxyClientTls::no_verify_config().is_ok());
+    }
+
+    #[test]
+    fn config_for_picks_local_vs_public() {
+        let local = ProxyClientTls::no_verify_config().unwrap();
+        let public = ProxyClientTls::no_verify_config().unwrap();
+        let tls = ProxyClientTls::new(local.clone(), public.clone());
+        let local_target = UpstreamTarget::from_url_str("https://127.0.0.1:8443").unwrap();
+        let public_target = UpstreamTarget::from_url_str("https://api.example.com").unwrap();
+        assert!(Arc::ptr_eq(&tls.config_for(&local_target, "test"), &local));
+        assert!(Arc::ptr_eq(
+            &tls.config_for(&public_target, "test"),
+            &public
+        ));
+    }
+}

--- a/crates/yerd-proxy/src/forward/mod.rs
+++ b/crates/yerd-proxy/src/forward/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod fcgi;
 pub mod http;
+pub mod proxy;
 pub mod script_file;
 pub mod static_file;
 pub mod upgrade;

--- a/crates/yerd-proxy/src/forward/proxy.rs
+++ b/crates/yerd-proxy/src/forward/proxy.rs
@@ -7,6 +7,7 @@
 //! which `handle_request` would map to a 500.
 
 use std::net::IpAddr;
+use std::time::Duration;
 
 use http::header::{CONTENT_TYPE, SERVER};
 use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode};
@@ -22,6 +23,13 @@ use crate::error::ProxyError;
 use crate::forward::upgrade;
 use crate::forward::{bytes_body, empty_body, BoxBody};
 
+/// Cap on establishing the upstream connection (TCP connect, then TLS handshake
+/// for an https upstream), so a black-hole host can't hang the request
+/// indefinitely. Deliberately bounds *connection setup* only, not the
+/// response-header wait or the body stream, so a legitimately slow-first-byte or
+/// long-lived streaming upstream is never cut off.
+const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// Forward `req` to `target`. `peer`/`https`/`client_host` seed the
 /// `X-Forwarded-*` headers; `client_tls`/`tld` choose the upstream TLS policy.
 pub async fn forward(
@@ -36,14 +44,24 @@ pub async fn forward(
     add_forwarded_headers(req.headers_mut(), peer, https, client_host);
     let is_upgrade = upgrade::is_upgrade(req.headers());
 
-    let tcp = match TcpStream::connect((target.host(), target.port())).await {
-        Ok(t) => t,
-        Err(e) => {
+    let connect = TcpStream::connect((target.host(), target.port()));
+    let tcp = match tokio::time::timeout(UPSTREAM_CONNECT_TIMEOUT, connect).await {
+        Ok(Ok(t)) => t,
+        Ok(Err(e)) => {
             tracing::debug!(
                 target: "yerd_proxy::proxy",
                 error = %e,
                 upstream = %target,
                 "upstream connect failed"
+            );
+            return Ok(bad_gateway_response());
+        }
+        Err(_) => {
+            tracing::debug!(
+                target: "yerd_proxy::proxy",
+                upstream = %target,
+                timeout_secs = UPSTREAM_CONNECT_TIMEOUT.as_secs(),
+                "upstream connect timed out"
             );
             return Ok(bad_gateway_response());
         }
@@ -65,14 +83,24 @@ pub async fn forward(
                     return Ok(bad_gateway_response());
                 }
             };
-        let tls = match connector.connect(server_name, tcp).await {
-            Ok(t) => t,
-            Err(e) => {
+        let handshake = connector.connect(server_name, tcp);
+        let tls = match tokio::time::timeout(UPSTREAM_CONNECT_TIMEOUT, handshake).await {
+            Ok(Ok(t)) => t,
+            Ok(Err(e)) => {
                 tracing::debug!(
                     target: "yerd_proxy::proxy",
                     error = %e,
                     upstream = %target,
                     "upstream TLS handshake failed"
+                );
+                return Ok(bad_gateway_response());
+            }
+            Err(_) => {
+                tracing::debug!(
+                    target: "yerd_proxy::proxy",
+                    upstream = %target,
+                    timeout_secs = UPSTREAM_CONNECT_TIMEOUT.as_secs(),
+                    "upstream TLS handshake timed out"
                 );
                 return Ok(bad_gateway_response());
             }
@@ -137,9 +165,11 @@ where
     Ok(Response::from_parts(rparts, boxed))
 }
 
-/// Set `X-Forwarded-*` / `X-Real-IP` on the outgoing request. `X-Forwarded-For`
-/// appends to any existing chain; the original `Host` header is left untouched
-/// (upstreams like Reverb key on it).
+/// Set `X-Forwarded-*` / `X-Real-IP` on the outgoing request. The proxy is the
+/// trust boundary for these `.test` requests, so `X-Forwarded-For` is
+/// **overwritten** with the immediate peer rather than appended to a
+/// client-supplied chain (which a client could otherwise spoof). The original
+/// `Host` header is left untouched (upstreams like Reverb key on it).
 fn add_forwarded_headers(headers: &mut HeaderMap, peer: IpAddr, https: bool, client_host: &str) {
     let proto = if https { "https" } else { "http" };
     if let Ok(v) = HeaderValue::from_str(proto) {
@@ -150,15 +180,8 @@ fn add_forwarded_headers(headers: &mut HeaderMap, peer: IpAddr, https: bool, cli
     }
     let peer_str = peer.to_string();
     if let Ok(v) = HeaderValue::from_str(&peer_str) {
-        headers.insert(HeaderName::from_static("x-real-ip"), v);
-    }
-    let xff_name = HeaderName::from_static("x-forwarded-for");
-    let chained = match headers.get(&xff_name).and_then(|v| v.to_str().ok()) {
-        Some(prev) if !prev.is_empty() => format!("{prev}, {peer_str}"),
-        _ => peer_str,
-    };
-    if let Ok(v) = HeaderValue::from_str(&chained) {
-        headers.insert(xff_name, v);
+        headers.insert(HeaderName::from_static("x-real-ip"), v.clone());
+        headers.insert(HeaderName::from_static("x-forwarded-for"), v);
     }
 }
 
@@ -187,11 +210,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn forwarded_for_appends_to_existing_chain() {
+    fn forwarded_for_overwrites_client_supplied_chain() {
         let mut headers = HeaderMap::new();
+        // A client-supplied (spoofable) chain must be replaced, not appended to.
         headers.insert(
             HeaderName::from_static("x-forwarded-for"),
-            HeaderValue::from_static("203.0.113.7"),
+            HeaderValue::from_static("203.0.113.7, 10.0.0.1"),
         );
         add_forwarded_headers(
             &mut headers,
@@ -199,17 +223,14 @@ mod tests {
             true,
             "app.test",
         );
-        assert_eq!(
-            headers.get("x-forwarded-for").unwrap(),
-            "203.0.113.7, 198.51.100.2"
-        );
+        assert_eq!(headers.get("x-forwarded-for").unwrap(), "198.51.100.2");
         assert_eq!(headers.get("x-forwarded-proto").unwrap(), "https");
         assert_eq!(headers.get("x-forwarded-host").unwrap(), "app.test");
         assert_eq!(headers.get("x-real-ip").unwrap(), "198.51.100.2");
     }
 
     #[test]
-    fn forwarded_for_starts_a_fresh_chain() {
+    fn forwarded_for_sets_peer_when_absent() {
         let mut headers = HeaderMap::new();
         add_forwarded_headers(
             &mut headers,

--- a/crates/yerd-proxy/src/forward/proxy.rs
+++ b/crates/yerd-proxy/src/forward/proxy.rs
@@ -1,0 +1,228 @@
+//! Reverse-proxy forwarder for whole-host proxies and path-into-site rules.
+//!
+//! Forwards a request to an arbitrary `http(s)://host:port` upstream. Handles
+//! both normal requests (streaming the original body and response) and
+//! `Connection: Upgrade` websockets (via [`crate::forward::upgrade::tunnel_over`]).
+//! A dead or unreachable upstream yields `Ok(502 Bad Gateway)` - never an `Err`,
+//! which `handle_request` would map to a 500.
+
+use std::net::IpAddr;
+
+use http::header::{CONTENT_TYPE, SERVER};
+use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode};
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use yerd_core::UpstreamTarget;
+
+use crate::client_tls::ProxyClientTls;
+use crate::error::ProxyError;
+use crate::forward::upgrade;
+use crate::forward::{bytes_body, empty_body, BoxBody};
+
+/// Forward `req` to `target`. `peer`/`https`/`client_host` seed the
+/// `X-Forwarded-*` headers; `client_tls`/`tld` choose the upstream TLS policy.
+pub async fn forward(
+    mut req: Request<Incoming>,
+    target: &UpstreamTarget,
+    client_tls: &ProxyClientTls,
+    tld: &str,
+    peer: IpAddr,
+    https: bool,
+    client_host: &str,
+) -> Result<Response<BoxBody>, ProxyError> {
+    add_forwarded_headers(req.headers_mut(), peer, https, client_host);
+    let is_upgrade = upgrade::is_upgrade(req.headers());
+
+    let tcp = match TcpStream::connect((target.host(), target.port())).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::debug!(
+                target: "yerd_proxy::proxy",
+                error = %e,
+                upstream = %target,
+                "upstream connect failed"
+            );
+            return Ok(bad_gateway_response());
+        }
+    };
+
+    if target.secure() {
+        let config = client_tls.config_for(target, tld);
+        let connector = TlsConnector::from(config);
+        let server_name =
+            match rustls::pki_types::ServerName::try_from(target.server_name().to_owned()) {
+                Ok(name) => name,
+                Err(e) => {
+                    tracing::debug!(
+                        target: "yerd_proxy::proxy",
+                        error = %e,
+                        upstream = %target,
+                        "invalid upstream server name"
+                    );
+                    return Ok(bad_gateway_response());
+                }
+            };
+        let tls = match connector.connect(server_name, tcp).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::debug!(
+                    target: "yerd_proxy::proxy",
+                    error = %e,
+                    upstream = %target,
+                    "upstream TLS handshake failed"
+                );
+                return Ok(bad_gateway_response());
+            }
+        };
+        run(req, TokioIo::new(tls), is_upgrade).await
+    } else {
+        run(req, TokioIo::new(tcp), is_upgrade).await
+    }
+}
+
+/// Drive the request over an already-connected `io` (TCP or TLS).
+async fn run<IO>(
+    req: Request<Incoming>,
+    io: IO,
+    is_upgrade: bool,
+) -> Result<Response<BoxBody>, ProxyError>
+where
+    IO: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+{
+    if is_upgrade {
+        upgrade::tunnel_over(req, io).await
+    } else {
+        forward_plain(req, io).await
+    }
+}
+
+/// Non-upgrade path: stream the original request body upstream and the response
+/// body back, stripping hop-by-hop headers on both sides.
+async fn forward_plain<IO>(req: Request<Incoming>, io: IO) -> Result<Response<BoxBody>, ProxyError>
+where
+    IO: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+{
+    let (mut sender, conn) = match hyper::client::conn::http1::handshake(io).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::debug!(target: "yerd_proxy::proxy", error = %e, "upstream handshake failed");
+            return Ok(bad_gateway_response());
+        }
+    };
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            tracing::debug!(target: "yerd_proxy::proxy", error = %e, "upstream connection ended");
+        }
+    });
+
+    let (mut parts, body) = req.into_parts();
+    upgrade::strip_hop_by_hop_only(&mut parts.headers);
+    let upstream_req = Request::from_parts(parts, body);
+
+    let resp = match sender.send_request(upstream_req).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(target: "yerd_proxy::proxy", error = %e, "upstream request failed");
+            return Ok(bad_gateway_response());
+        }
+    };
+    let (mut rparts, rbody) = resp.into_parts();
+    upgrade::strip_hop_by_hop_only(&mut rparts.headers);
+    let boxed: BoxBody = rbody
+        .map_err(|e| std::io::Error::other(e.to_string()))
+        .boxed();
+    Ok(Response::from_parts(rparts, boxed))
+}
+
+/// Set `X-Forwarded-*` / `X-Real-IP` on the outgoing request. `X-Forwarded-For`
+/// appends to any existing chain; the original `Host` header is left untouched
+/// (upstreams like Reverb key on it).
+fn add_forwarded_headers(headers: &mut HeaderMap, peer: IpAddr, https: bool, client_host: &str) {
+    let proto = if https { "https" } else { "http" };
+    if let Ok(v) = HeaderValue::from_str(proto) {
+        headers.insert(HeaderName::from_static("x-forwarded-proto"), v);
+    }
+    if let Ok(v) = HeaderValue::from_str(client_host) {
+        headers.insert(HeaderName::from_static("x-forwarded-host"), v);
+    }
+    let peer_str = peer.to_string();
+    if let Ok(v) = HeaderValue::from_str(&peer_str) {
+        headers.insert(HeaderName::from_static("x-real-ip"), v);
+    }
+    let xff_name = HeaderName::from_static("x-forwarded-for");
+    let chained = match headers.get(&xff_name).and_then(|v| v.to_str().ok()) {
+        Some(prev) if !prev.is_empty() => format!("{prev}, {peer_str}"),
+        _ => peer_str,
+    };
+    if let Ok(v) = HeaderValue::from_str(&chained) {
+        headers.insert(xff_name, v);
+    }
+}
+
+/// `502 Bad Gateway` for an unreachable/failed upstream.
+fn bad_gateway_response() -> Response<BoxBody> {
+    Response::builder()
+        .status(StatusCode::BAD_GATEWAY)
+        .header(SERVER, HeaderValue::from_static(yerd_core::PROXY_SERVER_ID))
+        .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(bytes_body(b"Proxy upstream unavailable.\n"))
+        .unwrap_or_else(|_| {
+            let mut resp = Response::new(empty_body());
+            *resp.status_mut() = StatusCode::BAD_GATEWAY;
+            resp
+        })
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forwarded_for_appends_to_existing_chain() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-forwarded-for"),
+            HeaderValue::from_static("203.0.113.7"),
+        );
+        add_forwarded_headers(
+            &mut headers,
+            "198.51.100.2".parse().unwrap(),
+            true,
+            "app.test",
+        );
+        assert_eq!(
+            headers.get("x-forwarded-for").unwrap(),
+            "203.0.113.7, 198.51.100.2"
+        );
+        assert_eq!(headers.get("x-forwarded-proto").unwrap(), "https");
+        assert_eq!(headers.get("x-forwarded-host").unwrap(), "app.test");
+        assert_eq!(headers.get("x-real-ip").unwrap(), "198.51.100.2");
+    }
+
+    #[test]
+    fn forwarded_for_starts_a_fresh_chain() {
+        let mut headers = HeaderMap::new();
+        add_forwarded_headers(
+            &mut headers,
+            "198.51.100.2".parse().unwrap(),
+            false,
+            "app.test",
+        );
+        assert_eq!(headers.get("x-forwarded-for").unwrap(), "198.51.100.2");
+        assert_eq!(headers.get("x-forwarded-proto").unwrap(), "http");
+    }
+
+    #[test]
+    fn bad_gateway_is_502() {
+        assert_eq!(bad_gateway_response().status(), StatusCode::BAD_GATEWAY);
+    }
+}

--- a/crates/yerd-proxy/src/forward/upgrade.rs
+++ b/crates/yerd-proxy/src/forward/upgrade.rs
@@ -163,9 +163,6 @@ static HOP_BY_HOP_FIXED: &[&str] = &[
 /// `Connection: upgrade`, and an arbitrary upstream's `Transfer-Encoding` /
 /// `Keep-Alive` response headers must not leak through hyper's re-framing.
 pub(crate) fn strip_hop_by_hop_only(headers: &mut HeaderMap) {
-    // `HeaderName::as_str()` is always lowercase, so no per-header allocation is
-    // needed; only the `Connection`-value tokens (arbitrary case) are compared
-    // case-insensitively.
     let conn_tokens: Vec<&str> = headers
         .get_all(CONNECTION)
         .iter()

--- a/crates/yerd-proxy/src/forward/upgrade.rs
+++ b/crates/yerd-proxy/src/forward/upgrade.rs
@@ -16,7 +16,7 @@ use std::net::SocketAddr;
 
 use http::header::{CONNECTION, UPGRADE};
 use http::{HeaderMap, HeaderValue};
-use http_body_util::Empty;
+use http_body_util::{BodyExt, Empty};
 use hyper::body::Incoming;
 use hyper::upgrade::Upgraded;
 use hyper::{Request, Response};
@@ -46,18 +46,38 @@ pub fn is_upgrade(headers: &HeaderMap) -> bool {
 /// Forward an upgrade request to a FrankenPHP backend and run the
 /// bidirectional tunnel.
 pub async fn forward(
-    mut req: Request<Incoming>,
+    req: Request<Incoming>,
     addr: SocketAddr,
 ) -> Result<Response<BoxBody>, ProxyError> {
-    let on_client = hyper::upgrade::on(&mut req);
-
     let tcp = TcpStream::connect(addr)
         .await
         .map_err(|source| ProxyError::BackendConnect {
             backend: format!("franken:{addr}"),
             source,
         })?;
-    let io = TokioIo::new(tcp);
+    tunnel_over(req, TokioIo::new(tcp)).await
+}
+
+/// Run an upgrade (websocket) tunnel over an already-connected `io` (plain TCP
+/// or TLS). Shared by the FrankenPHP path ([`forward`]) and the reverse-proxy
+/// path (`crate::forward::proxy`). The upstream request is sent with an empty
+/// body (an upgrade handshake carries none) and the original `Upgrade` /
+/// `Connection` headers preserved so the peer completes the switch.
+///
+/// If the upstream declines the upgrade (any status other than `101`, e.g.
+/// Reverb's `403` + JSON error body for a bad `wss` handshake), its real
+/// response is returned with the body streamed through and hop-by-hop stripped
+/// without the tunnel's `Connection: upgrade` re-stamp, rather than hijacking a
+/// tunnel that would never carry data.
+pub(crate) async fn tunnel_over<IO>(
+    mut req: Request<Incoming>,
+    io: IO,
+) -> Result<Response<BoxBody>, ProxyError>
+where
+    IO: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+{
+    let on_client = hyper::upgrade::on(&mut req);
+
     let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
         .await
         .map_err(|source| ProxyError::Hyper { source })?;
@@ -67,7 +87,7 @@ pub async fn forward(
             tracing::debug!(
                 target: "yerd_proxy::upgrade",
                 error = %e,
-                "FrankenPhp upgrade connection ended"
+                "upgrade connection ended"
             );
         }
     });
@@ -81,7 +101,16 @@ pub async fn forward(
 
     let on_backend = hyper::upgrade::on(&mut backend_resp);
 
-    let (mut parts, _body) = backend_resp.into_parts();
+    let (mut parts, body) = backend_resp.into_parts();
+
+    if parts.status != http::StatusCode::SWITCHING_PROTOCOLS {
+        strip_hop_by_hop_only(&mut parts.headers);
+        let boxed: BoxBody = body
+            .map_err(|e| std::io::Error::other(e.to_string()))
+            .boxed();
+        return Ok(Response::from_parts(parts, boxed));
+    }
+
     strip_hop_by_hop(&mut parts.headers);
     let resp: Response<BoxBody> = Response::from_parts(parts, empty_body());
 
@@ -125,6 +154,39 @@ static HOP_BY_HOP_FIXED: &[&str] = &[
     "transfer-encoding",
     "trailer",
 ];
+
+/// Strip hop-by-hop headers per RFC 9110 §7.6.1 **without** re-stamping
+/// `Connection` (and dropping any `Upgrade`). This is the variant the plain
+/// reverse-proxy path uses on both the request and the response: unlike
+/// [`strip_hop_by_hop`] (which keeps `Upgrade` and re-adds `Connection:
+/// upgrade` for the tunnel), a normal proxied request must not carry
+/// `Connection: upgrade`, and an arbitrary upstream's `Transfer-Encoding` /
+/// `Keep-Alive` response headers must not leak through hyper's re-framing.
+pub(crate) fn strip_hop_by_hop_only(headers: &mut HeaderMap) {
+    let conn_tokens: Vec<String> = headers
+        .get_all(CONNECTION)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(',').map(|t| t.trim().to_ascii_lowercase()))
+        .collect();
+    let to_remove: Vec<http::HeaderName> = headers
+        .iter()
+        .filter_map(|(name, _)| {
+            let lower = name.as_str().to_ascii_lowercase();
+            if lower == "upgrade"
+                || HOP_BY_HOP_FIXED.contains(&lower.as_str())
+                || conn_tokens.iter().any(|t| t == &lower)
+            {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    for name in to_remove {
+        headers.remove(&name);
+    }
+}
 
 /// Strip hop-by-hop headers per RFC 9110 §7.6.1.
 fn strip_hop_by_hop(headers: &mut HeaderMap) {
@@ -199,6 +261,39 @@ mod tests {
         assert!(h.get(UPGRADE).is_some());
         assert_eq!(h.get(CONNECTION).unwrap(), "upgrade");
         assert!(h.get(http::header::TRANSFER_ENCODING).is_none());
+        assert!(h.get(http::header::CONTENT_TYPE).is_some());
+    }
+
+    /// The strip-only variant (used on normal proxied requests/responses) drops
+    /// `Upgrade`/`Connection`/`Transfer-Encoding` and does NOT re-stamp
+    /// `Connection: upgrade`.
+    #[test]
+    fn strip_hop_by_hop_only_removes_upgrade_and_connection_no_restamp() {
+        let mut h = HeaderMap::new();
+        h.insert(UPGRADE, "websocket".parse().unwrap());
+        h.insert(CONNECTION, "keep-alive, upgrade".parse().unwrap());
+        h.insert(http::header::TRANSFER_ENCODING, "chunked".parse().unwrap());
+        h.insert("keep-alive", "timeout=5".parse().unwrap());
+        h.insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+        strip_hop_by_hop_only(&mut h);
+        assert!(h.get(UPGRADE).is_none());
+        assert!(h.get(CONNECTION).is_none());
+        assert!(h.get(http::header::TRANSFER_ENCODING).is_none());
+        assert!(h.get("keep-alive").is_none());
+        assert!(h.get(http::header::CONTENT_TYPE).is_some());
+    }
+
+    /// A `Connection`-listed custom token is hop-by-hop and removed, with no
+    /// `Connection` header left behind.
+    #[test]
+    fn strip_hop_by_hop_only_removes_connection_listed_tokens() {
+        let mut h = HeaderMap::new();
+        h.insert(CONNECTION, "x-custom".parse().unwrap());
+        h.insert("x-custom", "drop-me".parse().unwrap());
+        h.insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+        strip_hop_by_hop_only(&mut h);
+        assert!(h.get("x-custom").is_none());
+        assert!(h.get(CONNECTION).is_none());
         assert!(h.get(http::header::CONTENT_TYPE).is_some());
     }
 

--- a/crates/yerd-proxy/src/forward/upgrade.rs
+++ b/crates/yerd-proxy/src/forward/upgrade.rs
@@ -163,19 +163,22 @@ static HOP_BY_HOP_FIXED: &[&str] = &[
 /// `Connection: upgrade`, and an arbitrary upstream's `Transfer-Encoding` /
 /// `Keep-Alive` response headers must not leak through hyper's re-framing.
 pub(crate) fn strip_hop_by_hop_only(headers: &mut HeaderMap) {
-    let conn_tokens: Vec<String> = headers
+    // `HeaderName::as_str()` is always lowercase, so no per-header allocation is
+    // needed; only the `Connection`-value tokens (arbitrary case) are compared
+    // case-insensitively.
+    let conn_tokens: Vec<&str> = headers
         .get_all(CONNECTION)
         .iter()
         .filter_map(|v| v.to_str().ok())
-        .flat_map(|s| s.split(',').map(|t| t.trim().to_ascii_lowercase()))
+        .flat_map(|s| s.split(',').map(str::trim))
         .collect();
     let to_remove: Vec<http::HeaderName> = headers
         .iter()
         .filter_map(|(name, _)| {
-            let lower = name.as_str().to_ascii_lowercase();
+            let lower = name.as_str();
             if lower == "upgrade"
-                || HOP_BY_HOP_FIXED.contains(&lower.as_str())
-                || conn_tokens.iter().any(|t| t == &lower)
+                || HOP_BY_HOP_FIXED.contains(&lower)
+                || conn_tokens.iter().any(|t| t.eq_ignore_ascii_case(lower))
             {
                 Some(name.clone())
             } else {
@@ -190,20 +193,21 @@ pub(crate) fn strip_hop_by_hop_only(headers: &mut HeaderMap) {
 
 /// Strip hop-by-hop headers per RFC 9110 §7.6.1.
 fn strip_hop_by_hop(headers: &mut HeaderMap) {
-    let conn_tokens: Vec<String> = headers
+    let conn_tokens: Vec<&str> = headers
         .get_all(CONNECTION)
         .iter()
         .filter_map(|v| v.to_str().ok())
-        .flat_map(|s| s.split(',').map(|t| t.trim().to_ascii_lowercase()))
+        .flat_map(|s| s.split(',').map(str::trim))
         .collect();
     let to_remove: Vec<http::HeaderName> = headers
         .iter()
         .filter_map(|(name, _)| {
-            let lower = name.as_str().to_ascii_lowercase();
+            let lower = name.as_str();
             if lower == "upgrade" {
                 return None;
             }
-            if HOP_BY_HOP_FIXED.contains(&lower.as_str()) || conn_tokens.iter().any(|t| t == &lower)
+            if HOP_BY_HOP_FIXED.contains(&lower)
+                || conn_tokens.iter().any(|t| t.eq_ignore_ascii_case(lower))
             {
                 Some(name.clone())
             } else {

--- a/crates/yerd-proxy/src/lib.rs
+++ b/crates/yerd-proxy/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::doc_markdown)]
 
 pub mod backend;
+pub mod client_tls;
 pub mod error;
 pub mod forward;
 pub mod pure;
@@ -18,6 +19,7 @@ pub mod tls;
 pub mod traits;
 
 pub use backend::Backend;
+pub use client_tls::ProxyClientTls;
 pub use error::ProxyError;
 pub use server::{HttpsBinding, ProxyServer, SharedRouter};
 pub use traits::{BackendResolver, CertStore, LoginTokenConsumer};

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -361,14 +361,14 @@ async fn dispatch<R: BackendResolver, L: LoginTokenConsumer>(
 
     let https = matches!(listener, Listener::Https);
 
-    let (site, unbound, matched_proxy) = match resolve_request(&router, &req, &host).await? {
+    let (site, unbound, matched) = match resolve_request(&router, &req, &host).await? {
         Routed::Site {
             site,
             unbound,
-            matched_proxy,
-        } => (site, unbound, matched_proxy),
+            matched,
+        } => (site, unbound, matched),
         Routed::Proxy {
-            target,
+            forward,
             secure,
             unbound,
         } => {
@@ -377,12 +377,11 @@ async fn dispatch<R: BackendResolver, L: LoginTokenConsumer>(
                     return https_redirect(&host, &req, port);
                 }
             }
-            let tld = router.read().await.config().tld().to_owned();
             return proxy_fwd::forward(
                 req,
-                &target,
+                &forward.target,
                 client_tls.as_ref(),
-                &tld,
+                &forward.tld,
                 peer_addr.ip(),
                 https,
                 &host,
@@ -398,13 +397,12 @@ async fn dispatch<R: BackendResolver, L: LoginTokenConsumer>(
         }
     }
 
-    if let Some(target) = matched_proxy {
-        let tld = router.read().await.config().tld().to_owned();
+    if let Some(forward) = matched {
         return proxy_fwd::forward(
             req,
-            &target,
+            &forward.target,
             client_tls.as_ref(),
-            &tld,
+            &forward.tld,
             peer_addr.ip(),
             https,
             &host,
@@ -627,20 +625,29 @@ fn https_redirect(
         })
 }
 
+/// A resolved reverse-proxy forward: the upstream plus the router's TLD,
+/// both captured while the router read guard is held so the forward path in
+/// [`dispatch`] needs no second lock acquisition. The TLD is allocated only when
+/// a request actually forwards to a proxy, never on the plain-PHP path.
+struct ProxyTarget {
+    target: UpstreamTarget,
+    tld: String,
+}
+
 /// Outcome of resolving a request: a PHP site to serve (optionally intercepted
 /// by a path-prefix proxy rule), a whole-host proxy, or a ready-made response
 /// (404 / 303 switch / picker) to return as-is.
 enum Routed {
     /// A PHP site to forward to. `unbound` skips the HTTP→HTTPS redirect;
-    /// `matched_proxy` is `Some` when a path-prefix rule intercepts this request.
+    /// `matched` is `Some` when a path-prefix rule intercepts this request.
     Site {
         site: Site,
         unbound: bool,
-        matched_proxy: Option<UpstreamTarget>,
+        matched: Option<ProxyTarget>,
     },
     /// A whole-host reverse proxy to forward to.
     Proxy {
-        target: UpstreamTarget,
+        forward: ProxyTarget,
         secure: bool,
         unbound: bool,
     },
@@ -662,17 +669,24 @@ async fn resolve_request(
     match guard.resolve_route(host) {
         Some(Route::Php(site)) => {
             let site = site.clone();
-            let matched_proxy = match_rule(guard.rules_for(site.name()), req.uri().path())
-                .map(|rule| rule.target().clone());
+            let matched = match_rule(guard.rules_for(site.name()), req.uri().path()).map(|rule| {
+                ProxyTarget {
+                    target: rule.target().clone(),
+                    tld: guard.config().tld().to_owned(),
+                }
+            });
             return Ok(Routed::Site {
                 site,
                 unbound: false,
-                matched_proxy,
+                matched,
             });
         }
         Some(Route::Proxy(proxy)) => {
             return Ok(Routed::Proxy {
-                target: proxy.target().clone(),
+                forward: ProxyTarget {
+                    target: proxy.target().clone(),
+                    tld: guard.config().tld().to_owned(),
+                },
                 secure: proxy.secure(),
                 unbound: false,
             });
@@ -699,7 +713,7 @@ async fn resolve_request(
         UnboundDecision::Serve(site) => Ok(Routed::Site {
             site,
             unbound: true,
-            matched_proxy: None,
+            matched: None,
         }),
         UnboundDecision::Switch { name, location } => {
             Ok(Routed::Respond(switch_response(&name, &location)?))

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -710,11 +710,19 @@ async fn resolve_request(
         cookie,
         accept,
     ) {
-        UnboundDecision::Serve(site) => Ok(Routed::Site {
-            site,
-            unbound: true,
-            matched: None,
-        }),
+        UnboundDecision::Serve(site) => {
+            let matched = match_rule(guard.rules_for(site.name()), req.uri().path()).map(|rule| {
+                ProxyTarget {
+                    target: rule.target().clone(),
+                    tld: guard.config().tld().to_owned(),
+                }
+            });
+            Ok(Routed::Site {
+                site,
+                unbound: true,
+                matched,
+            })
+        }
         UnboundDecision::Switch { name, location } => {
             Ok(Routed::Respond(switch_response(&name, &location)?))
         }

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -16,13 +16,14 @@ use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 use tokio_rustls::TlsAcceptor;
-use yerd_core::{Site, SiteKind, SiteRouter};
+use yerd_core::{match_rule, Route, Site, SiteKind, SiteRouter, UpstreamTarget};
 
 use crate::backend::Backend;
+use crate::client_tls::ProxyClientTls;
 use crate::error::ProxyError;
 use crate::forward::{
-    bytes_body, empty_body, fcgi, http as http_fwd, owned_bytes_body, script_file, static_file,
-    upgrade, BoxBody,
+    bytes_body, empty_body, fcgi, http as http_fwd, owned_bytes_body, proxy as proxy_fwd,
+    script_file, static_file, upgrade, BoxBody,
 };
 use crate::pure::cgi_params;
 use crate::pure::query;
@@ -85,6 +86,7 @@ impl ProxyServer {
         login_tokens: Arc<L>,
         login_prepend_script: Option<std::path::PathBuf>,
         symlink_protection: Arc<AtomicBool>,
+        client_tls: Arc<ProxyClientTls>,
         shutdown: S,
     ) -> Result<(), ProxyError>
     where
@@ -114,6 +116,7 @@ impl ProxyServer {
         let http_login_tokens = login_tokens.clone();
         let http_login_prepend = login_prepend_script.clone();
         let http_symlink_protection = symlink_protection.clone();
+        let http_client_tls = client_tls.clone();
         let http_notify = notify.clone();
         let http_accept = tokio::spawn(async move {
             let notified = http_notify.notified();
@@ -130,8 +133,9 @@ impl ProxyServer {
                                 let login_tokens = http_login_tokens.clone();
                                 let login_prepend = http_login_prepend.clone();
                                 let symlink_protection = http_symlink_protection.clone();
+                                let client_tls = http_client_tls.clone();
                                 tokio::spawn(serve_http_connection(
-                                    stream, peer, router, resolver, login_tokens, login_prepend, redirect_port.clone(), symlink_protection,
+                                    stream, peer, router, resolver, login_tokens, login_prepend, redirect_port.clone(), symlink_protection, client_tls,
                                 ));
                             }
                             Err(e) => {
@@ -155,6 +159,7 @@ impl ProxyServer {
             let login_tokens = login_tokens.clone();
             let login_prepend_script = login_prepend_script.clone();
             let symlink_protection = symlink_protection.clone();
+            let secure_client_tls = client_tls.clone();
             let notify_https = notify.clone();
             Some(tokio::spawn(async move {
                 let notified = notify_https.notified();
@@ -172,8 +177,9 @@ impl ProxyServer {
                                     let login_prepend = login_prepend_script.clone();
                                     let symlink_protection = symlink_protection.clone();
                                     let acceptor = acceptor.clone();
+                                    let client_tls = secure_client_tls.clone();
                                     tokio::spawn(serve_https_connection(
-                                        stream, peer, router, resolver, login_tokens, login_prepend, acceptor, symlink_protection,
+                                        stream, peer, router, resolver, login_tokens, login_prepend, acceptor, symlink_protection, client_tls,
                                     ));
                                 }
                                 Err(e) => {
@@ -211,6 +217,7 @@ async fn serve_http_connection<R: BackendResolver, L: LoginTokenConsumer>(
     login_prepend_script: Option<std::path::PathBuf>,
     redirect_port: Option<Arc<AtomicU16>>,
     symlink_protection: Arc<AtomicBool>,
+    client_tls: Arc<ProxyClientTls>,
 ) {
     let server_addr = stream
         .local_addr()
@@ -228,6 +235,7 @@ async fn serve_http_connection<R: BackendResolver, L: LoginTokenConsumer>(
             login_prepend_script.clone(),
             redirect_port.clone(),
             symlink_protection.clone(),
+            client_tls.clone(),
         )
     });
     let conn = hyper::server::conn::http1::Builder::new()
@@ -246,6 +254,7 @@ async fn serve_https_connection<R: BackendResolver, L: LoginTokenConsumer>(
     login_prepend_script: Option<std::path::PathBuf>,
     acceptor: TlsAcceptor,
     symlink_protection: Arc<AtomicBool>,
+    client_tls: Arc<ProxyClientTls>,
 ) {
     let server_addr = stream
         .local_addr()
@@ -274,6 +283,7 @@ async fn serve_https_connection<R: BackendResolver, L: LoginTokenConsumer>(
             login_prepend_script.clone(),
             None,
             symlink_protection.clone(),
+            client_tls.clone(),
         )
     });
     let conn = hyper::server::conn::http1::Builder::new()
@@ -296,6 +306,7 @@ async fn handle_request<R: BackendResolver, L: LoginTokenConsumer>(
     login_prepend_script: Option<std::path::PathBuf>,
     redirect_port: Option<Arc<AtomicU16>>,
     symlink_protection: Arc<AtomicBool>,
+    client_tls: Arc<ProxyClientTls>,
 ) -> Result<Response<BoxBody>, std::convert::Infallible> {
     match dispatch(
         req,
@@ -308,6 +319,7 @@ async fn handle_request<R: BackendResolver, L: LoginTokenConsumer>(
         login_prepend_script,
         redirect_port,
         symlink_protection,
+        client_tls,
     )
     .await
     {
@@ -335,6 +347,7 @@ async fn dispatch<R: BackendResolver, L: LoginTokenConsumer>(
     login_prepend_script: Option<std::path::PathBuf>,
     redirect_port: Option<Arc<AtomicU16>>,
     symlink_protection: Arc<AtomicBool>,
+    client_tls: Arc<ProxyClientTls>,
 ) -> Result<Response<BoxBody>, ProxyError> {
     let redirect_port = redirect_port.map(|p| p.load(Ordering::Relaxed));
     let Some(host) = req
@@ -346,35 +359,61 @@ async fn dispatch<R: BackendResolver, L: LoginTokenConsumer>(
         return Ok(bad_request_response());
     };
 
-    let (site, unbound) = match resolve_request(&router, &req, &host).await? {
-        Routed::Site { site, unbound } => (site, unbound),
+    let https = matches!(listener, Listener::Https);
+
+    let (site, unbound, matched_proxy) = match resolve_request(&router, &req, &host).await? {
+        Routed::Site {
+            site,
+            unbound,
+            matched_proxy,
+        } => (site, unbound, matched_proxy),
+        Routed::Proxy {
+            target,
+            secure,
+            unbound,
+        } => {
+            if matches!(listener, Listener::Http) && !unbound {
+                if let (true, Some(port)) = (secure, redirect_port) {
+                    return https_redirect(&host, &req, port);
+                }
+            }
+            let tld = router.read().await.config().tld().to_owned();
+            return proxy_fwd::forward(
+                req,
+                &target,
+                client_tls.as_ref(),
+                &tld,
+                peer_addr.ip(),
+                https,
+                &host,
+            )
+            .await;
+        }
         Routed::Respond(resp) => return Ok(resp),
     };
-    let served_root = site.served_root();
-    let allowed_root = site.document_root().to_path_buf();
 
     if matches!(listener, Listener::Http) && !unbound {
         if let (true, Some(port)) = (site.secure(), redirect_port) {
-            let pq = req
-                .uri()
-                .path_and_query()
-                .map_or("/", http::uri::PathAndQuery::as_str);
-            let loc = build_redirect_uri(&host, pq, port);
-            let resp = Response::builder()
-                .status(StatusCode::MOVED_PERMANENTLY)
-                .header(
-                    LOCATION,
-                    HeaderValue::from_str(&loc).map_err(|_| ProxyError::BackendProtocol {
-                        source: std::io::Error::other("invalid redirect URI"),
-                    })?,
-                )
-                .body(empty_body())
-                .map_err(|_| ProxyError::BackendProtocol {
-                    source: std::io::Error::other("redirect response build failed"),
-                })?;
-            return Ok(resp);
+            return https_redirect(&host, &req, port);
         }
     }
+
+    if let Some(target) = matched_proxy {
+        let tld = router.read().await.config().tld().to_owned();
+        return proxy_fwd::forward(
+            req,
+            &target,
+            client_tls.as_ref(),
+            &tld,
+            peer_addr.ip(),
+            https,
+            &host,
+        )
+        .await;
+    }
+
+    let served_root = site.served_root();
+    let allowed_root = site.document_root().to_path_buf();
 
     let backend = resolver.backend_for(&site).await.map_err(|e| match e {
         ProxyError::BackendResolver { .. }
@@ -385,8 +424,6 @@ async fn dispatch<R: BackendResolver, L: LoginTokenConsumer>(
             source: Box::new(other),
         },
     })?;
-
-    let https = matches!(listener, Listener::Https);
 
     if upgrade::is_upgrade(req.headers()) {
         return match backend {
@@ -563,11 +600,50 @@ fn resolve_static_outcome(outcome: static_file::StaticOutcome) -> Option<Respons
     }
 }
 
-/// Outcome of resolving a request: either a site to serve, or a ready-made
-/// response (404 / 303 switch / picker) to return as-is.
+/// `301` HTTP→HTTPS redirect to `host` on `port`, preserving the path+query.
+/// Shared by the whole-host-proxy and PHP-site redirect branches in
+/// [`dispatch`].
+fn https_redirect(
+    host: &str,
+    req: &Request<Incoming>,
+    port: u16,
+) -> Result<Response<BoxBody>, ProxyError> {
+    let pq = req
+        .uri()
+        .path_and_query()
+        .map_or("/", http::uri::PathAndQuery::as_str);
+    let loc = build_redirect_uri(host, pq, port);
+    Response::builder()
+        .status(StatusCode::MOVED_PERMANENTLY)
+        .header(
+            LOCATION,
+            HeaderValue::from_str(&loc).map_err(|_| ProxyError::BackendProtocol {
+                source: std::io::Error::other("invalid redirect URI"),
+            })?,
+        )
+        .body(empty_body())
+        .map_err(|_| ProxyError::BackendProtocol {
+            source: std::io::Error::other("redirect response build failed"),
+        })
+}
+
+/// Outcome of resolving a request: a PHP site to serve (optionally intercepted
+/// by a path-prefix proxy rule), a whole-host proxy, or a ready-made response
+/// (404 / 303 switch / picker) to return as-is.
 enum Routed {
-    /// A site to forward to. `unbound` skips the HTTP→HTTPS redirect.
-    Site { site: Site, unbound: bool },
+    /// A PHP site to forward to. `unbound` skips the HTTP→HTTPS redirect;
+    /// `matched_proxy` is `Some` when a path-prefix rule intercepts this request.
+    Site {
+        site: Site,
+        unbound: bool,
+        matched_proxy: Option<UpstreamTarget>,
+    },
+    /// A whole-host reverse proxy to forward to.
+    Proxy {
+        target: UpstreamTarget,
+        secure: bool,
+        unbound: bool,
+    },
     /// A synthetic response to return directly.
     Respond(Response<BoxBody>),
 }
@@ -583,11 +659,25 @@ async fn resolve_request(
     host: &str,
 ) -> Result<Routed, ProxyError> {
     let guard = router.read().await;
-    if let Some(site) = guard.resolve(host).cloned() {
-        return Ok(Routed::Site {
-            site,
-            unbound: false,
-        });
+    match guard.resolve_route(host) {
+        Some(Route::Php(site)) => {
+            let site = site.clone();
+            let matched_proxy = match_rule(guard.rules_for(site.name()), req.uri().path())
+                .map(|rule| rule.target().clone());
+            return Ok(Routed::Site {
+                site,
+                unbound: false,
+                matched_proxy,
+            });
+        }
+        Some(Route::Proxy(proxy)) => {
+            return Ok(Routed::Proxy {
+                target: proxy.target().clone(),
+                secure: proxy.secure(),
+                unbound: false,
+            });
+        }
+        None => {}
     }
     if !unbound::is_loopback_host(host) {
         return Ok(Routed::Respond(not_found_response()));
@@ -609,6 +699,7 @@ async fn resolve_request(
         UnboundDecision::Serve(site) => Ok(Routed::Site {
             site,
             unbound: true,
+            matched_proxy: None,
         }),
         UnboundDecision::Switch { name, location } => {
             Ok(Routed::Respond(switch_response(&name, &location)?))

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -26,7 +26,15 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 
 use yerd_core::{PhpVersion, RouterConfig, Site, SiteRouter, Tld};
-use yerd_proxy::{Backend, BackendResolver, ProxyError, ProxyServer};
+use yerd_proxy::{Backend, BackendResolver, ProxyClientTls, ProxyError, ProxyServer};
+
+/// A client-TLS bundle for tests: both configs accept any certificate (tests
+/// only reach loopback upstreams).
+fn test_client_tls() -> Arc<ProxyClientTls> {
+    let local = ProxyClientTls::no_verify_config().unwrap();
+    let public = ProxyClientTls::no_verify_config().unwrap();
+    Arc::new(ProxyClientTls::new(local, public))
+}
 
 // ─── Test resolver ──────────────────────────────────────────────────
 
@@ -243,6 +251,7 @@ async fn proxy_forwards_to_fcgi_backend() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -337,6 +346,7 @@ async fn valid_login_token_adds_auto_prepend_and_strips_token_from_query() {
             login_tokens,
             Some(prepend_path),
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -428,6 +438,7 @@ async fn secure_site_redirect_does_not_consume_login_token() {
             login_tokens,
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -482,6 +493,7 @@ async fn unknown_host_returns_404() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -519,6 +531,7 @@ async fn missing_host_header_returns_400() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -569,6 +582,7 @@ async fn static_file_is_served_without_touching_fcgi() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -621,6 +635,7 @@ async fn directory_index_html_served_when_no_index_php() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -669,6 +684,7 @@ async fn directory_index_htm_served_as_fallback() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -730,6 +746,7 @@ async fn index_php_present_wins_over_index_html() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -801,6 +818,7 @@ async fn subdirectory_index_php_wins_over_root_index_php() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -872,6 +890,7 @@ async fn direct_script_execution_gated_to_wordpress_sites() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -939,6 +958,7 @@ async fn directory_with_no_index_at_all_falls_through_to_fcgi() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -1000,6 +1020,7 @@ async fn nonexistent_directory_falls_through_to_fcgi() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -1050,6 +1071,7 @@ async fn head_request_to_directory_index_returns_empty_body() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -1131,6 +1153,7 @@ async fn symlink_within_document_root_outside_served_root_is_served() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -1191,6 +1214,7 @@ async fn symlink_escaping_document_root_returns_403() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -1255,6 +1279,7 @@ async fn symlink_escaping_document_root_is_served_when_protection_off() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(false)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -1314,6 +1339,7 @@ async fn symlinked_index_html_escaping_root_is_not_served() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },

--- a/crates/yerd-proxy/tests/integration_https.rs
+++ b/crates/yerd-proxy/tests/integration_https.rs
@@ -30,8 +30,18 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 
 use yerd_core::{PhpVersion, RouterConfig, Site, SiteRouter, Tld};
-use yerd_proxy::{Backend, BackendResolver, CertStore, HttpsBinding, ProxyError, ProxyServer};
+use yerd_proxy::{
+    Backend, BackendResolver, CertStore, HttpsBinding, ProxyClientTls, ProxyError, ProxyServer,
+};
 use yerd_tls::{CertAuthority, Validity};
+
+/// A client-TLS bundle for tests: both configs accept any certificate (tests
+/// only reach loopback upstreams).
+fn test_client_tls() -> Arc<ProxyClientTls> {
+    let local = ProxyClientTls::no_verify_config().unwrap();
+    let public = ProxyClientTls::no_verify_config().unwrap();
+    Arc::new(ProxyClientTls::new(local, public))
+}
 
 // ─── Resolver ───────────────────────────────────────────────────────
 
@@ -195,6 +205,7 @@ async fn https_handshake_routes_to_backend() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },
@@ -263,6 +274,7 @@ async fn http_redirect_tracks_live_public_port_updates() {
             Arc::new(NoLoginTokens),
             None,
             Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
             async move {
                 let _ = rx_shutdown.await;
             },

--- a/crates/yerd-proxy/tests/integration_proxy.rs
+++ b/crates/yerd-proxy/tests/integration_proxy.rs
@@ -165,10 +165,24 @@ async fn whole_host_and_path_rules_and_bad_gateway() {
     let upstream = spawn_upstream(up_rx).await;
     let upstream_url = format!("http://127.0.0.1:{}", upstream.port());
 
-    let dead_port = {
-        let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        l.local_addr().unwrap().port()
-    };
+    // A controlled failing upstream: accept each connection and immediately close
+    // it, so a proxied request deterministically fails with 502 - no reliance on
+    // an ephemeral port staying free (which would race the request's connect).
+    let dead_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_port = dead_listener.local_addr().unwrap().port();
+    let (dead_tx, mut dead_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut dead_rx => break,
+                accepted = dead_listener.accept() => {
+                    if let Ok((stream, _)) = accepted {
+                        drop(stream);
+                    }
+                }
+            }
+        }
+    });
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let proxy_addr = proxy_listener.local_addr().unwrap();
@@ -244,6 +258,7 @@ async fn whole_host_and_path_rules_and_bad_gateway() {
 
     let _ = tx_shutdown.send(());
     let _ = up_tx.send(());
+    let _ = dead_tx.send(());
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
 }
 

--- a/crates/yerd-proxy/tests/integration_proxy.rs
+++ b/crates/yerd-proxy/tests/integration_proxy.rs
@@ -1,0 +1,271 @@
+//! Reverse-proxy integration test: whole-host proxy, path-into-site rule with
+//! PHP fall-through, and 502 on a dead upstream. Drives `ProxyServer::serve`
+//! against a fake HTTP upstream that echoes the request path and whether an
+//! `X-Forwarded-For` header was present (proxied requests carry it; the plain
+//! FrankenPHP fall-through does not).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::doc_markdown
+)]
+
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use http_body_util::{BodyExt, Empty};
+use hyper::Request;
+use hyper_util::rt::TokioIo;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
+
+use yerd_core::{
+    PhpVersion, ProxyRule, ProxySite, RouterConfig, Site, SiteRouter, Tld, UpstreamTarget,
+};
+use yerd_proxy::{Backend, BackendResolver, CertStore, ProxyClientTls, ProxyError, ProxyServer};
+
+struct StaticResolver {
+    backend: Backend,
+}
+
+#[async_trait]
+impl BackendResolver for StaticResolver {
+    async fn backend_for(&self, _site: &Site) -> Result<Backend, ProxyError> {
+        Ok(self.backend.clone())
+    }
+}
+
+struct StubCertStore;
+impl CertStore for StubCertStore {
+    fn certified_key(&self, _: &str) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        None
+    }
+}
+impl std::fmt::Debug for StubCertStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("StubCertStore")
+    }
+}
+
+struct NoLoginTokens;
+impl yerd_proxy::LoginTokenConsumer for NoLoginTokens {
+    fn consume(&self, _site: &str, _token: &str) -> Option<String> {
+        None
+    }
+}
+
+fn test_client_tls() -> Arc<ProxyClientTls> {
+    let local = ProxyClientTls::no_verify_config().unwrap();
+    let public = ProxyClientTls::no_verify_config().unwrap();
+    Arc::new(ProxyClientTls::new(local, public))
+}
+
+/// Spawn a fake HTTP/1.1 upstream: for each connection, read the request head
+/// and reply with a body echoing the request path and whether `x-forwarded-for`
+/// was present. Runs until `shutdown` fires.
+async fn spawn_upstream(shutdown: oneshot::Receiver<()>) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut shutdown = shutdown;
+        loop {
+            tokio::select! {
+                _ = &mut shutdown => break,
+                accepted = listener.accept() => {
+                    let Ok((mut stream, _)) = accepted else { continue };
+                    tokio::spawn(async move {
+                        let mut buf = Vec::new();
+                        let mut chunk = [0u8; 1024];
+                        let head_end = loop {
+                            let n = match stream.read(&mut chunk).await {
+                                Ok(0) | Err(_) => return,
+                                Ok(n) => n,
+                            };
+                            buf.extend_from_slice(&chunk[..n]);
+                            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                                break pos + 4;
+                            }
+                        };
+                        let text = String::from_utf8_lossy(&buf[..head_end]).to_ascii_lowercase();
+                        let path = String::from_utf8_lossy(&buf[..head_end])
+                            .lines()
+                            .next()
+                            .and_then(|line| line.split_whitespace().nth(1))
+                            .unwrap_or("?")
+                            .to_owned();
+                        let xff = text.contains("x-forwarded-for:");
+                        let conn_upgrade = text
+                            .lines()
+                            .filter(|l| l.starts_with("connection:"))
+                            .any(|l| l.contains("upgrade"));
+                        let want: usize = text
+                            .lines()
+                            .find_map(|l| l.strip_prefix("content-length:"))
+                            .and_then(|v| v.trim().parse().ok())
+                            .unwrap_or(0);
+                        let mut body_bytes = buf.len().saturating_sub(head_end);
+                        while body_bytes < want {
+                            let n = match stream.read(&mut chunk).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(n) => n,
+                            };
+                            body_bytes += n;
+                        }
+                        let body = format!(
+                            "path={path};xff={};bodylen={body_bytes};connupg={}",
+                            u8::from(xff),
+                            u8::from(conn_upgrade)
+                        );
+                        let resp = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        );
+                        let _ = stream.write_all(resp.as_bytes()).await;
+                        let _ = stream.flush().await;
+                    });
+                }
+            }
+        }
+    });
+    addr
+}
+
+async fn client_get(addr: SocketAddr, host: &str, path: &str) -> (u16, String) {
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = Request::builder()
+        .method("GET")
+        .uri(path)
+        .header("Host", host)
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+    let resp = sender.send_request(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&body).into_owned())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn whole_host_and_path_rules_and_bad_gateway() {
+    yerd_proxy::tls::init_crypto_once();
+
+    let (up_tx, up_rx) = oneshot::channel::<()>();
+    let upstream = spawn_upstream(up_rx).await;
+    let upstream_url = format!("http://127.0.0.1:{}", upstream.port());
+
+    let dead_port = {
+        let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        l.local_addr().unwrap().port()
+    };
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let cfg = RouterConfig::with_tld(Tld::new("test").unwrap());
+    let mut router = SiteRouter::new(cfg);
+    let app = Site::linked("app", "/srv/www/app", PhpVersion::new(8, 3)).unwrap();
+    router.insert(app).unwrap();
+    router.set_proxy_rules(
+        "app",
+        vec![ProxyRule::new("/ws", UpstreamTarget::from_url_str(&upstream_url).unwrap()).unwrap()],
+    );
+    router
+        .insert_proxy(
+            ProxySite::new(
+                "reverb",
+                UpstreamTarget::from_url_str(&upstream_url).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    router
+        .insert_proxy(
+            ProxySite::new(
+                "dead",
+                UpstreamTarget::from_url_str(&format!("http://127.0.0.1:{dead_port}")).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::FrankenPhp { addr: upstream },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            Arc::new(NoLoginTokens),
+            None,
+            Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, body) = client_get(proxy_addr, "reverb.test", "/foo").await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "path=/foo;xff=1;bodylen=0;connupg=0");
+
+    let (status, body) = client_get(proxy_addr, "app.test", "/ws/x").await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "path=/ws/x;xff=1;bodylen=0;connupg=0");
+
+    let (status, body) = client_get(proxy_addr, "app.test", "/plain").await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "path=/plain;xff=0;bodylen=0;connupg=0");
+
+    let (status, body) = client_post(proxy_addr, "reverb.test", "/submit", "hello-body").await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "path=/submit;xff=1;bodylen=10;connupg=0");
+
+    let (status, _) = client_get(proxy_addr, "dead.test", "/").await;
+    assert_eq!(status, 502);
+
+    let _ = tx_shutdown.send(());
+    let _ = up_tx.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+}
+
+async fn client_post(addr: SocketAddr, host: &str, path: &str, body: &str) -> (u16, String) {
+    use http_body_util::Full;
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Full<Bytes>>(io)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("Host", host)
+        .header("Content-Length", body.len())
+        .body(Full::new(Bytes::from(body.to_owned())))
+        .unwrap();
+    let resp = sender.send_request(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let out = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&out).into_owned())
+}

--- a/crates/yerd-supervise/src/real.rs
+++ b/crates/yerd-supervise/src/real.rs
@@ -68,12 +68,48 @@ impl ProcessSpawner for TokioProcessSpawner {
     fn spawn(&self, cmd: StdCommand) -> Result<TokioChild, io::Error> {
         let mut tokio_cmd = tokio::process::Command::from(cmd);
         tokio_cmd.kill_on_drop(true);
-        let child = tokio_cmd.spawn()?;
+        let child = spawn_retrying_text_file_busy(&mut tokio_cmd)?;
         let pid = child
             .id()
             .ok_or_else(|| io::Error::other("child has no pid"))?;
         Ok(TokioChild { inner: child, pid })
     }
+}
+
+/// Spawn `cmd`, retrying briefly on `ETXTBSY` ("text file busy").
+///
+/// A multithreaded program that writes an executable and then execs it can hit
+/// `ETXTBSY` transiently: the kernel refuses to exec a file while any fd still
+/// holds it open for writing, and a sibling thread's not-yet-closed writer fd
+/// (or one snapshotted into a concurrent `fork`) can briefly hold it. The writer
+/// closes promptly, so a small bounded retry clears the race rather than
+/// surfacing a spurious spawn failure. The first attempt succeeds in the
+/// overwhelmingly common case, so this adds no cost on the happy path.
+fn spawn_retrying_text_file_busy(
+    cmd: &mut tokio::process::Command,
+) -> io::Result<tokio::process::Child> {
+    const MAX_ATTEMPTS: usize = 5;
+    let mut result = cmd.spawn();
+    let mut attempts = 1;
+    while attempts < MAX_ATTEMPTS && matches!(&result, Err(e) if is_text_file_busy(e)) {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        result = cmd.spawn();
+        attempts += 1;
+    }
+    result
+}
+
+/// Whether `e` is `ETXTBSY` (executable busy). Matched on the raw errno rather
+/// than `io::ErrorKind::ExecutableFileBusy` to stay within the crate's 1.77 MSRV
+/// (that variant stabilised in 1.83).
+#[cfg(unix)]
+fn is_text_file_busy(e: &io::Error) -> bool {
+    e.raw_os_error() == Some(nix::libc::ETXTBSY)
+}
+
+#[cfg(not(unix))]
+fn is_text_file_busy(_e: &io::Error) -> bool {
+    false
 }
 
 /// Production [`ChildHandle`] wrapping `tokio::process::Child`.
@@ -122,7 +158,8 @@ impl ChildHandle for TokioChild {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::group_signal_target;
+    use super::{group_signal_target, is_text_file_busy};
+    use std::io;
 
     #[test]
     fn group_signal_target_rejects_zero_and_overflow() {
@@ -133,5 +170,16 @@ mod tests {
             None,
             "a PID that overflows i32 must not be signalled"
         );
+    }
+
+    #[test]
+    fn is_text_file_busy_matches_only_etxtbsy() {
+        assert!(is_text_file_busy(&io::Error::from_raw_os_error(
+            nix::libc::ETXTBSY
+        )));
+        assert!(!is_text_file_busy(&io::Error::from_raw_os_error(
+            nix::libc::ENOENT
+        )));
+        assert!(!is_text_file_busy(&io::Error::other("not an os error")));
     }
 }

--- a/crates/yerd-supervise/src/real.rs
+++ b/crates/yerd-supervise/src/real.rs
@@ -76,23 +76,26 @@ impl ProcessSpawner for TokioProcessSpawner {
     }
 }
 
-/// Spawn `cmd`, retrying briefly on `ETXTBSY` ("text file busy").
+/// Spawn `cmd`, retrying on `ETXTBSY` ("text file busy").
 ///
 /// A multithreaded program that writes an executable and then execs it can hit
 /// `ETXTBSY` transiently: the kernel refuses to exec a file while any fd still
 /// holds it open for writing, and a sibling thread's not-yet-closed writer fd
-/// (or one snapshotted into a concurrent `fork`) can briefly hold it. The writer
-/// closes promptly, so a small bounded retry clears the race rather than
-/// surfacing a spurious spawn failure. The first attempt succeeds in the
-/// overwhelmingly common case, so this adds no cost on the happy path.
+/// (or one snapshotted into a concurrent `fork`) can briefly hold it. Because
+/// Rust opens files `O_CLOEXEC`, that inherited fd is dropped the instant the
+/// racing child execs, so the window is very short. This is a synchronous trait
+/// method that may run on a Tokio worker, so it must not block the worker with a
+/// timed sleep; instead each retry `yield_now()`s (a cooperative hand-off to the
+/// runnable fd-closing thread) before trying again. The first attempt succeeds
+/// in the overwhelmingly common case, so the happy path pays nothing.
 fn spawn_retrying_text_file_busy(
     cmd: &mut tokio::process::Command,
 ) -> io::Result<tokio::process::Child> {
-    const MAX_ATTEMPTS: usize = 5;
+    const MAX_ATTEMPTS: usize = 20;
     let mut result = cmd.spawn();
     let mut attempts = 1;
     while attempts < MAX_ATTEMPTS && matches!(&result, Err(e) if is_text_file_busy(e)) {
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::thread::yield_now();
         result = cmd.spawn();
         attempts += 1;
     }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -154,6 +154,7 @@ export default withMermaid({
           text: 'Using Yerd',
           items: [
             { text: 'Sites', link: '/guide/sites' },
+            { text: 'Reverse Proxies', link: '/guide/proxies' },
             { text: 'PHP Versions', link: '/guide/php-versions' },
             { text: 'Code Coverage', link: '/guide/code-coverage' },
             { text: 'Tooling', link: '/guide/tooling' },
@@ -178,6 +179,7 @@ export default withMermaid({
             { text: 'Overview', link: '/reference/cli/' },
             { text: 'Sites', link: '/reference/cli/sites' },
             { text: 'Domains', link: '/reference/cli/domains' },
+            { text: 'Proxies', link: '/reference/cli/proxies' },
             { text: 'HTTPS', link: '/reference/cli/https' },
             { text: 'PHP', link: '/reference/cli/php' },
             { text: 'Tooling', link: '/reference/cli/tooling' },

--- a/docs/developer/config-schema-history.md
+++ b/docs/developer/config-schema-history.md
@@ -28,7 +28,28 @@ Each entry below states what changed, whether the daemon's own migration is a ba
 
 ## Version-by-version
 
-### v13 (current)
+### v14 (current)
+
+**Added:** the optional `[[proxies]]` array (whole-host reverse proxies) and the `[proxy_rules]` table (per-site path-prefix rules). Both default to empty when absent, so an uncustomised file omits them entirely.
+
+```toml
+[[proxies]]
+name = "reverb"
+target = "http://127.0.0.1:8080"
+secure = true
+
+[[proxy_rules.linked.myapp]]
+prefix = "/app"
+target = "http://127.0.0.1:8080"
+```
+
+`[proxy_rules]` is split by site class exactly like `[domains]`: `[proxy_rules.linked.<name>]` keys by site name, `[proxy_rules.parked."<docroot>"]` by byte-exact document-root. Removing a site's last rule drops its key, so the file round-trips byte-identically.
+
+**Migration from v13:** bare version bump - both sections default to empty when absent, so a v13 file needs no other change to become a valid v14 file.
+
+**To downgrade to v13:** change `version = 14` to `version = 13`, then delete any `[[proxies]]` entries and the whole `[proxy_rules]` table (a v13 daemon rejects the unknown tables under `deny_unknown_fields`, it doesn't just ignore them). Those proxies and rules stop being served; the sites they were attached to are otherwise unaffected.
+
+### v13
 
 **Added:** the optional per-site `front_controller` key (bool) inside `[[linked]]` and `[[overrides]]` - the toggle between single-front-controller mode (every request funnels through the site-root `index.php`) and direct script execution (a named `.php` under the served root runs directly). Absent = auto: a framework served from a subdirectory (non-empty `web_subpath`) defaults to front-controller mode; WordPress (any layout) and plain root-served sites default to direct execution.
 

--- a/docs/developer/ipc-protocol.md
+++ b/docs/developer/ipc-protocol.md
@@ -280,6 +280,10 @@ The multi-domain feature adds three more `SiteEntry` fields alongside `is_wordpr
 For read/unread tracking, `MailSummary` gained a `read: bool` (last field) and `MailStatus` gained an `unread: u32` (last field), both `#[serde(default)]`. A missing key decodes to `false`/`0`, so old daemons and old clients interoperate without a `PROTOCOL_VERSION` bump; the goldens grew a `,"read":false` / `,"unread":0` suffix. The matching mutator is the additive `Request::MarkMailsRead { ids }`.
 :::
 
+::: info Reverse proxies are additive requests plus their own response variant
+The proxy feature adds four mutators - `AddProxy { name, url }`, `RemoveProxy { name }`, `AddProxyRule { site, prefix, url }`, `RemoveProxyRule { site, prefix }` (all reply with the generic `Ok`) - and one query, `ListProxies`. Because a whole-host proxy is **not** a `Site`, it can't ride `Response::Sites`/`SiteEntry`; `ListProxies` gets a dedicated `Response::Proxies { proxies: Vec<ProxyEntry>, rules: Vec<ProxyRuleEntry> }` instead, where `ProxyEntry { name, target, secure }` and `ProxyRuleEntry { site, prefix, target }` are all `String`/`bool` so the `Response` `Eq` derive holds. New variants are additive by serde tag, so existing pins are byte-identical and no `PROTOCOL_VERSION` bump is needed. `url` stays a `String` on the wire; the daemon parses and validates it (returning a typed error) rather than the client.
+:::
+
 ### ErrorCode
 
 Failures are a `Response::Error { code, message }` where `code` is machine-readable and `message` is for human display:

--- a/docs/guide/proxies.md
+++ b/docs/guide/proxies.md
@@ -1,0 +1,88 @@
+# Reverse Proxies
+
+Yerd can put a `.test` address in front of a service it doesn't run itself - a
+Reverb server, a Node or Vite dev server, a Docker container, anything already
+listening on a port. The service gets Yerd's DNS, its trusted HTTPS, and a clean
+`.test` hostname, with no extra config on the service's side.
+
+There are two shapes, and you'll usually want the second for Laravel work:
+
+- A **whole-host proxy** gives a service its own hostname: `reverb.test` → a
+  service on `localhost:8080`.
+- A **path rule** routes one path *on an existing site* to a service:
+  `myapp.test/app` → a service, while every other path on `myapp.test` is still
+  served by PHP. This keeps everything **same-origin**, which is exactly what
+  Laravel Reverb needs (`wss://myapp.test/app`) so cookies and CORS work without
+  a second domain.
+
+Unlike [Herd](https://herd.laravel.com), which writes an nginx vhost, Yerd's
+proxy is built into its own request path - there's nothing to configure and no
+web server to reload.
+
+## Whole-host proxies
+
+Point a new `.test` host at a running service:
+
+```sh
+yerd proxy add reverb http://localhost:8080
+```
+
+Now `http://reverb.test/` reaches the service. Serve it over HTTPS the same way
+you would a site - a proxy is secured on its own name:
+
+```sh
+yerd secure reverb
+# https://reverb.test/  (trusted cert, HTTP redirects to HTTPS)
+```
+
+Remove it with `yerd proxy remove reverb`.
+
+## Path rules (the Reverb case)
+
+Attach a path to an existing site. Say `myapp` is a Laravel app and Reverb is
+running on `:8080`:
+
+```sh
+yerd proxy add myapp /app http://127.0.0.1:8080
+```
+
+- `https://myapp.test/` and everything else → **PHP** (Laravel), unchanged.
+- `https://myapp.test/app` (and `/app/...`) → **Reverb**, websockets included.
+
+The rule inherits the site's TLS, so once `myapp` is secured the `/app` path is
+too - your JS client connects to `wss://myapp.test/app` on the same origin. The
+full path is passed through to the upstream unchanged (`/app/...` reaches
+Reverb as `/app/...`), which is what Reverb expects.
+
+Remove a rule with `yerd proxy remove myapp /app`.
+
+## Upstreams and headers
+
+The upstream is `http://host:port` or `https://host:port`. For an `https://`
+upstream, Yerd verifies the certificate for a genuine public host but **skips
+verification for a local host** (`localhost`, a loopback/private IP, or a `.test`
+name) - self-signed dev backends are the norm there.
+
+Yerd preserves the original `Host` header (many upstreams key vhosts on it) and
+adds `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Real-IP`.
+Websocket upgrades are tunnelled through. If the upstream is down, a request
+returns **`502 Bad Gateway`** rather than hanging.
+
+::: warning You can't proxy to Yerd itself
+A target that points back into Yerd - a `.test` host, or `localhost` on the port
+Yerd's own proxy is listening on - is rejected, because it would loop forever.
+Point the target at the service's real port instead. In rootless mode Yerd binds
+`8080`/`8443`, so a dev server on one of those ports will need to move.
+:::
+
+## Listing what's configured
+
+```sh
+yerd proxy list
+```
+
+shows every whole-host proxy and every per-site path rule. `yerd --json proxy
+list` gives the same data as JSON for scripting or the desktop app.
+
+For the full command surface, flags, and validation rules, see the
+[Proxies CLI reference](../reference/cli/proxies).

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -34,6 +34,7 @@ yerd [--json] <COMMAND> [ARGS...]
 | --- | --- |
 | [Sites](./sites) | `sites`, `park`, `unpark`, `link`, `unlink`, `root` |
 | [Domains](./domains) | `domain list`, `domain add`, `domain remove`, `domain primary`, `domain reset` |
+| [Proxies](./proxies) | `proxy add`, `proxy remove`, `proxy list` |
 | [HTTPS](./https) | `secure`, `unsecure` |
 | [PHP](./php) | `use`, `install php`, `uninstall php`, `update php`, `restart php`, `list php`, `list parked`, `set php`, `unset php`, `php ext add`/`remove`/`list` |
 | [Tooling](./tooling) | `tools`, `install tool`, `uninstall tool`, `path install`, `path uninstall`, `path print` |

--- a/docs/reference/cli/proxies.md
+++ b/docs/reference/cli/proxies.md
@@ -1,0 +1,93 @@
+# Proxies
+
+A **reverse proxy** fronts an already-running service with a Yerd `.test`
+address, so it gets the same DNS, HTTPS, and browser experience as a PHP site -
+without Yerd running the service itself. Two shapes:
+
+- A **whole-host proxy** maps a new host to a service: `reverb.test` → a Reverb,
+  Node, Vite, or Docker service on some port.
+- A **path rule** maps a path *on an existing site* to a service:
+  `myapp.test/app` → a service, while every other path on `myapp.test` keeps
+  being served by PHP. This is the same-origin setup Laravel Reverb wants
+  (`wss://myapp.test/app`), so cookies and CORS just work.
+
+`yerd proxy add`'s two forms are distinguished by argument count: two arguments
+create a whole-host proxy, three attach a path rule to a site.
+
+| Command | Description | Example |
+| --- | --- | --- |
+| `yerd proxy add <NAME> <URL>` | Create a whole-host proxy (`<NAME>.test` → `<URL>`). | `yerd proxy add reverb http://localhost:8080` |
+| `yerd proxy add <SITE> <PREFIX> <URL>` | Add a path rule: requests under `<PREFIX>` on `<SITE>.test` proxy to `<URL>`. | `yerd proxy add myapp /app http://127.0.0.1:8080` |
+| `yerd proxy remove <NAME>` | Remove a whole-host proxy. | `yerd proxy remove reverb` |
+| `yerd proxy remove <SITE> <PREFIX>` | Remove a path rule from a site. | `yerd proxy remove myapp /app` |
+| `yerd proxy list` | List every whole-host proxy and per-site path rule. | `yerd proxy list` |
+
+```sh
+# Whole-host: front a Reverb server on its own .test domain
+yerd proxy add reverb http://localhost:8080
+curl http://reverb.test/          # → the Reverb service
+
+# Serve it over HTTPS - a proxy secures exactly like a site
+yerd secure reverb
+curl https://reverb.test/
+
+# Path rule (the Reverb same-origin case): /app on an existing Laravel site
+yerd proxy add myapp /app http://127.0.0.1:8080
+# https://myapp.test/        → PHP (Laravel)
+# https://myapp.test/app     → Reverb (websockets included)
+
+# List, then remove
+yerd proxy list
+yerd proxy remove myapp /app
+yerd proxy remove reverb
+```
+
+A path rule inherits its parent site's TLS: securing `myapp` (`yerd secure
+myapp`) also secures its `/app` rule. A whole-host proxy is secured on its own
+name (`yerd secure reverb` / `yerd unsecure reverb`), exactly like a site.
+
+## Upstreams
+
+The upstream `<URL>` is `http://host:port` or `https://host:port`. The port is
+required for anything but the default (`80`/`443`). For an `https://` upstream,
+Yerd verifies the certificate for a genuine public host, but **skips
+verification for a local host** (`localhost`, a loopback/private IP, or a
+`.test` name) - self-signed dev backends are the norm there.
+
+The request path is passed to the upstream **unchanged** (an nginx
+`proxy_pass` with no trailing path), so a path rule's prefix reaches the
+upstream too: `myapp.test/app/foo` → `<URL>/app/foo`. Yerd preserves the
+original `Host` header and adds the usual `X-Forwarded-For`,
+`X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Real-IP` headers. Websocket
+(`Connection: Upgrade`) traffic is tunnelled through, so Reverb/Vite HMR work.
+
+If the upstream is down, a proxied request returns **`502 Bad Gateway`** rather
+than hanging.
+
+## How a request routes
+
+For an incoming host, Yerd resolves it to a site or a whole-host proxy, then:
+
+- a **whole-host proxy** forwards every request to its upstream (no PHP);
+- a **site** with a matching **path rule** forwards that request to the rule's
+  upstream; every other path is served by PHP as usual. Matching is
+  longest-prefix with path boundaries, so `/app` matches `/app` and `/app/x`
+  but **not** `/apple`.
+
+If a whole-host proxy's name collides with a real site's apex, the site wins and
+the proxy is dropped (surfaced by [`yerd doctor`](./diagnostics)).
+
+::: details Client-side validation & guards
+`proxy add` validates the upstream URL and, for a path rule, that the prefix
+begins with `/`, before connecting - a malformed value fails with a usage error
+(exit code `2`). The daemon rejects a target that would **loop back into Yerd**:
+a `.test` host, or a loopback host on one of Yerd's own bound proxy ports. A
+proxy name that collides with an existing site or proxy is rejected as
+"already exists".
+:::
+
+## See also
+
+- [HTTPS & Certificates](../../guide/https) - how `secure` mints a trusted cert.
+- [Reverse Proxies](../../guide/proxies) - the guide-level walkthrough.
+- [Domains](./domains) - give a proxy or site more `.test` names.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,12 +44,12 @@ Every field below maps one-to-one to a field in `schema.rs`. The on-disk shape a
 | `domains`   | table                | Per-site domain sets (primary, aliases, subdomains, wildcards).   | empty          |
 
 ::: warning Unknown keys are rejected
-The parser uses `deny_unknown_fields` at every level. A typo'd or stray key (top-level, or inside `[ports]`, `[php]`, `[parked]`, `[mail]`, `[dumps]`, `[dumps.features]`, `[domains]`, a `[domains.linked.<name>]` / `[domains.parked."<docroot>"]` entry, a `[services.<id>]` table, a `[[linked]]` entry, an `[[overrides]]` entry, or a `[[php.extensions.<version>]]` entry) is a hard parse error - the daemon will refuse to load the file rather than silently ignore it.
+The parser uses `deny_unknown_fields` at every level. A typo'd or stray key (top-level, or inside `[ports]`, `[php]`, `[parked]`, `[mail]`, `[dumps]`, `[dumps.features]`, `[domains]`, a `[domains.linked.<name>]` / `[domains.parked."<docroot>"]` entry, `[proxy_rules]`, a `[[proxies]]` entry, a `[services.<id>]` table, a `[[linked]]` entry, an `[[overrides]]` entry, or a `[[php.extensions.<version>]]` entry) is a hard parse error - the daemon will refuse to load the file rather than silently ignore it.
 :::
 
 ### `version`
 
-The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `13`, and Yerd always writes `version = 13`. Older `version = 1` through `version = 12` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
+The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `14`, and Yerd always writes `version = 14`. Older `version = 1` through `version = 13` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
 
 ### `tld`
 
@@ -380,16 +380,64 @@ primary = "corp"
 added = ["shop-staging"]
 ```
 
+### `[[proxies]]`
+
+Whole-host reverse proxies - a `<name>.<tld>` host forwarded wholesale to a
+running service, with no PHP or document root. **Empty by default** (the array
+is omitted from the file) until you add one with [`yerd proxy`](./cli/proxies).
+Order is preserved on round-trip.
+
+| Field    | TOML type | Meaning                                                         |
+| -------- | --------- | --------------------------------------------------------------- |
+| `name`   | string    | The proxy's DNS label; it answers on `<name>.<tld>`.            |
+| `target` | string    | The upstream URL, `http://host:port` or `https://host:port`.    |
+| `secure` | bool      | Whether the proxy is served over HTTPS (toggled by `yerd secure`). |
+
+```toml
+[[proxies]]
+name = "reverb"
+target = "http://127.0.0.1:8080"
+secure = true
+```
+
+### `[proxy_rules]`
+
+Per-site path-prefix proxy rules - a path on an existing site forwarded to a
+service while every other path is served by PHP. **Empty by default** (the whole
+table is omitted) until you add a rule. Split by site class exactly like
+`[domains]`: linked rules key by site name, parked rules by byte-exact
+document-root, so routing survives a directory rename.
+
+| Key                    | TOML type                       | Meaning                                       |
+| ---------------------- | ------------------------------- | --------------------------------------------- |
+| `[proxy_rules.linked]` | table (`name → array of rules`) | Rules for **linked** sites, keyed by name.    |
+| `[proxy_rules.parked]` | table (`docroot → array`)       | Rules for **parked** sites, keyed by docroot. |
+
+Each rule is a `{ prefix, target }` table. Removing a site's last rule drops its
+key entirely, so the file round-trips byte-identically.
+
+```toml
+[[proxy_rules.linked.myapp]]
+prefix = "/app"
+target = "http://127.0.0.1:8080"
+```
+
+`Config::validate` enforces the structural rules it can see (proxy names unique
+among proxies and against linked sites; a site's rule prefixes unique; no target
+pointing at a `.<tld>` host). Collisions with parked sites and the
+loopback-on-own-port loop guard are enforced by the daemon, which alone knows
+the actively bound ports and sees parked sites on disk.
+
 ## Schema versioning and migration
 
-Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `13`.
+Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `14`.
 
 When the daemon loads a file, it routes on the version it finds:
 
 ```text
-found  > CURRENT (13)   →  error (UnsupportedVersion) - a newer Yerd wrote this file
-found == CURRENT (13)   →  parse directly
-found  < CURRENT (13)   →  walk forward migration steps, then parse
+found  > CURRENT (14)   →  error (UnsupportedVersion) - a newer Yerd wrote this file
+found == CURRENT (14)   →  parse directly
+found  < CURRENT (14)   →  walk forward migration steps, then parse
 ```
 
 A file written by a *newer* Yerd than you are running is refused rather than misread. Older files are migrated forward in place, one version at a time, before the normal wire-deserialisation and validation run:
@@ -406,6 +454,7 @@ A file written by a *newer* Yerd than you are running is refused rather than mis
 - **`v10 → v11`** is a bare version bump: v11 only **added** the optional `[domains]` table (per-site domain sets), which defaults to empty when absent. Same rationale - the bump lets an older binary refuse a `[domains]`-bearing file cleanly rather than tripping `deny_unknown_fields`. No existing keys change, so a v10 file needs no structural rewrite.
 - **`v11 → v12`** is a bare version bump: v12 only **added** the top-level `symlink_protection` scalar (defaults to `true` when absent).
 - **`v12 → v13`** is a bare version bump: v13 only **added** the optional per-site `front_controller` key (inside `[[linked]]` and `[[overrides]]`), which defaults to auto when absent.
+- **`v13 → v14`** is a bare version bump: v14 only **added** the optional `[[proxies]]` array and `[proxy_rules]` table (reverse proxies and per-site path rules), both of which default to empty when absent. Same rationale - the bump lets an older binary refuse a proxy-bearing file cleanly rather than tripping `deny_unknown_fields`.
 
 The on-disk schema version is deliberately decoupled from the IPC protocol version; the two evolve independently.
 
@@ -429,11 +478,11 @@ Yerd does not `fsync` the file or its parent directory after a save. For a devel
 
 ## A complete annotated example
 
-This is a valid `yerd.toml` covering the core fields (see the sections above for the newer optional tables - `update_channel`, `[tunnel]`, `[groups]`, `[php.extensions]`, `[domains]`, `wp_auto_login` - omitted here for brevity):
+This is a valid `yerd.toml` covering the core fields (see the sections above for the newer optional tables - `update_channel`, `[tunnel]`, `[groups]`, `[php.extensions]`, `[domains]`, `[[proxies]]`, `[proxy_rules]`, `wp_auto_login` - omitted here for brevity):
 
 ```toml
-# Schema version - mandatory, always written as 13 by this release.
-version = 13
+# Schema version - mandatory, always written as 14 by this release.
+version = 14
 
 # TLD served by the resolver; sites resolve as <name>.test
 tld = "test"


### PR DESCRIPTION
## What does this PR do?

Adds various proxy commands to the CLI (no GUI yet)

## Related issues

related to #38 and #92 

## Type of change

- [x] New feature
- [x] Documentation

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reverse proxy support for whole hosts and per-site path-prefix rules, including CLI commands: `yerd proxy add`, `yerd proxy remove`, and `yerd proxy list`.
  * Integrated proxy routing into HTTP/HTTPS handling, with WebSocket upgrade tunneling and consistent forwarding behavior.
  * Added public-upstream client TLS verification and proxy-aware daemon startup/test wiring.
* **Bug Fixes**
  * Prevented proxy routing loops and improved validation for malformed, duplicate, and self-forwarding proxy targets/rules, plus proxy/site name collision handling.
* **Documentation**
  * Added a reverse proxy guide and updated CLI/config reference docs for schema version 14 (`[[proxies]]`, `[proxy_rules]`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->