### PR TITLE
[Fix] Replace underscore for parked/linked folders

### DIFF
--- a/apps/yerd-gui/src/lib/siteName.test.ts
+++ b/apps/yerd-gui/src/lib/siteName.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { slugifySiteName } from "./siteName";
+
+describe("slugifySiteName", () => {
+  it("mirrors the Rust slugify_site_name cases", () => {
+    const cases: [string, string | null][] = [
+      ["My Project", "my-project"],
+      ["my_app", "my-app"],
+      ["example.com", "example-com"],
+      ["ex.com", "ex-com"],
+      ["a..b", "a-b"],
+      ["-leading", "leading"],
+      ["trailing-", "trailing"],
+      ["already-valid", "already-valid"],
+      ["???", null],
+      ["", null],
+    ];
+    for (const [input, expected] of cases) {
+      expect(slugifySiteName(input), `input ${JSON.stringify(input)}`).toBe(expected);
+    }
+  });
+
+  it("treats non-ASCII letters as separators, mirroring Rust is_ascii_alphanumeric", () => {
+    const cases: [string, string | null][] = [
+      ["café", "caf"],
+      ["a①b", "a-b"],
+      ["naïve", "na-ve"],
+      ["ﬀ", null],
+    ];
+    for (const [input, expected] of cases) {
+      expect(slugifySiteName(input), `input ${JSON.stringify(input)}`).toBe(expected);
+    }
+  });
+
+  it("caps at 63 chars without a trailing hyphen", () => {
+    const slug = slugifySiteName("a".repeat(65));
+    expect(slug).not.toBeNull();
+    expect(slug?.length).toBe(63);
+    expect(slug?.endsWith("-")).toBe(false);
+  });
+
+  it("does not leave a dangling hyphen when a separator lands on the boundary", () => {
+    const slug = slugifySiteName(`${"a".repeat(62)} ${"b".repeat(5)}`);
+    expect(slug?.length).toBe(62);
+    expect(slug?.endsWith("-")).toBe(false);
+  });
+});

--- a/apps/yerd-gui/src/lib/siteName.ts
+++ b/apps/yerd-gui/src/lib/siteName.ts
@@ -1,0 +1,38 @@
+/**
+ * Derive a valid site name from an arbitrary string (typically a chosen folder's
+ * last path component), for the Link modal's auto-naming.
+ *
+ * A faithful mirror of the CLI/daemon's `slugify_site_name`
+ * (`crates/yerd-core/src/site.rs`): lowercases, replaces every run of characters
+ * outside `[a-z0-9]` (`_`, `.`, spaces, ...) with a single `-`, trims
+ * leading/trailing `-`, and caps at the 63-byte DNS-label limit. Returns `null`
+ * when nothing valid remains. Its output is always `[a-z0-9-]` with no
+ * leading/trailing/doubled `-`, so the daemon's strict `Site::linked` validator
+ * always accepts it. Keep the two in step.
+ *
+ * `for..of` iterates Unicode code points, matching the Rust `raw.chars()` loop,
+ * and the 63-cap is applied to the already-ASCII output so `.length` counts
+ * bytes.
+ */
+export function slugifySiteName(raw: string): string | null {
+  let out = "";
+  for (const ch of raw) {
+    if (isAsciiAlphanumeric(ch)) {
+      out += ch.toLowerCase();
+    } else if (out.length > 0 && !out.endsWith("-")) {
+      out += "-";
+    }
+  }
+  while (out.endsWith("-")) out = out.slice(0, -1);
+  if (out === "") return null;
+  if (out.length > 63) {
+    out = out.slice(0, 63);
+    while (out.endsWith("-")) out = out.slice(0, -1);
+  }
+  return out === "" ? null : out;
+}
+
+function isAsciiAlphanumeric(ch: string): boolean {
+  if (ch.length !== 1) return false;
+  return (ch >= "0" && ch <= "9") || (ch >= "a" && ch <= "z") || (ch >= "A" && ch <= "Z");
+}

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -42,6 +42,7 @@ import Spinner from "@/components/ui/Spinner.vue";
 import Switch from "@/components/ui/Switch.vue";
 import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { sitesIntent } from "@/lib/shortcuts/sitesIntent";
+import { slugifySiteName } from "@/lib/siteName";
 import { useSitesGroupState } from "@/lib/sitesGroupState";
 import { useDaemon } from "@/composables/useDaemon";
 import { usePoll } from "@/composables/usePoll";
@@ -571,18 +572,37 @@ async function confirmUnpark(close: () => void): Promise<void> {
 const linkOpen = ref(false);
 const linkName = ref("");
 const linkPath = ref("");
+// True once the user types in the name field, so choosing a folder never
+// clobbers a name they entered themselves. Native `input` events fire only on
+// real keystrokes, not on the programmatic prefill in `chooseLinkDir`.
+const linkNameDirty = ref(false);
+// A folder-derived or typed name is converted to a valid slug on submit, so
+// validity is "does it slugify to something", not the raw `[a-z0-9-]` shape.
 const linkValid = computed(
-  () => /^[a-z0-9-]+$/i.test(linkName.value.trim()) && linkPath.value.trim() !== "",
+  () => slugifySiteName(linkName.value) !== null && linkPath.value.trim() !== "",
 );
+
+watch(linkOpen, (open) => {
+  if (open) linkNameDirty.value = linkName.value.trim() !== "";
+});
+
+function baseName(path: string): string {
+  const trimmed = path.replace(/[/\\]+$/, "");
+  const parts = trimmed.split(/[/\\]/);
+  return parts[parts.length - 1] ?? "";
+}
 
 async function chooseLinkDir(): Promise<void> {
   const dir = await pickDirectory();
-  if (dir) linkPath.value = dir;
+  if (!dir) return;
+  linkPath.value = dir;
+  if (!linkNameDirty.value) linkName.value = slugifySiteName(baseName(dir)) ?? "";
 }
 
 async function confirmLink(close: () => void): Promise<void> {
-  const name = linkName.value.trim();
+  const name = slugifySiteName(linkName.value);
   const path = linkPath.value.trim();
+  if (!name) return;
   close();
   rowBusy.value = "link";
   try {
@@ -590,6 +610,7 @@ async function confirmLink(close: () => void): Promise<void> {
     toast.success(`Linked ${name}`);
     linkName.value = "";
     linkPath.value = "";
+    linkNameDirty.value = false;
     await load({ force: true });
   } catch (e) {
     toast.error("Link failed", (e as IpcError).message);
@@ -1083,7 +1104,13 @@ async function shareSitePublicly(s: Site): Promise<void> {
     <!-- link modal -->
     <Modal v-model:open="linkOpen" title="Link a site">
       <label class="text-sm font-medium" for="linkname">Name (single label)</label>
-      <Input id="linkname" v-model="linkName" placeholder="e.g. myapp" class="mt-2" />
+      <Input
+        id="linkname"
+        v-model="linkName"
+        placeholder="e.g. myapp"
+        class="mt-2"
+        @input="linkNameDirty = true"
+      />
       <label class="mt-4 block text-sm font-medium" for="linkpath">Directory</label>
       <div class="mt-2 flex gap-2">
         <Input id="linkpath" v-model="linkPath" placeholder="/path/to/project" />

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -583,7 +583,11 @@ const linkValid = computed(
 );
 
 watch(linkOpen, (open) => {
-  if (open) linkNameDirty.value = linkName.value.trim() !== "";
+  if (!open) {
+    linkName.value = "";
+    linkPath.value = "";
+    linkNameDirty.value = false;
+  }
 });
 
 function baseName(path: string): string {
@@ -608,9 +612,6 @@ async function confirmLink(close: () => void): Promise<void> {
   try {
     await link(name, path);
     toast.success(`Linked ${name}`);
-    linkName.value = "";
-    linkPath.value = "";
-    linkNameDirty.value = false;
     await load({ force: true });
   } catch (e) {
     toast.error("Link failed", (e as IpcError).message);

--- a/bin/yerdd/src/mutate.rs
+++ b/bin/yerdd/src/mutate.rs
@@ -9,9 +9,9 @@
 //! ## Name normalisation
 //!
 //! The router and `cfg.linked` are keyed by the **lowercased** site name
-//! (`scan_sites` slugifies discovered directory names, whose output is
-//! lowercase; the `Site` constructors lowercase too). Unlike the proxy's host
-//! path, the IPC mutation
+//! (`scan_sites` normalises discovered directory names - keeping already-valid
+//! names and slugifying the rest, both lowercase; the `Site` constructors
+//! lowercase too). Unlike the proxy's host path, the IPC mutation
 //! path has no `host::normalise`, so [`apply`] lowercases the request `name`
 //! itself before every lookup - otherwise `yerd use Blog 8.4` would look up
 //! `"Blog"`, miss the stored `"blog"`, and wrongly report "not found".

--- a/bin/yerdd/src/mutate.rs
+++ b/bin/yerdd/src/mutate.rs
@@ -9,8 +9,9 @@
 //! ## Name normalisation
 //!
 //! The router and `cfg.linked` are keyed by the **lowercased** site name
-//! (`scan_sites` lowercases discovered directory names; the `Site`
-//! constructors lowercase too). Unlike the proxy's host path, the IPC mutation
+//! (`scan_sites` slugifies discovered directory names, whose output is
+//! lowercase; the `Site` constructors lowercase too). Unlike the proxy's host
+//! path, the IPC mutation
 //! path has no `host::normalise`, so [`apply`] lowercases the request `name`
 //! itself before every lookup - otherwise `yerd use Blog 8.4` would look up
 //! `"Blog"`, miss the stored `"blog"`, and wrongly report "not found".

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -587,12 +587,12 @@ pub(crate) fn scan_sites(
             }
         };
         for entry in entries.flatten() {
-            let Some(name_lower) = parked_site_name(&entry, &linked_names) else {
+            let Some(slug) = parked_site_name(&entry, &linked_names) else {
                 continue;
             };
             let doc_root = entry.path();
             if let Some(site) = build_parked_site(
-                &name_lower,
+                &slug,
                 &doc_root,
                 default_php,
                 cfg,
@@ -608,9 +608,12 @@ pub(crate) fn scan_sites(
     Ok((parked, watch_roots))
 }
 
-/// Filter one parked-directory entry to its lowercased site name, or `None` to
-/// skip it (non-UTF-8, hidden, not a directory, or shadowed by a linked site -
-/// linked wins on a name collision).
+/// Filter one parked-directory entry to its site name, or `None` to skip it
+/// (non-UTF-8, hidden, not a directory, no valid name after normalising, or
+/// shadowed by a linked site - linked wins on a name collision). The name is run
+/// through [`yerd_core::normalize_site_name`]: an already-valid name is kept, and
+/// one the validator would reject (`_`, `.`, ...) is slugified rather than
+/// dropped.
 fn parked_site_name(
     entry: &std::fs::DirEntry,
     linked_names: &std::collections::HashSet<&str>,
@@ -629,11 +632,14 @@ fn parked_site_name(
     if !entry.metadata().ok()?.is_dir() {
         return None;
     }
-    let name_lower = name.to_ascii_lowercase();
-    if linked_names.contains(name_lower.as_str()) {
+    let Some(slug) = yerd_core::normalize_site_name(name) else {
+        tracing::debug!(name = %name, "skipping parked dir with no valid site name");
+        return None;
+    };
+    if linked_names.contains(slug.as_str()) {
         return None;
     }
-    Some(name_lower)
+    Some(slug)
 }
 
 /// Build a parked [`Site`] for `doc_root`, re-applying any persisted per-site
@@ -642,18 +648,18 @@ fn parked_site_name(
 /// unresolved detection serves the root provisionally and pushes `doc_root` onto
 /// `watch_roots`. Returns `None` (logging) for an invalid site name.
 fn build_parked_site(
-    name_lower: &str,
+    slug: &str,
     doc_root: &std::path::Path,
     default_php: PhpVersion,
     cfg: &yerd_config::Config,
     detect_cache: &DetectCache,
     watch_roots: &mut Vec<PathBuf>,
 ) -> Option<Site> {
-    let mut site = match Site::parked(name_lower, doc_root, default_php) {
+    let mut site = match Site::parked(slug, doc_root, default_php) {
         Ok(site) => site,
         Err(e) => {
             tracing::debug!(
-                name = %name_lower,
+                name = %slug,
                 error = %e,
                 "skipping invalid parked-site name"
             );
@@ -808,6 +814,24 @@ mod tests {
         let mut names: Vec<&str> = sites.iter().map(yerd_core::Site::name).collect();
         names.sort_unstable();
         assert_eq!(names, vec!["app1", "app2"]);
+    }
+
+    #[test]
+    fn scan_sites_slugifies_underscored_parked_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parked_root = tmp.path().join("Sites");
+        std::fs::create_dir_all(parked_root.join("foo_bar")).unwrap();
+
+        let mut cfg = yerd_config::Config::default();
+        cfg.parked
+            .paths
+            .insert(parked_root.to_string_lossy().into_owned());
+
+        let dirs = make_dirs(tmp.path());
+        let (sites, _) =
+            scan_sites(&cfg, PhpVersion::new(8, 3), &dirs, &DetectCache::new()).unwrap();
+        let names: Vec<&str> = sites.iter().map(yerd_core::Site::name).collect();
+        assert_eq!(names, vec!["foo-bar"]);
     }
 
     #[test]
@@ -1086,10 +1110,13 @@ mod tests {
     }
 
     #[test]
-    fn parked_site_name_filters_and_lowercases() {
+    fn parked_site_name_filters_and_slugifies() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("MyApp")).unwrap();
+        std::fs::create_dir_all(root.join("foo_bar")).unwrap();
+        std::fs::create_dir_all(root.join("ex.com")).unwrap();
+        std::fs::create_dir_all(root.join("keep--me")).unwrap();
         std::fs::create_dir_all(root.join(".hidden")).unwrap();
         std::fs::create_dir_all(root.join("linked")).unwrap();
         std::fs::write(root.join("afile"), b"x").unwrap();
@@ -1104,6 +1131,9 @@ mod tests {
             got.insert(key, parked_site_name(&entry, &linked));
         }
         assert_eq!(got.get("MyApp").unwrap().as_deref(), Some("myapp"));
+        assert_eq!(got.get("foo_bar").unwrap().as_deref(), Some("foo-bar"));
+        assert_eq!(got.get("ex.com").unwrap().as_deref(), Some("ex-com"));
+        assert_eq!(got.get("keep--me").unwrap().as_deref(), Some("keep--me"));
         assert_eq!(got.get(".hidden").unwrap().as_deref(), None);
         assert_eq!(got.get("afile").unwrap().as_deref(), None);
         assert_eq!(got.get("linked").unwrap().as_deref(), None);

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -587,12 +587,12 @@ pub(crate) fn scan_sites(
             }
         };
         for entry in entries.flatten() {
-            let Some(slug) = parked_site_name(&entry, &linked_names) else {
+            let Some(site_name) = parked_site_name(&entry, &linked_names) else {
                 continue;
             };
             let doc_root = entry.path();
             if let Some(site) = build_parked_site(
-                &slug,
+                &site_name,
                 &doc_root,
                 default_php,
                 cfg,
@@ -632,14 +632,14 @@ fn parked_site_name(
     if !entry.metadata().ok()?.is_dir() {
         return None;
     }
-    let Some(slug) = yerd_core::normalize_site_name(name) else {
+    let Some(site_name) = yerd_core::normalize_site_name(name) else {
         tracing::debug!(name = %name, "skipping parked dir with no valid site name");
         return None;
     };
-    if linked_names.contains(slug.as_str()) {
+    if linked_names.contains(site_name.as_str()) {
         return None;
     }
-    Some(slug)
+    Some(site_name)
 }
 
 /// Build a parked [`Site`] for `doc_root`, re-applying any persisted per-site
@@ -648,18 +648,18 @@ fn parked_site_name(
 /// unresolved detection serves the root provisionally and pushes `doc_root` onto
 /// `watch_roots`. Returns `None` (logging) for an invalid site name.
 fn build_parked_site(
-    slug: &str,
+    site_name: &str,
     doc_root: &std::path::Path,
     default_php: PhpVersion,
     cfg: &yerd_config::Config,
     detect_cache: &DetectCache,
     watch_roots: &mut Vec<PathBuf>,
 ) -> Option<Site> {
-    let mut site = match Site::parked(slug, doc_root, default_php) {
+    let mut site = match Site::parked(site_name, doc_root, default_php) {
         Ok(site) => site,
         Err(e) => {
             tracing::debug!(
-                name = %slug,
+                name = %site_name,
                 error = %e,
                 "skipping invalid parked-site name"
             );

--- a/crates/yerd-core/src/lib.rs
+++ b/crates/yerd-core/src/lib.rs
@@ -47,5 +47,5 @@ pub use php::PhpVersion;
 pub use php_extensions::{ExtError, NameErrorReason, PathErrorReason};
 pub use php_settings::{PhpSettingError, ValueErrorReason};
 pub use router::{RouterConfig, SiteRouter};
-pub use site::{slugify_site_name, Site, SiteKind};
+pub use site::{normalize_site_name, slugify_site_name, Site, SiteKind};
 pub use tld::Tld;

--- a/crates/yerd-core/src/site.rs
+++ b/crates/yerd-core/src/site.rs
@@ -322,6 +322,24 @@ pub fn slugify_site_name(raw: &str) -> Option<String> {
     }
 }
 
+/// Normalise a discovered directory name to a site name for the daemon's parked
+/// scan. A name that is already valid is kept as-is (only lowercased), so a
+/// folder that was servable before keeps its exact `.test` hostname across
+/// upgrades; a name the strict validator would reject (`_`, `.`, a leading
+/// hyphen, ...) is [`slugify_site_name`]d instead of being dropped. Returns
+/// `None` only when slugging leaves nothing valid.
+///
+/// This differs from `yerd link`'s auto-naming, which always slugifies: link is
+/// a one-shot suggestion the user sees and can edit, whereas a parked name is a
+/// site's persistent identity that should not change under the user's feet.
+#[must_use]
+pub fn normalize_site_name(raw: &str) -> Option<String> {
+    match validate_and_lowercase_name(raw) {
+        Ok(name) => Some(name),
+        Err(_) => slugify_site_name(raw),
+    }
+}
+
 /// A web subpath is safe to join onto the document root iff it is a plain
 /// relative path: no root, no drive/UNC prefix, and no `..` component. Such a
 /// path can only ever resolve to a descendant of the document root. Used by
@@ -564,6 +582,35 @@ mod tests {
         for input in ["My Project", "my_app", "example.com", "a..b"] {
             let slug = slugify_site_name(input).unwrap();
             assert!(Site::parked(&slug, "/x", v83()).is_ok(), "slug {slug:?}");
+        }
+    }
+
+    #[test]
+    fn normalize_site_name_keeps_valid_names_and_slugifies_the_rest() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("MyApp", Some("myapp")),
+            ("already-valid", Some("already-valid")),
+            ("foo--bar", Some("foo--bar")),
+            ("foo_bar", Some("foo-bar")),
+            ("example.com", Some("example-com")),
+            ("-leading", Some("leading")),
+            ("???", None),
+            ("", None),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                normalize_site_name(input).as_deref(),
+                *expected,
+                "input {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_site_name_result_is_always_valid() {
+        for input in ["MyApp", "foo--bar", "my_app", "example.com", "-leading"] {
+            let name = normalize_site_name(input).unwrap();
+            assert!(Site::parked(&name, "/x", v83()).is_ok(), "name {name:?}");
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Replaces _ with - for parked/linked folders

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent site-name normalization for both site discovery and the “Link a site” flow, generating valid lowercase slugs.

* **Bug Fixes**
  * Link form validation now uses the same slug rules as discovery.
  * Manually typed link names are preserved when choosing a directory.
  * Discovery/parked-site naming now skips entries that normalize to invalid names or collide with linked-site names, including correct DNS-length/trailing-separator handling.

* **Tests**
  * Added unit tests covering common and edge-case slugification/normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->