### PR TITLE
[Fix] Consistent add button styling

### DIFF
--- a/apps/yerd-gui/src/views/ProxiesView.vue
+++ b/apps/yerd-gui/src/views/ProxiesView.vue
@@ -326,7 +326,7 @@ onUnmounted(
       <template #actions>
         <DropdownMenu>
           <DropdownMenuTrigger as-child>
-            <Button>
+            <Button size="sm">
               <Plus class="size-4" /> New <ChevronDown class="size-3.5 opacity-70" />
             </Button>
           </DropdownMenuTrigger>

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -706,7 +706,7 @@ async function shareSitePublicly(s: Site): Promise<void> {
       <template #actions>
         <DropdownMenu>
           <DropdownMenuTrigger as-child>
-            <Button>
+            <Button size="sm">
               <Plus class="size-4" /> Create <ChevronDown class="size-3.5 opacity-70" />
             </Button>
           </DropdownMenuTrigger>


### PR DESCRIPTION
## What does this PR do?

Updates the Sites Create and Proxies New button to be consistent with the services add button. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed

@coderabbitai ignore