### PR TITLE
[Fix] Added --no-defaults for MySQL and MariaDB

### DIFF
--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -454,13 +454,19 @@ fn apply_macos(staged: &Path, relaunch_gui: bool, gui_owns_daemon: bool) -> Resu
     }
 }
 
-/// A per-invocation unique suffix (pid + nanoseconds) for staging paths.
+/// A per-invocation unique suffix for staging paths: pid + nanoseconds + a
+/// process-lifetime counter. The pid keeps concurrent processes from colliding;
+/// the counter guarantees successive calls within one process differ even when
+/// the nanosecond clock has coarse resolution and returns the same instant.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn unique_suffix() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| d.as_nanos());
-    format!("{}-{nanos}", std::process::id())
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("{}-{nanos}-{seq}", std::process::id())
 }
 
 /// Stop the daemon (best-effort) so it releases its executable inode.
@@ -953,8 +959,9 @@ mod tests {
         );
     }
 
-    /// Two reads differ because the nanosecond clock advances, and the value
-    /// carries this process's pid so concurrent stagers can't collide.
+    /// Two reads differ because of the process-lifetime counter (not the clock,
+    /// which may be coarse), and the value carries this process's pid so
+    /// concurrent stagers can't collide.
     #[test]
     fn unique_suffix_is_per_call_distinct() {
         let a = unique_suffix();

--- a/crates/yerd-services/src/service.rs
+++ b/crates/yerd-services/src/service.rs
@@ -415,8 +415,13 @@ impl ServiceDefinition for MySql {
     fn as_database(&self) -> Option<SqlEngine> {
         Some(SqlEngine::MySql)
     }
+    /// `--no-defaults` must be the first argument: it stops mysqld reading the
+    /// host's system option files (`/etc/my.cnf`, ...), whose `log-error` and
+    /// `user` directives point at root-owned paths a rootless Yerd can't use and
+    /// would abort init. The normal-run path stays isolated via `--defaults-file`.
     fn init_args(&self, staging: &std::path::Path) -> Vec<OsString> {
         vec![
+            OsString::from("--no-defaults"),
             OsString::from("--initialize-insecure"),
             OsString::from(format!("--datadir={}", staging.display())),
         ]
@@ -484,8 +489,12 @@ impl ServiceDefinition for MariaDb {
     fn as_database(&self) -> Option<SqlEngine> {
         Some(SqlEngine::MariaDb)
     }
+    /// `--no-defaults` must be the first argument, for the same reason as `MySQL`:
+    /// keep `mariadb-install-db` from picking up the host's system option files,
+    /// which under a rootless Yerd would abort init.
     fn init_args(&self, staging: &std::path::Path) -> Vec<OsString> {
         vec![
+            OsString::from("--no-defaults"),
             OsString::from("--basedir=."),
             OsString::from(format!("--datadir={}", staging.display())),
             OsString::from("--auth-root-authentication-method=normal"),
@@ -922,7 +931,11 @@ mod tests {
             .collect();
         assert_eq!(
             m_args,
-            vec!["--initialize-insecure", "--datadir=/x/staging"]
+            vec![
+                "--no-defaults",
+                "--initialize-insecure",
+                "--datadir=/x/staging"
+            ]
         );
 
         let maria = reg().get("mariadb").unwrap();
@@ -931,7 +944,8 @@ mod tests {
             .iter()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
-        assert_eq!(ma_args[0], "--basedir=.");
+        assert_eq!(ma_args[0], "--no-defaults");
+        assert_eq!(ma_args[1], "--basedir=.");
 
         let pg = reg().get("postgres").unwrap();
         let pg_args: Vec<String> = pg


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Yerd installed services such as MySQL and MariaDB were attempting to read and execute using the global mysql config files if present, which caused rootless errors. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MySQL and MariaDB initialization by ensuring default option files no longer interfere with setup.
  - Strengthened the order of initialization arguments for more consistent database startup.
  - Improved macOS staging path uniqueness so repeated operations in the same process don’t collide.
- **Tests**
  - Updated unit test expectations and related rationale to reflect the revised initialization and staging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->