### PR TITLE
[Fix] WordPress site creation when an external wp-cli is on PATH

### DIFF
--- a/apps/yerd-gui/src/components/site-create/CreateWordPressWizard.vue
+++ b/apps/yerd-gui/src/components/site-create/CreateWordPressWizard.vue
@@ -636,7 +636,7 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
                 variant="outline"
                 :disabled="installBusy || (row.id === 'wp-cli' && !managedComposer)"
                 :title="row.id === 'wp-cli' && !managedComposer ? 'Yerd\'s own Composer is required to build WP-CLI' : ''"
-                @click="row.id === 'php' ? installFirstPhp() : installPrereq(row.id as 'composer' | 'wp-cli')"
+                @click="row.id === 'php' ? installFirstPhp() : installPrereq(row.id)"
               >
                 Install
               </Button>

--- a/apps/yerd-gui/src/components/site-create/CreateWordPressWizard.vue
+++ b/apps/yerd-gui/src/components/site-create/CreateWordPressWizard.vue
@@ -200,15 +200,45 @@ function toolAvailable(id: string): boolean {
   return tools.value.some((t) => t.id === id && (t.installed || t.external));
 }
 // Managed-only: building WP-CLI requires Yerd's own Composer (an external
-// Composer can't build it) - same asymmetry as the Laravel installer.
+// Composer can't build it) - same asymmetry as the Laravel installer. The
+// daemon never reports WP-CLI itself as `external`, since scaffolding execs
+// Yerd's own boot-fs.php rather than a PATH-resolved `wp`.
 const managedComposer = computed(() =>
   tools.value.some((t) => t.id === "composer" && t.installed),
 );
-const needsComposer = computed(() => !toolAvailable("composer"));
 const needsWpCli = computed(() => !toolAvailable("wp-cli"));
+// Composer's only role here is building WP-CLI, so it's a prerequisite exactly
+// when WP-CLI still has to be built - scaffolding an installed WP-CLI never
+// shells out to Composer.
+const needsComposer = computed(() => needsWpCli.value && !managedComposer.value);
 const noPhp = computed(() => props.phpVersions.length === 0);
 
 const ready = computed(() => !noPhp.value && !needsComposer.value && !needsWpCli.value);
+
+interface PrereqRow {
+  id: "php" | "composer" | "wp-cli";
+  label: string;
+  sub: string;
+  ok: boolean;
+}
+
+// Composer is listed only while it's actually required: its role here is
+// building WP-CLI, so once WP-CLI is installed it isn't a prerequisite and
+// showing it as "Installed" would claim something we haven't checked.
+const prereqRows = computed<PrereqRow[]>(() => [
+  { id: "php", label: "PHP", sub: "Runtime", ok: !noPhp.value },
+  ...(needsWpCli.value
+    ? [
+        {
+          id: "composer" as const,
+          label: "Composer",
+          sub: "Builds WP-CLI",
+          ok: !needsComposer.value,
+        },
+      ]
+    : []),
+  { id: "wp-cli", label: "WP-CLI", sub: "wp command", ok: !needsWpCli.value },
+]);
 const installBusy = computed(() => installingAll.value || installingTool.value !== null);
 
 async function refreshTools(): Promise<void> {
@@ -275,16 +305,7 @@ async function installAllMissing(): Promise<void> {
   try {
     if (noPhp.value && !(await installFirstPhp())) return;
     if (needsComposer.value && !(await installPrereq("composer"))) return;
-    if (needsWpCli.value) {
-      if (!managedComposer.value) {
-        toast.error(
-          "Can't install WP-CLI",
-          "Yerd needs its own Composer to build it - install Yerd's Composer first.",
-        );
-        return;
-      }
-      if (!(await installPrereq("wp-cli"))) return;
-    }
+    if (needsWpCli.value && !(await installPrereq("wp-cli"))) return;
     await nextTick();
     toast.success("Toolchain ready");
   } finally {
@@ -587,19 +608,15 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
         <div>
           <p class="text-sm font-medium">A few tools are needed first</p>
           <p class="text-xs text-muted-foreground">
-            Creating a WordPress site needs PHP, Composer and WP-CLI. Install the missing ones to
-            continue.
+            Creating a WordPress site needs PHP and WP-CLI (which Yerd's own Composer builds).
+            Install the missing ones to continue.
           </p>
         </div>
       </div>
 
       <div class="divide-y rounded-lg border">
         <div
-          v-for="row in [
-            { id: 'php', label: 'PHP', sub: 'Runtime', ok: !noPhp },
-            { id: 'composer', label: 'Composer', sub: 'Dependency manager', ok: !needsComposer },
-            { id: 'wp-cli', label: 'WP-CLI', sub: 'wp command', ok: !needsWpCli },
-          ]"
+          v-for="row in prereqRows"
           :key="row.id"
           class="flex items-center justify-between gap-3 px-3 py-2.5"
         >

--- a/apps/yerd-gui/src/views/ToolingView.vue
+++ b/apps/yerd-gui/src/views/ToolingView.vue
@@ -48,19 +48,22 @@ const composerInstalled = computed(() =>
   tools.value.some((t) => t.id === "composer" && t.installed),
 );
 
-const COMPOSER_REQUIRED_HINT = "Yerd's own Composer is required to build this tool.";
+const COMPOSER_REQUIRED_HINT =
+  "Yerd's own Composer is required to build this tool - install Yerd's Composer first.";
 
 /** The Laravel installer and WP-CLI are built via Composer, so they can't install without it. */
 function blockedNoComposer(t: ToolStatus): boolean {
   return (t.id === "laravel" || t.id === "wp-cli") && !composerInstalled.value;
 }
 
-/** Explains an External tool: it's not a problem, just not Yerd's to manage. */
+/** Explains an External tool: your copy is fine, but Yerd's own is still
+ *  installable - some managed tools are built with Yerd's Composer, so hiding
+ *  Install here used to leave no way to get it. */
 function externalHint(t: ToolStatus): string {
   const found = t.external_path
     ? `Already on your PATH at ${t.external_path}`
     : "Already on your PATH from another install";
-  return `${found} - Yerd isn't managing this copy, so there's nothing to install or update.`;
+  return `${found} - Yerd isn't managing that copy. You can still install Yerd's own alongside it.`;
 }
 
 const uninstallOpen = ref(false);
@@ -235,22 +238,23 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
                         <Trash2 class="size-3.5" />
                       </Button>
                     </template>
-                    <span
-                      v-else-if="t.external"
-                      class="text-xs text-muted-foreground"
-                      :title="externalHint(t)"
-                    >
-                      Managed by you
-                    </span>
-                    <Button
-                      v-else
-                      size="sm"
-                      :disabled="busy !== null || blockedNoComposer(t)"
-                      :title="blockedNoComposer(t) ? COMPOSER_REQUIRED_HINT : ''"
-                      @click="doInstall(t)"
-                    >
-                      <Download class="mr-1.5 size-3.5" /> Install
-                    </Button>
+                    <template v-else>
+                      <span
+                        v-if="t.external"
+                        class="cursor-help text-xs text-muted-foreground"
+                        :title="externalHint(t)"
+                      >
+                        Managed by you
+                      </span>
+                      <Button
+                        size="sm"
+                        :disabled="busy !== null || blockedNoComposer(t)"
+                        :title="blockedNoComposer(t) ? COMPOSER_REQUIRED_HINT : ''"
+                        @click="doInstall(t)"
+                      >
+                        <Download class="mr-1.5 size-3.5" /> Install
+                      </Button>
+                    </template>
                   </div>
                 </td>
               </tr>

--- a/apps/yerd-gui/src/views/ToolingView.vue
+++ b/apps/yerd-gui/src/views/ToolingView.vue
@@ -58,12 +58,14 @@ function blockedNoComposer(t: ToolStatus): boolean {
 
 /** Explains an External tool: your copy is fine, but Yerd's own is still
  *  installable - some managed tools are built with Yerd's Composer, so hiding
- *  Install here used to leave no way to get it. */
+ *  Install here used to leave no way to get it. Yerd's {data}/bin is prepended
+ *  to PATH, so its copy wins once installed - say so rather than implying the
+ *  two sit side by side. */
 function externalHint(t: ToolStatus): string {
   const found = t.external_path
     ? `Already on your PATH at ${t.external_path}`
     : "Already on your PATH from another install";
-  return `${found} - Yerd isn't managing that copy. You can still install Yerd's own alongside it.`;
+  return `${found} - Yerd isn't managing that copy. Installing Yerd's own will take precedence over it on your PATH.`;
 }
 
 const uninstallOpen = ref(false);

--- a/bin/yerdd/src/create_site/mod.rs
+++ b/bin/yerdd/src/create_site/mod.rs
@@ -170,10 +170,11 @@ fn probe_writable(parent: &Path) -> Result<(), String> {
 }
 
 /// Install `tool` inline if it's neither managed nor available externally on
-/// the user's PATH, streaming an `Installing {display_name}` phase update
-/// into this job's log. Only for tools the job actually resolves via PATH
+/// the user's PATH, streaming the install into this job's log (see
+/// [`install_tool_inline`]). Only for tools the job actually resolves via PATH
 /// (Laravel's optional Node/Bun); a tool the job runs by its managed
-/// filesystem entry point must use [`ensure_managed_tool`] instead.
+/// filesystem entry point must use [`ensure_managed_tool`] instead - see
+/// [`Tool::accepts_external`] for which is which.
 async fn ensure_tool(
     id: &str,
     tool: Tool,

--- a/bin/yerdd/src/create_site/mod.rs
+++ b/bin/yerdd/src/create_site/mod.rs
@@ -204,20 +204,39 @@ async fn ensure_managed_tool(id: &str, tool: Tool, state: &Arc<DaemonState>) -> 
     install_tool_inline(id, tool, state).await
 }
 
-/// Download + install `tool` under the tool-mutation lock, streaming an
-/// `Installing {display_name}` phase update into this job's log, then
-/// reconcile the `{data}/bin` shims.
+/// Download + install `tool` under the tool-mutation lock, streaming both an
+/// `Installing {display_name}` phase update and the installer's own output
+/// into this job's log, then reconcile the `{data}/bin` shims.
+///
+/// The output stream matters: WP-CLI is built by a `composer create-project`
+/// that routinely runs for minutes (its own timeout is 10), so without it the
+/// wizard sits on a bare phase label long enough to read as hung. Mirrors
+/// `ipc_server::install_tool_streamed`'s drain - `tx` must be dropped before
+/// awaiting it, or the reader never sees the channel close.
 async fn install_tool_inline(id: &str, tool: Tool, state: &Arc<DaemonState>) -> Result<(), String> {
     state
         .jobs
         .set_phase(id, format!("Installing {}", tool.display_name()))
         .await;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let drain = {
+        let state = state.clone();
+        let id = id.to_owned();
+        tokio::spawn(async move {
+            while let Some(line) = rx.recv().await {
+                state.jobs.push_log(&id, line).await;
+            }
+        })
+    };
+
     let dl = crate::php_install::ReqwestDownloader::new();
     let guard = state.tool_mutate.lock().await;
-    tools::install(tool, &state.dirs, &dl, None)
-        .await
-        .map_err(|e| format!("failed to install {}: {e}", tool.display_name()))?;
+    let result = tools::install(tool, &state.dirs, &dl, Some(&tx)).await;
     drop(guard);
+    drop(tx);
+    let _ = drain.await;
+
+    result.map_err(|e| format!("failed to install {}: {e}", tool.display_name()))?;
     crate::ipc_server::reconcile_tool_shims_now(state).await;
     Ok(())
 }

--- a/bin/yerdd/src/create_site/mod.rs
+++ b/bin/yerdd/src/create_site/mod.rs
@@ -171,8 +171,9 @@ fn probe_writable(parent: &Path) -> Result<(), String> {
 
 /// Install `tool` inline if it's neither managed nor available externally on
 /// the user's PATH, streaming an `Installing {display_name}` phase update
-/// into this job's log. Shared by both frameworks' Preflight steps (Laravel's
-/// optional Node/Bun, WordPress's required WP-CLI).
+/// into this job's log. Only for tools the job actually resolves via PATH
+/// (Laravel's optional Node/Bun); a tool the job runs by its managed
+/// filesystem entry point must use [`ensure_managed_tool`] instead.
 async fn ensure_tool(
     id: &str,
     tool: Tool,
@@ -187,6 +188,26 @@ async fn ensure_tool(
     {
         return Ok(());
     }
+    install_tool_inline(id, tool, state).await
+}
+
+/// Like [`ensure_tool`], but an external copy on the user's PATH does not
+/// count: only a managed install satisfies it. WordPress's Preflight needs
+/// this for WP-CLI, because every `wp` step runs the managed `boot-fs.php`
+/// entry point directly (see `wordpress::run_wp_step`), never a
+/// PATH-resolved `wp`, so accepting an external install would let the job
+/// proceed and then fail spawning a path that doesn't exist.
+async fn ensure_managed_tool(id: &str, tool: Tool, state: &Arc<DaemonState>) -> Result<(), String> {
+    if tools::installed_version(&state.dirs, tool).is_some() {
+        return Ok(());
+    }
+    install_tool_inline(id, tool, state).await
+}
+
+/// Download + install `tool` under the tool-mutation lock, streaming an
+/// `Installing {display_name}` phase update into this job's log, then
+/// reconcile the `{data}/bin` shims.
+async fn install_tool_inline(id: &str, tool: Tool, state: &Arc<DaemonState>) -> Result<(), String> {
     state
         .jobs
         .set_phase(id, format!("Installing {}", tool.display_name()))
@@ -527,5 +548,45 @@ mod tests {
             Response::JobStarted { .. } => {}
             other => panic!("expected JobStarted, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn ensure_managed_tool_short_circuits_on_managed_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(crate::test_support::state_in(tmp.path()));
+        let tool_dir = state.dirs.data.join("tools").join("wp-cli");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(tool_dir.join(".version"), "v2.12.0\n").unwrap();
+        let result = ensure_managed_tool("job", Tool::WpCli, &state).await;
+        assert!(result.is_ok());
+    }
+
+    /// The regression behind issue #150: an external `wp` on the user's PATH
+    /// satisfies [`ensure_tool`] but must not satisfy [`ensure_managed_tool`],
+    /// because the WordPress job only ever runs the managed `boot-fs.php`.
+    /// With nothing managed, the managed variant proceeds to a real install,
+    /// which fails fast here because these dirs contain no PHP to run
+    /// Composer with - no network is touched.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn external_wp_satisfies_ensure_tool_but_not_ensure_managed_tool() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(crate::test_support::state_in(tmp.path()));
+        let ext = tmp.path().join("extbin");
+        std::fs::create_dir_all(&ext).unwrap();
+        let wp = ext.join("wp");
+        std::fs::write(&wp, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&wp, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let user_dirs = vec![ext];
+        let external_ok = ensure_tool("job", Tool::WpCli, &user_dirs, &state).await;
+        assert!(external_ok.is_ok());
+
+        let err = ensure_managed_tool("job", Tool::WpCli, &state)
+            .await
+            .unwrap_err();
+        assert!(err.contains("failed to install WP-CLI"), "{err}");
     }
 }

--- a/bin/yerdd/src/create_site/wordpress.rs
+++ b/bin/yerdd/src/create_site/wordpress.rs
@@ -47,6 +47,17 @@ pub(super) async fn run(
         return Outcome::Failed(format!("invalid WordPress admin account: {e}"));
     }
 
+    if let Err(msg) = super::check_target_dir(&project_dir) {
+        return Outcome::Failed(msg);
+    }
+    if let Err(msg) = super::probe_writable(&spec.parent_dir) {
+        return Outcome::Failed(msg);
+    }
+    let db_name = resolve_db_name(name, options);
+    if let Err(e) = database::validate_db_name(&db_name) {
+        return Outcome::Failed(format!("invalid database name: {e}"));
+    }
+
     if let Err(msg) = ensure_wp_cli(id, state).await {
         return Outcome::Failed(msg);
     }
@@ -57,16 +68,6 @@ pub(super) async fn run(
              (or run `yerd install tool wp-cli`)",
             boot_fs.display()
         ));
-    }
-    if let Err(msg) = super::check_target_dir(&project_dir) {
-        return Outcome::Failed(msg);
-    }
-    if let Err(msg) = super::probe_writable(&spec.parent_dir) {
-        return Outcome::Failed(msg);
-    }
-    let db_name = resolve_db_name(name, options);
-    if let Err(e) = database::validate_db_name(&db_name) {
-        return Outcome::Failed(format!("invalid database name: {e}"));
     }
     if super::is_cancelled(&cancel_rx) {
         return Outcome::Cancelled;

--- a/bin/yerdd/src/create_site/wordpress.rs
+++ b/bin/yerdd/src/create_site/wordpress.rs
@@ -220,17 +220,31 @@ pub(super) async fn run(
     Outcome::Succeeded
 }
 
-/// Ensure the managed WP-CLI, installing the managed Composer first when it's
-/// missing: [`tools::wp_cli::install`] builds the bundle by running yerd's own
-/// Composer phar and refuses outright without it, and an external Composer
-/// can't stand in. Only reached when WP-CLI itself has to be built - once it
-/// is installed, scaffolding never touches Composer, so a user running only
-/// their own Composer is never made to take yerd's copy for no reason.
+/// Ensure the managed WP-CLI, which [`tools::wp_cli::install`] builds by
+/// running yerd's own Composer phar - it refuses outright without one, and an
+/// external Composer can't stand in.
+///
+/// WP-CLI is installed inline because it *is* what was asked for: no managed
+/// build, no WordPress site. Composer is only its builder, so a missing one is
+/// reported rather than installed: yerd's tools are symlinked into `{data}/bin`,
+/// which the shell profile *prepends* to `PATH`, so quietly installing it would
+/// take over the `composer` command in every one of the user's unrelated
+/// projects and run it under yerd's PHP. That's the user's call to make, not a
+/// side effect of creating a site - the wizard offers it as an explicit prereq,
+/// and this mirrors the Laravel flow, which likewise refuses rather than
+/// installing a Composer nobody asked for. Only reached when WP-CLI has to be
+/// built; once installed, scaffolding never touches Composer at all.
 async fn ensure_wp_cli(id: &str, state: &Arc<DaemonState>) -> Result<(), String> {
     if tools::installed_version(&state.dirs, Tool::WpCli).is_some() {
         return Ok(());
     }
-    super::ensure_managed_tool(id, Tool::Composer, state).await?;
+    if tools::installed_version(&state.dirs, Tool::Composer).is_none() {
+        return Err(
+            "Yerd's own Composer is required to build WP-CLI (an external one can't) - \
+                    install it from the Tooling page, or run `yerd install tool composer`"
+                .to_owned(),
+        );
+    }
     super::ensure_managed_tool(id, Tool::WpCli, state).await
 }
 
@@ -654,6 +668,39 @@ fn permalink_structure_args() -> Vec<String> {
 mod tests {
     use super::*;
     use yerd_ipc::WordPressDatabase;
+
+    /// Writes `tool`'s `.version` marker, the sole signal
+    /// [`tools::installed_version`] reads to call a tool managed-installed.
+    fn mark_installed(state: &DaemonState, tool: Tool) {
+        let dir = state.dirs.data.join("tools").join(tool.id());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(".version"), "v1.2.3\n").unwrap();
+    }
+
+    #[tokio::test]
+    async fn ensure_wp_cli_is_satisfied_by_a_managed_wp_cli_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(crate::test_support::state_in(tmp.path()));
+        mark_installed(&state, Tool::WpCli);
+        assert!(ensure_wp_cli("job", &state).await.is_ok());
+    }
+
+    /// Yerd's tools are symlinked into `{data}/bin`, which the shell profile
+    /// prepends to `PATH` - so installing Composer here would silently take
+    /// over the user's `composer` in unrelated projects. Creating a site must
+    /// report it instead, never install it.
+    #[tokio::test]
+    async fn ensure_wp_cli_reports_a_missing_composer_rather_than_installing_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(crate::test_support::state_in(tmp.path()));
+        let err = ensure_wp_cli("job", &state).await.unwrap_err();
+        assert!(err.contains("Composer"), "{err}");
+        assert!(err.contains("yerd install tool composer"), "{err}");
+        assert!(
+            tools::installed_version(&state.dirs, Tool::Composer).is_none(),
+            "a create-site job must never install Composer behind the user's back"
+        );
+    }
 
     fn opts() -> WordPressOptions {
         WordPressOptions {

--- a/bin/yerdd/src/create_site/wordpress.rs
+++ b/bin/yerdd/src/create_site/wordpress.rs
@@ -1,5 +1,7 @@
 //! WordPress scaffolding via WP-CLI - the WordPress-specific body of the
-//! create-site job. Preflight ensures WP-CLI is installed; Provisioning
+//! create-site job. Preflight ensures the *managed* WP-CLI is installed (an
+//! external `wp` on PATH doesn't count, since every step runs the managed
+//! `boot-fs.php` entry point directly); Provisioning
 //! database ensures a MySQL/MariaDB engine is installed+running and creates
 //! the site's database; Downloading/Configuring/Installing run `wp core
 //! download` / `wp config create` / `wp core install` with piped, streamed
@@ -45,11 +47,16 @@ pub(super) async fn run(
         return Outcome::Failed(format!("invalid WordPress admin account: {e}"));
     }
 
-    let user_dirs = crate::tools::external::resolve_user_path()
-        .await
-        .unwrap_or_default();
-    if let Err(msg) = super::ensure_tool(id, Tool::WpCli, &user_dirs, state).await {
+    if let Err(msg) = ensure_wp_cli(id, state).await {
         return Outcome::Failed(msg);
+    }
+    let boot_fs = tools::wp_cli::boot_path(dirs);
+    if !boot_fs.is_file() {
+        return Outcome::Failed(format!(
+            "WP-CLI is installed but {} is missing - reinstall WP-CLI from the Tooling page \
+             (or run `yerd install tool wp-cli`)",
+            boot_fs.display()
+        ));
     }
     if let Err(msg) = super::check_target_dir(&project_dir) {
         return Outcome::Failed(msg);
@@ -92,7 +99,6 @@ pub(super) async fn run(
         rollback(&project_dir, db_created, &def, &db_name, state).await;
         return Outcome::Failed(format!("{}: {e}", project_dir.display()));
     }
-    let boot_fs = tools::wp_cli::boot_path(dirs);
     let download_args = download_args(options);
     state
         .jobs
@@ -212,6 +218,20 @@ pub(super) async fn run(
         .push_log(id, format!("serving {scheme}://{name}.{tld}"))
         .await;
     Outcome::Succeeded
+}
+
+/// Ensure the managed WP-CLI, installing the managed Composer first when it's
+/// missing: [`tools::wp_cli::install`] builds the bundle by running yerd's own
+/// Composer phar and refuses outright without it, and an external Composer
+/// can't stand in. Only reached when WP-CLI itself has to be built - once it
+/// is installed, scaffolding never touches Composer, so a user running only
+/// their own Composer is never made to take yerd's copy for no reason.
+async fn ensure_wp_cli(id: &str, state: &Arc<DaemonState>) -> Result<(), String> {
+    if tools::installed_version(&state.dirs, Tool::WpCli).is_some() {
+        return Ok(());
+    }
+    super::ensure_managed_tool(id, Tool::Composer, state).await?;
+    super::ensure_managed_tool(id, Tool::WpCli, state).await
 }
 
 /// The database name to provision: `options.database.name` if given,

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1307,11 +1307,18 @@ pub(crate) async fn reconcile_tool_shims_now(state: &DaemonState) {
 }
 
 /// Build the tool list and tag any *not* Yerd-managed tool that's available on
-/// the user's PATH as `external` (Tooling shows "External", no actions). Skips the
-/// (login-shell) PATH resolution entirely when everything is already managed.
+/// the user's PATH as `external` (Tooling shows "External", no actions). Tools
+/// that [don't accept an external copy](crate::tools::Tool::accepts_external)
+/// are never tagged - yerd needs its own build, so Tooling must keep offering
+/// Install. Skips the (login-shell) PATH resolution entirely when no remaining
+/// tool could be tagged.
 async fn list_tools_with_external(state: &DaemonState) -> Vec<yerd_ipc::ToolStatus> {
     let mut tools = crate::tools::list_status(&state.dirs);
-    if tools.iter().all(|t| t.installed) {
+    let taggable = |t: &yerd_ipc::ToolStatus| {
+        !t.installed
+            && crate::tools::Tool::parse(&t.id).is_some_and(crate::tools::Tool::accepts_external)
+    };
+    if !tools.iter().any(taggable) {
         return tools;
     }
     let Some(dirs) = crate::tools::external::resolve_user_path().await else {
@@ -1320,7 +1327,7 @@ async fn list_tools_with_external(state: &DaemonState) -> Vec<yerd_ipc::ToolStat
     let data_bin = crate::tools::bin_dir(&state.dirs);
     let data_root = &state.dirs.data;
     for t in &mut tools {
-        if t.installed {
+        if !taggable(t) {
             continue;
         }
         if let Some(tool) = crate::tools::Tool::parse(&t.id) {

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1307,10 +1307,11 @@ pub(crate) async fn reconcile_tool_shims_now(state: &DaemonState) {
 }
 
 /// Build the tool list and tag any *not* Yerd-managed tool that's available on
-/// the user's PATH as `external` (Tooling shows "External", no actions). Tools
-/// that [don't accept an external copy](crate::tools::Tool::accepts_external)
-/// are never tagged - yerd needs its own build, so Tooling must keep offering
-/// Install. Skips the (login-shell) PATH resolution entirely when no remaining
+/// the user's PATH as `external` (Tooling shows an "External" badge but still
+/// offers **Install**, to add yerd's own copy alongside it). Tools that
+/// [don't accept an external copy](crate::tools::Tool::accepts_external) are
+/// never tagged - yerd needs its own build, so Tooling shows them as simply not
+/// installed. Skips the (login-shell) PATH resolution entirely when no remaining
 /// tool could be tagged.
 async fn list_tools_with_external(state: &DaemonState) -> Vec<yerd_ipc::ToolStatus> {
     let mut tools = crate::tools::list_status(&state.dirs);

--- a/bin/yerdd/src/tools/mod.rs
+++ b/bin/yerdd/src/tools/mod.rs
@@ -105,6 +105,26 @@ impl Tool {
         }
     }
 
+    /// Whether a copy of [`Self::primary_bin`] already on the user's PATH can
+    /// stand in for a managed install, so Tooling reports it as `external`
+    /// (nothing for yerd to install) rather than missing.
+    ///
+    /// False for WP-CLI: every yerd path that runs `wp` (WordPress site
+    /// creation, the admin-user list, URL sync) execs the *managed*
+    /// `boot-fs.php` entry point directly rather than a PATH-resolved `wp`, so
+    /// an external copy satisfies none of them. Reporting one as external hid
+    /// Tooling's Install action for a tool yerd genuinely needs its own copy
+    /// of, and let the WordPress wizard call the toolchain ready - which is
+    /// how a site create reached `wp core download` and failed spawning a
+    /// `boot-fs.php` that was never installed (issue #150).
+    #[must_use]
+    pub const fn accepts_external(self) -> bool {
+        match self {
+            Tool::Composer | Tool::Node | Tool::Bun | Tool::Laravel => true,
+            Tool::WpCli => false,
+        }
+    }
+
     /// Parse a wire id back to a `Tool`.
     #[must_use]
     pub fn parse(id: &str) -> Option<Tool> {
@@ -450,6 +470,18 @@ mod tests {
         assert_eq!(Tool::Bun.exposed_bins(), &["bun", "bunx"]);
         assert_eq!(Tool::Composer.primary_bin(), "composer");
         assert_eq!(Tool::Laravel.display_name(), "Laravel Installer");
+    }
+
+    /// Issue #150: an external `wp` can't stand in for the managed build, so
+    /// Tooling must keep offering Install rather than reporting it external.
+    #[test]
+    fn wp_cli_never_accepts_an_external_copy() {
+        assert!(!Tool::WpCli.accepts_external());
+        for t in Tool::ALL {
+            if t != Tool::WpCli {
+                assert!(t.accepts_external(), "{t:?} should accept an external copy");
+            }
+        }
     }
 
     #[test]

--- a/bin/yerdd/src/tools/mod.rs
+++ b/bin/yerdd/src/tools/mod.rs
@@ -105,17 +105,18 @@ impl Tool {
         }
     }
 
-    /// Whether a copy of [`Self::primary_bin`] already on the user's PATH can
-    /// stand in for a managed install, so Tooling reports it as `external`
-    /// (nothing for yerd to install) rather than missing.
+    /// Whether a copy of [`Self::primary_bin`] already on the user's PATH
+    /// satisfies this tool's prerequisite, so a site-create job can use it and
+    /// Tooling tags it `external`. This only decides whether a *managed* copy is
+    /// required: Tooling still offers **Install** either way, so yerd's own copy
+    /// can always be added alongside an external one.
     ///
     /// False for WP-CLI: every yerd path that runs `wp` (WordPress site
     /// creation, the admin-user list, URL sync) execs the *managed*
     /// `boot-fs.php` entry point directly rather than a PATH-resolved `wp`, so
-    /// an external copy satisfies none of them. Reporting one as external hid
-    /// Tooling's Install action for a tool yerd genuinely needs its own copy
-    /// of, and let the WordPress wizard call the toolchain ready - which is
-    /// how a site create reached `wp core download` and failed spawning a
+    /// an external copy satisfies none of them and must not pass preflight. When
+    /// one wrongly did, the WordPress wizard called the toolchain ready and a
+    /// site create reached `wp core download`, then failed spawning a
     /// `boot-fs.php` that was never installed (issue #150).
     #[must_use]
     pub const fn accepts_external(self) -> bool {

--- a/docs/developer/dev-tools.md
+++ b/docs/developer/dev-tools.md
@@ -49,7 +49,9 @@ impl Tool {
     pub const ALL: [Tool; 5];
     pub const fn id(self) -> &'static str;            // "composer" | "node" | "bun" | "laravel" | "wp-cli"
     pub const fn display_name(self) -> &'static str;  // for the UI
+    pub const fn primary_bin(self) -> &'static str;   // the command external detection looks for
     pub const fn exposed_bins(self) -> &'static [&'static str]; // commands on PATH
+    pub const fn accepts_external(self) -> bool;      // may a PATH copy stand in?
     pub fn parse(id: &str) -> Option<Tool>;           // wire id → Tool
 }
 ```
@@ -57,6 +59,18 @@ impl Tool {
 `exposed_bins` is the single source of truth for which `{data}/bin` names a tool
 owns: `composer`; `node`/`npm`/`npx`; `bun`/`bunx`; `laravel`; `wp`. It drives
 both shim creation and pruning.
+
+`accepts_external` is the source of truth for whether a copy already on the
+user's `PATH` can substitute for a managed install. It is `false` only for
+`WpCli`, and that asymmetry is load-bearing: the Laravel flow resolves and execs
+whatever `laravel`/`composer` it finds, whereas every WP-CLI caller (WordPress
+scaffolding, the admin-user list, URL sync, the `wp` shim) execs the *managed*
+`vendor/wp-cli/wp-cli/php/boot-fs.php` by path and can never use an external
+`wp`. Reporting one as external is what caused
+[#150](https://github.com/RichardAnderson/yerd/issues/150) - preflight passed,
+then scaffolding failed spawning a `boot-fs.php` that was never installed. Keep
+`ListTools` and any new preflight honest to this flag rather than re-deriving
+the rule.
 
 Failures are a binary-local `thiserror` enum (the tools subsystem has no library
 crate of its own, so this mirrors `MutateError`/`DaemonError` rather than the

--- a/docs/guide/sites.md
+++ b/docs/guide/sites.md
@@ -84,7 +84,7 @@ When it finishes, the project is on disk, registered (parked or linked), served 
 The same **Create** menu can scaffold a brand-new WordPress install for you. Choose **New WordPress site** to launch a four-step wizard - **Basics → WordPress → Database → Review** - that provisions a database, runs WP-CLI's `core download`/`config create`/`core install`, sets pretty permalinks, and registers the result as a `.test` site automatically.
 
 ::: tip Prerequisites
-Creating a WordPress site needs a PHP version, **Composer**, and **WP-CLI**. If any are missing, the wizard offers to install them first (WP-CLI is built via Composer, so Composer installs first if it's missing too) - see [Tooling](./tooling).
+Creating a WordPress site needs a PHP version and **WP-CLI**, and the wizard offers to install whatever's missing. WP-CLI must be Yerd's own build - Yerd runs it directly rather than through a `wp` on your `PATH`, so an [externally installed](./tooling#external-tools) `wp` doesn't count and your own copy is left alone. Yerd's **Composer** builds WP-CLI, so it's offered as a prerequisite too when WP-CLI still needs installing - see [Tooling](./tooling).
 :::
 
 ### Basics

--- a/docs/guide/tooling.md
+++ b/docs/guide/tooling.md
@@ -7,7 +7,8 @@ reaches for - [Composer](https://getcomposer.org), [Node.js](https://nodejs.org)
 self-contained binaries fetched on demand (the Laravel installer and WP-CLI are
 built via Composer) and dropped onto your `PATH`. No system package manager, no
 global install, nothing to uninstall by hand. Already have one installed
-elsewhere? Yerd [detects it](#external-tools) and uses it instead.
+elsewhere? Yerd [detects it](#external-tools) and, for most tools, uses it
+instead.
 
 | Tool | `id` | Provides | Source |
 |---|---|---|---|
@@ -35,8 +36,9 @@ lists the developer tools Yerd manages and their install status:
   each showing the commands it provides.
 - Click **Install** to fetch the latest release; once installed you get
   **Update** (re-fetch the current latest) and **Uninstall**.
-- A tool you've installed yourself shows an **External** badge with no actions -
-  see [External tools](#external-tools) below.
+- A tool you've installed yourself shows an **External** badge and a *Managed by
+  you* note. **Install** is still offered, so you can take Yerd's own copy as
+  well - see [External tools](#external-tools) below.
 - The Laravel installer and WP-CLI are built with Composer, so their **Install**
   button stays disabled until Yerd's own Composer is installed.
 - Each tool is placed on your `PATH` alongside PHP and managed entirely by Yerd,
@@ -68,14 +70,15 @@ Composer.
 
 ## External tools
 
-You don't have to let Yerd manage these tools. If you already have `composer`,
-`node`, `bun`, the `laravel` installer, or `wp` available on your `PATH` - via
-Homebrew, `nvm`/`fnm`, a global `composer require`, etc. - Yerd **detects** it
-and treats it as already available:
+You don't have to let Yerd manage most of these tools. If you already have
+`composer`, `node`, `bun`, or the `laravel` installer available on your `PATH` -
+via Homebrew, `nvm`/`fnm`, a global `composer require`, etc. - Yerd **detects**
+it and treats it as already available:
 
 - On the **Tooling** page the tool shows an **External** badge (instead of a
-  version) with **no Install / Update / Uninstall actions** - it's yours to manage,
-  not Yerd's.
+  version) and a *Managed by you* note - it's yours to manage, not Yerd's. You
+  can still press **Install** to take Yerd's own copy alongside it, which you'll
+  need if you want Yerd to build the Laravel installer or WP-CLI.
 - The [Laravel site wizard](./sites#create-a-new-laravel-site) and site scaffolding
   accept external Composer / Node / Bun / Laravel as satisfying their
   prerequisites, so you won't be asked to install a second copy. Externally
@@ -84,13 +87,22 @@ and treats it as already available:
 
 A couple of things to know:
 
+- **WP-CLI is the exception: an external `wp` doesn't count.** Yerd runs WP-CLI
+  by executing its own build directly rather than by calling `wp` on your `PATH`,
+  so it always needs its own copy and never reports one you installed yourself as
+  *External*. Your `wp` keeps working exactly as before; the
+  [WordPress site wizard](./sites#create-a-new-wordpress-site) will simply offer
+  to install Yerd's WP-CLI as a prerequisite.
 - **Managed tools win.** If a tool is both Yerd-installed and on your `PATH`, the
   Yerd-managed one takes precedence (its `{data}/bin` shim is earlier on `PATH`).
+  That includes `composer`, so installing Yerd's copy changes which `composer`
+  your other projects get.
 - **Building the *managed* Laravel installer or WP-CLI needs Yerd's own
   Composer.** An external Composer is fine for *scaffolding*, but it can't build
   Yerd's managed `laravel`/`wp-cli` tools - so their **Install** stays disabled
-  until you install Yerd's Composer (or you can just keep using your external
-  copy).
+  until you install Yerd's Composer. For the Laravel installer you can skip that
+  entirely and keep using your external copy; WP-CLI has no such fallback, per
+  the exception above.
 
 ::: tip How detection works
 Because the daemon runs with a minimal environment, Yerd reads your login shell's


### PR DESCRIPTION
## What does this PR do?

WordPress site creation accepted an externally-installed wp on PATH as satisfying its WP-CLI requirement but then always ran Yerd's own, never-installed boot-fs.php, so it now requires and installs the managed build - streaming the install into the job log - instead of trusting a copy it can never actually run.

## Related issues

closes #150 

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets` is clean
- [ ] `cargo test` passes
- [ ] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [ ] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - WordPress site creation now gates on Yerd-managed WP-CLI, with Composer requested only when needed to build it.
  - Tool setup now shows live installation progress and command output.

- **Bug Fixes**
  - External `wp` on your PATH no longer satisfies WP-CLI prerequisites.
  - External tool detection is tightened so only eligible PATH tools are treated as satisfying requirements.

- **Documentation**
  - Updated WordPress prerequisite and Tooling guidance to clarify managed vs external behavior, precedence, and WP-CLI exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->