### PR TITLE
[Feat] Per-version PHP settings overrides

### DIFF
--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -345,6 +345,14 @@ pub async fn set_php_settings(
 }
 
 #[tauri::command]
+pub async fn set_php_version_settings(
+    version: PhpVersion,
+    settings: std::collections::BTreeMap<String, String>,
+) -> Result<Response, GuiError> {
+    finish(exchange(&Request::SetPhpVersionSettings { version, settings }).await?)
+}
+
+#[tauri::command]
 pub async fn list_php_extensions() -> Result<Response, GuiError> {
     finish(exchange(&Request::ListPhpExtensions).await?)
 }

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -89,6 +89,7 @@ fn main() {
             commands::set_update_channel,
             commands::apply_update,
             commands::set_php_settings,
+            commands::set_php_version_settings,
             commands::list_php_extensions,
             commands::add_php_extension,
             commands::remove_php_extension,

--- a/apps/yerd-gui/src/components/PhpVersionConfig.vue
+++ b/apps/yerd-gui/src/components/PhpVersionConfig.vue
@@ -87,7 +87,6 @@ const displayErrorsOptions = computed(() => {
 async function saveSettings(): Promise<void> {
   busy.value = true;
   try {
-    // Send every field; blank values remove the override (inherit again).
     const r = await setPhpVersionSettings(props.version, { ...form.value });
     seed(r.version_settings?.[props.version] ?? {});
     toast.success(

--- a/apps/yerd-gui/src/components/PhpVersionConfig.vue
+++ b/apps/yerd-gui/src/components/PhpVersionConfig.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { ChevronDown, Info } from "lucide-vue-next";
+
+import Badge from "@/components/ui/Badge.vue";
+import Button from "@/components/ui/Button.vue";
+import Input from "@/components/ui/Input.vue";
+import Select from "@/components/ui/Select.vue";
+import Spinner from "@/components/ui/Spinner.vue";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useToast } from "@/composables/useToast";
+import { IpcError, setPhpVersionSettings } from "@/ipc/client";
+import type { PhpVersion, PhpVersionsResponse } from "@/ipc/types";
+import {
+  DISPLAY_ERRORS_HINT,
+  effectiveValue,
+  overrideCount,
+  SETTING_KEYS,
+  TEXT_SETTINGS,
+} from "@/lib/phpSettings";
+
+const props = defineProps<{
+  version: PhpVersion;
+  /** The global `[php.settings]` defaults this version inherits from. */
+  globalSettings: Record<string, string>;
+  /** This version's sparse setting overrides (may be empty). */
+  overrides: Record<string, string>;
+}>();
+
+const emit = defineEmits<{
+  /** Fired with the daemon's refreshed version list after a successful save. */
+  (e: "updated", r: PhpVersionsResponse): void;
+}>();
+
+const toast = useToast();
+const open = ref(false);
+const busy = ref(false);
+
+// ── per-version settings form ──
+// Fields hold only the override value; an empty field means "inherit" (the
+// placeholder shows what is inherited). Same pristine/seed discipline as the
+// global settings form: server refreshes only reseed while there are no
+// unsaved edits.
+const form = ref<Record<string, string>>({});
+let lastSeeded: Record<string, string> = {};
+
+function seed(overrides: Record<string, string>): void {
+  const next: Record<string, string> = {};
+  for (const k of SETTING_KEYS) next[k] = overrides[k] ?? "";
+  form.value = next;
+  lastSeeded = { ...next };
+}
+
+function pristine(): boolean {
+  return SETTING_KEYS.every((k) => (form.value[k] ?? "") === (lastSeeded[k] ?? ""));
+}
+
+watch(
+  () => props.overrides,
+  (o) => {
+    if (pristine()) seed(o);
+  },
+  { immediate: true },
+);
+
+const badgeCount = computed(() => overrideCount(props.overrides));
+
+function inheritedLabel(key: string, fallback: string): string {
+  const inherited = effectiveValue(props.globalSettings, {}, key);
+  return `${inherited ?? fallback} (inherited)`;
+}
+
+const displayErrorsOptions = computed(() => {
+  const inherited = effectiveValue(props.globalSettings, {}, "display_errors");
+  return [
+    { value: "", label: `- inherit (${inherited ?? "default"}) -` },
+    { value: "On", label: "On" },
+    { value: "Off", label: "Off" },
+  ];
+});
+
+async function saveSettings(): Promise<void> {
+  busy.value = true;
+  try {
+    // Send every field; blank values remove the override (inherit again).
+    const r = await setPhpVersionSettings(props.version, { ...form.value });
+    seed(r.version_settings?.[props.version] ?? {});
+    toast.success(
+      `PHP ${props.version} settings updated`,
+      "The pool restarts to apply the changes.",
+    );
+    emit("updated", r);
+  } catch (e) {
+    toast.error(`Couldn't update PHP ${props.version} settings`, (e as IpcError).message);
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="rounded-lg border border-border">
+    <button
+      type="button"
+      class="flex w-full items-center justify-between px-4 py-3 text-left"
+      :aria-expanded="open"
+      @click="open = !open"
+    >
+      <span class="flex items-center gap-2">
+        <span class="font-mono text-sm font-medium">PHP {{ version }}</span>
+        <Badge v-if="badgeCount" variant="secondary">
+          {{ badgeCount }} override{{ badgeCount === 1 ? "" : "s" }}
+        </Badge>
+      </span>
+      <ChevronDown class="size-4 transition-transform" :class="{ 'rotate-180': open }" />
+    </button>
+
+    <div v-if="open" class="border-t border-border px-4 py-4">
+      <TooltipProvider :delay-duration="0">
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div v-for="s in TEXT_SETTINGS" :key="s.key">
+            <div class="flex items-center gap-1">
+              <label class="text-xs font-medium" :for="`set-${version}-${s.key}`">
+                {{ s.label }}
+              </label>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <span class="inline-flex cursor-help text-muted-foreground">
+                    <Info class="size-3.5" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">{{ s.hint }}</TooltipContent>
+              </Tooltip>
+            </div>
+            <Input
+              :id="`set-${version}-${s.key}`"
+              v-model="form[s.key]"
+              :placeholder="inheritedLabel(s.key, s.placeholder)"
+              class="mt-1"
+            />
+          </div>
+          <div>
+            <div class="flex items-center gap-1">
+              <span class="text-xs font-medium">Display errors</span>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <span class="inline-flex cursor-help text-muted-foreground">
+                    <Info class="size-3.5" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">{{ DISPLAY_ERRORS_HINT }}</TooltipContent>
+              </Tooltip>
+            </div>
+            <div class="mt-1">
+              <Select
+                class="w-full"
+                :model-value="form.display_errors ?? ''"
+                :options="displayErrorsOptions"
+                :aria-label="`display_errors for PHP ${version}`"
+                @update:model-value="(v: string) => (form.display_errors = v)"
+              />
+            </div>
+          </div>
+        </div>
+      </TooltipProvider>
+
+      <div class="mt-4 flex items-center justify-between gap-2">
+        <span class="text-xs text-muted-foreground">
+          Empty fields inherit the default settings above.
+        </span>
+        <Button size="sm" :disabled="busy" @click="saveSettings">
+          <Spinner v-if="busy" class="size-4" />
+          {{ busy ? "Applying…" : "Save" }}
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/yerd-gui/src/ipc/client.test.ts
+++ b/apps/yerd-gui/src/ipc/client.test.ts
@@ -20,6 +20,7 @@ import {
   setFrontController,
   setMailEnabled,
   setMailPort,
+  setPhpVersionSettings,
   setPrimaryDomain,
   setSymlinkProtection,
   status,
@@ -163,6 +164,21 @@ describe("client → command mapping", () => {
       name: "blog",
       domain: "corp.test",
     });
+  });
+
+  it("setPhpVersionSettings sends the version and settings map", async () => {
+    invokeMock.mockResolvedValue({
+      type: "php_versions",
+      installed: ["8.3"],
+      default: "8.3",
+      version_settings: { "8.3": { memory_limit: "1G" } },
+    });
+    const r = await setPhpVersionSettings("8.3", { memory_limit: "1G" });
+    expect(invokeMock).toHaveBeenCalledWith("set_php_version_settings", {
+      version: "8.3",
+      settings: { memory_limit: "1G" },
+    });
+    expect(r.version_settings?.["8.3"]?.memory_limit).toBe("1G");
   });
 
   it("resetDomains sends just the name", async () => {

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -395,6 +395,21 @@ export async function setPhpSettings(
   ) as PhpVersionsResponse;
 }
 
+/**
+ * Merge per-version overrides of the allowlisted settings for one installed
+ * version and apply them to that version's FPM pool + CLI ini. An empty-string
+ * value removes the override (the global default applies again). Returns the
+ * refreshed version list.
+ */
+export async function setPhpVersionSettings(
+  version: PhpVersion,
+  settings: Record<string, string>,
+): Promise<PhpVersionsResponse> {
+  return ensureOk(
+    await call<Response>("set_php_version_settings", { version, settings }),
+  ) as PhpVersionsResponse;
+}
+
 // ── php extensions ───────────────────────────────────────────────────────────
 
 /** Registered custom extensions, keyed by version string (e.g. `"8.5"`). */

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -521,6 +521,9 @@ export type Response =
       default: PhpVersion;
       updates?: PhpUpdate[];
       settings?: Record<string, string>;
+      /** Sparse per-version overrides of `settings`, keyed by version string
+       *  (e.g. `"8.3"`). Absent when no overrides are set / older daemon. */
+      version_settings?: Record<PhpVersion, Record<string, string>>;
     }
   | {
       type: "available_php";

--- a/apps/yerd-gui/src/lib/phpSettings.test.ts
+++ b/apps/yerd-gui/src/lib/phpSettings.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { effectiveValue, overrideCount, SETTING_KEYS } from "./phpSettings";
+
+describe("effectiveValue", () => {
+  const global = { memory_limit: "512M", max_execution_time: "60" };
+
+  it("prefers the per-version override", () => {
+    expect(effectiveValue(global, { memory_limit: "1G" }, "memory_limit")).toBe("1G");
+  });
+
+  it("falls back to the global value", () => {
+    expect(effectiveValue(global, {}, "memory_limit")).toBe("512M");
+  });
+
+  it("treats an empty override as inherit", () => {
+    expect(effectiveValue(global, { memory_limit: "" }, "memory_limit")).toBe("512M");
+  });
+
+  it("is undefined when neither layer sets the key (PHP default)", () => {
+    expect(effectiveValue(global, {}, "display_errors")).toBeUndefined();
+  });
+});
+
+describe("overrideCount", () => {
+  it("counts only non-empty allowlisted overrides", () => {
+    expect(overrideCount({})).toBe(0);
+    expect(
+      overrideCount({ memory_limit: "1G", display_errors: "Off", max_input_time: "" }),
+    ).toBe(2);
+    expect(overrideCount({ not_a_setting: "x" })).toBe(0);
+  });
+
+  it("SETTING_KEYS covers the 8 allowlisted settings", () => {
+    expect(SETTING_KEYS).toHaveLength(8);
+    expect(SETTING_KEYS).toContain("display_errors");
+  });
+});

--- a/apps/yerd-gui/src/lib/phpSettings.ts
+++ b/apps/yerd-gui/src/lib/phpSettings.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared metadata and pure helpers for the PHP settings UI: the allowlisted
+ * settings' form fields (used by the global card and each per-version panel)
+ * and the inherit/override logic for per-version configuration. The daemon is
+ * the validation authority; the checks here only power inline hints.
+ */
+
+/** Text-input settings of the daemon's fixed allowlist (all but display_errors). */
+export const TEXT_SETTINGS = [
+  {
+    key: "memory_limit",
+    label: "Memory limit",
+    placeholder: "512M",
+    hint: "Most memory one script may use. Size like 256M, 512M or 2G (use G, not GB). -1 means unlimited.",
+  },
+  {
+    key: "max_execution_time",
+    label: "Max execution time (s)",
+    placeholder: "60",
+    hint: "How long a script may run before it's stopped. Whole seconds, e.g. 60. 0 means no limit.",
+  },
+  {
+    key: "max_input_time",
+    label: "Max input time (s)",
+    placeholder: "60",
+    hint: "How long a script may spend reading request data (POST and uploads). Whole seconds, e.g. 60.",
+  },
+  {
+    key: "max_file_uploads",
+    label: "Max file uploads",
+    placeholder: "20",
+    hint: "How many files may be uploaded in one request. Whole number, e.g. 20.",
+  },
+  {
+    key: "upload_max_filesize",
+    label: "Upload max filesize",
+    placeholder: "100M",
+    hint: "Largest single uploaded file. Size like 8M, 100M or 1G (use G, not GB).",
+  },
+  {
+    key: "post_max_size",
+    label: "Post max size",
+    placeholder: "100M",
+    hint: "Largest POST body; set this at or above the upload size. Size like 8M, 100M or 1G (use G, not GB).",
+  },
+  {
+    key: "error_reporting",
+    label: "Error reporting",
+    placeholder: "E_ALL",
+    hint: "Which error levels PHP reports. An integer or a constant expression, e.g. E_ALL or E_ALL & ~E_DEPRECATED.",
+  },
+] as const;
+
+export const DISPLAY_ERRORS_HINT =
+  "Whether PHP shows errors in the page output. On is handy in development; Off is safer in production.";
+
+export const DISPLAY_ERRORS_OPTIONS = [
+  { value: "", label: "- default -" },
+  { value: "On", label: "On" },
+  { value: "Off", label: "Off" },
+] as const;
+
+/** Every allowlisted setting name, including the select-backed display_errors. */
+export const SETTING_KEYS: readonly string[] = [
+  ...TEXT_SETTINGS.map((s) => s.key),
+  "display_errors",
+];
+
+/**
+ * The value a version effectively runs with for `key`: its override when set,
+ * else the global default, else `undefined` (PHP's built-in default).
+ */
+export function effectiveValue(
+  global: Record<string, string>,
+  overrides: Record<string, string>,
+  key: string,
+): string | undefined {
+  const o = overrides[key];
+  if (o !== undefined && o !== "") return o;
+  const g = global[key];
+  return g !== undefined && g !== "" ? g : undefined;
+}
+
+/** How many allowlisted settings a version's override map actually overrides. */
+export function overrideCount(overrides: Record<string, string>): number {
+  return SETTING_KEYS.filter((k) => (overrides[k] ?? "") !== "").length;
+}

--- a/apps/yerd-gui/src/views/PhpView.vue
+++ b/apps/yerd-gui/src/views/PhpView.vue
@@ -60,7 +60,13 @@ import {
   uninstallPhp,
   updatePhp,
 } from "@/ipc/client";
-import type { PhpPoolStatus, PhpUpdate, PhpVersion } from "@/ipc/types";
+import type { PhpPoolStatus, PhpUpdate, PhpVersion, PhpVersionsResponse } from "@/ipc/types";
+import PhpVersionConfig from "@/components/PhpVersionConfig.vue";
+import {
+  DISPLAY_ERRORS_HINT,
+  DISPLAY_ERRORS_OPTIONS,
+  TEXT_SETTINGS,
+} from "@/lib/phpSettings";
 import { humaniseBytes, poolStateLabel, poolStateTone } from "@/lib/utils";
 
 const toast = useToast();
@@ -104,62 +110,9 @@ const updateByVersion = computed<Record<string, PhpUpdate>>(() => {
 const hasUpdates = computed(() => updates.value.length > 0);
 
 // ── global PHP ini settings ──
-// Text fields plus an On/Off select for display_errors. A blank field means
-// "use PHP's default" (the daemon removes the key).
-const TEXT_SETTINGS = [
-  {
-    key: "memory_limit",
-    label: "Memory limit",
-    placeholder: "512M",
-    hint: "Most memory one script may use. Size like 256M, 512M or 2G (use G, not GB). -1 means unlimited.",
-  },
-  {
-    key: "max_execution_time",
-    label: "Max execution time (s)",
-    placeholder: "60",
-    hint: "How long a script may run before it's stopped. Whole seconds, e.g. 60. 0 means no limit.",
-  },
-  {
-    key: "max_input_time",
-    label: "Max input time (s)",
-    placeholder: "60",
-    hint: "How long a script may spend reading request data (POST and uploads). Whole seconds, e.g. 60.",
-  },
-  {
-    key: "max_file_uploads",
-    label: "Max file uploads",
-    placeholder: "20",
-    hint: "How many files may be uploaded in one request. Whole number, e.g. 20.",
-  },
-  {
-    key: "upload_max_filesize",
-    label: "Upload max filesize",
-    placeholder: "100M",
-    hint: "Largest single uploaded file. Size like 8M, 100M or 1G (use G, not GB).",
-  },
-  {
-    key: "post_max_size",
-    label: "Post max size",
-    placeholder: "100M",
-    hint: "Largest POST body; set this at or above the upload size. Size like 8M, 100M or 1G (use G, not GB).",
-  },
-  {
-    key: "error_reporting",
-    label: "Error reporting",
-    placeholder: "E_ALL",
-    hint: "Which error levels PHP reports. An integer or a constant expression, e.g. E_ALL or E_ALL & ~E_DEPRECATED.",
-  },
-] as const;
-
-const DISPLAY_ERRORS_HINT =
-  "Whether PHP shows errors in the page output. On is handy in development; Off is safer in production.";
-
-const DISPLAY_ERRORS_OPTIONS = [
-  { value: "", label: "- default -" },
-  { value: "On", label: "On" },
-  { value: "Off", label: "Off" },
-] as const;
-
+// Text fields plus an On/Off select for display_errors (field metadata shared
+// with the per-version panels via lib/phpSettings). A blank field means "use
+// PHP's default" (the daemon removes the key).
 const settingsForm = ref<Record<string, string>>({});
 // Snapshot of the values last seeded from the server, so we can tell whether the
 // user has edited the form since (and thus whether a fresh server value may
@@ -211,6 +164,15 @@ async function saveSettings(): Promise<void> {
   } finally {
     busy.value = null;
   }
+}
+
+// ── per-version configuration ──
+// Each installed version gets a collapsible panel (PhpVersionConfig) holding
+// its setting overrides. The panel does its own saves and hands back the
+// daemon's refreshed version list.
+function onVersionConfigUpdated(r: PhpVersionsResponse): void {
+  mutate(() => r);
+  void reloadPhp({ force: true });
 }
 
 // ── custom extensions ──────────────────────────────────────────────────────
@@ -715,6 +677,28 @@ onUnmounted(
               {{ busy === "settings" ? "Applying…" : "Save" }}
             </Button>
           </div>
+        </CardContent>
+      </Card>
+
+      <!-- Per-version setting overrides. -->
+      <Card v-if="!loading && installed.length" class="mt-8">
+        <CardHeader>
+          <CardTitle>Per-version configuration</CardTitle>
+          <CardDescription>
+            Override the default settings for a single version; empty fields
+            inherit the defaults above. Saving restarts only that version's
+            pool.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="flex flex-col gap-3">
+          <PhpVersionConfig
+            v-for="v in installed"
+            :key="v"
+            :version="v"
+            :global-settings="data?.settings ?? {}"
+            :overrides="data?.version_settings?.[v] ?? {}"
+            @updated="onVersionConfigUpdated"
+          />
         </CardContent>
       </Card>
 

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -622,6 +622,10 @@ pub enum SetTarget {
         setting: String,
         /// Setting value, e.g. `512M`.
         value: String,
+        /// Apply only to this installed PHP version (overrides the global
+        /// default for that version).
+        #[arg(long = "php", value_name = "VERSION")]
+        php: Option<String>,
     },
 }
 
@@ -632,6 +636,10 @@ pub enum UnsetTarget {
     Php {
         /// Setting name, e.g. `memory_limit`.
         setting: String,
+        /// Reset only this version's override; the global default applies
+        /// again.
+        #[arg(long = "php", value_name = "VERSION")]
+        php: Option<String>,
     },
 }
 

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -624,8 +624,8 @@ pub enum SetTarget {
         value: String,
         /// Apply only to this installed PHP version (overrides the global
         /// default for that version).
-        #[arg(long = "php", value_name = "VERSION")]
-        php: Option<String>,
+        #[arg(long = "only", value_name = "VERSION")]
+        only: Option<String>,
     },
 }
 
@@ -638,8 +638,8 @@ pub enum UnsetTarget {
         setting: String,
         /// Reset only this version's override; the global default applies
         /// again.
-        #[arg(long = "php", value_name = "VERSION")]
-        php: Option<String>,
+        #[arg(long = "only", value_name = "VERSION")]
+        only: Option<String>,
     },
 }
 

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -53,12 +53,12 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
                 crate::cli::SetTarget::Php {
                     setting,
                     value,
-                    php,
+                    only,
                 },
         } => {
             validate_php_setting(setting, Some(value))?;
             let settings = std::collections::BTreeMap::from([(setting.clone(), value.clone())]);
-            match php {
+            match only {
                 Some(v) => Request::SetPhpVersionSettings {
                     version: parse_php(v)?,
                     settings,
@@ -67,11 +67,11 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
             }
         }
         Command::Unset {
-            target: crate::cli::UnsetTarget::Php { setting, php },
+            target: crate::cli::UnsetTarget::Php { setting, only },
         } => {
             validate_php_setting(setting, None)?;
             let settings = std::collections::BTreeMap::from([(setting.clone(), String::new())]);
-            match php {
+            match only {
                 Some(v) => Request::SetPhpVersionSettings {
                     version: parse_php(v)?,
                     settings,
@@ -1549,7 +1549,7 @@ mod tests {
                 target: crate::cli::SetTarget::Php {
                     setting: "memory_limit".into(),
                     value: "512M".into(),
-                    php: None
+                    only: None
                 }
             })
             .unwrap(),
@@ -1565,7 +1565,7 @@ mod tests {
                 target: crate::cli::SetTarget::Php {
                     setting: "memory_limit".into(),
                     value: "1G".into(),
-                    php: Some("8.3".into())
+                    only: Some("8.3".into())
                 }
             })
             .unwrap(),
@@ -1581,7 +1581,7 @@ mod tests {
             to_request(&Command::Unset {
                 target: crate::cli::UnsetTarget::Php {
                     setting: "memory_limit".into(),
-                    php: None
+                    only: None
                 }
             })
             .unwrap(),
@@ -1596,7 +1596,7 @@ mod tests {
             to_request(&Command::Unset {
                 target: crate::cli::UnsetTarget::Php {
                     setting: "memory_limit".into(),
-                    php: Some("8.3".into())
+                    only: Some("8.3".into())
                 }
             })
             .unwrap(),
@@ -1880,7 +1880,7 @@ mod tests {
             target: crate::cli::SetTarget::Php {
                 setting: "not_a_setting".into(),
                 value: "1".into(),
-                php: None,
+                only: None,
             },
         }) {
             Err(ClientError::Usage(_)) => {}
@@ -1890,7 +1890,7 @@ mod tests {
             target: crate::cli::SetTarget::Php {
                 setting: "memory_limit".into(),
                 value: "bogus".into(),
-                php: None,
+                only: None,
             },
         }) {
             Err(ClientError::Usage(_)) => {}
@@ -1900,7 +1900,7 @@ mod tests {
             target: crate::cli::SetTarget::Php {
                 setting: "memory_limit".into(),
                 value: "1G".into(),
-                php: Some("bogus".into()),
+                only: Some("bogus".into()),
             },
         }) {
             Err(ClientError::Usage(_)) => {}
@@ -3045,7 +3045,7 @@ mod tests {
         match to_request(&Command::Unset {
             target: crate::cli::UnsetTarget::Php {
                 setting: "not_a_setting".into(),
-                php: None,
+                only: None,
             },
         }) {
             Err(ClientError::Usage(_)) => {}

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -49,19 +49,34 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
             }
         }
         Command::Set {
-            target: crate::cli::SetTarget::Php { setting, value },
+            target:
+                crate::cli::SetTarget::Php {
+                    setting,
+                    value,
+                    php,
+                },
         } => {
             validate_php_setting(setting, Some(value))?;
-            Request::SetPhpSettings {
-                settings: std::collections::BTreeMap::from([(setting.clone(), value.clone())]),
+            let settings = std::collections::BTreeMap::from([(setting.clone(), value.clone())]);
+            match php {
+                Some(v) => Request::SetPhpVersionSettings {
+                    version: parse_php(v)?,
+                    settings,
+                },
+                None => Request::SetPhpSettings { settings },
             }
         }
         Command::Unset {
-            target: crate::cli::UnsetTarget::Php { setting },
+            target: crate::cli::UnsetTarget::Php { setting, php },
         } => {
             validate_php_setting(setting, None)?;
-            Request::SetPhpSettings {
-                settings: std::collections::BTreeMap::from([(setting.clone(), String::new())]),
+            let settings = std::collections::BTreeMap::from([(setting.clone(), String::new())]);
+            match php {
+                Some(v) => Request::SetPhpVersionSettings {
+                    version: parse_php(v)?,
+                    settings,
+                },
+                None => Request::SetPhpSettings { settings },
             }
         }
         Command::Php {
@@ -738,7 +753,14 @@ pub fn render(resp: &Response, json: bool) -> Rendered {
             default,
             updates,
             settings,
-        } => Rendered::ok(format_php_versions(installed, *default, updates, settings)),
+            version_settings,
+        } => Rendered::ok(format_php_versions(
+            installed,
+            *default,
+            updates,
+            settings,
+            version_settings,
+        )),
         Response::AvailablePhp {
             available,
             installed,
@@ -1126,6 +1148,10 @@ fn format_php_versions(
     default: PhpVersion,
     updates: &[yerd_ipc::PhpUpdate],
     settings: &std::collections::BTreeMap<String, String>,
+    version_settings: &std::collections::BTreeMap<
+        PhpVersion,
+        std::collections::BTreeMap<String, String>,
+    >,
 ) -> String {
     let versions = if installed.is_empty() {
         format!("no PHP versions installed (default: {default}) - `yerd install php {default}`")
@@ -1146,15 +1172,35 @@ fn format_php_versions(
             .collect::<Vec<_>>()
             .join("\n")
     };
-    if settings.is_empty() {
-        return versions;
-    }
     let mut out = versions;
-    out.push_str("\n\nsettings:");
-    for (k, v) in settings {
-        let _ = write!(out, "\n  {k} = {v}");
+    if !settings.is_empty() {
+        out.push_str("\n\nsettings:");
+        for (k, v) in settings {
+            let _ = write!(out, "\n  {k} = {v}");
+        }
+    }
+    for v in installed {
+        let Some(map) = version_settings.get(v) else {
+            continue;
+        };
+        let _ = write!(out, "\n\nPHP {v}:");
+        for (k, val) in map {
+            let _ = write!(
+                out,
+                "\n  {k} = {val}  (overrides {})",
+                global_of(settings, k)
+            );
+        }
     }
     out
+}
+
+/// The global value a per-version override shadows, for display; "PHP default"
+/// when the setting isn't set globally.
+fn global_of(settings: &std::collections::BTreeMap<String, String>, key: &str) -> String {
+    settings
+        .get(key)
+        .map_or_else(|| "PHP default".to_owned(), |v| format!("global {v}"))
 }
 
 /// Render the installable versions, tagging the ones already installed.
@@ -1502,7 +1548,8 @@ mod tests {
             to_request(&Command::Set {
                 target: crate::cli::SetTarget::Php {
                     setting: "memory_limit".into(),
-                    value: "512M".into()
+                    value: "512M".into(),
+                    php: None
                 }
             })
             .unwrap(),
@@ -1514,13 +1561,47 @@ mod tests {
             }
         );
         assert_eq!(
+            to_request(&Command::Set {
+                target: crate::cli::SetTarget::Php {
+                    setting: "memory_limit".into(),
+                    value: "1G".into(),
+                    php: Some("8.3".into())
+                }
+            })
+            .unwrap(),
+            Request::SetPhpVersionSettings {
+                version: PhpVersion::new(8, 3),
+                settings: std::collections::BTreeMap::from([(
+                    "memory_limit".to_string(),
+                    "1G".to_string()
+                )])
+            }
+        );
+        assert_eq!(
             to_request(&Command::Unset {
                 target: crate::cli::UnsetTarget::Php {
-                    setting: "memory_limit".into()
+                    setting: "memory_limit".into(),
+                    php: None
                 }
             })
             .unwrap(),
             Request::SetPhpSettings {
+                settings: std::collections::BTreeMap::from([(
+                    "memory_limit".to_string(),
+                    String::new()
+                )])
+            }
+        );
+        assert_eq!(
+            to_request(&Command::Unset {
+                target: crate::cli::UnsetTarget::Php {
+                    setting: "memory_limit".into(),
+                    php: Some("8.3".into())
+                }
+            })
+            .unwrap(),
+            Request::SetPhpVersionSettings {
+                version: PhpVersion::new(8, 3),
                 settings: std::collections::BTreeMap::from([(
                     "memory_limit".to_string(),
                     String::new()
@@ -1799,6 +1880,7 @@ mod tests {
             target: crate::cli::SetTarget::Php {
                 setting: "not_a_setting".into(),
                 value: "1".into(),
+                php: None,
             },
         }) {
             Err(ClientError::Usage(_)) => {}
@@ -1808,6 +1890,17 @@ mod tests {
             target: crate::cli::SetTarget::Php {
                 setting: "memory_limit".into(),
                 value: "bogus".into(),
+                php: None,
+            },
+        }) {
+            Err(ClientError::Usage(_)) => {}
+            other => panic!("expected Usage error, got {other:?}"),
+        }
+        match to_request(&Command::Set {
+            target: crate::cli::SetTarget::Php {
+                setting: "memory_limit".into(),
+                value: "1G".into(),
+                php: Some("bogus".into()),
             },
         }) {
             Err(ClientError::Usage(_)) => {}
@@ -1996,6 +2089,7 @@ mod tests {
                     latest: "8.3.31".into(),
                 }],
                 settings: std::collections::BTreeMap::new(),
+                version_settings: Box::new(std::collections::BTreeMap::new()),
             },
             false,
         );
@@ -2012,10 +2106,50 @@ mod tests {
                 default: PhpVersion::new(8, 3),
                 updates: vec![],
                 settings: std::collections::BTreeMap::new(),
+                version_settings: Box::new(std::collections::BTreeMap::new()),
             },
             false,
         );
         assert!(empty.stdout.contains("no PHP versions installed"));
+    }
+
+    #[test]
+    fn renders_php_versions_with_per_version_overrides() {
+        let v83 = PhpVersion::new(8, 3);
+        let r = render(
+            &Response::PhpVersions {
+                installed: vec![v83, PhpVersion::new(8, 5)],
+                default: PhpVersion::new(8, 5),
+                updates: vec![],
+                settings: std::collections::BTreeMap::from([(
+                    "memory_limit".to_string(),
+                    "512M".to_string(),
+                )]),
+                version_settings: Box::new(std::collections::BTreeMap::from([(
+                    v83,
+                    std::collections::BTreeMap::from([
+                        ("memory_limit".to_string(), "1G".to_string()),
+                        ("display_errors".to_string(), "Off".to_string()),
+                    ]),
+                )])),
+            },
+            false,
+        );
+        assert_eq!(r.code, 0);
+        assert!(r.stdout.contains("PHP 8.3:"), "got: {}", r.stdout);
+        assert!(
+            r.stdout
+                .contains("memory_limit = 1G  (overrides global 512M)"),
+            "got: {}",
+            r.stdout
+        );
+        assert!(
+            r.stdout
+                .contains("display_errors = Off  (overrides PHP default)"),
+            "got: {}",
+            r.stdout
+        );
+        assert!(!r.stdout.contains("PHP 8.5:"), "got: {}", r.stdout);
     }
 
     #[test]
@@ -2139,6 +2273,7 @@ mod tests {
                     ("memory_limit".to_string(), "512M".to_string()),
                     ("display_errors".to_string(), "On".to_string()),
                 ]),
+                version_settings: Box::new(std::collections::BTreeMap::new()),
             },
             false,
         );
@@ -2910,6 +3045,7 @@ mod tests {
         match to_request(&Command::Unset {
             target: crate::cli::UnsetTarget::Php {
                 setting: "not_a_setting".into(),
+                php: None,
             },
         }) {
             Err(ClientError::Usage(_)) => {}

--- a/bin/yerd/tests/cli_e2e.rs
+++ b/bin/yerd/tests/cli_e2e.rs
@@ -373,4 +373,116 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_secs(5), ipc_task).await;
         drop(keep_alive);
     }
+
+    /// Per-version PHP config over the socket: `yerd set php ... --php 8.3`
+    /// and the `NotFound` guard for an uninstalled version. PHP 8.3 is faked
+    /// on disk (binaries only; no pool is running).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::too_many_lines)]
+    async fn php_version_config_round_trips_against_daemon() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = make_dirs(tmp.path());
+        let cfg_path = dirs.config.join("yerd.toml");
+
+        let base = dirs.data.join("php").join("php-8.3");
+        std::fs::create_dir_all(base.join("sbin")).unwrap();
+        std::fs::create_dir_all(base.join("bin")).unwrap();
+        std::fs::write(base.join("sbin").join("php-fpm"), b"x").unwrap();
+        std::fs::write(base.join("bin").join("php"), b"x").unwrap();
+
+        let daemon =
+            yerdd::startup::bring_up_with_dirs(dirs.clone(), valid_config(), cfg_path.clone())
+                .await
+                .expect("bring_up_with_dirs");
+        let sock = dirs.runtime.join("yerd.sock");
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let state = daemon.state.clone();
+        let ipc_task = tokio::spawn(yerdd::ipc_server::run(
+            daemon.ipc_listener,
+            state,
+            shutdown_rx,
+        ));
+        let keep_alive = (
+            daemon.lock,
+            daemon.dns_bound,
+            daemon.http_listener,
+            daemon.https_listener,
+            daemon.php_manager,
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let v83 = yerd_core::PhpVersion::new(8, 3);
+        let set_override = Command::Set {
+            target: yerd::cli::SetTarget::Php {
+                setting: "memory_limit".into(),
+                value: "1G".into(),
+                php: Some("8.3".into()),
+            },
+        };
+        match send(&sock, &set_override).await {
+            Response::PhpVersions {
+                version_settings, ..
+            } => {
+                assert_eq!(
+                    version_settings
+                        .get(&v83)
+                        .and_then(|m| m.get("memory_limit"))
+                        .map(String::as_str),
+                    Some("1G")
+                );
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+
+        match send(
+            &sock,
+            &Command::Set {
+                target: yerd::cli::SetTarget::Php {
+                    setting: "memory_limit".into(),
+                    value: "1G".into(),
+                    php: Some("8.4".into()),
+                },
+            },
+        )
+        .await
+        {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::NotFound),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+
+        let per_version_ini =
+            std::fs::read_to_string(dirs.data.join("php-cli-8.3.ini")).expect("per-version ini");
+        assert!(per_version_ini.contains("memory_limit = 1G\n"));
+        let base_ini = std::fs::read_to_string(dirs.data.join("php-cli.ini")).expect("base ini");
+        assert!(!base_ini.contains("1G"));
+
+        let on_disk = std::fs::read_to_string(&cfg_path).expect("config written");
+        assert!(
+            on_disk.contains("[php.version_settings.\"8.3\"]"),
+            "{on_disk}"
+        );
+        match send(
+            &sock,
+            &Command::Unset {
+                target: yerd::cli::UnsetTarget::Php {
+                    setting: "memory_limit".into(),
+                    php: Some("8.3".into()),
+                },
+            },
+        )
+        .await
+        {
+            Response::PhpVersions {
+                version_settings, ..
+            } => {
+                assert!(!version_settings.contains_key(&v83));
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+
+        shutdown_tx.send_replace(true);
+        let _ = tokio::time::timeout(Duration::from_secs(5), ipc_task).await;
+        drop(keep_alive);
+    }
 }

--- a/bin/yerd/tests/cli_e2e.rs
+++ b/bin/yerd/tests/cli_e2e.rs
@@ -374,7 +374,7 @@ mod tests {
         drop(keep_alive);
     }
 
-    /// Per-version PHP config over the socket: `yerd set php ... --php 8.3`
+    /// Per-version PHP config over the socket: `yerd set php ... --only 8.3`
     /// and the `NotFound` guard for an uninstalled version. PHP 8.3 is faked
     /// on disk (binaries only; no pool is running).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -417,7 +417,7 @@ mod tests {
             target: yerd::cli::SetTarget::Php {
                 setting: "memory_limit".into(),
                 value: "1G".into(),
-                php: Some("8.3".into()),
+                only: Some("8.3".into()),
             },
         };
         match send(&sock, &set_override).await {
@@ -441,7 +441,7 @@ mod tests {
                 target: yerd::cli::SetTarget::Php {
                     setting: "memory_limit".into(),
                     value: "1G".into(),
-                    php: Some("8.4".into()),
+                    only: Some("8.4".into()),
                 },
             },
         )
@@ -467,7 +467,7 @@ mod tests {
             &Command::Unset {
                 target: yerd::cli::UnsetTarget::Php {
                     setting: "memory_limit".into(),
-                    php: Some("8.3".into()),
+                    only: Some("8.3".into()),
                 },
             },
         )

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1785,7 +1785,7 @@ async fn set_php_settings(
     php_versions_response(state).await
 }
 
-/// `set/unset php --php <version>` - merge per-version overrides of the
+/// `set/unset php --only <version>` - merge per-version overrides of the
 /// allowlisted settings into the config and apply them to that version's FPM
 /// pool and CLI ini. An empty-string value removes the override (the global
 /// value applies again). Same lock order and `php_settings_mutate` discipline

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1731,11 +1731,14 @@ async fn set_symlink_protection(enabled: bool, state: &DaemonState) -> Response 
 /// Order (build → validate → save → commit → drop config guard → restart
 /// pools): the config write is fail-closed; the per-pool restart is best-effort
 /// and runs *after* the config guard is released, under a single `php_manager`
-/// lock so no request can `ensure` a stale-config pool mid-update.
+/// lock so no request can `ensure` a stale-config pool mid-update. The whole
+/// sequence holds `php_settings_mutate`, so an overlapping settings request
+/// can't push a stale snapshot into the manager after a newer one applied.
 async fn set_php_settings(
     settings: std::collections::BTreeMap<String, String>,
     state: &DaemonState,
 ) -> Response {
+    let _mutate_guard = state.php_settings_mutate.lock().await;
     let mut cfg_guard = state.config.lock().await;
     let mut new = cfg_guard.clone();
     for (key, value) in settings {
@@ -1785,8 +1788,8 @@ async fn set_php_settings(
 /// `set/unset php --php <version>` - merge per-version overrides of the
 /// allowlisted settings into the config and apply them to that version's FPM
 /// pool and CLI ini. An empty-string value removes the override (the global
-/// value applies again). Same lock order as [`set_php_settings`], but only the
-/// affected version's pool restarts.
+/// value applies again). Same lock order and `php_settings_mutate` discipline
+/// as [`set_php_settings`], but only the affected version's pool restarts.
 async fn set_php_version_settings(
     version: yerd_core::PhpVersion,
     settings: std::collections::BTreeMap<String, String>,
@@ -1795,6 +1798,7 @@ async fn set_php_version_settings(
     if let Some(resp) = require_installed(version, state) {
         return resp;
     }
+    let _mutate_guard = state.php_settings_mutate.lock().await;
     let mut cfg_guard = state.config.lock().await;
     let mut new = cfg_guard.clone();
     for (key, value) in settings {
@@ -1863,7 +1867,8 @@ fn require_installed(version: yerd_core::PhpVersion, state: &DaemonState) -> Opt
 /// live `PhpManager`, restart the affected version's pool if it is currently
 /// running, and rewrite the per-version CLI inis. Follows `set_php_settings`'s
 /// lock discipline: the config lock is released before the manager lock is
-/// taken.
+/// taken. Runs under the caller's `php_settings_mutate` guard, which is what
+/// keeps the config re-read here from racing a concurrent settings mutation.
 async fn apply_version_php_config(state: &DaemonState, affected: yerd_core::PhpVersion) {
     let version_settings = {
         let cfg = state.config.lock().await;

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -203,6 +203,9 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         Request::UpdatePhp { version } => update_php(version, state).await,
         Request::AvailablePhp => available_php_response(state).await,
         Request::SetPhpSettings { settings } => set_php_settings(settings, state).await,
+        Request::SetPhpVersionSettings { version, settings } => {
+            set_php_version_settings(version, settings, state).await
+        }
         Request::AddPhpExtension {
             version,
             path,
@@ -456,15 +459,20 @@ fn installed_versions(state: &DaemonState) -> Vec<yerd_core::PhpVersion> {
 /// Build the `PhpVersions` reply: installed versions, the live global default,
 /// cached update annotations, and the global ini settings. Read-only; no network.
 async fn php_versions_response(state: &DaemonState) -> Response {
-    let (default, settings) = {
+    let (default, settings, version_settings) = {
         let cfg = state.config.lock().await;
-        (cfg.php.default, cfg.php.settings.clone())
+        (
+            cfg.php.default,
+            cfg.php.settings.clone(),
+            cfg.php.version_settings.clone(),
+        )
     };
     Response::PhpVersions {
         installed: installed_versions(state),
         default,
         updates: crate::php_updates::cached_updates(state).await,
         settings,
+        version_settings: Box::new(version_settings),
     }
 }
 
@@ -1273,15 +1281,20 @@ fn bundle_contains_ca(ca_pem: &str, bundle_pem: &str) -> bool {
 }
 
 pub(crate) async fn write_cli_ini_now(state: &DaemonState) {
-    let (settings, extensions) = {
+    let (settings, extensions, version_settings) = {
         let cfg = state.config.lock().await;
-        (cfg.php.settings.clone(), cfg.php.extensions.clone())
+        (
+            cfg.php.settings.clone(),
+            cfg.php.extensions.clone(),
+            cfg.php.version_settings.clone(),
+        )
     };
     if let Err(e) = crate::php_install::write_cli_ini(
         &state.dirs,
         &settings,
         state.php_ca_bundle.as_deref(),
         &extensions,
+        &version_settings,
     ) {
         tracing::warn!(error = %e, "failed to write CLI php.ini");
     }
@@ -1743,7 +1756,7 @@ async fn set_php_settings(
     if let Err(e) = new.save(&state.config_path) {
         return internal(format!("config save failed: {e}"));
     }
-    let applied = settings_to_vec(&new.php.settings);
+    let applied = new.php.settings.clone();
     *cfg_guard = new;
     drop(cfg_guard);
 
@@ -1759,6 +1772,105 @@ async fn set_php_settings(
     write_cli_ini_now(state).await;
     tracing::info!("applied global PHP settings");
     php_versions_response(state).await
+}
+
+/// `set/unset php --php <version>` - merge per-version overrides of the
+/// allowlisted settings into the config and apply them to that version's FPM
+/// pool and CLI ini. An empty-string value removes the override (the global
+/// value applies again). Same lock order as [`set_php_settings`], but only the
+/// affected version's pool restarts.
+async fn set_php_version_settings(
+    version: yerd_core::PhpVersion,
+    settings: std::collections::BTreeMap<String, String>,
+    state: &DaemonState,
+) -> Response {
+    if let Some(resp) = require_installed(version, state) {
+        return resp;
+    }
+    let mut cfg_guard = state.config.lock().await;
+    let mut new = cfg_guard.clone();
+    for (key, value) in settings {
+        if value.is_empty() {
+            if let Some(map) = new.php.version_settings.get_mut(&version) {
+                map.remove(&key);
+            }
+            continue;
+        }
+        if let Err(e) = yerd_core::php_settings::validate_value(&key, &value) {
+            return Response::Error {
+                code: ErrorCode::InvalidPath,
+                message: e.to_string(),
+            };
+        }
+        let canonical = yerd_core::php_settings::canonical_value(&key, &value);
+        new.php
+            .version_settings
+            .entry(version)
+            .or_default()
+            .insert(key, canonical);
+    }
+    if new
+        .php
+        .version_settings
+        .get(&version)
+        .is_some_and(std::collections::BTreeMap::is_empty)
+    {
+        new.php.version_settings.remove(&version);
+    }
+
+    if new.php.version_settings == cfg_guard.php.version_settings {
+        drop(cfg_guard);
+        return php_versions_response(state).await;
+    }
+
+    if let Err(e) = new.validate() {
+        return internal(format!("config validation failed: {e}"));
+    }
+    if let Err(e) = new.save(&state.config_path) {
+        return internal(format!("config save failed: {e}"));
+    }
+    *cfg_guard = new;
+    drop(cfg_guard);
+
+    apply_version_php_config(state, version).await;
+    tracing::info!(version = %version, "applied per-version PHP settings");
+    php_versions_response(state).await
+}
+
+/// `NotFound` error when `version` has no installed CLI binary, else `None`.
+/// Per-version config only makes sense for an installed version (mirrors
+/// `add_php_extension`).
+fn require_installed(version: yerd_core::PhpVersion, state: &DaemonState) -> Option<Response> {
+    let php_bin = crate::php_install::cli_binary_path(&state.dirs, version);
+    if php_bin.exists() {
+        return None;
+    }
+    Some(Response::Error {
+        code: ErrorCode::NotFound,
+        message: format!("PHP {version} is not installed - run `yerd install php {version}`"),
+    })
+}
+
+/// Push the config's per-version settings overrides into the
+/// live `PhpManager`, restart the affected version's pool if it is currently
+/// running, and rewrite the per-version CLI inis. Follows `set_php_settings`'s
+/// lock discipline: the config lock is released before the manager lock is
+/// taken.
+async fn apply_version_php_config(state: &DaemonState, affected: yerd_core::PhpVersion) {
+    let version_settings = {
+        let cfg = state.config.lock().await;
+        cfg.php.version_settings.clone()
+    };
+    {
+        let mut mgr = state.php_manager.lock().await;
+        mgr.set_ini_overrides(version_settings);
+        if mgr.snapshots().iter().any(|s| s.version == affected) {
+            if let Err(e) = mgr.restart(affected).await {
+                tracing::warn!(version = %affected, error = %e, "failed to restart FPM pool after per-version PHP config change");
+            }
+        }
+    }
+    write_cli_ini_now(state).await;
 }
 
 /// Register a custom extension for `version`: validate, load-probe, persist, then
@@ -1937,14 +2049,6 @@ async fn extension_load_map(
                 .collect();
             (*v, loads)
         })
-        .collect()
-}
-
-/// A config settings map as sorted `(name, value)` pairs for the pool manager.
-fn settings_to_vec(settings: &std::collections::BTreeMap<String, String>) -> Vec<(String, String)> {
-    settings
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
         .collect()
 }
 
@@ -3515,6 +3619,85 @@ Subject: Captured\r\n\r\nhi\r\n";
             Response::PhpVersions { settings, .. } => {
                 assert!(!settings.contains_key("memory_limit"));
                 assert!(settings.contains_key("display_errors"));
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+    }
+
+    /// Dispatch a single-entry `SetPhpVersionSettings` request.
+    async fn set_version_setting(
+        state: &DaemonState,
+        version: PhpVersion,
+        name: &str,
+        value: &str,
+    ) -> Response {
+        dispatch(
+            Request::SetPhpVersionSettings {
+                version,
+                settings: std::collections::BTreeMap::from([(name.to_string(), value.to_string())]),
+            },
+            state,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn set_php_version_settings_persists_canonicalises_and_falls_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        let v83 = PhpVersion::new(8, 3);
+        fake_install(&state.dirs, v83);
+
+        assert!(matches!(
+            set_version_setting(&state, PhpVersion::new(8, 5), "memory_limit", "1G").await,
+            Response::Error {
+                code: ErrorCode::NotFound,
+                ..
+            }
+        ));
+
+        let _ = set_version_setting(&state, v83, "memory_limit", "1G").await;
+        match set_version_setting(&state, v83, "display_errors", "off").await {
+            Response::PhpVersions {
+                version_settings, ..
+            } => {
+                let map = version_settings.get(&v83).expect("8.3 overrides present");
+                assert_eq!(map.get("memory_limit").map(String::as_str), Some("1G"));
+                assert_eq!(map.get("display_errors").map(String::as_str), Some("Off"));
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+
+        assert!(matches!(
+            set_version_setting(&state, v83, "memory_limit", "bogus").await,
+            Response::Error { .. }
+        ));
+        assert!(matches!(
+            set_version_setting(&state, v83, "allow_url_fopen", "1").await,
+            Response::Error { .. }
+        ));
+        assert_eq!(
+            state
+                .config
+                .lock()
+                .await
+                .php
+                .version_settings
+                .get(&v83)
+                .and_then(|m| m.get("memory_limit"))
+                .map(String::as_str),
+            Some("1G")
+        );
+
+        let _ = set_version_setting(&state, v83, "memory_limit", "").await;
+        match set_version_setting(&state, v83, "display_errors", "").await {
+            Response::PhpVersions {
+                version_settings, ..
+            } => {
+                assert!(
+                    !version_settings.contains_key(&v83),
+                    "emptied override map must drop the version key"
+                );
             }
             other => panic!("expected PhpVersions, got {other:?}"),
         }

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -227,12 +227,15 @@ pub async fn install(
 /// each atomically (temp + rename) so a crash mid-write can't leave PHP reading a
 /// truncated ini:
 ///
-/// - the base `{data}/php-cli.ini` (settings only, no extensions), kept for the
-///   shell-profile `PHPRC` export and any non-shim `php`;
-/// - one `{data}/php-cli-<minor>.ini` per **installed** version, adding that
-///   version's registered extensions. Writing per *installed* version (not per
-///   config key) is load-bearing: a version whose last extension was just removed
-///   still gets its file rewritten back to base-only, rather than left stale.
+/// - the base `{data}/php-cli.ini` (global settings only, no extensions and no
+///   per-version entries), kept for the shell-profile `PHPRC` export and any
+///   non-shim `php`;
+/// - one `{data}/php-cli-<minor>.ini` per **installed** version, rendering that
+///   version's *effective* settings (global merged with its sparse overrides)
+///   and its registered extensions. Writing per *installed* version (not per
+///   config key) is load-bearing: a version whose last extension/override was
+///   just removed still gets its file rewritten back to base-only, rather than
+///   left stale.
 ///
 /// Always rewrites (idempotent).
 pub fn write_cli_ini(
@@ -240,6 +243,10 @@ pub fn write_cli_ini(
     settings: &std::collections::BTreeMap<String, String>,
     ca_bundle: Option<&Path>,
     extensions: &std::collections::BTreeMap<PhpVersion, Vec<yerd_config::ExtEntry>>,
+    version_settings: &std::collections::BTreeMap<
+        PhpVersion,
+        std::collections::BTreeMap<String, String>,
+    >,
 ) -> std::io::Result<()> {
     std::fs::create_dir_all(&dirs.data)?;
     let base = decorate_cli_ini(
@@ -248,6 +255,7 @@ pub fn write_cli_ini(
     );
     yerd_php::io::atomic_write::write(&dirs.data.join("php-cli.ini"), base.as_bytes())?;
 
+    let no_overrides = std::collections::BTreeMap::new();
     let installed =
         yerd_php::discover_bundled(dirs).map_err(|e| std::io::Error::other(e.to_string()))?;
     for (v, _) in installed {
@@ -260,7 +268,11 @@ pub fn write_cli_ini(
                     .collect()
             })
             .unwrap_or_default();
-        let body = yerd_core::php_settings::render_cli_ini_with_ext(settings, &refs);
+        let effective = yerd_core::php_settings::merge_effective(
+            settings,
+            version_settings.get(&v).unwrap_or(&no_overrides),
+        );
+        let body = yerd_core::php_settings::render_cli_ini_with_ext(&effective, &refs);
         let contents = decorate_cli_ini(&body, ca_bundle);
         let name = format!("php-cli-{}.{}.ini", v.major, v.minor);
         yerd_php::io::atomic_write::write(&dirs.data.join(name), contents.as_bytes())?;
@@ -719,19 +731,20 @@ mod tests {
         let settings = std::collections::BTreeMap::new();
 
         let exts = std::collections::BTreeMap::new();
-        write_cli_ini(&dirs, &settings, None, &exts).unwrap();
+        let no_vs = std::collections::BTreeMap::new();
+        write_cli_ini(&dirs, &settings, None, &exts, &no_vs).unwrap();
         let without = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
         assert!(!without.contains("openssl.cafile"));
         assert!(!without.contains("curl.cainfo"));
 
         let bundle = dirs.data.join("cacert.pem");
-        write_cli_ini(&dirs, &settings, Some(&bundle), &exts).unwrap();
+        write_cli_ini(&dirs, &settings, Some(&bundle), &exts, &no_vs).unwrap();
         let with = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
         assert!(with.contains(&format!("openssl.cafile = {}\n", bundle.display())));
         assert!(with.contains(&format!("curl.cainfo = {}\n", bundle.display())));
 
         for bad in ["/d/ca\ncert.pem", "/d/ca;cert.pem", "/d/ca#cert.pem"] {
-            write_cli_ini(&dirs, &settings, Some(Path::new(bad)), &exts).unwrap();
+            write_cli_ini(&dirs, &settings, Some(Path::new(bad)), &exts, &no_vs).unwrap();
             let injected = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
             assert!(
                 !injected.contains("openssl.cafile"),
@@ -739,6 +752,34 @@ mod tests {
             );
             assert!(!injected.contains("curl.cainfo"), "not skipped for {bad:?}");
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_cli_ini_scopes_overrides_to_the_version_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let fpm_dir = dirs.data.join("php").join("php-8.3").join("sbin");
+        std::fs::create_dir_all(&fpm_dir).unwrap();
+        std::fs::write(fpm_dir.join("php-fpm"), b"#!/bin/sh\n").unwrap();
+
+        let settings =
+            std::collections::BTreeMap::from([("memory_limit".to_string(), "512M".to_string())]);
+        let exts = std::collections::BTreeMap::new();
+        let v83 = yerd_core::PhpVersion::new(8, 3);
+        let version_settings = std::collections::BTreeMap::from([(
+            v83,
+            std::collections::BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
+        )]);
+        write_cli_ini(&dirs, &settings, None, &exts, &version_settings).unwrap();
+
+        let base = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
+        assert!(base.contains("memory_limit = 512M\n"), "got: {base}");
+        assert!(!base.contains("1G"), "override leaked into base: {base}");
+
+        let per = std::fs::read_to_string(dirs.data.join("php-cli-8.3.ini")).unwrap();
+        assert!(per.contains("memory_limit = 1G\n"), "got: {per}");
+        assert!(!per.contains("512M"), "global shadowed override: {per}");
     }
 
     #[test]

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -325,6 +325,7 @@ pub async fn bring_up_with_dirs(
         tool_mutate: tokio::sync::Mutex::new(()),
         tunnel_mutate: tokio::sync::Mutex::new(()),
         php_mutate: tokio::sync::Mutex::new(()),
+        php_settings_mutate: tokio::sync::Mutex::new(()),
         jobs: crate::jobs::JobRegistry::default(),
         reserved_names: tokio::sync::Mutex::new(std::collections::HashSet::new()),
         wordpress_versions: tokio::sync::RwLock::new(None),

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -198,14 +198,8 @@ pub async fn bring_up_with_dirs(
         std::process::id(),
         binaries,
     );
-    php_manager.set_ini_settings(
-        config
-            .php
-            .settings
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect(),
-    );
+    php_manager.set_ini_settings(config.php.settings.clone());
+    php_manager.set_ini_overrides(config.php.version_settings.clone());
     php_manager.set_dump_ext(Some(yerd_php::DumpExtSettings {
         so_dir: dirs.data.join("php-ext"),
         ini_defines: vec![(

--- a/bin/yerdd/src/state.rs
+++ b/bin/yerdd/src/state.rs
@@ -163,6 +163,12 @@ pub struct DaemonState {
     /// version (+ this daemon's pid), so two installs of the *same* version would
     /// otherwise clobber each other's staging + race the final rename.
     pub php_mutate: Mutex<()>,
+    /// Serializes PHP ini-settings mutations (`set/unset php`, global and
+    /// per-version). The config read-modify-save and the follow-up apply to the
+    /// live `PhpManager` release the config lock in between, so without this
+    /// guard an overlapping request could replay a stale settings snapshot into
+    /// the manager after a newer one was already applied.
+    pub php_settings_mutate: Mutex<()>,
     /// Background-job registry. Long-running operations (site creation) run as
     /// jobs whose streamed progress the client polls via `JobStatus`.
     pub jobs: crate::jobs::JobRegistry,

--- a/bin/yerdd/src/test_support.rs
+++ b/bin/yerdd/src/test_support.rs
@@ -96,6 +96,7 @@ pub fn state_in(tmp: &Path) -> DaemonState {
         tool_mutate: Mutex::new(()),
         tunnel_mutate: Mutex::new(()),
         php_mutate: Mutex::new(()),
+        php_settings_mutate: Mutex::new(()),
         jobs: crate::jobs::JobRegistry::default(),
         reserved_names: Mutex::new(std::collections::HashSet::new()),
         wordpress_versions: RwLock::new(None),

--- a/crates/yerd-config/src/lib.rs
+++ b/crates/yerd-config/src/lib.rs
@@ -73,4 +73,9 @@ pub use schema::{
 /// key inside `[[linked]]` and `[[overrides]]` for the per-site
 /// front-controller-vs-direct-execution toggle (defaults to auto when absent).
 /// Both v11→v12 and v12→v13 are bare version bumps.
-pub const CURRENT_VERSION: u32 = 15;
+///
+/// v16 added the optional `[php.version_settings]` table
+/// ([`PhpSection::version_settings`]) for per-version overrides of the global
+/// PHP settings. It defaults (empty) when absent, so v15→v16 is a bare
+/// version bump.
+pub const CURRENT_VERSION: u32 = 16;

--- a/crates/yerd-config/src/migrate.rs
+++ b/crates/yerd-config/src/migrate.rs
@@ -19,7 +19,7 @@ pub(crate) type MigrationStep = fn(&mut Value) -> Result<(), ConfigError>;
 /// Forward-migration steps, indexed so that **`STEPS[N]` walks `vN → v(N+1)`**.
 /// This matches [`up`], which indexes `STEPS[current]` (== the version being
 /// migrated *from*). Example: a v1 file is migrated by `STEPS[1]`. When
-/// `CURRENT_VERSION == 15`, `STEPS = [v0→v1, …, v13→v14, v14→v15]`, length 15.
+/// `CURRENT_VERSION == 16`, `STEPS = [v0→v1, …, v14→v15, v15→v16]`, length 16.
 ///
 /// `STEPS[0]` (v0→v1) is only reachable via a hand-crafted `version = 0` file -
 /// v0 was never written to disk - but it must exist so that `STEPS[1]` does.
@@ -39,6 +39,7 @@ pub(crate) const STEPS: &[MigrationStep] = &[
     migrate_v12_to_v13,
     migrate_v13_to_v14,
     migrate_v14_to_v15,
+    migrate_v15_to_v16,
 ];
 
 /// `v0 → v1`: bump the version. v0 predates any shipped config, so there is no
@@ -176,6 +177,15 @@ fn migrate_v14_to_v15(value: &mut Value) -> Result<(), ConfigError> {
     set_version(value, 15)
 }
 
+/// `v15 → v16`: bump the version. v16 added the optional
+/// `[php.version_settings]` table, which defaults (empty) when absent, so an
+/// in-place version bump is the entire migration. Installed versions are
+/// discovered from disk, invisible to this pure step, so per-version tables
+/// cannot (and need not) be seeded here.
+fn migrate_v15_to_v16(value: &mut Value) -> Result<(), ConfigError> {
+    set_version(value, 16)
+}
+
 /// Set the top-level `version` key, erroring if the root is not a table.
 fn set_version(value: &mut Value, n: i64) -> Result<(), ConfigError> {
     let table = value.as_table_mut().ok_or(ConfigError::Migration {
@@ -245,7 +255,14 @@ mod tests {
 
     #[test]
     fn current_version_pinned() {
-        assert_eq!(crate::CURRENT_VERSION, 15);
+        assert_eq!(crate::CURRENT_VERSION, 16);
+    }
+
+    #[test]
+    fn v15_to_v16_is_a_bare_version_bump() {
+        let mut v: Value = toml::from_str("version = 15\n").unwrap();
+        migrate_v15_to_v16(&mut v).unwrap();
+        assert_eq!(read_version(&v).unwrap(), 16);
     }
 
     #[test]

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -276,6 +276,10 @@ struct PhpSectionWire {
     // raw here and validated in `TryFrom<Wire>` / `validate`.
     #[serde(default)]
     extensions: BTreeMap<String, Vec<ExtEntryWire>>,
+    // v16: sparse per-version overrides of the allowlisted settings, keyed by
+    // version string like `extensions`. Additive: pre-v16 files omit it.
+    #[serde(default)]
+    version_settings: BTreeMap<String, BTreeMap<String, String>>,
 }
 
 impl Default for PhpSectionWire {
@@ -284,6 +288,7 @@ impl Default for PhpSectionWire {
             default: PhpSection::default().default.to_string(),
             settings: BTreeMap::new(),
             extensions: BTreeMap::new(),
+            version_settings: BTreeMap::new(),
         }
     }
 }
@@ -452,6 +457,7 @@ impl TryFrom<Wire> for Config {
             default: yerd_core::PhpVersion::from_str(&w.php.default)?,
             settings: w.php.settings,
             extensions: convert_extensions(w.php.extensions)?,
+            version_settings: convert_version_settings(w.php.version_settings)?,
         };
         let ports = Ports {
             http: w.ports.http,
@@ -664,6 +670,29 @@ fn convert_extensions(
             })
             .collect();
         out.insert(v, converted);
+    }
+    Ok(out)
+}
+
+/// Convert the raw wire per-version settings map into the typed
+/// [`PhpSection::version_settings`] shape. A bad version key surfaces as
+/// [`ConfigError::Core`] (matching `convert_extensions`), but individual
+/// entries are filtered **leniently**: an unsupported name or invalid value -
+/// e.g. from a hand-edit - is dropped rather than failing the load, so a bad
+/// entry can never stop the daemon. Strictness lives at set time (CLI/daemon).
+fn convert_version_settings(
+    wire: BTreeMap<String, BTreeMap<String, String>>,
+) -> Result<BTreeMap<yerd_core::PhpVersion, BTreeMap<String, String>>, ConfigError> {
+    let mut out = BTreeMap::new();
+    for (ver, entries) in wire {
+        let v = yerd_core::PhpVersion::from_str(&ver)?;
+        let kept: BTreeMap<String, String> = entries
+            .into_iter()
+            .filter(|(k, val)| yerd_core::php_settings::validate_value(k, val).is_ok())
+            .collect();
+        if !kept.is_empty() {
+            out.insert(v, kept);
+        }
     }
     Ok(out)
 }
@@ -1101,7 +1130,7 @@ mod tests {
         match Config::from_toml("version = 99\n") {
             Err(ConfigError::UnsupportedVersion {
                 found: 99,
-                current: 15,
+                current: 16,
             }) => {}
             other => panic!("expected UnsupportedVersion, got {other:?}"),
         }
@@ -2182,6 +2211,56 @@ php = "not-a-version"
         assert_eq!(v[0].name, "scrypt");
         assert_eq!(v[0].path, "/opt/php/pecl/scrypt.so");
         assert!(!v[0].zend);
+    }
+
+    #[test]
+    fn version_settings_round_trip() {
+        let s = "version = 16\n[php]\ndefault = \"8.3\"\n\
+                 [php.version_settings.\"8.3\"]\nmemory_limit = \"1G\"\n";
+        let c = Config::from_toml(s).unwrap();
+        let v83 = yerd_core::PhpVersion::new(8, 3);
+        assert_eq!(
+            c.php
+                .version_settings
+                .get(&v83)
+                .and_then(|m| m.get("memory_limit"))
+                .map(String::as_str),
+            Some("1G")
+        );
+        let back = Config::from_toml(&c.to_toml().unwrap()).unwrap();
+        assert_eq!(back, c);
+    }
+
+    /// Load-time leniency: invalid entries inside the v16 table are dropped
+    /// without failing the load, while valid siblings survive. Strictness
+    /// lives at set time (CLI/daemon), not here - a bad hand-edit must never
+    /// stop the daemon.
+    #[test]
+    fn invalid_version_settings_entries_are_dropped_leniently() {
+        let s = "version = 16\n[php]\ndefault = \"8.3\"\n\
+                 [php.version_settings.\"8.3\"]\n\
+                 memory_limit = \"1G\"\n\
+                 allow_url_fopen = \"1\"\n\
+                 max_execution_time = \"bogus\"\n";
+        let c = Config::from_toml(s).unwrap();
+        let v83 = yerd_core::PhpVersion::new(8, 3);
+        let vs = c.php.version_settings.get(&v83).unwrap();
+        assert_eq!(vs.len(), 1);
+        assert_eq!(vs.get("memory_limit").map(String::as_str), Some("1G"));
+    }
+
+    /// A table whose entries are all dropped disappears entirely, and a bad
+    /// version key still errors (matching `convert_extensions`).
+    #[test]
+    fn fully_invalid_version_settings_table_vanishes_and_bad_version_key_errors() {
+        let s = "version = 16\n[php]\ndefault = \"8.3\"\n\
+                 [php.version_settings.\"8.3\"]\nallow_url_fopen = \"1\"\n";
+        let c = Config::from_toml(s).unwrap();
+        assert!(c.php.version_settings.is_empty());
+
+        let bad = "version = 16\n[php]\ndefault = \"8.3\"\n\
+                   [php.version_settings.\"eight\"]\nmemory_limit = \"1G\"\n";
+        assert!(Config::from_toml(bad).is_err());
     }
 
     #[test]

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -407,6 +407,14 @@ pub struct PhpSection {
     /// daemon additionally load-probes it before persisting. `BTreeMap`/`Vec`
     /// keep serialisation order stable.
     pub extensions: BTreeMap<PhpVersion, Vec<ExtEntry>>,
+    /// Sparse per-version overrides of the allowlisted [`Self::settings`],
+    /// keyed by PHP version then directive name. The effective value for a
+    /// version is its override when present, else the global value (see
+    /// [`yerd_core::php_settings::merge_effective`]). Empty by default, so
+    /// `[php.version_settings.*]` tables are omitted from a default config.
+    /// Entries are validated leniently at load time: an invalid or
+    /// unsupported entry is dropped rather than failing the load.
+    pub version_settings: BTreeMap<PhpVersion, BTreeMap<String, String>>,
 }
 
 /// One registered custom PHP extension (see [`PhpSection::extensions`]).
@@ -431,6 +439,7 @@ impl Default for PhpSection {
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect(),
             extensions: BTreeMap::new(),
+            version_settings: BTreeMap::new(),
         }
     }
 }

--- a/crates/yerd-config/src/serialize.rs
+++ b/crates/yerd-config/src/serialize.rs
@@ -174,6 +174,11 @@ struct PhpSectionSer<'a> {
     // table. `skip_serializing_if` receives `&&BTreeMap`, hence `map_is_empty`.
     #[serde(skip_serializing_if = "map_is_empty")]
     settings: &'a BTreeMap<String, String>,
+    // Sub-tables keyed by version string (`[php.version_settings."8.3"]`).
+    // Skipped when empty so a default config stays byte-identical to pre-v16.
+    // Placed after `settings`, before `extensions`.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    version_settings: BTreeMap<String, &'a BTreeMap<String, String>>,
     // Array-of-tables keyed by version string (`[[php.extensions."8.5"]]`).
     // Skipped when empty so a default config emits no `[php.extensions]` region
     // (byte-shape goldens assume no extra tables). A trailing sub-table region,
@@ -259,6 +264,12 @@ pub(crate) fn to_toml(c: &Config) -> Result<String, ConfigError> {
         php: PhpSectionSer {
             default: &c.php.default,
             settings: &c.php.settings,
+            version_settings: c
+                .php
+                .version_settings
+                .iter()
+                .map(|(v, m)| (v.to_string(), m))
+                .collect(),
             extensions: c
                 .php
                 .extensions
@@ -438,8 +449,8 @@ mod tests {
     fn default_to_toml_starts_with_version_line() {
         let s = to_toml(&Config::default()).unwrap();
         assert!(
-            s.starts_with("version = 15\n"),
-            "expected `version = 15` first line; got: {s}"
+            s.starts_with("version = 16\n"),
+            "expected `version = 16` first line; got: {s}"
         );
     }
 

--- a/crates/yerd-config/tests/io.rs
+++ b/crates/yerd-config/tests/io.rs
@@ -23,6 +23,7 @@ fn save_then_load_round_trip() {
         default: PhpVersion::new(8, 2),
         settings: std::collections::BTreeMap::new(),
         extensions: std::collections::BTreeMap::new(),
+        version_settings: std::collections::BTreeMap::new(),
     };
     original.parked.paths.insert("/srv/sites".to_string());
     original

--- a/crates/yerd-config/tests/roundtrip.rs
+++ b/crates/yerd-config/tests/roundtrip.rs
@@ -55,6 +55,7 @@ fn populated_expected() -> Config {
         default: PhpVersion::new(8, 2),
         settings: std::collections::BTreeMap::new(),
         extensions: std::collections::BTreeMap::new(),
+        version_settings: std::collections::BTreeMap::new(),
     };
     c.parked.paths.insert("docroot-a".to_string());
     c.parked.paths.insert("docroot-b".to_string());

--- a/crates/yerd-config/tests/toml_byte_shape.rs
+++ b/crates/yerd-config/tests/toml_byte_shape.rs
@@ -61,8 +61,8 @@ fn populated() -> Config {
 fn default_config_starts_with_version_line() {
     let s = Config::default().to_toml().unwrap();
     assert!(
-        s.starts_with("version = 15\n"),
-        "expected first line `version = 15`; got: {s}"
+        s.starts_with("version = 16\n"),
+        "expected first line `version = 16`; got: {s}"
     );
 }
 
@@ -347,6 +347,53 @@ fn populated_php_settings_emit_subtable_after_default_and_round_trip() {
         back.php.settings.get("memory_limit").map(String::as_str),
         Some("512M")
     );
+}
+
+#[test]
+fn default_config_emits_no_version_settings_table() {
+    let s = Config::default().to_toml().unwrap();
+    assert!(
+        !s.contains("[php.version_settings"),
+        "default config must omit version_settings; got: {s}"
+    );
+}
+
+#[test]
+fn populated_version_settings_emit_between_settings_and_extensions() {
+    let mut c = Config::default();
+    let v83 = PhpVersion::new(8, 3);
+    c.php.version_settings.insert(
+        v83,
+        std::collections::BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
+    );
+    c.php.extensions.insert(
+        v83,
+        vec![yerd_config::ExtEntry {
+            name: "xdebug".to_string(),
+            path: "/a/xdebug.so".to_string(),
+            zend: true,
+        }],
+    );
+    let s = c.to_toml().unwrap();
+
+    assert!(
+        s.contains("[php.version_settings.\"8.3\"]"),
+        "missing version_settings table; got: {s}"
+    );
+    assert!(s.contains("memory_limit = \"1G\""), "got: {s}");
+
+    let settings_at = s.find("[php.settings]").expect("[php.settings] present");
+    let vs_at = s
+        .find("[php.version_settings.")
+        .expect("version_settings present");
+    let ext_at = s.find("[[php.extensions.").expect("extensions present");
+    assert!(
+        settings_at < vs_at && vs_at < ext_at,
+        "expected settings < version_settings < extensions; got: {s}"
+    );
+
+    let back = Config::from_toml(&s).unwrap();
+    assert_eq!(back, c);
 }
 
 #[test]

--- a/crates/yerd-core/src/php_settings.rs
+++ b/crates/yerd-core/src/php_settings.rs
@@ -219,6 +219,25 @@ pub fn render_cover_ini(base: &str, pcov_so: &std::path::Path) -> Option<String>
     Some(out)
 }
 
+/// Merge a version's sparse per-version overrides onto the global settings:
+/// the union of both maps with the override value winning per key. Unsupported
+/// keys are dropped defensively from either side, so the result only ever
+/// contains allowlisted settings. This is the single home of the
+/// global-vs-per-version precedence rule; `yerd-php` and the daemon both call
+/// it rather than re-deriving effective values.
+#[must_use]
+pub fn merge_effective(
+    global: &std::collections::BTreeMap<String, String>,
+    overrides: &std::collections::BTreeMap<String, String>,
+) -> std::collections::BTreeMap<String, String> {
+    global
+        .iter()
+        .chain(overrides.iter())
+        .filter(|(k, _)| is_supported(k))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
 /// The FPM directive a setting renders as: `"php_flag"` for booleans, else
 /// `"php_value"`. `None` if the setting is not supported.
 #[must_use]
@@ -510,6 +529,40 @@ mod tests {
         assert!(ini.contains("display_errors = On\n"));
         assert!(!ini.contains("upload_max_filesize"));
         assert!(!ini.contains("post_max_size"));
+    }
+
+    #[test]
+    fn merge_effective_override_precedence_and_filtering() {
+        use std::collections::BTreeMap;
+        let map = |pairs: &[(&str, &str)]| -> BTreeMap<String, String> {
+            pairs
+                .iter()
+                .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+                .collect()
+        };
+
+        let global = map(&[("memory_limit", "512M"), ("max_execution_time", "60")]);
+        let overrides = map(&[("memory_limit", "1G")]);
+        let merged = merge_effective(&global, &overrides);
+        assert_eq!(merged.get("memory_limit").map(String::as_str), Some("1G"));
+        assert_eq!(
+            merged.get("max_execution_time").map(String::as_str),
+            Some("60")
+        );
+
+        let override_only = merge_effective(&BTreeMap::new(), &map(&[("display_errors", "Off")]));
+        assert_eq!(
+            override_only.get("display_errors").map(String::as_str),
+            Some("Off")
+        );
+
+        let dropped = merge_effective(
+            &map(&[("allow_url_fopen", "1")]),
+            &map(&[("not_a_setting", "x")]),
+        );
+        assert!(dropped.is_empty());
+
+        assert!(merge_effective(&BTreeMap::new(), &BTreeMap::new()).is_empty());
     }
 
     #[test]

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -188,6 +188,16 @@ pub enum Request {
         /// Setting name → value (e.g. `"memory_limit" -> "512M"`); `""` removes.
         settings: BTreeMap<String, String>,
     },
+    /// Merge per-version overrides of the allowlisted PHP ini settings into the
+    /// config and apply them to that version's FPM pool and CLI ini. An
+    /// empty-string value removes the override (the global value applies again).
+    SetPhpVersionSettings {
+        /// The installed PHP version the overrides apply to.
+        version: PhpVersion,
+        /// Setting name → value (e.g. `"memory_limit" -> "1G"`); `""` removes
+        /// the per-version override so the global default falls through.
+        settings: BTreeMap<String, String>,
+    },
     /// Register a custom PHP extension for a version: the daemon validates and
     /// load-probes the `.so`, persists it, and loads it into that version's FPM
     /// pool and CLI ini.
@@ -754,6 +764,7 @@ mod variant_name_pinning {
             Request::CheckPhpUpdates => {}
             Request::AvailablePhp => {}
             Request::SetPhpSettings { .. } => {}
+            Request::SetPhpVersionSettings { .. } => {}
             Request::AddPhpExtension { .. } => {}
             Request::RemovePhpExtension { .. } => {}
             Request::ListPhpExtensions => {}

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -111,6 +111,14 @@ pub enum Response {
         /// (`"memory_limit" -> "512M"`). Empty when none are set.
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         settings: BTreeMap<String, String>,
+        /// Sparse per-version overrides of `settings`, keyed by version. A
+        /// version's effective value is its override when present, else the
+        /// global value. Empty when no overrides are set; `#[serde(default)]`
+        /// keeps older daemons (which omit it) decodable. Boxed so the nested
+        /// maps don't bloat every `Response` value (same reason as
+        /// [`Self::Status`]); `Box<T>` serializes transparently.
+        #[serde(default, skip_serializing_if = "boxed_version_map_is_empty")]
+        version_settings: Box<BTreeMap<PhpVersion, BTreeMap<String, String>>>,
     },
     /// Reply to [`crate::Request::AvailablePhp`].
     AvailablePhp {
@@ -451,6 +459,12 @@ pub struct WordPressAdminUser {
     pub display_name: String,
 }
 
+/// `skip_serializing_if` predicate for [`Response::PhpVersions`]'s boxed
+/// per-version maps (the `&Box<_>` field reference deref-coerces here).
+fn boxed_version_map_is_empty(m: &BTreeMap<PhpVersion, BTreeMap<String, String>>) -> bool {
+    m.is_empty()
+}
+
 /// An available newer patch for an installed PHP minor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PhpUpdate {
@@ -607,6 +621,7 @@ mod variant_name_pinning {
             default: PhpVersion::new(8, 5),
             updates: vec![],
             settings: BTreeMap::new(),
+            version_settings: Box::new(BTreeMap::new()),
         });
         pin_response(Response::AvailablePhp {
             available: vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)],

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -124,6 +124,7 @@ fn encode_then_decode_response_roundtrip() {
         default: PhpVersion::new(8, 5),
         updates: vec![],
         settings: BTreeMap::new(),
+        version_settings: Box::new(BTreeMap::new()),
     });
     assert_response_roundtrips(Response::PhpVersions {
         installed: vec![PhpVersion::new(8, 5)],
@@ -134,6 +135,10 @@ fn encode_then_decode_response_roundtrip() {
             latest: "8.5.7".into(),
         }],
         settings: BTreeMap::from([("memory_limit".to_string(), "512M".to_string())]),
+        version_settings: Box::new(BTreeMap::from([(
+            PhpVersion::new(8, 5),
+            BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
+        )])),
     });
     assert_response_roundtrips(Response::Parked { paths: vec![] });
     assert_response_roundtrips(Response::Parked {

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -613,6 +613,7 @@ fn response_php_versions_byte_shape() {
         default: PhpVersion::new(8, 5),
         updates: vec![],
         settings: BTreeMap::new(),
+        version_settings: Box::new(BTreeMap::new()),
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
@@ -654,6 +655,7 @@ fn response_php_versions_with_updates_byte_shape() {
             latest: "8.5.7".into(),
         }],
         settings: BTreeMap::new(),
+        version_settings: Box::new(BTreeMap::new()),
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
@@ -673,6 +675,7 @@ fn response_php_versions_with_settings_byte_shape() {
             ("memory_limit".to_string(), "512M".to_string()),
             ("display_errors".to_string(), "On".to_string()),
         ]),
+        version_settings: Box::new(BTreeMap::new()),
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
@@ -680,6 +683,36 @@ fn response_php_versions_with_settings_byte_shape() {
         r#"{"type":"php_versions","installed":["8.5"],"default":"8.5","settings":{"display_errors":"On","memory_limit":"512M"}}"#
     );
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+}
+
+#[test]
+fn response_php_versions_with_version_settings_byte_shape() {
+    let r = Response::PhpVersions {
+        installed: vec![PhpVersion::new(8, 3)],
+        default: PhpVersion::new(8, 3),
+        updates: vec![],
+        settings: BTreeMap::new(),
+        version_settings: Box::new(BTreeMap::from([(
+            PhpVersion::new(8, 3),
+            BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
+        )])),
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"php_versions","installed":["8.3"],"default":"8.3","version_settings":{"8.3":{"memory_limit":"1G"}}}"#
+    );
+    assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+
+    let legacy = r#"{"type":"php_versions","installed":["8.3"],"default":"8.3"}"#;
+    let decoded: Response = serde_json::from_str(legacy).unwrap();
+    assert!(matches!(
+        decoded,
+        Response::PhpVersions {
+            ref version_settings,
+            ..
+        } if version_settings.is_empty()
+    ));
 }
 
 #[test]
@@ -703,6 +736,20 @@ fn request_set_php_settings_byte_shape() {
         r#"{"type":"set_php_settings","settings":{"max_execution_time":"30","memory_limit":"512M"}}"#
     );
     assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), populated);
+}
+
+#[test]
+fn request_set_php_version_settings_byte_shape() {
+    let r = Request::SetPhpVersionSettings {
+        version: PhpVersion::new(8, 3),
+        settings: BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"set_php_version_settings","version":"8.3","settings":{"memory_limit":"1G"}}"#
+    );
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
 }
 
 #[test]

--- a/crates/yerd-php/src/manager.rs
+++ b/crates/yerd-php/src/manager.rs
@@ -132,7 +132,8 @@ where
     binder: ActivePortBinder,
     pools: BTreeMap<PhpVersion, Pool<S::Child>>,
     binaries: BTreeMap<PhpVersion, PathBuf>,
-    ini_settings: Vec<(String, String)>,
+    ini_settings: BTreeMap<String, String>,
+    ini_overrides: BTreeMap<PhpVersion, BTreeMap<String, String>>,
     dump_ext: Option<DumpExtSettings>,
     extensions: BTreeMap<PhpVersion, Vec<ExtLoad>>,
     ca_bundle: Option<PathBuf>,
@@ -171,7 +172,8 @@ where
             binder,
             pools: BTreeMap::new(),
             binaries,
-            ini_settings: Vec::new(),
+            ini_settings: BTreeMap::new(),
+            ini_overrides: BTreeMap::new(),
             dump_ext: None,
             extensions: BTreeMap::new(),
             ca_bundle: None,
@@ -193,11 +195,20 @@ where
 
     /// Replace the global PHP ini settings applied to every pool.
     ///
-    /// Stored as `(name, value)` pairs and injected into each pool's rendered
-    /// FPM config on the next `ensure` (a running pool keeps its current config
-    /// until restarted - the daemon restarts live pools after calling this).
-    pub fn set_ini_settings(&mut self, settings: Vec<(String, String)>) {
+    /// Injected into each pool's rendered FPM config on the next `ensure` (a
+    /// running pool keeps its current config until restarted - the daemon
+    /// restarts live pools after calling this).
+    pub fn set_ini_settings(&mut self, settings: BTreeMap<String, String>) {
         self.ini_settings = settings;
+    }
+
+    /// Replace the sparse per-version overrides of the global ini settings,
+    /// keyed by PHP version. Merged over [`Self::set_ini_settings`]'s map via
+    /// [`yerd_core::php_settings::merge_effective`] when a pool's config is
+    /// rendered. Takes effect on the next `ensure` / restart of a pool, like
+    /// `set_extensions`.
+    pub fn set_ini_overrides(&mut self, overrides: BTreeMap<PhpVersion, BTreeMap<String, String>>) {
+        self.ini_overrides = overrides;
     }
 
     /// Configure daemon-managed dump-extension loading. When set, each pool that
@@ -273,7 +284,11 @@ where
         }
 
         let mut cfg = PoolConfig::dev_defaults(v, listen, &self.dirs, self.instance_id);
-        cfg.ini = self.ini_settings.clone();
+        let no_overrides = BTreeMap::new();
+        let overrides = self.ini_overrides.get(&v).unwrap_or(&no_overrides);
+        cfg.ini = yerd_core::php_settings::merge_effective(&self.ini_settings, overrides)
+            .into_iter()
+            .collect();
         cfg.ca_bundle = self.ca_bundle.clone();
 
         if let Some(ext) = &self.dump_ext {

--- a/crates/yerd-php/tests/fpm_conf_golden.rs
+++ b/crates/yerd-php/tests/fpm_conf_golden.rs
@@ -43,3 +43,38 @@ catch_workers_output = yes
 ";
     assert_eq!(render_fpm_conf(&cfg), want);
 }
+
+#[test]
+fn ini_settings_render_exact() {
+    let dirs = PlatformDirs {
+        config: PathBuf::from("/yerd/cfg"),
+        data: PathBuf::from("/yerd/data"),
+        state: PathBuf::from("/yerd/state"),
+        cache: PathBuf::from("/yerd/cache"),
+        runtime: PathBuf::from("/yerd/run"),
+    };
+    let v = PhpVersion::new(8, 3);
+    let listen = Listen::UnixSocket(PathBuf::from("/yerd/run/fpm-8.3-1234.sock"));
+    let mut cfg = PoolConfig::dev_defaults(v, listen, &dirs, 1234);
+    cfg.ini = vec![
+        ("display_errors".to_string(), "On".to_string()),
+        ("memory_limit".to_string(), "1G".to_string()),
+    ];
+
+    let want = "\
+[global]
+pid = /yerd/state/fpm-8.3-1234.pid
+error_log = /yerd/state/fpm-8.3-1234.log
+daemonize = no
+
+[yerd-8.3]
+listen = /yerd/run/fpm-8.3-1234.sock
+pm = ondemand
+pm.max_children = 16
+clear_env = no
+catch_workers_output = yes
+php_flag[display_errors] = On
+php_value[memory_limit] = 1G
+";
+    assert_eq!(render_fpm_conf(&cfg), want);
+}

--- a/docs/developer/config-schema-history.md
+++ b/docs/developer/config-schema-history.md
@@ -28,7 +28,30 @@ Each entry below states what changed, whether the daemon's own migration is a ba
 
 ## Version-by-version
 
-### v14 (current)
+### v16 (current)
+
+**Added:** the optional `[php.version_settings]` table - per-version overrides of the global PHP settings. `[php.version_settings."<version>"]` holds sparse overrides of the allowlisted `[php.settings]` directives for one installed version. It defaults to empty when absent, so an uncustomised file omits it entirely.
+
+```toml
+[php.version_settings."8.3"]
+memory_limit = "1G"
+```
+
+The table loads **leniently**: an invalid entry (e.g. from a hand-edit) is dropped during parsing rather than failing the load, so a bad entry can never stop the daemon. A malformed version key is still a hard error, and the strict validation lives at set time (CLI/GUI/IPC).
+
+**Migration from v15:** bare version bump - the table defaults to empty when absent, so a v15 file needs no other change to become a valid v16 file.
+
+**To downgrade to v15:** change `version = 16` to `version = 15`, then delete any `[php.version_settings.*]` tables (a v15 daemon rejects the unknown tables under `deny_unknown_fields`, it doesn't just ignore them). Every version falls back to the global `[php.settings]` values.
+
+### v15
+
+**Added:** the multi-instance services rework - the optional per-instance `site` field inside `[services.<id>]` tables and the `"{type}:{site}"` wire ids for per-site app servers, plus a behaviour change: the `enabled` flag now actually gates boot autostart (before v15 every installed engine auto-started regardless).
+
+**Migration from v14:** structural but small - the migration marks every existing single-instance engine (colon-free `[services.<id>]` key) `enabled = true`, so engines installed before the upgrade keep starting with Yerd now that the flag is enforced.
+
+**To downgrade to v14:** change `version = 15` to `version = 14`, then delete any per-site `[services."<type>:<site>"]` tables and any `site = "..."` lines (a v14 daemon rejects the unknown field under `deny_unknown_fields`). Single-instance `enabled` flags survive; a v14 daemon auto-starts every installed engine regardless of the flag.
+
+### v14
 
 **Added:** the optional `[[proxies]]` array (whole-host reverse proxies) and the `[proxy_rules]` table (per-site path-prefix rules). Both default to empty when absent, so an uncustomised file omits them entirely.
 

--- a/docs/developer/ipc-protocol.md
+++ b/docs/developer/ipc-protocol.md
@@ -168,6 +168,7 @@ The variant set is the daemon's whole RPC surface - liveness, site management, P
 | `InstallPhpStreamed { version }` | `{"type":"install_php_streamed","version":"8.5"}` (replies `JobStarted`; poll `JobStatus`) |
 | `UpdatePhp { version: Option }` | `{"type":"update_php","version":"8.5"}` or `…,"version":null` |
 | `SetPhpSettings { settings }` | `{"type":"set_php_settings","settings":{…}}` |
+| `SetPhpVersionSettings { version, settings }` | `{"type":"set_php_version_settings","version":"8.3","settings":{…}}` (per-version overrides; `""` removes → falls back to global) |
 | `AddPhpExtension { version, path, name: Option, zend }` | `{"type":"add_php_extension","version":"8.5","path":"/a/scrypt.so","name":null,"zend":false}` |
 | `RemovePhpExtension { version, name }` | `{"type":"remove_php_extension","version":"8.5","name":"scrypt"}` |
 | `ListPhpExtensions` | `{"type":"list_php_extensions"}` (replies `PhpExtensions { by_version }`) |
@@ -365,7 +366,7 @@ The JSON shapes are the **published contract**, pinned three ways so a rename or
    }).unwrap(), r#"{"type":"set_php","name":"foo","version":"8.3"}"#);
    ```
 
-   It also pins additive back-compat: `Response::Info` decodes legacy daemons that omit `http_port`/`https_port` (they default to 0), and `Response::PhpVersions` skips an empty `updates`/`settings` on the wire so the bytes match the pre-field shape.
+   It also pins additive back-compat: `Response::Info` decodes legacy daemons that omit `http_port`/`https_port` (they default to 0), and `Response::PhpVersions` skips an empty `updates`/`settings`/`version_settings` on the wire so the bytes match the pre-field shape.
 
 2. **Inline `variant_name_pinning` modules** in `request.rs` and `response.rs` contain exhaustive `match` arms over the (in-crate, so matchable despite `#[non_exhaustive]`) enums. A renamed Rust variant fails to compile there - integration tests can't catch this across the crate boundary.
 

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -282,12 +282,12 @@ and rendered into FPM config.
 ### Per-version configuration
 
 Every setting can also be pinned for a **single** installed version with the
-`--php` flag - the override wins over the global default for that version only,
+`--only` flag - the override wins over the global default for that version only,
 and applies to both its FPM pool and its CLI:
 
 ```sh
-yerd set php memory_limit 1G --php 8.3   # only PHP 8.3 gets 1G
-yerd unset php memory_limit --php 8.3    # 8.3 inherits the global value again
+yerd set php memory_limit 1G --only 8.3   # only PHP 8.3 gets 1G
+yerd unset php memory_limit --only 8.3    # 8.3 inherits the global value again
 ```
 
 A per-version change restarts only that version's pool, and per-version
@@ -308,8 +308,8 @@ PHP page: one expandable panel per installed version with the settings form
 | `yerd update php [<version>]` | Update one (or all) versions to the latest patch. |
 | `yerd uninstall php <version>` | Remove a version's files (blocked if a site uses it). |
 | `yerd restart php [<version>]` | Restart one (or all) running FPM pools. |
-| `yerd set php <setting> <value> [--php <version>]` | Set a global PHP ini default, or a per-version override with `--php`. |
-| `yerd unset php <setting> [--php <version>]` | Reset a global setting to PHP's built-in value. With `--php`, remove one version's override so the global value applies again. |
+| `yerd set php <setting> <value> [--only <version>]` | Set a global PHP ini default, or a per-version override with `--only`. |
+| `yerd unset php <setting> [--only <version>]` | Reset a global setting to PHP's built-in value. With `--only`, remove one version's override so the global value applies again. |
 | `yerd php ext add <version> <path> [--zend] [--name <name>]` | Register a custom extension (load-probed) for a version. |
 | `yerd php ext remove <version> <name>` | Remove a registered extension. |
 | `yerd php ext list` | List registered custom extensions, grouped by version. |

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -13,6 +13,7 @@ The fastest way to manage PHP is the **PHP** page (under the **Environment** gro
 - **Refresh** re-checks for updates and **Update all** updates every version with one pending - [updates are notify-only](#updates-are-notify-only).
 - Each row's `⋯` menu offers **Restart**, **Set default** (marks it with a star), **Update** (when available), and **Uninstall**; **Restart all** restarts every running pool.
 - A **Default settings** card edits the [global ini defaults](#tuning-php-settings) applied to every version; leave a field blank to use PHP's built-in default, and saving restarts running pools to apply.
+- A **Per-version configuration** card holds one expandable panel per installed version: the same settings form scoped to that version (empty fields inherit the defaults; see [Per-version configuration](#per-version-configuration)). Saving restarts only that version's pool.
 - A **Custom extensions** card registers extra `.so` extensions per version (see [Custom extensions](#custom-extensions)); each is load-probed before it's saved, and broken registrations are flagged.
 
 ## From the command line
@@ -278,6 +279,23 @@ reference](../reference/cli/php#global-php-ini-settings) for the full list and t
 [Configuration Reference](../reference/configuration#php) for how they're stored
 and rendered into FPM config.
 
+### Per-version configuration
+
+Every setting can also be pinned for a **single** installed version with the
+`--php` flag - the override wins over the global default for that version only,
+and applies to both its FPM pool and its CLI:
+
+```sh
+yerd set php memory_limit 1G --php 8.3   # only PHP 8.3 gets 1G
+yerd unset php memory_limit --php 8.3    # 8.3 inherits the global value again
+```
+
+A per-version change restarts only that version's pool, and per-version
+configuration survives uninstalling and reinstalling the version. In the
+desktop app the same lives in the **Per-version configuration** card on the
+PHP page: one expandable panel per installed version with the settings form
+(empty fields inherit the defaults).
+
 ### Command summary
 
 | Command | What it does |
@@ -290,8 +308,8 @@ and rendered into FPM config.
 | `yerd update php [<version>]` | Update one (or all) versions to the latest patch. |
 | `yerd uninstall php <version>` | Remove a version's files (blocked if a site uses it). |
 | `yerd restart php [<version>]` | Restart one (or all) running FPM pools. |
-| `yerd set php <setting> <value>` | Set a global PHP ini default (all versions). |
-| `yerd unset php <setting>` | Reset a global PHP ini default to PHP's built-in value. |
+| `yerd set php <setting> <value> [--php <version>]` | Set a global PHP ini default, or a per-version override with `--php`. |
+| `yerd unset php <setting> [--php <version>]` | Reset a setting to PHP's built-in value (or drop one version's override). |
 | `yerd php ext add <version> <path> [--zend] [--name <name>]` | Register a custom extension (load-probed) for a version. |
 | `yerd php ext remove <version> <name>` | Remove a registered extension. |
 | `yerd php ext list` | List registered custom extensions, grouped by version. |

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -309,7 +309,7 @@ PHP page: one expandable panel per installed version with the settings form
 | `yerd uninstall php <version>` | Remove a version's files (blocked if a site uses it). |
 | `yerd restart php [<version>]` | Restart one (or all) running FPM pools. |
 | `yerd set php <setting> <value> [--php <version>]` | Set a global PHP ini default, or a per-version override with `--php`. |
-| `yerd unset php <setting> [--php <version>]` | Reset a setting to PHP's built-in value (or drop one version's override). |
+| `yerd unset php <setting> [--php <version>]` | Reset a global setting to PHP's built-in value. With `--php`, remove one version's override so the global value applies again. |
 | `yerd php ext add <version> <path> [--zend] [--name <name>]` | Register a custom extension (load-probed) for a version. |
 | `yerd php ext remove <version> <name>` | Remove a registered extension. |
 | `yerd php ext list` | List registered custom extensions, grouped by version. |

--- a/docs/reference/cli/php.md
+++ b/docs/reference/cli/php.md
@@ -57,14 +57,21 @@ Installed versions are printed one per line; the current default is marked `(def
 
 | Command | Description | Example |
 | --- | --- | --- |
-| `yerd set php <SETTING> <VALUE>` | Set a global PHP ini default applied to every installed version. | `yerd set php memory_limit 512M` |
-| `yerd unset php <SETTING>` | Reset a global PHP ini default to PHP's built-in value. | `yerd unset php memory_limit` |
+| `yerd set php <SETTING> <VALUE> [--php <VERSION>]` | Set a PHP ini default. With `--php`, only that installed version is affected (a per-version override). | `yerd set php memory_limit 512M` |
+| `yerd unset php <SETTING> [--php <VERSION>]` | Reset a setting to PHP's built-in value. With `--php`, only that version's override is removed (the global default applies again). | `yerd unset php memory_limit` |
 
 ```sh
 yerd set php memory_limit 512M
 yerd set php display_errors On
 yerd unset php memory_limit
+yerd set php memory_limit 1G --php 8.3    # only PHP 8.3 gets 1G
+yerd unset php memory_limit --php 8.3     # 8.3 inherits the global value again
 ```
+
+**Precedence:** a version's effective value is its `--php` override when set, else
+the global value, else PHP's built-in default. Changing a per-version value
+restarts **only** that version's pool; a global change restarts every running
+pool. Per-version values survive uninstalling and reinstalling the version.
 
 The setting name (and, for `set`, the value) is validated client-side before connecting, so a typo or an out-of-shape value is a clean usage error rather than a round-trip. The supported settings are:
 

--- a/docs/reference/cli/php.md
+++ b/docs/reference/cli/php.md
@@ -57,18 +57,18 @@ Installed versions are printed one per line; the current default is marked `(def
 
 | Command | Description | Example |
 | --- | --- | --- |
-| `yerd set php <SETTING> <VALUE> [--php <VERSION>]` | Set a PHP ini default. With `--php`, only that installed version is affected (a per-version override). | `yerd set php memory_limit 512M` |
-| `yerd unset php <SETTING> [--php <VERSION>]` | Reset a setting to PHP's built-in value. With `--php`, only that version's override is removed (the global default applies again). | `yerd unset php memory_limit` |
+| `yerd set php <SETTING> <VALUE> [--only <VERSION>]` | Set a PHP ini default. With `--only`, only that installed version is affected (a per-version override). | `yerd set php memory_limit 512M` |
+| `yerd unset php <SETTING> [--only <VERSION>]` | Reset a setting to PHP's built-in value. With `--only`, only that version's override is removed (the global default applies again). | `yerd unset php memory_limit` |
 
 ```sh
 yerd set php memory_limit 512M
 yerd set php display_errors On
 yerd unset php memory_limit
-yerd set php memory_limit 1G --php 8.3    # only PHP 8.3 gets 1G
-yerd unset php memory_limit --php 8.3     # 8.3 inherits the global value again
+yerd set php memory_limit 1G --only 8.3    # only PHP 8.3 gets 1G
+yerd unset php memory_limit --only 8.3     # 8.3 inherits the global value again
 ```
 
-**Precedence:** a version's effective value is its `--php` override when set, else
+**Precedence:** a version's effective value is its `--only` override when set, else
 the global value, else PHP's built-in default. Changing a per-version value
 restarts **only** that version's pool; a global change restarts every running
 pool. Per-version values survive uninstalling and reinstalling the version.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,7 @@ Every field below maps one-to-one to a field in `schema.rs`. The on-disk shape a
 
 | Key         | TOML type            | Meaning                                                            | Default        |
 | ----------- | -------------------- | ----------------------------------------------------------------- | -------------- |
-| `version`   | integer              | On-disk schema version. **Mandatory.**                            | `13`           |
+| `version`   | integer              | On-disk schema version. **Mandatory.**                            | `16`           |
 | `tld`       | string               | TLD served by Yerd's resolver.                                    | `"test"`       |
 | `dns_port`  | integer (u16)        | Loopback port for the embedded `.test` DNS responder.             | `1053`         |
 | `symlink_protection` | boolean     | Refuse to serve assets/scripts reached via a symlink resolving outside a site's document root. | `true` |
@@ -49,7 +49,7 @@ The parser uses `deny_unknown_fields` at every level. A typo'd or stray key (top
 
 ### `version`
 
-The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `14`, and Yerd always writes `version = 14`. Older `version = 1` through `version = 13` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
+The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `16`, and Yerd always writes `version = 16`. Older `version = 1` through `version = 15` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
 
 ### `tld`
 
@@ -100,11 +100,12 @@ Validation rules (enforced by `Config::validate`): neither `http` nor `https` ma
 
 PHP defaults applied across sites.
 
-| Key          | TOML type | Meaning                                                      | Default |
-| ------------ | --------- | ------------------------------------------------------------ | ------- |
-| `default`    | string    | Default PHP version for new sites (e.g. `"8.3"`).            | `"8.3"` |
-| `settings`   | table     | Global PHP ini directives applied to every installed version's FPM pool. | empty   |
-| `extensions` | table     | Custom `.so` extensions to load, keyed by PHP version.       | empty   |
+| Key                | TOML type | Meaning                                                      | Default |
+| ------------------ | --------- | ------------------------------------------------------------ | ------- |
+| `default`          | string    | Default PHP version for new sites (e.g. `"8.3"`).            | `"8.3"` |
+| `settings`         | table     | Global PHP ini directives applied to every installed version's FPM pool. | empty   |
+| `version_settings` | table     | Sparse per-version overrides of `settings`, keyed by PHP version. | empty   |
+| `extensions`       | table     | Custom `.so` extensions to load, keyed by PHP version.       | empty   |
 
 `default` is a `MAJOR.MINOR` version string validated by `yerd-core`'s `PhpVersion`; an out-of-range minor or a non-numeric value is rejected. See [PHP Versions](../guide/php-versions).
 
@@ -131,6 +132,27 @@ upload_max_filesize = "64M"
 ::: warning Setting an unsupported directive fails the load
 An unknown directive name or a malformed value makes the whole config invalid (`InvalidPhpSetting`). Stick to the table above.
 :::
+
+`[php.version_settings."<version>"]` (schema v16) holds **per-version
+overrides** of the same allowlisted settings, keyed by PHP version string. A
+version's effective value is its override when present, else the global
+`[php.settings]` value, else PHP's built-in default. Omitted entirely when no
+overrides are set.
+
+```toml
+[php.version_settings."8.3"]
+memory_limit = "1G"
+```
+
+::: tip This table loads leniently
+Unlike `[php.settings]`, a hand-edited invalid entry in `version_settings`
+never fails the load - it is silently dropped while valid siblings survive, so
+a bad edit can't stop the daemon. Setting values through the CLI/GUI still
+validates strictly. A malformed *version key* (e.g. `"eight"`) is still a hard
+error.
+:::
+
+Manage this with [`yerd set php --php <version>`](cli/php#global-php-ini-settings) or the desktop app's **Per-version configuration** card.
 
 `[php.extensions]` maps a **PHP version string** to an array of custom extensions to load into both that version's FPM pool and its CLI. It is written as an array-of-tables per version and omitted entirely when empty. Because a native `.so` is ABI-bound to a PHP minor, an entry only applies to the version it is keyed under.
 
@@ -430,14 +452,14 @@ the actively bound ports and sees parked sites on disk.
 
 ## Schema versioning and migration
 
-Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `14`.
+Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `16`.
 
 When the daemon loads a file, it routes on the version it finds:
 
 ```text
-found  > CURRENT (14)   →  error (UnsupportedVersion) - a newer Yerd wrote this file
-found == CURRENT (14)   →  parse directly
-found  < CURRENT (14)   →  walk forward migration steps, then parse
+found  > CURRENT (16)   →  error (UnsupportedVersion) - a newer Yerd wrote this file
+found == CURRENT (16)   →  parse directly
+found  < CURRENT (16)   →  walk forward migration steps, then parse
 ```
 
 A file written by a *newer* Yerd than you are running is refused rather than misread. Older files are migrated forward in place, one version at a time, before the normal wire-deserialisation and validation run:
@@ -455,6 +477,8 @@ A file written by a *newer* Yerd than you are running is refused rather than mis
 - **`v11 → v12`** is a bare version bump: v12 only **added** the top-level `symlink_protection` scalar (defaults to `true` when absent).
 - **`v12 → v13`** is a bare version bump: v13 only **added** the optional per-site `front_controller` key (inside `[[linked]]` and `[[overrides]]`), which defaults to auto when absent.
 - **`v13 → v14`** is a bare version bump: v14 only **added** the optional `[[proxies]]` array and `[proxy_rules]` table (reverse proxies and per-site path rules), both of which default to empty when absent. Same rationale - the bump lets an older binary refuse a proxy-bearing file cleanly rather than tripping `deny_unknown_fields`.
+- **`v14 → v15`** is the multi-instance services rework: v15 **added** the optional per-instance `site` field and the `"{type}:{site}"` wire ids (both additive), and made the `enabled` flag actually gate boot autostart. The migration marks every existing single-instance engine `enabled = true` so previously-installed engines keep starting with Yerd across the upgrade.
+- **`v15 → v16`** is a bare version bump: v16 only **added** the optional `[php.version_settings]` table (per-version overrides of the global PHP settings), which defaults to empty when absent.
 
 The on-disk schema version is deliberately decoupled from the IPC protocol version; the two evolve independently.
 
@@ -481,8 +505,8 @@ Yerd does not `fsync` the file or its parent directory after a save. For a devel
 This is a valid `yerd.toml` covering the core fields (see the sections above for the newer optional tables - `update_channel`, `[tunnel]`, `[groups]`, `[php.extensions]`, `[domains]`, `[[proxies]]`, `[proxy_rules]`, `wp_auto_login` - omitted here for brevity):
 
 ```toml
-# Schema version - mandatory, always written as 14 by this release.
-version = 14
+# Schema version - mandatory, always written as 16 by this release.
+version = 16
 
 # TLD served by the resolver; sites resolve as <name>.test
 tld = "test"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -152,7 +152,7 @@ validates strictly. A malformed *version key* (e.g. `"eight"`) is still a hard
 error.
 :::
 
-Manage this with [`yerd set php --php <version>`](cli/php#global-php-ini-settings) or the desktop app's **Per-version configuration** card.
+Manage this with [`yerd set php --only <version>`](cli/php#global-php-ini-settings) or the desktop app's **Per-version configuration** card.
 
 `[php.extensions]` maps a **PHP version string** to an array of custom extensions to load into both that version's FPM pool and its CLI. It is written as an array-of-tables per version and omitted entirely when empty. Because a native `.so` is ABI-bound to a PHP minor, an entry only applies to the version it is keyed under.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Yerd! Please fill in the sections below. -->

## What does this PR do?

Lets each installed PHP version carry its own values for the managed ini settings, Herd-style, instead of one global set applied to every version.

<img width="1086" height="906" alt="CleanShot 2026-07-17 at 08 26 46" src="https://github.com/user-attachments/assets/7e998529-ccbe-4753-a878-82c831f87baf" />

**Motivation:** the managed settings are currently global, so a single memory-hungry legacy project forces its `memory_limit`/`max_execution_time` onto every other version. This scopes the values Yerd already manages to the version that needs them — the allowlist itself is unchanged.

**Semantics** — sparse overrides layered over the existing global defaults:

- Effective value for version `v`, key `k` = `version_settings[v][k]` if present, else global `settings[k]`, else PHP's built-in default. The precedence rule lives in one place, `yerd_core::php_settings::merge_effective`; `yerd-php` and `yerdd` both call it.
- `yerd set php memory_limit 1G --php 8.3` sets an override; `yerd unset php memory_limit --php 8.3` removes it (global applies again). Without `--php`, behaviour is exactly as before.
- Applied to that version's FPM pool and its `php-cli-<ver>.ini`; the base `php-cli.ini` stays global-only. A per-version change restarts **only** that version's pool (mirrors `apply_extensions`); global changes still restart all pools.
- Overrides survive uninstall/reinstall of the version (same policy as `php.extensions`).
- GUI: a "Per-version configuration" card on the PHP page — one expandable panel per installed version, same settings form, empty fields inherit (placeholder shows the inherited value), override-count badge.

**Storage & migration** — config schema v15 → v16, adding a sparse `[php.version_settings."8.3"]` table:

- The bump is a bare version bump. Sparse-overrides-over-global was chosen deliberately: `yerd-config` migrations are pure and installed versions are discovered from disk, so a migration cannot enumerate versions to copy the global map per-version. The table is skip-when-empty, so a default config stays byte-identical (pinned by the byte-shape goldens).
- **Load is lenient, set is strict:** an invalid or unsupported entry in the new table (e.g. from a hand-edit) is dropped during parsing — a bad entry can never stop the daemon — while the CLI/GUI/IPC set path validates strictly with the existing `yerd-core` typed validators. A malformed version key is still a hard error, matching `convert_extensions`.

**IPC** — additive only, no protocol bump: new `SetPhpVersionSettings { version, settings }` request (`""` value removes → falls back to global) and a `version_settings` field on `Response::PhpVersions` (`#[serde(default, skip_serializing_if)]`, so old daemons decode fine and the empty wire shape is byte-identical — pinned in `wire_stability.rs`). The new response field is boxed, following `Response::Status`'s precedent, to keep the `Response` enum small (`clippy::result_large_err`).

**Validation stays where it was:** values go through the existing `php_settings::validate_value`/`canonical_value` security boundary at set time, load time, and defensively at render time. No new validation surface is introduced.

**Tests:** table tests for `merge_effective`; config parse/round-trip/byte-shape tests for the new table (including the lenient-drop behaviour); wire pins for the new request/field plus a legacy-decode test; daemon handler tests (persist, canonicalisation, empty-string removal, inner-map cleanup, invalid/unsupported rejection, not-installed → `NotFound`); a `write_cli_ini` test asserting the override lands in the per-version ini and not the base; CLI mapping table tests; an end-to-end test driving `set/unset --php` against a real daemon on a tempdir; vitest for the GUI client payloads and the inherit/override helpers.

## Related issues

Closes #154 

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable per-version PHP configuration in the desktop app, including override badges and Save flow.
  * Added `--php <VERSION>` to `set`/`unset` PHP ini settings to target a specific installed version.
  * Per-version overrides apply to both FPM and CLI, take precedence over global defaults, restart only the affected version, and persist across reinstallations.
* **Documentation**
  * Updated guides and CLI/config/schema references for per-version overrides and schema v16.
* **Bug Fixes**
  * Improved validation/normalization so unsupported keys are ignored and empty values remove overrides cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->