### PR TITLE
[Feat] Mails: attachment support and clickable links along with individual email deleting

### DIFF
--- a/apps/yerd-gui/package-lock.json
+++ b/apps/yerd-gui/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "yerd-gui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yerd-gui",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.2.0",
         "@tauri-apps/plugin-opener": "^2.2.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "isomorphic-dompurify": "^3.19.0",
         "lucide-vue-next": "^0.460.0",
         "reka-ui": "^2.9.8",
         "tailwind-merge": "^2.5.5",
@@ -63,6 +64,37 @@
         "lru-cache": "^10.4.3"
       }
     },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -107,6 +139,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -202,6 +246,30 @@
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -664,6 +732,23 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1489,6 +1574,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
@@ -2035,6 +2127,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2320,6 +2421,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2402,7 +2516,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -2442,6 +2555,15 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/ds-store": {
       "version": "0.1.6",
@@ -3261,7 +3383,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-property": {
@@ -3287,6 +3408,317 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.19.0.tgz",
+      "integrity": "sha512-ynZ/6cVv4Trpt1FEd5TkHsHtLs+y/YQGb+ocIIVRdc+DkiYRbxlEL/IiSeSeQXwopQcG5FhoeIUJa1l26IgSpw==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.12",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "license": "MIT"
+    },
+    "node_modules/isomorphic-dompurify/node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3467,6 +3899,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4057,7 +4495,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4148,6 +4585,15 @@
       "optional": true,
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4267,7 +4713,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -4526,7 +4971,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -4797,6 +5241,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unorm": {
@@ -6129,7 +6582,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -6350,7 +6802,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -6360,7 +6811,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/apps/yerd-gui/package.json
+++ b/apps/yerd-gui/package.json
@@ -19,6 +19,7 @@
     "@tauri-apps/plugin-opener": "^2.2.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "isomorphic-dompurify": "^3.19.0",
     "lucide-vue-next": "^0.460.0",
     "reka-ui": "^2.9.8",
     "tailwind-merge": "^2.5.5",

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -902,14 +902,17 @@ pub async fn job_cancel(job_id: String) -> Result<Response, GuiError> {
 
 /// Persist a mail attachment into the app cache and return its absolute path.
 ///
-/// The OS opener cannot open a `data:` URL as a document, so the frontend writes
-/// the decoded attachment bytes here first and then opens the returned path.
+/// The OS opener cannot open a `data:` URL as a document, so the frontend sends
+/// the attachment as standard base64; we decode and write the file here, then
+/// the GUI opens the returned path. Keeping base64 until this boundary avoids
+/// shipping a large `number[]` through the webview IPC JSON path.
 #[tauri::command]
 pub async fn save_mail_attachment(
     app: tauri::AppHandle,
     filename: String,
-    bytes: Vec<u8>,
+    data: String,
 ) -> Result<String, GuiError> {
+    let bytes = base64_decode(&data)?;
     let mut dir = app
         .path()
         .app_cache_dir()
@@ -928,6 +931,74 @@ pub async fn save_mail_attachment(
     std::fs::write(&dir, bytes)
         .map_err(|e| GuiError::internal(format!("could not write attachment: {e}")))?;
     Ok(dir.to_string_lossy().into_owned())
+}
+
+/// Standard (padded) base64 decode for attachment payloads.
+///
+/// Kept local to avoid a new dependency for this one host helper (mirrors the
+/// encoder in `yerd-mail`'s MIME path).
+fn base64_decode(input: &str) -> Result<Vec<u8>, GuiError> {
+    fn sextet(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+
+    let raw = input.as_bytes();
+    if raw.len() % 4 != 0 {
+        return Err(GuiError::internal("attachment data is not valid base64"));
+    }
+    let mut out = Vec::with_capacity(raw.len() / 4 * 3);
+    for chunk in raw.chunks_exact(4) {
+        let (c0, c1, c2, c3) = (
+            chunk.first().copied().unwrap_or(0),
+            chunk.get(1).copied().unwrap_or(0),
+            chunk.get(2).copied().unwrap_or(0),
+            chunk.get(3).copied().unwrap_or(0),
+        );
+        let pad2 = c2 == b'=';
+        let pad3 = c3 == b'=';
+        if pad2 && !pad3 {
+            return Err(GuiError::internal("attachment data is not valid base64"));
+        }
+        let s0 = sextet(c0).ok_or_else(|| {
+            GuiError::internal("attachment data is not valid base64")
+        })?;
+        let s1 = sextet(c1).ok_or_else(|| {
+            GuiError::internal("attachment data is not valid base64")
+        })?;
+        let s2 = if pad2 {
+            0
+        } else {
+            sextet(c2).ok_or_else(|| {
+                GuiError::internal("attachment data is not valid base64")
+            })?
+        };
+        let s3 = if pad3 {
+            0
+        } else {
+            sextet(c3).ok_or_else(|| {
+                GuiError::internal("attachment data is not valid base64")
+            })?
+        };
+        let n = (u32::from(s0) << 18)
+            | (u32::from(s1) << 12)
+            | (u32::from(s2) << 6)
+            | u32::from(s3);
+        out.push(((n >> 16) & 0xff) as u8);
+        if !pad2 {
+            out.push(((n >> 8) & 0xff) as u8);
+        }
+        if !pad3 {
+            out.push((n & 0xff) as u8);
+        }
+    }
+    Ok(out)
 }
 
 fn safe_attachment_filename(name: &str) -> String {
@@ -1001,5 +1072,21 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(safe_attachment_filename(input), expected, "input={input:?}");
         }
+    }
+
+    #[test]
+    fn base64_decode_matches_known_vectors() {
+        assert_eq!(base64_decode("").unwrap(), b"");
+        assert_eq!(base64_decode("Zg==").unwrap(), b"f");
+        assert_eq!(base64_decode("Zm8=").unwrap(), b"fo");
+        assert_eq!(base64_decode("Zm9v").unwrap(), b"foo");
+        assert_eq!(base64_decode("Zm9vYmFy").unwrap(), b"foobar");
+    }
+
+    #[test]
+    fn base64_decode_rejects_invalid_input() {
+        assert!(base64_decode("Zg").is_err());
+        assert!(base64_decode("!!!!").is_err());
+        assert!(base64_decode("Zm9v====").is_err());
     }
 }

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -954,16 +954,18 @@ fn base64_decode(input: &str) -> Result<Vec<u8>, GuiError> {
         return Err(GuiError::internal("attachment data is not valid base64"));
     }
     let mut out = Vec::with_capacity(raw.len() / 4 * 3);
-    for chunk in raw.chunks_exact(4) {
-        let (c0, c1, c2, c3) = (
-            chunk.first().copied().unwrap_or(0),
-            chunk.get(1).copied().unwrap_or(0),
-            chunk.get(2).copied().unwrap_or(0),
-            chunk.get(3).copied().unwrap_or(0),
-        );
+    let quartets = raw.len() / 4;
+    for (i, chunk) in raw.chunks_exact(4).enumerate() {
+        let [c0, c1, c2, c3] = <[u8; 4]>::try_from(chunk).map_err(|_| {
+            GuiError::internal("attachment data is not valid base64")
+        })?;
         let pad2 = c2 == b'=';
         let pad3 = c3 == b'=';
         if pad2 && !pad3 {
+            return Err(GuiError::internal("attachment data is not valid base64"));
+        }
+        let is_last = i + 1 == quartets;
+        if (pad2 || pad3) && !is_last {
             return Err(GuiError::internal("attachment data is not valid base64"));
         }
         let s0 = sextet(c0).ok_or_else(|| {
@@ -1088,5 +1090,9 @@ mod tests {
         assert!(base64_decode("Zg").is_err());
         assert!(base64_decode("!!!!").is_err());
         assert!(base64_decode("Zm9v====").is_err());
+        assert!(
+            base64_decode("Zg==Zm8=").is_err(),
+            "padding must only appear on the final quartet"
+        );
     }
 }

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -5,8 +5,10 @@
 //! ever sees a success variant or a typed failure. There is no business logic
 //! here - that lives in the daemon and its crates (the thin-client rule).
 
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tauri::Manager;
 use yerd_core::PhpVersion;
@@ -21,6 +23,9 @@ use crate::ipc::{exchange, exchange_timeout};
 /// trips for a wedged/crash-looping daemon - letting the poller advance instead
 /// of hanging. Heavy/mutating commands deliberately stay unbounded.
 const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Cached mail attachment files older than this are removed on the next save.
+const MAIL_ATTACHMENT_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Convert a daemon `Response::Error` into a `GuiError`; pass success through.
 fn finish(resp: Response) -> Result<Response, GuiError> {
@@ -604,13 +609,19 @@ pub async fn get_mail(id: String) -> Result<Response, GuiError> {
 }
 
 #[tauri::command]
-pub async fn clear_mails() -> Result<Response, GuiError> {
-    finish(exchange(&Request::ClearMails).await?)
+pub async fn clear_mails(app: tauri::AppHandle) -> Result<Response, GuiError> {
+    let resp = finish(exchange(&Request::ClearMails).await?)?;
+    clear_mail_attachment_cache(&app);
+    Ok(resp)
 }
 
+/// Delete selected messages and drop the host attachment cache (files are not
+/// keyed by mail id, so they follow the mailbox lifecycle as a whole).
 #[tauri::command]
-pub async fn delete_mails(ids: Vec<String>) -> Result<Response, GuiError> {
-    finish(exchange(&Request::DeleteMails { ids }).await?)
+pub async fn delete_mails(app: tauri::AppHandle, ids: Vec<String>) -> Result<Response, GuiError> {
+    let resp = finish(exchange(&Request::DeleteMails { ids }).await?)?;
+    clear_mail_attachment_cache(&app);
+    Ok(resp)
 }
 
 #[tauri::command]
@@ -913,24 +924,89 @@ pub async fn save_mail_attachment(
     data: String,
 ) -> Result<String, GuiError> {
     let bytes = base64_decode(&data)?;
+    let dir = mail_attachments_dir(&app)?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| GuiError::internal(format!("could not create attachment cache: {e}")))?;
+    purge_stale_mail_attachments(&dir);
+
+    let path = write_mail_attachment_file(&dir, &safe_attachment_filename(&filename), &bytes)?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+fn mail_attachments_dir(app: &tauri::AppHandle) -> Result<PathBuf, GuiError> {
     let mut dir = app
         .path()
         .app_cache_dir()
         .map_err(|e| GuiError::internal(format!("could not locate cache directory: {e}")))?;
     dir.push("mail-attachments");
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| GuiError::internal(format!("could not create attachment cache: {e}")))?;
+    Ok(dir)
+}
 
-    let safe_name = safe_attachment_filename(&filename);
+fn clear_mail_attachment_cache(app: &tauri::AppHandle) {
+    if let Ok(dir) = mail_attachments_dir(app) {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+fn purge_stale_mail_attachments(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+        let Ok(age) = now.duration_since(modified) else {
+            continue;
+        };
+        if age > MAIL_ATTACHMENT_MAX_AGE {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+/// Create `{stamp}-{name}` (or `{stamp}-{n}-{name}` on collision) with
+/// `create_new` so two saves in the same millisecond cannot truncate each other.
+fn write_mail_attachment_file(
+    dir: &Path,
+    safe_name: &str,
+    bytes: &[u8],
+) -> Result<PathBuf, GuiError> {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| GuiError::internal(format!("system clock error: {e}")))?
         .as_millis();
-    dir.push(format!("{stamp}-{safe_name}"));
 
-    std::fs::write(&dir, bytes)
-        .map_err(|e| GuiError::internal(format!("could not write attachment: {e}")))?;
-    Ok(dir.to_string_lossy().into_owned())
+    for attempt in 0u32..1000 {
+        let file_name = if attempt == 0 {
+            format!("{stamp}-{safe_name}")
+        } else {
+            format!("{stamp}-{attempt}-{safe_name}")
+        };
+        let path = dir.join(&file_name);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                file.write_all(bytes)
+                    .map_err(|e| GuiError::internal(format!("could not write attachment: {e}")))?;
+                return Ok(path);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(GuiError::internal(format!("could not write attachment: {e}")));
+            }
+        }
+    }
+    Err(GuiError::internal(
+        "could not write attachment: too many name collisions",
+    ))
 }
 
 /// Standard (padded) base64 decode for attachment payloads.
@@ -1085,5 +1161,15 @@ mod tests {
             base64_decode("Zg==Zm8=").is_err(),
             "padding must only appear on the final quartet"
         );
+    }
+
+    #[test]
+    fn write_mail_attachment_file_uses_unique_names_on_collision() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = write_mail_attachment_file(dir.path(), "a.txt", b"one").expect("first write");
+        let second = write_mail_attachment_file(dir.path(), "a.txt", b"two").expect("second write");
+        assert_ne!(first, second);
+        assert_eq!(std::fs::read(&first).expect("read first"), b"one");
+        assert_eq!(std::fs::read(&second).expect("read second"), b"two");
     }
 }

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -6,7 +6,9 @@
 //! here - that lives in the daemon and its crates (the thin-client rule).
 
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use tauri::Manager;
 use yerd_core::PhpVersion;
 use yerd_ipc::{ErrorCode, Request, Response};
 
@@ -896,6 +898,59 @@ pub async fn job_cancel(job_id: String) -> Result<Response, GuiError> {
     finish(exchange(&Request::JobCancel { job_id }).await?)
 }
 
+// ── host helpers ───────────────────────────────────────────────────────────
+
+/// Persist a mail attachment into the app cache and return its absolute path.
+///
+/// The OS opener cannot open a `data:` URL as a document, so the frontend writes
+/// the decoded attachment bytes here first and then opens the returned path.
+#[tauri::command]
+pub async fn save_mail_attachment(
+    app: tauri::AppHandle,
+    filename: String,
+    bytes: Vec<u8>,
+) -> Result<String, GuiError> {
+    let mut dir = app
+        .path()
+        .app_cache_dir()
+        .map_err(|e| GuiError::internal(format!("could not locate cache directory: {e}")))?;
+    dir.push("mail-attachments");
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| GuiError::internal(format!("could not create attachment cache: {e}")))?;
+
+    let safe_name = safe_attachment_filename(&filename);
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| GuiError::internal(format!("system clock error: {e}")))?
+        .as_millis();
+    dir.push(format!("{stamp}-{safe_name}"));
+
+    std::fs::write(&dir, bytes)
+        .map_err(|e| GuiError::internal(format!("could not write attachment: {e}")))?;
+    Ok(dir.to_string_lossy().into_owned())
+}
+
+fn safe_attachment_filename(name: &str) -> String {
+    let candidate = name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or("attachment")
+        .trim();
+    let filtered: String = candidate
+        .chars()
+        .map(|c| match c {
+            ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            c if c.is_control() => '_',
+            c => c,
+        })
+        .collect();
+    if filtered.is_empty() {
+        "attachment".to_owned()
+    } else {
+        filtered
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
@@ -930,5 +985,21 @@ mod tests {
         assert_eq!(code_str(&ErrorCode::AlreadyExists), "already_exists");
         assert_eq!(code_str(&ErrorCode::InvalidPath), "invalid_path");
         assert_eq!(code_str(&ErrorCode::Internal), "internal");
+    }
+
+    #[test]
+    fn safe_attachment_filename_strips_path_and_unsafe_chars() {
+        let cases = [
+            ("invoice.pdf", "invoice.pdf"),
+            ("../../etc/passwd", "passwd"),
+            (r"C:\Temp\report.pdf", "report.pdf"),
+            ("bad:name*.pdf", "bad_name_.pdf"),
+            ("   ", "attachment"),
+            ("", "attachment"),
+            ("ok name.docx", "ok name.docx"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(safe_attachment_filename(input), expected, "input={input:?}");
+        }
     }
 }

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -994,8 +994,13 @@ fn write_mail_attachment_file(
         let path = dir.join(&file_name);
         match OpenOptions::new().write(true).create_new(true).open(&path) {
             Ok(mut file) => {
-                file.write_all(bytes)
-                    .map_err(|e| GuiError::internal(format!("could not write attachment: {e}")))?;
+                if let Err(e) = file.write_all(bytes) {
+                    drop(file);
+                    let _ = std::fs::remove_file(&path);
+                    return Err(GuiError::internal(format!(
+                        "could not write attachment: {e}"
+                    )));
+                }
                 return Ok(path);
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -956,9 +956,8 @@ fn base64_decode(input: &str) -> Result<Vec<u8>, GuiError> {
     let mut out = Vec::with_capacity(raw.len() / 4 * 3);
     let quartets = raw.len() / 4;
     for (i, chunk) in raw.chunks_exact(4).enumerate() {
-        let [c0, c1, c2, c3] = <[u8; 4]>::try_from(chunk).map_err(|_| {
-            GuiError::internal("attachment data is not valid base64")
-        })?;
+        let [c0, c1, c2, c3] = <[u8; 4]>::try_from(chunk)
+            .map_err(|_| GuiError::internal("attachment data is not valid base64"))?;
         let pad2 = c2 == b'=';
         let pad3 = c3 == b'=';
         if pad2 && !pad3 {
@@ -968,30 +967,22 @@ fn base64_decode(input: &str) -> Result<Vec<u8>, GuiError> {
         if (pad2 || pad3) && !is_last {
             return Err(GuiError::internal("attachment data is not valid base64"));
         }
-        let s0 = sextet(c0).ok_or_else(|| {
-            GuiError::internal("attachment data is not valid base64")
-        })?;
-        let s1 = sextet(c1).ok_or_else(|| {
-            GuiError::internal("attachment data is not valid base64")
-        })?;
+        let s0 =
+            sextet(c0).ok_or_else(|| GuiError::internal("attachment data is not valid base64"))?;
+        let s1 =
+            sextet(c1).ok_or_else(|| GuiError::internal("attachment data is not valid base64"))?;
         let s2 = if pad2 {
             0
         } else {
-            sextet(c2).ok_or_else(|| {
-                GuiError::internal("attachment data is not valid base64")
-            })?
+            sextet(c2).ok_or_else(|| GuiError::internal("attachment data is not valid base64"))?
         };
         let s3 = if pad3 {
             0
         } else {
-            sextet(c3).ok_or_else(|| {
-                GuiError::internal("attachment data is not valid base64")
-            })?
+            sextet(c3).ok_or_else(|| GuiError::internal("attachment data is not valid base64"))?
         };
-        let n = (u32::from(s0) << 18)
-            | (u32::from(s1) << 12)
-            | (u32::from(s2) << 6)
-            | u32::from(s3);
+        let n =
+            (u32::from(s0) << 18) | (u32::from(s1) << 12) | (u32::from(s2) << 6) | u32::from(s3);
         out.push(((n >> 16) & 0xff) as u8);
         if !pad2 {
             out.push(((n >> 8) & 0xff) as u8);

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -1005,7 +1005,9 @@ fn write_mail_attachment_file(
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(e) => {
-                return Err(GuiError::internal(format!("could not write attachment: {e}")));
+                return Err(GuiError::internal(format!(
+                    "could not write attachment: {e}"
+                )));
             }
         }
     }
@@ -1097,7 +1099,7 @@ fn safe_attachment_filename(name: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
 

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -172,6 +172,7 @@ fn main() {
             commands::create_site,
             commands::job_status,
             commands::job_cancel,
+            commands::save_mail_attachment,
             show_dumps_window,
             daemon::daemon_installed,
             daemon::daemon_diagnostics,

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -864,6 +864,14 @@ export async function openInBrowser(url: string): Promise<void> {
   await openUrl(url);
 }
 
+/** Save decoded attachment bytes in the app cache and return the file path. */
+export async function saveMailAttachment(
+  filename: string,
+  bytes: number[],
+): Promise<string> {
+  return call<string>("save_mail_attachment", { filename, bytes });
+}
+
 /** Reveal a file or directory in the OS file manager. */
 export async function openPath(path: string): Promise<void> {
   const { revealItemInDir } = await import("@tauri-apps/plugin-opener");

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -864,12 +864,12 @@ export async function openInBrowser(url: string): Promise<void> {
   await openUrl(url);
 }
 
-/** Save decoded attachment bytes in the app cache and return the file path. */
+/** Save attachment bytes (standard base64) in the app cache; return the path. */
 export async function saveMailAttachment(
   filename: string,
-  bytes: number[],
+  data: string,
 ): Promise<string> {
-  return call<string>("save_mail_attachment", { filename, bytes });
+  return call<string>("save_mail_attachment", { filename, data });
 }
 
 /** Reveal a file or directory in the OS file manager. */

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -197,6 +197,16 @@ export interface MailHeader {
   value: string;
 }
 
+/** crates/yerd-ipc/src/status.rs - MailAttachment. */
+export interface MailAttachment {
+  filename: string;
+  content_type: string;
+  /** Decoded byte count (before base64 encoding). */
+  size: number;
+  /** Standard (padded) base64-encoded attachment bytes. */
+  data: string;
+}
+
 /** crates/yerd-ipc/src/status.rs - MailDetail. */
 export interface MailDetail {
   id: string;
@@ -208,6 +218,9 @@ export interface MailDetail {
   /** Decoded text/html body (cid: images already rewritten to data: URLs). */
   html_body: string | null;
   text_body: string | null;
+  /** Non-inline attachments. Omitted on the wire (and therefore undefined here)
+   *  when the message has none, or when talking to an older daemon. */
+  attachments?: MailAttachment[];
 }
 
 export interface StatusReport {

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -150,6 +150,15 @@ describe("prepareHtmlBody", () => {
     expect(out).not.toContain("onclick");
     expect(out).toContain('data-yerd-url="https://ok.example/"');
   });
+
+  it("strips image maps so area hrefs cannot navigate the frame", () => {
+    const out = prepareHtmlBody(
+      `<img usemap="#m" src="https://example.com/x.png"><map name="m"><area href="https://evil.example" shape="rect" coords="0,0,10,10"></map>`,
+    );
+    expect(out).not.toContain("<map");
+    expect(out).not.toContain("<area");
+    expect(out).toContain('usemap="#m"');
+  });
 });
 
 describe("linkifyText", () => {

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveExternalHref, resolveFrameLink } from "./mailLinks";
+import {
+  eventTargetElement,
+  linkifyText,
+  prepareHtmlBody,
+  resolveExternalHref,
+  resolveFrameLink,
+} from "./mailLinks";
 
 describe("resolveExternalHref", () => {
   it("returns absolute http(s) URLs to open", () => {
@@ -77,6 +83,18 @@ describe("resolveFrameLink", () => {
     });
   });
 
+  it("walks up from a Text node inside the link (the common click target)", () => {
+    const a = anchorWith("https://msi-portal.test/materials");
+    a.appendChild(a.ownerDocument.createTextNode("View all materials"));
+    const text = a.firstChild;
+    expect(text?.nodeType).toBe(Node.TEXT_NODE);
+    expect(eventTargetElement(text)).toBe(a);
+    expect(resolveFrameLink(text)).toEqual({
+      kind: "open",
+      url: "https://msi-portal.test/materials",
+    });
+  });
+
   it("lets same-document `#` anchors scroll", () => {
     expect(resolveFrameLink(anchorWith("#section"))).toEqual({ kind: "scroll" });
     expect(resolveFrameLink(anchorWith("#"))).toEqual({ kind: "scroll" });
@@ -95,5 +113,85 @@ describe("resolveFrameLink", () => {
     doc.body.append(p);
     expect(resolveFrameLink(p)).toBeNull();
     expect(resolveFrameLink(null)).toBeNull();
+  });
+
+  it("opens via data-yerd-url when present", () => {
+    const doc = frameDoc();
+    const a = doc.createElement("a");
+    a.setAttribute("href", "#");
+    a.setAttribute("data-yerd-url", "https://msi-portal.test/materials/share/abc");
+    doc.body.append(a);
+    expect(resolveFrameLink(a)).toEqual({
+      kind: "open",
+      url: "https://msi-portal.test/materials/share/abc",
+    });
+  });
+});
+
+describe("prepareHtmlBody", () => {
+  it("stamps openable anchors with data-yerd-url", () => {
+    const out = prepareHtmlBody(
+      `<p><a href="https://msi-portal.test/download">Download</a></p>`,
+    );
+    expect(out).toContain('data-yerd-url="https://msi-portal.test/download"');
+    expect(out).toContain('href="https://msi-portal.test/download"');
+  });
+
+  it("leaves non-openable anchors alone", () => {
+    const out = prepareHtmlBody(`<a href="#section">Jump</a>`);
+    expect(out).not.toContain("data-yerd-url");
+  });
+
+  it("strips scripts and inline handlers before stamping", () => {
+    const out = prepareHtmlBody(
+      `<p onclick="alert(1)"><script>alert(1)</script><a href="https://ok.example">Ok</a></p>`,
+    );
+    expect(out).not.toContain("<script");
+    expect(out).not.toContain("onclick");
+    expect(out).toContain('data-yerd-url="https://ok.example/"');
+  });
+});
+
+describe("linkifyText", () => {
+  it("wraps http/https URLs in anchor tags", () => {
+    const out = linkifyText("Visit https://example.com for details.");
+    expect(out).toContain("<a ");
+    expect(out).toContain('data-url="https://example.com/"');
+    expect(out).toContain("Visit");
+    expect(out).toContain("for details.");
+  });
+
+  it("wraps mailto links in anchor tags", () => {
+    const out = linkifyText("Email us at mailto:hi@example.com please.");
+    expect(out).toContain('data-url="mailto:hi@example.com"');
+  });
+
+  it("HTML-escapes message content before linkifying", () => {
+    const out = linkifyText("<script>alert(1)</script> https://safe.example.com");
+    expect(out).toContain("&lt;script&gt;");
+    expect(out).not.toContain("<script>");
+    expect(out).toContain('data-url="https://safe.example.com/"');
+  });
+
+  it("does not linkify javascript: or data: URLs", () => {
+    const out = linkifyText("Bad: javascript:alert(1) and data:text/html,hi");
+    expect(out).not.toContain("<a ");
+  });
+
+  it("strips trailing punctuation from URLs", () => {
+    const out = linkifyText("See https://example.com/path.");
+    // The trailing period must not be part of the href.
+    expect(out).not.toContain('data-url="https://example.com/path."');
+    expect(out).toContain('data-url="https://example.com/path"');
+  });
+
+  it("returns plain escaped text when there are no URLs", () => {
+    const out = linkifyText("Hello & goodbye.");
+    expect(out).toBe("Hello &amp; goodbye.");
+    expect(out).not.toContain("<a ");
+  });
+
+  it("handles an empty string", () => {
+    expect(linkifyText("")).toBe("");
   });
 });

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -49,9 +49,8 @@ describe("resolveExternalHref", () => {
 
 describe("resolveFrameLink", () => {
   // Build the anchor inside a real iframe's document, so `target` comes from a
-  // different realm than this module - exactly the production shape (clicks
-  // originate in the email frame). A same-realm `document.createElement` anchor
-  // would not exercise the cross-realm path where `instanceof Element` fails.
+  // different realm than this module - exactly the production shape for
+  // cross-realm duck-typing where `instanceof Element` fails.
   function frameDoc(): Document {
     const iframe = document.createElement("iframe");
     document.body.append(iframe);
@@ -84,7 +83,7 @@ describe("resolveFrameLink", () => {
     });
   });
 
-  it("walks up from a Text node inside the link (the common click target)", () => {
+  it("walks up from a text node inside the link (the common click target)", () => {
     const a = anchorWith("https://msi-portal.test/materials");
     a.appendChild(a.ownerDocument.createTextNode("View all materials"));
     const text = a.firstChild;
@@ -116,6 +115,18 @@ describe("resolveFrameLink", () => {
     expect(resolveFrameLink(null)).toBeNull();
   });
 
+  it("opens via data-url from legacy plain-text linkify", () => {
+    const doc = frameDoc();
+    const a = doc.createElement("a");
+    a.setAttribute("href", "#");
+    a.setAttribute("data-url", "https://example.com/");
+    doc.body.append(a);
+    expect(resolveFrameLink(a)).toEqual({
+      kind: "open",
+      url: "https://example.com/",
+    });
+  });
+
   it("opens via data-yerd-url when present", () => {
     const doc = frameDoc();
     const a = doc.createElement("a");
@@ -130,19 +141,21 @@ describe("resolveFrameLink", () => {
 });
 
 describe("buildMailFrameDocument", () => {
-  it("preserves head styles and stylesheet links", () => {
+  it("preserves head styles and remote stylesheet links", () => {
     const { head, body } = buildMailFrameDocument(`<!doctype html><html><head>
 <style>.title { color: red; }</style>
 <link rel="stylesheet" href="https://cdn.example.com/mail.css">
 <meta http-equiv="refresh" content="0;url=https://evil.example">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'">
 </head><body><p class="title">Hi</p></body></html>`);
     expect(head).toContain(".title { color: red; }");
     expect(head).toContain('href="https://cdn.example.com/mail.css"');
     expect(head).not.toContain("refresh");
+    expect(head).not.toContain("Content-Security-Policy");
     expect(body).toContain('class="title"');
   });
 
-  it("stamps openable anchors and strips image maps from the body", () => {
+  it("stamps openable anchors, neutralizes href, and strips image maps", () => {
     const { body } = buildMailFrameDocument(
       `<map name="m"><area href="https://evil.example" shape="rect" coords="0,0,1,1"></map>
        <a href="https://ok.example">Ok</a>`,
@@ -150,21 +163,60 @@ describe("buildMailFrameDocument", () => {
     expect(body).not.toContain("<map");
     expect(body).not.toContain("<area");
     expect(body).toContain('data-yerd-url="https://ok.example/"');
+    expect(body).toMatch(/href="#"/);
+    expect(body).not.toContain('href="https://ok.example');
+  });
+
+  it("strips scripts, inline handlers, and javascript: URLs", () => {
+    const { body } = buildMailFrameDocument(
+      `<p onclick="alert(1)"><script>alert(1)</script><a href="javascript:alert(1)">x</a><a href="https://ok.example">Ok</a></p>`,
+    );
+    expect(body).not.toContain("<script");
+    expect(body).not.toContain("onclick");
+    expect(body).not.toContain("javascript:");
+    expect(body).toContain('data-yerd-url="https://ok.example/"');
+  });
+
+  it("strips svg and math markup", () => {
+    const { body } = buildMailFrameDocument(
+      `<svg onload="alert(1)"><text>x</text></svg><math><mi>x</mi></math><p>Hi</p>`,
+    );
+    expect(body).not.toContain("<svg");
+    expect(body).not.toContain("<math");
+    expect(body).toContain("Hi");
+  });
+
+  it("keeps remote images", () => {
+    const { body } = buildMailFrameDocument(
+      `<img src="https://cdn.example.com/logo.png" alt="logo">`,
+    );
+    expect(body).toContain('src="https://cdn.example.com/logo.png"');
+  });
+
+  it("drops non-stylesheet link tags", () => {
+    const { head } = buildMailFrameDocument(`<!doctype html><html><head>
+<link rel="prefetch" href="https://evil.example/x">
+<link rel="stylesheet" href="https://cdn.example.com/ok.css">
+</head><body></body></html>`);
+    expect(head).not.toContain("prefetch");
+    expect(head).toContain("ok.css");
   });
 });
 
 describe("prepareHtmlBody", () => {
-  it("stamps openable anchors with data-yerd-url", () => {
+  it("stamps openable anchors with data-yerd-url and neutralizes href", () => {
     const out = prepareHtmlBody(
       `<p><a href="https://msi-portal.test/download">Download</a></p>`,
     );
     expect(out).toContain('data-yerd-url="https://msi-portal.test/download"');
-    expect(out).toContain('href="https://msi-portal.test/download"');
+    expect(out).toMatch(/href="#"/);
+    expect(out).not.toContain('href="https://msi-portal.test/download"');
   });
 
   it("leaves non-openable anchors alone", () => {
     const out = prepareHtmlBody(`<a href="#section">Jump</a>`);
     expect(out).not.toContain("data-yerd-url");
+    expect(out).toContain('href="#section"');
   });
 
   it("strips scripts and inline handlers before stamping", () => {
@@ -176,13 +228,13 @@ describe("prepareHtmlBody", () => {
     expect(out).toContain('data-yerd-url="https://ok.example/"');
   });
 
-  it("strips image maps so area hrefs cannot navigate the frame", () => {
+  it("strips image maps so area hrefs cannot navigate", () => {
     const out = prepareHtmlBody(
       `<img usemap="#m" src="https://example.com/x.png"><map name="m"><area href="https://evil.example" shape="rect" coords="0,0,10,10"></map>`,
     );
     expect(out).not.toContain("<map");
     expect(out).not.toContain("<area");
-    expect(out).toContain('usemap="#m"');
+    expect(out).toContain('src="https://example.com/x.png"');
   });
 });
 
@@ -190,21 +242,21 @@ describe("linkifyText", () => {
   it("wraps http/https URLs in anchor tags", () => {
     const out = linkifyText("Visit https://example.com for details.");
     expect(out).toContain("<a ");
-    expect(out).toContain('data-url="https://example.com/"');
+    expect(out).toContain('data-yerd-url="https://example.com/"');
     expect(out).toContain("Visit");
     expect(out).toContain("for details.");
   });
 
   it("wraps mailto links in anchor tags", () => {
     const out = linkifyText("Email us at mailto:hi@example.com please.");
-    expect(out).toContain('data-url="mailto:hi@example.com"');
+    expect(out).toContain('data-yerd-url="mailto:hi@example.com"');
   });
 
   it("HTML-escapes message content before linkifying", () => {
     const out = linkifyText("<script>alert(1)</script> https://safe.example.com");
     expect(out).toContain("&lt;script&gt;");
     expect(out).not.toContain("<script>");
-    expect(out).toContain('data-url="https://safe.example.com/"');
+    expect(out).toContain('data-yerd-url="https://safe.example.com/"');
   });
 
   it("does not linkify javascript: or data: URLs", () => {
@@ -214,8 +266,8 @@ describe("linkifyText", () => {
 
   it("strips trailing punctuation from URLs", () => {
     const out = linkifyText("See https://example.com/path.");
-    expect(out.includes('data-url="https://example.com/path."')).toBe(false);
-    expect(out).toContain('data-url="https://example.com/path"');
+    expect(out.includes('data-yerd-url="https://example.com/path."')).toBe(false);
+    expect(out).toContain('data-yerd-url="https://example.com/path"');
   });
 
   it("returns plain escaped text when there are no URLs", () => {
@@ -236,6 +288,7 @@ describe("linkifyText", () => {
     expect(doc.querySelector("[onmouseover]")).toBeNull();
     expect(doc.body.querySelectorAll("a")).toHaveLength(1);
     const anchor = doc.body.querySelector("a");
-    expect(anchor?.getAttributeNames().sort()).toEqual(["class", "data-url", "href"]);
+    expect(anchor?.getAttributeNames().sort()).toEqual(["class", "data-yerd-url", "href"]);
+    expect(anchor?.getAttribute("href")).toBe("#");
   });
 });

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -225,6 +225,24 @@ describe("buildMailFrameDocument", () => {
     expect(body).not.toContain("cdn.example.com");
   });
 
+  it("strips string-form @import without opt-in", () => {
+    const { head } = buildMailFrameDocument(`<!doctype html><html><head>
+<style>@import "https://cdn.example.com/mail.css"; .ok { color: red; }</style>
+</head><body></body></html>`);
+    expect(head).not.toContain("cdn.example.com");
+    expect(head).toContain(".ok { color: red; }");
+  });
+
+  it("keeps string-form @import when loadRemoteContent is true", () => {
+    const { head } = buildMailFrameDocument(
+      `<!doctype html><html><head>
+<style>@import "https://cdn.example.com/mail.css";</style>
+</head><body></body></html>`,
+      { loadRemoteContent: true },
+    );
+    expect(head).toContain('@import "https://cdn.example.com/mail.css"');
+  });
+
   it("drops non-stylesheet link tags", () => {
     const { head } = buildMailFrameDocument(`<!doctype html><html><head>
 <link rel="prefetch" href="https://evil.example/x">
@@ -239,7 +257,7 @@ describe("listRemoteContentUrls", () => {
   it("lists remote stylesheets, images, and CSS urls without loading them", () => {
     const refs = listRemoteContentUrls(`<!doctype html><html><head>
 <link rel="stylesheet" href="https://cdn.example.com/mail.css">
-<style>.bg { background: url(https://cdn.example.com/bg.png); }</style>
+<style>@import "https://cdn.example.com/imported.css"; .bg { background: url(https://cdn.example.com/bg.png); }</style>
 </head><body>
 <img src="https://cdn.example.com/logo.png" alt="logo">
 <img src="cid:inline@local" alt="inline">
@@ -249,6 +267,7 @@ describe("listRemoteContentUrls", () => {
       { url: "https://cdn.example.com/mail.css", kind: "stylesheet" },
       { url: "https://cdn.example.com/logo.png", kind: "image" },
       { url: "https://cdn.example.com/x.png", kind: "css-url" },
+      { url: "https://cdn.example.com/imported.css", kind: "stylesheet" },
       { url: "https://cdn.example.com/bg.png", kind: "css-url" },
     ]);
   });

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildMailFrameDocument,
   eventTargetElement,
   linkifyText,
   prepareHtmlBody,
@@ -125,6 +126,30 @@ describe("resolveFrameLink", () => {
       kind: "open",
       url: "https://msi-portal.test/materials/share/abc",
     });
+  });
+});
+
+describe("buildMailFrameDocument", () => {
+  it("preserves head styles and stylesheet links", () => {
+    const { head, body } = buildMailFrameDocument(`<!doctype html><html><head>
+<style>.title { color: red; }</style>
+<link rel="stylesheet" href="https://cdn.example.com/mail.css">
+<meta http-equiv="refresh" content="0;url=https://evil.example">
+</head><body><p class="title">Hi</p></body></html>`);
+    expect(head).toContain(".title { color: red; }");
+    expect(head).toContain('href="https://cdn.example.com/mail.css"');
+    expect(head).not.toContain("refresh");
+    expect(body).toContain('class="title"');
+  });
+
+  it("stamps openable anchors and strips image maps from the body", () => {
+    const { body } = buildMailFrameDocument(
+      `<map name="m"><area href="https://evil.example" shape="rect" coords="0,0,1,1"></map>
+       <a href="https://ok.example">Ok</a>`,
+    );
+    expect(body).not.toContain("<map");
+    expect(body).not.toContain("<area");
+    expect(body).toContain('data-yerd-url="https://ok.example/"');
   });
 });
 

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -225,6 +225,13 @@ describe("buildMailFrameDocument", () => {
     expect(body).not.toContain("cdn.example.com");
   });
 
+  it("neutralizes remote CSS url() smuggled behind a comment", () => {
+    const { head } = buildMailFrameDocument(`<!doctype html><html><head>
+<style>.bg { background: url(/* */"https://cdn.example.com/track.png"); }</style>
+</head><body></body></html>`);
+    expect(head).not.toContain("cdn.example.com");
+  });
+
   it("strips string-form @import without opt-in", () => {
     const { head } = buildMailFrameDocument(`<!doctype html><html><head>
 <style>@import "https://cdn.example.com/mail.css"; .ok { color: red; }</style>

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -4,6 +4,7 @@ import {
   buildMailFrameDocument,
   eventTargetElement,
   linkifyText,
+  listRemoteContentUrls,
   prepareHtmlBody,
   resolveExternalHref,
   resolveFrameLink,
@@ -48,10 +49,7 @@ describe("resolveExternalHref", () => {
 });
 
 describe("resolveFrameLink", () => {
-  // Build the anchor inside a real iframe's document, so `target` comes from a
-  // different realm than this module - exactly the production shape for
-  // cross-realm duck-typing where `instanceof Element` fails.
-  function frameDoc(): Document {
+  function crossRealmDocument(): Document {
     const iframe = document.createElement("iframe");
     document.body.append(iframe);
     const doc = iframe.contentDocument;
@@ -60,7 +58,7 @@ describe("resolveFrameLink", () => {
   }
 
   function anchorWith(href: string, child?: string): Element {
-    const doc = frameDoc();
+    const doc = crossRealmDocument();
     const a = doc.createElement("a");
     a.setAttribute("href", href);
     if (child) a.innerHTML = child;
@@ -108,7 +106,7 @@ describe("resolveFrameLink", () => {
   });
 
   it("returns null when the click isn't on a link", () => {
-    const doc = frameDoc();
+    const doc = crossRealmDocument();
     const p = doc.createElement("p");
     doc.body.append(p);
     expect(resolveFrameLink(p)).toBeNull();
@@ -116,7 +114,7 @@ describe("resolveFrameLink", () => {
   });
 
   it("opens via data-url from legacy plain-text linkify", () => {
-    const doc = frameDoc();
+    const doc = crossRealmDocument();
     const a = doc.createElement("a");
     a.setAttribute("href", "#");
     a.setAttribute("data-url", "https://example.com/");
@@ -128,7 +126,7 @@ describe("resolveFrameLink", () => {
   });
 
   it("opens via data-yerd-url when present", () => {
-    const doc = frameDoc();
+    const doc = crossRealmDocument();
     const a = doc.createElement("a");
     a.setAttribute("href", "#");
     a.setAttribute("data-yerd-url", "https://msi-portal.test/materials/share/abc");
@@ -141,7 +139,7 @@ describe("resolveFrameLink", () => {
 });
 
 describe("buildMailFrameDocument", () => {
-  it("preserves head styles and remote stylesheet links", () => {
+  it("preserves inline head styles and strips remote stylesheet links by default", () => {
     const { head, body } = buildMailFrameDocument(`<!doctype html><html><head>
 <style>.title { color: red; }</style>
 <link rel="stylesheet" href="https://cdn.example.com/mail.css">
@@ -149,10 +147,20 @@ describe("buildMailFrameDocument", () => {
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'">
 </head><body><p class="title">Hi</p></body></html>`);
     expect(head).toContain(".title { color: red; }");
-    expect(head).toContain('href="https://cdn.example.com/mail.css"');
+    expect(head).not.toContain("cdn.example.com/mail.css");
     expect(head).not.toContain("refresh");
     expect(head).not.toContain("Content-Security-Policy");
     expect(body).toContain('class="title"');
+  });
+
+  it("keeps remote stylesheet links when loadRemoteContent is true", () => {
+    const { head } = buildMailFrameDocument(
+      `<!doctype html><html><head>
+<link rel="stylesheet" href="https://cdn.example.com/mail.css">
+</head><body></body></html>`,
+      { loadRemoteContent: true },
+    );
+    expect(head).toContain('href="https://cdn.example.com/mail.css"');
   });
 
   it("stamps openable anchors, neutralizes href, and strips image maps", () => {
@@ -186,11 +194,35 @@ describe("buildMailFrameDocument", () => {
     expect(body).toContain("Hi");
   });
 
-  it("keeps remote images", () => {
+  it("strips remote images by default", () => {
     const { body } = buildMailFrameDocument(
       `<img src="https://cdn.example.com/logo.png" alt="logo">`,
     );
+    expect(body).not.toContain("cdn.example.com/logo.png");
+  });
+
+  it("keeps remote images when loadRemoteContent is true", () => {
+    const { body } = buildMailFrameDocument(
+      `<img src="https://cdn.example.com/logo.png" alt="logo">`,
+      { loadRemoteContent: true },
+    );
     expect(body).toContain('src="https://cdn.example.com/logo.png"');
+  });
+
+  it("keeps cid and data images without opt-in", () => {
+    const { body } = buildMailFrameDocument(
+      `<img src="cid:logo@local" alt="cid"><img src="data:image/png;base64,abc" alt="data">`,
+    );
+    expect(body).toContain('src="cid:logo@local"');
+    expect(body).toContain('src="data:image/png;base64,abc"');
+  });
+
+  it("neutralizes remote CSS url() without opt-in", () => {
+    const { head, body } = buildMailFrameDocument(`<!doctype html><html><head>
+<style>.bg { background: url(https://cdn.example.com/bg.png); }</style>
+</head><body><div style="background-image: url('https://cdn.example.com/x.png')"></div></body></html>`);
+    expect(head).not.toContain("cdn.example.com");
+    expect(body).not.toContain("cdn.example.com");
   });
 
   it("drops non-stylesheet link tags", () => {
@@ -199,7 +231,39 @@ describe("buildMailFrameDocument", () => {
 <link rel="stylesheet" href="https://cdn.example.com/ok.css">
 </head><body></body></html>`);
     expect(head).not.toContain("prefetch");
-    expect(head).toContain("ok.css");
+    expect(head).not.toContain("ok.css");
+  });
+});
+
+describe("listRemoteContentUrls", () => {
+  it("lists remote stylesheets, images, and CSS urls without loading them", () => {
+    const refs = listRemoteContentUrls(`<!doctype html><html><head>
+<link rel="stylesheet" href="https://cdn.example.com/mail.css">
+<style>.bg { background: url(https://cdn.example.com/bg.png); }</style>
+</head><body>
+<img src="https://cdn.example.com/logo.png" alt="logo">
+<img src="cid:inline@local" alt="inline">
+<div style="background-image: url('//cdn.example.com/x.png')"></div>
+</body></html>`);
+    expect(refs).toEqual([
+      { url: "https://cdn.example.com/mail.css", kind: "stylesheet" },
+      { url: "https://cdn.example.com/logo.png", kind: "image" },
+      { url: "https://cdn.example.com/x.png", kind: "css-url" },
+      { url: "https://cdn.example.com/bg.png", kind: "css-url" },
+    ]);
+  });
+
+  it("dedupes the same URL used in multiple places", () => {
+    const refs = listRemoteContentUrls(
+      `<img src="https://cdn.example.com/logo.png"><img src="https://cdn.example.com/logo.png">`,
+    );
+    expect(refs).toEqual([
+      { url: "https://cdn.example.com/logo.png", kind: "image" },
+    ]);
+  });
+
+  it("returns an empty list when there is no remote content", () => {
+    expect(listRemoteContentUrls(`<p>Hi <img src="cid:x"></p>`)).toEqual([]);
   });
 });
 
@@ -234,7 +298,7 @@ describe("prepareHtmlBody", () => {
     );
     expect(out).not.toContain("<map");
     expect(out).not.toContain("<area");
-    expect(out).toContain('src="https://example.com/x.png"');
+    expect(out).not.toContain("example.com/x.png");
   });
 });
 

--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -180,8 +180,7 @@ describe("linkifyText", () => {
 
   it("strips trailing punctuation from URLs", () => {
     const out = linkifyText("See https://example.com/path.");
-    // The trailing period must not be part of the href.
-    expect(out).not.toContain('data-url="https://example.com/path."');
+    expect(out.includes('data-url="https://example.com/path."')).toBe(false);
     expect(out).toContain('data-url="https://example.com/path"');
   });
 
@@ -193,5 +192,16 @@ describe("linkifyText", () => {
 
   it("handles an empty string", () => {
     expect(linkifyText("")).toBe("");
+  });
+
+  it("does not let quote entities in a URL inject attributes", () => {
+    const out = linkifyText(
+      'Click https://example.test/x&quot;onmouseover=&quot;alert(1) here',
+    );
+    const doc = new DOMParser().parseFromString(out, "text/html");
+    expect(doc.querySelector("[onmouseover]")).toBeNull();
+    expect(doc.body.querySelectorAll("a")).toHaveLength(1);
+    const anchor = doc.body.querySelector("a");
+    expect(anchor?.getAttributeNames().sort()).toEqual(["class", "data-url", "href"]);
   });
 });

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -15,28 +15,42 @@ const URL_PATTERN =
   /(?:https?:\/\/|mailto:|tel:)[^\s"'<>)\]]+(?<![.,)])/g;
 
 /**
- * Convert URLs in a plain-text email body into clickable `<a>` tags. The
- * output is intended for use with `v-html` so the text is HTML-escaped first
- * to prevent any message content from injecting markup; only the synthesised
- * `<a>` tags are trusted HTML.
+ * Convert URLs in a plain-text email body into clickable `<a>` tags for
+ * `v-html`. Anchors are built with DOM APIs (`textContent` / `.href` /
+ * `dataset`) so message content cannot inject attributes via entity decoding
+ * (e.g. `&quot;` inside a matched URL). Non-URL text is appended as text
+ * nodes and therefore HTML-escaped by the browser when serialised.
  *
- * Each anchor carries a `data-url` attribute containing the validated URL so
- * the click handler can read it via event delegation without re-parsing.
+ * Only URLs that pass {@link resolveExternalHref} become links. Each anchor
+ * carries `data-url` with the validated URL for event-delegation click
+ * handling.
  */
 export function linkifyText(text: string): string {
-  // Escape HTML special characters so raw message content can't inject tags.
-  const escaped = text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-  // Replace URL matches with anchor tags. `resolveExternalHref` validates the
-  // scheme so only safe, openable URLs become links.
-  return escaped.replace(URL_PATTERN, (raw) => {
+  const container = document.createElement("div");
+  let offset = 0;
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const raw = match[0];
+    const index = match.index ?? 0;
+    if (index > offset) {
+      container.append(document.createTextNode(text.slice(offset, index)));
+    }
     const url = resolveExternalHref(raw);
-    if (!url) return raw;
-    return `<a href="${url}" class="text-brand underline cursor-pointer" data-url="${url}">${raw}</a>`;
-  });
+    if (url) {
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.dataset.url = url;
+      anchor.className = "text-brand underline cursor-pointer";
+      anchor.textContent = raw;
+      container.append(anchor);
+    } else {
+      container.append(document.createTextNode(raw));
+    }
+    offset = index + raw.length;
+  }
+  if (offset < text.length) {
+    container.append(document.createTextNode(text.slice(offset)));
+  }
+  return container.innerHTML;
 }
 
 /**
@@ -77,16 +91,18 @@ function isInPageFragment(rawHref: string | null): boolean {
   return (rawHref?.trim() ?? "").startsWith("#");
 }
 
+const NODE_TEXT = 3;
+
 /**
  * Coerce an event target to an Element. Clicks on link text yield a Text node
- * (no `closest`); climb to `parentElement` so we can still find the `<a>`.
- * Duck-typed for cross-realm iframe targets where `instanceof` is unreliable.
+ * (`NODE_TEXT`, no `closest`); climb to `parentElement` so we can still find
+ * the `<a>`. Duck-typed for cross-realm targets where `instanceof` is
+ * unreliable.
  */
 export function eventTargetElement(target: EventTarget | null): Element | null {
   if (!target || typeof target !== "object") return null;
   const node = target as { nodeType?: number; parentElement?: Element | null; closest?: unknown };
-  // Node.ELEMENT_NODE === 1, Node.TEXT_NODE === 3
-  if (node.nodeType === 3) return node.parentElement ?? null;
+  if (node.nodeType === NODE_TEXT) return node.parentElement ?? null;
   if (typeof node.closest === "function") return target as Element;
   return node.parentElement ?? null;
 }
@@ -96,17 +112,16 @@ export function eventTargetElement(target: EventTarget | null): Element | null {
  * when the click isn't on a link (leave it alone); otherwise a
  * {@link FrameLinkAction}: openable schemes go to the OS browser, same-document
  * `#` anchors are left to scroll, and everything else (relative, same-origin,
- * `javascript:`) is blocked so the sandboxed frame can't navigate itself away
- * from the email. Walks up to the nearest `<a href>` so clicks on nested content
- * (e.g. `<a><img></a>` or link text) resolve.
+ * `javascript:`) is blocked so the preview can't navigate away from the email.
+ * Walks up to the nearest `<a href>` / `a[data-yerd-url]` so clicks on nested
+ * content (e.g. `<a><img></a>` or link text) resolve.
  *
- * The target comes from the iframe's own realm, whose `Element` differs from
- * this module's, so `instanceof Element` would always be false. We duck-type on
- * `closest` instead (absent on `document`/`window` targets) to stay realm-safe.
+ * Prefers `data-yerd-url` (stamped by {@link prepareHtmlBody}) over the visible
+ * `href` so openable links still work when the displayed href is a fragment
+ * placeholder or was rewritten. Duck-types on `closest` for cross-realm
+ * targets where `instanceof Element` would fail.
  */
 export function resolveFrameLink(target: EventTarget | null): FrameLinkAction | null {
-  // Prefer data-yerd-url (stamped by prepareHtmlBody) so we still open even if
-  // the visible href was rewritten or is a same-document fragment placeholder.
   const el = eventTargetElement(target);
   const anchor = el?.closest?.("a[href], a[data-yerd-url]") ?? null;
   if (!anchor) return null;

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -1,3 +1,6 @@
+import DOMPurify from "isomorphic-dompurify";
+import type { Config } from "dompurify";
+
 /** Schemes a captured email may link to that we route to the OS browser (or the
  *  OS handler, for mailto/tel). Everything else - relative paths, in-page `#`
  *  anchors, `javascript:`, `data:`, `file:` - is ignored so a message can never
@@ -22,8 +25,8 @@ const URL_PATTERN =
  * nodes and therefore HTML-escaped by the browser when serialised.
  *
  * Only URLs that pass {@link resolveExternalHref} become links. Each anchor
- * carries `data-url` with the validated URL for event-delegation click
- * handling.
+ * carries `data-yerd-url` with the validated URL; `href` is `#` so navigation
+ * cannot bypass the click handler.
  */
 export function linkifyText(text: string): string {
   const container = document.createElement("div");
@@ -37,8 +40,8 @@ export function linkifyText(text: string): string {
     const url = resolveExternalHref(raw);
     if (url) {
       const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.dataset.url = url;
+      anchor.href = "#";
+      anchor.dataset.yerdUrl = url;
       anchor.className = "text-brand underline cursor-pointer";
       anchor.textContent = raw;
       container.append(anchor);
@@ -76,10 +79,9 @@ export function resolveExternalHref(rawHref: string | null | undefined): string 
   return OPENABLE_SCHEMES.has(url.protocol) ? url.href : null;
 }
 
-/** What to do with a click on an `<a href>` inside the email frame: `open` it in
+/** What to do with a click on an `<a href>` inside the email body: `open` it in
  *  the OS browser, let a same-document `#` anchor `scroll`, or `block` an
- *  in-frame navigation the preview must never perform (relative/same-origin
- *  links would otherwise load app content over the email). */
+ *  in-document navigation the preview must never perform. */
 export type FrameLinkAction =
   | { kind: "open"; url: string }
   | { kind: "scroll" }
@@ -111,122 +113,101 @@ export function eventTargetElement(target: EventTarget | null): Element | null {
  * Classify a click that landed on `target` inside an email body. Returns `null`
  * when the click isn't on a link (leave it alone); otherwise a
  * {@link FrameLinkAction}: openable schemes go to the OS browser, same-document
- * `#` anchors are left to scroll, and everything else (relative, same-origin,
- * `javascript:`) is blocked so the preview can't navigate away from the email.
- * Walks up to the nearest `<a href>` / `a[data-yerd-url]` so clicks on nested
- * content (e.g. `<a><img></a>` or link text) resolve.
- *
- * Prefers `data-yerd-url` (stamped by {@link prepareHtmlBody}) over the visible
- * `href` so openable links still work when the displayed href is a fragment
- * placeholder or was rewritten. Duck-types on `closest` for cross-realm
- * targets where `instanceof Element` would fail.
+ * `#` anchors are left to scroll, and everything else is blocked.
+ * Prefers `data-yerd-url` (stamped by {@link buildMailFrameDocument}) over the
+ * visible `href`.
  */
 export function resolveFrameLink(target: EventTarget | null): FrameLinkAction | null {
   const el = eventTargetElement(target);
   const anchor =
-    el?.closest?.("a[href], a[data-yerd-url], area[href]") ?? null;
+    el?.closest?.("a[href], a[data-yerd-url], a[data-url], area[href]") ?? null;
   if (!anchor) return null;
-  const stamped = anchor.getAttribute("data-yerd-url");
+  const stamped =
+    anchor.getAttribute("data-yerd-url") ?? anchor.getAttribute("data-url");
   const href = anchor.getAttribute("href");
   const url = resolveExternalHref(stamped) ?? resolveExternalHref(href);
   if (url) return { kind: "open", url };
   return isInPageFragment(href) ? { kind: "scroll" } : { kind: "block" };
 }
 
-/** Child-document CSP for the sandboxed mail iframe (paired with `buildMailFrameDocument`). */
-export const MAIL_FRAME_CSP =
-  "default-src 'none'; script-src 'unsafe-inline'; img-src data: http: https:; style-src 'unsafe-inline' http: https:";
-
-const STRIP_TAGS = new Set([
-  "script",
-  "iframe",
-  "object",
-  "embed",
-  "base",
-  "form",
-  "map",
-  "area",
-]);
+/** DOMPurify config for captured HTML email (head + body). */
+const MAIL_PURIFY_CONFIG: Config = {
+  WHOLE_DOCUMENT: true,
+  ADD_TAGS: ["link", "style", "meta", "head", "body", "html"],
+  ADD_ATTR: ["target", "rel", "media", "type", "as", "crossorigin", "http-equiv", "content", "name", "charset"],
+  FORBID_TAGS: [
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "form",
+    "input",
+    "button",
+    "textarea",
+    "select",
+    "option",
+    "map",
+    "area",
+    "svg",
+    "math",
+    "base",
+    "noscript",
+    "template",
+    "foreignObject",
+    "video",
+    "audio",
+    "source",
+    "track",
+  ],
+  // Allow data-* so we can stamp data-yerd-url after purify (and keep benign
+  // email data attributes). Event handlers are still stripped by DOMPurify.
+  ALLOW_DATA_ATTR: true,
+};
 
 /**
- * Trusted bootstrap script injected into the iframe `head` (not from email).
- * Forwards openable link clicks to the host via `postMessage` so link routing
- * works on WKWebView where parent `contentDocument` listeners are unreliable.
- * Email scripts remain blocked by sanitization + CSP `default-src 'none'`.
+ * Drop non-stylesheet `<link>` nodes and dangerous `<meta http-equiv>` values
+ * that DOMPurify may still allow when `meta` / `link` are on the allowlist.
  */
-export const MAIL_FRAME_CLICK_BRIDGE = `<script>
-document.addEventListener("click",function(e){
-  var el=e.target;
-  if(el&&el.nodeType===3)el=el.parentElement;
-  while(el){
-    var a=el.closest&&el.closest("a[href],a[data-yerd-url]");
-    if(a){
-      var stamped=a.getAttribute("data-yerd-url");
-      var href=a.getAttribute("href")||"";
-      var raw=(stamped||href).trim();
-      if(/^(https?:|mailto:|tel:)/i.test(raw)){
-        e.preventDefault();
-        parent.postMessage({type:"yerd-mail-link",url:raw},"*");
-        return;
-      }
-      if(href.trim().charAt(0)==="#")return;
-      e.preventDefault();
-      return;
-    }
-    el=el.parentElement;
+function filterHeadHazards(doc: Document): void {
+  for (const link of [...doc.querySelectorAll("link")]) {
+    const rel = link.getAttribute("rel")?.toLowerCase() ?? "";
+    if (!rel.includes("stylesheet")) link.remove();
   }
-},true);
-</script>`;
-
-function sanitizeMailDocument(doc: Document): void {
-  const roots: Element[] = [];
-  if (doc.head) roots.push(doc.head);
-  if (doc.body) roots.push(doc.body);
-  for (const root of roots) {
-    for (const el of [...root.querySelectorAll("*")]) {
-      const tag = el.tagName.toLowerCase();
-      if (tag === "link") {
-        const rel = el.getAttribute("rel")?.toLowerCase() ?? "";
-        if (!rel.includes("stylesheet")) el.remove();
-        continue;
-      }
-      if (tag === "meta") {
-        const equiv = el.getAttribute("http-equiv")?.toLowerCase() ?? "";
-        if (equiv === "refresh" || equiv === "set-cookie") el.remove();
-        continue;
-      }
-      if (STRIP_TAGS.has(tag)) {
-        el.remove();
-        continue;
-      }
-      for (const attr of [...el.attributes]) {
-        const name = attr.name.toLowerCase();
-        if (name.startsWith("on") || name === "srcdoc") {
-          el.removeAttribute(attr.name);
-          continue;
-        }
-        if (
-          (name === "href" || name === "src" || name === "xlink:href") &&
-          /^\s*javascript:/i.test(attr.value)
-        ) {
-          el.removeAttribute(attr.name);
-        }
-      }
+  for (const meta of [...doc.querySelectorAll("meta")]) {
+    const equiv = meta.getAttribute("http-equiv")?.toLowerCase() ?? "";
+    if (
+      equiv === "refresh" ||
+      equiv === "set-cookie" ||
+      equiv === "content-security-policy"
+    ) {
+      meta.remove();
     }
   }
 }
 
 /**
- * Sanitize a captured HTML email and stamp openable anchors with `data-yerd-url`.
- * Preserves `<head>` styles / stylesheet links so marketing emails keep their CSS.
+ * Stamp openable anchors with `data-yerd-url` and neutralize `href` to `#` so
+ * default navigation cannot bypass the host click handler.
+ */
+function stampOpenableAnchors(root: ParentNode): void {
+  for (const a of root.querySelectorAll("a[href]")) {
+    const url = resolveExternalHref(a.getAttribute("href"));
+    if (url) {
+      a.setAttribute("data-yerd-url", url);
+      a.setAttribute("href", "#");
+    }
+  }
+}
+
+/**
+ * Sanitize a captured HTML email with DOMPurify and stamp openable anchors.
+ * Preserves `<style>` and remote stylesheet `<link>` so marketing emails keep CSS.
  */
 export function buildMailFrameDocument(html: string): { head: string; body: string } {
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  sanitizeMailDocument(doc);
-  for (const a of doc.querySelectorAll("a[href]")) {
-    const url = resolveExternalHref(a.getAttribute("href"));
-    if (url) a.setAttribute("data-yerd-url", url);
-  }
+  const cleaned = DOMPurify.sanitize(html, MAIL_PURIFY_CONFIG);
+  const doc = new DOMParser().parseFromString(cleaned, "text/html");
+  filterHeadHazards(doc);
+  stampOpenableAnchors(doc);
   return {
     head: doc.head?.innerHTML ?? "",
     body: doc.body?.innerHTML ?? "",
@@ -235,23 +216,16 @@ export function buildMailFrameDocument(html: string): { head: string; body: stri
 
 /**
  * Strip executable / navigable hazards from captured HTML (body fragment).
- * Prefer {@link buildMailFrameDocument} for iframe rendering so `<head>` styles survive.
+ * Prefer {@link buildMailFrameDocument} when head styles must survive.
  */
 export function sanitizeMailHtml(html: string): string {
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  sanitizeMailDocument(doc);
-  return doc.body?.innerHTML ?? html;
+  return buildMailFrameDocument(html).body;
 }
 
 /**
  * Stamp openable `<a href>` tags with `data-yerd-url` (body HTML only).
- * @deprecated Prefer {@link buildMailFrameDocument} for the mail iframe.
+ * @deprecated Prefer {@link buildMailFrameDocument} for the mail viewer.
  */
 export function prepareHtmlBody(html: string): string {
-  const doc = new DOMParser().parseFromString(sanitizeMailHtml(html), "text/html");
-  for (const a of doc.querySelectorAll("a[href]")) {
-    const url = resolveExternalHref(a.getAttribute("href"));
-    if (url) a.setAttribute("data-yerd-url", url);
-  }
-  return doc.body?.innerHTML ?? html;
+  return buildMailFrameDocument(`<body>${html}</body>`).body;
 }

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -199,14 +199,153 @@ function stampOpenableAnchors(root: ParentNode): void {
   }
 }
 
+/** Options for {@link buildMailFrameDocument}. */
+export type BuildMailFrameOptions = {
+  /**
+   * When true, keep remote (`http`/`https`/`//`) stylesheets, images, and CSS
+   * `url(...)` references. Default `false` so merely opening a message cannot
+   * phone home (IP / read-receipt style tracking).
+   */
+  loadRemoteContent?: boolean;
+};
+
+export type RemoteContentKind = "stylesheet" | "image" | "css-url";
+
+/** A remote resource referenced by a captured HTML message. */
+export type RemoteContentRef = {
+  url: string;
+  kind: RemoteContentKind;
+};
+
+function isRemoteHttpUrl(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("data:") || trimmed.startsWith("cid:")) {
+    return false;
+  }
+  if (trimmed.startsWith("//")) return true;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeRemoteUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("//")) {
+    try {
+      return new URL(`https:${trimmed}`).href;
+    } catch {
+      return trimmed;
+    }
+  }
+  try {
+    return new URL(trimmed).href;
+  } catch {
+    return trimmed;
+  }
+}
+
+const CSS_URL_PATTERN = /url\s*\(\s*(['"]?)([^)'"]+)\1\s*\)/gi;
+
+/** Blank remote `url(...)` references inside CSS text (stylesheets / attributes). */
+function neutralizeRemoteCssUrls(css: string): string {
+  return css.replace(CSS_URL_PATTERN, (full, _q, raw: string) => {
+    return isRemoteHttpUrl(raw) ? "none" : full;
+  });
+}
+
+function collectCssRemoteUrls(css: string, add: (url: string, kind: RemoteContentKind) => void): void {
+  for (const match of css.matchAll(CSS_URL_PATTERN)) {
+    const raw = match[2];
+    if (isRemoteHttpUrl(raw)) add(raw, "css-url");
+  }
+}
+
 /**
- * Sanitize a captured HTML email with DOMPurify and stamp openable anchors.
- * Preserves `<style>` and remote stylesheet `<link>` so marketing emails keep CSS.
+ * List remote (`http`/`https`/`//`) resources in captured HTML without loading them.
+ * Dedupes by normalized URL. Used by the Mails sidebar so the user can inspect
+ * what would be fetched before opting in.
  */
-export function buildMailFrameDocument(html: string): { head: string; body: string } {
+export function listRemoteContentUrls(html: string): RemoteContentRef[] {
   const cleaned = DOMPurify.sanitize(html, MAIL_PURIFY_CONFIG);
   const doc = new DOMParser().parseFromString(cleaned, "text/html");
   filterHeadHazards(doc);
+  const seen = new Set<string>();
+  const out: RemoteContentRef[] = [];
+
+  const add = (raw: string, kind: RemoteContentKind): void => {
+    const url = normalizeRemoteUrl(raw);
+    if (seen.has(url)) return;
+    seen.add(url);
+    out.push({ url, kind });
+  };
+
+  for (const link of doc.querySelectorAll("link[href]")) {
+    const href = link.getAttribute("href");
+    if (isRemoteHttpUrl(href)) add(href!, "stylesheet");
+  }
+  for (const img of doc.querySelectorAll("img")) {
+    const src = img.getAttribute("src");
+    if (isRemoteHttpUrl(src)) add(src!, "image");
+    const srcset = img.getAttribute("srcset");
+    if (srcset) {
+      for (const part of srcset.split(",")) {
+        const candidate = part.trim().split(/\s+/)[0];
+        if (isRemoteHttpUrl(candidate)) add(candidate, "image");
+      }
+    }
+  }
+  for (const el of doc.querySelectorAll("[style]")) {
+    collectCssRemoteUrls(el.getAttribute("style") ?? "", add);
+  }
+  for (const styleEl of doc.querySelectorAll("style")) {
+    collectCssRemoteUrls(styleEl.textContent ?? "", add);
+  }
+  return out;
+}
+
+/**
+ * Remove sender-controlled remote resources so viewing mail does not fetch
+ * them until the user opts in via {@link BuildMailFrameOptions.loadRemoteContent}.
+ */
+function stripRemoteResources(doc: Document): void {
+  for (const link of [...doc.querySelectorAll("link[href]")]) {
+    if (isRemoteHttpUrl(link.getAttribute("href"))) link.remove();
+  }
+  for (const img of [...doc.querySelectorAll("img")]) {
+    if (isRemoteHttpUrl(img.getAttribute("src"))) {
+      img.removeAttribute("src");
+    }
+    if (img.hasAttribute("srcset")) img.removeAttribute("srcset");
+  }
+  for (const el of [...doc.querySelectorAll("[style]")]) {
+    const style = el.getAttribute("style");
+    if (!style) continue;
+    el.setAttribute("style", neutralizeRemoteCssUrls(style));
+  }
+  for (const styleEl of [...doc.querySelectorAll("style")]) {
+    const css = styleEl.textContent;
+    if (!css) continue;
+    styleEl.textContent = neutralizeRemoteCssUrls(css);
+  }
+}
+
+/**
+ * Sanitize a captured HTML email with DOMPurify and stamp openable anchors.
+ * Preserves inline `<style>` blocks. Remote stylesheets, images, and CSS URLs
+ * are stripped unless `loadRemoteContent` is true.
+ */
+export function buildMailFrameDocument(
+  html: string,
+  options: BuildMailFrameOptions = {},
+): { head: string; body: string } {
+  const cleaned = DOMPurify.sanitize(html, MAIL_PURIFY_CONFIG);
+  const doc = new DOMParser().parseFromString(cleaned, "text/html");
+  filterHeadHazards(doc);
+  if (!options.loadRemoteContent) stripRemoteResources(doc);
   stampOpenableAnchors(doc);
   return {
     head: doc.head?.innerHTML ?? "",

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -253,9 +253,19 @@ const CSS_URL_PATTERN = /url\s*\(\s*(['"]?)([^)'"]+)\1\s*\)/gi;
 const CSS_IMPORT_PATTERN =
   /@import\s+(?:url\s*\(\s*)?(['"]?)([^)'";\s]+)\1[^;]*;?/gi;
 
+/**
+ * Strip CSS block comments before scanning for remote references. A comment
+ * embedded inside a `url(...)` or `@import` token otherwise splits it so the
+ * regexes below skip it, letting a remote fetch slip past the opt-out. This
+ * closes the common case; regex CSS handling stays best-effort.
+ */
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
 /** Blank remote `url(...)` / `@import` references inside CSS text. */
 function neutralizeRemoteCss(css: string): string {
-  let out = css.replace(CSS_IMPORT_PATTERN, (full, _q, raw: string) => {
+  let out = stripCssComments(css).replace(CSS_IMPORT_PATTERN, (full, _q, raw: string) => {
     return isRemoteHttpUrl(raw) ? "" : full;
   });
   out = out.replace(CSS_URL_PATTERN, (full, _q, raw: string) => {
@@ -265,11 +275,12 @@ function neutralizeRemoteCss(css: string): string {
 }
 
 function collectCssRemoteUrls(css: string, add: (url: string, kind: RemoteContentKind) => void): void {
-  for (const match of css.matchAll(CSS_IMPORT_PATTERN)) {
+  const cleaned = stripCssComments(css);
+  for (const match of cleaned.matchAll(CSS_IMPORT_PATTERN)) {
     const raw = match[2];
     if (isRemoteHttpUrl(raw)) add(raw, "stylesheet");
   }
-  for (const match of css.matchAll(CSS_URL_PATTERN)) {
+  for (const match of cleaned.matchAll(CSS_URL_PATTERN)) {
     const raw = match[2];
     if (isRemoteHttpUrl(raw)) add(raw, "css-url");
   }

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -123,7 +123,8 @@ export function eventTargetElement(target: EventTarget | null): Element | null {
  */
 export function resolveFrameLink(target: EventTarget | null): FrameLinkAction | null {
   const el = eventTargetElement(target);
-  const anchor = el?.closest?.("a[href], a[data-yerd-url]") ?? null;
+  const anchor =
+    el?.closest?.("a[href], a[data-yerd-url], area[href]") ?? null;
   if (!anchor) return null;
   const stamped = anchor.getAttribute("data-yerd-url");
   const href = anchor.getAttribute("href");
@@ -133,13 +134,25 @@ export function resolveFrameLink(target: EventTarget | null): FrameLinkAction | 
 }
 
 /**
- * Strip executable / navigable hazards from a captured HTML email before it is
- * rendered in the host (Shadow DOM). Keeps inline styles and images so the
- * message still looks like email; removes scripts, frames, and inline handlers.
+ * Strip executable / navigable hazards from captured HTML before it enters the
+ * sandboxed iframe. Keeps inline styles and images; removes scripts, frames,
+ * image maps, forms, and inline handlers. Primary isolation is still the iframe
+ * sandbox + child CSP; this is defense in depth.
  */
 export function sanitizeMailHtml(html: string): string {
   const doc = new DOMParser().parseFromString(html, "text/html");
-  const strip = new Set(["script", "iframe", "object", "embed", "link", "meta", "base", "form"]);
+  const strip = new Set([
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "link",
+    "meta",
+    "base",
+    "form",
+    "map",
+    "area",
+  ]);
   for (const el of [...doc.body.querySelectorAll("*")]) {
     if (strip.has(el.tagName.toLowerCase())) {
       el.remove();
@@ -163,8 +176,8 @@ export function sanitizeMailHtml(html: string): string {
 }
 
 /**
- * Stamp openable `<a href>` tags with `data-yerd-url` before rendering.
- * The host click listener reads that attribute to open links in the OS browser.
+ * Stamp openable `<a href>` tags with `data-yerd-url` before the iframe srcdoc.
+ * The frame click listener reads that attribute to open links in the OS browser.
  */
 export function prepareHtmlBody(html: string): string {
   const doc = new DOMParser().parseFromString(sanitizeMailHtml(html), "text/html");

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -249,15 +249,26 @@ function normalizeRemoteUrl(raw: string): string {
 }
 
 const CSS_URL_PATTERN = /url\s*\(\s*(['"]?)([^)'"]+)\1\s*\)/gi;
+/** String or url() form: `@import "https://…"` / `@import url(https://…)`. */
+const CSS_IMPORT_PATTERN =
+  /@import\s+(?:url\s*\(\s*)?(['"]?)([^)'";\s]+)\1[^;]*;?/gi;
 
-/** Blank remote `url(...)` references inside CSS text (stylesheets / attributes). */
-function neutralizeRemoteCssUrls(css: string): string {
-  return css.replace(CSS_URL_PATTERN, (full, _q, raw: string) => {
+/** Blank remote `url(...)` / `@import` references inside CSS text. */
+function neutralizeRemoteCss(css: string): string {
+  let out = css.replace(CSS_IMPORT_PATTERN, (full, _q, raw: string) => {
+    return isRemoteHttpUrl(raw) ? "" : full;
+  });
+  out = out.replace(CSS_URL_PATTERN, (full, _q, raw: string) => {
     return isRemoteHttpUrl(raw) ? "none" : full;
   });
+  return out;
 }
 
 function collectCssRemoteUrls(css: string, add: (url: string, kind: RemoteContentKind) => void): void {
+  for (const match of css.matchAll(CSS_IMPORT_PATTERN)) {
+    const raw = match[2];
+    if (isRemoteHttpUrl(raw)) add(raw, "stylesheet");
+  }
   for (const match of css.matchAll(CSS_URL_PATTERN)) {
     const raw = match[2];
     if (isRemoteHttpUrl(raw)) add(raw, "css-url");
@@ -324,12 +335,12 @@ function stripRemoteResources(doc: Document): void {
   for (const el of [...doc.querySelectorAll("[style]")]) {
     const style = el.getAttribute("style");
     if (!style) continue;
-    el.setAttribute("style", neutralizeRemoteCssUrls(style));
+    el.setAttribute("style", neutralizeRemoteCss(style));
   }
   for (const styleEl of [...doc.querySelectorAll("style")]) {
     const css = styleEl.textContent;
     if (!css) continue;
-    styleEl.textContent = neutralizeRemoteCssUrls(css);
+    styleEl.textContent = neutralizeRemoteCss(css);
   }
 }
 

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -4,6 +4,41 @@
  *  drive navigation anywhere but a real external target the user chose. */
 const OPENABLE_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
 
+// ── plain-text URL linkification ──────────────────────────────────────────
+
+/**
+ * URL pattern that matches http/https/mailto/tel links in plain text. Stops at
+ * whitespace and common trailing punctuation (`.`, `,`, `)`, `]`, `>`, `"`,
+ * `'`) that are unlikely to be part of the URL itself.
+ */
+const URL_PATTERN =
+  /(?:https?:\/\/|mailto:|tel:)[^\s"'<>)\]]+(?<![.,)])/g;
+
+/**
+ * Convert URLs in a plain-text email body into clickable `<a>` tags. The
+ * output is intended for use with `v-html` so the text is HTML-escaped first
+ * to prevent any message content from injecting markup; only the synthesised
+ * `<a>` tags are trusted HTML.
+ *
+ * Each anchor carries a `data-url` attribute containing the validated URL so
+ * the click handler can read it via event delegation without re-parsing.
+ */
+export function linkifyText(text: string): string {
+  // Escape HTML special characters so raw message content can't inject tags.
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+  // Replace URL matches with anchor tags. `resolveExternalHref` validates the
+  // scheme so only safe, openable URLs become links.
+  return escaped.replace(URL_PATTERN, (raw) => {
+    const url = resolveExternalHref(raw);
+    if (!url) return raw;
+    return `<a href="${url}" class="text-brand underline cursor-pointer" data-url="${url}">${raw}</a>`;
+  });
+}
+
 /**
  * Decide what a clicked link in an email body should open. Returns the absolute
  * URL to hand to the OS (via the opener plugin), or `null` when the link should
@@ -43,23 +78,85 @@ function isInPageFragment(rawHref: string | null): boolean {
 }
 
 /**
+ * Coerce an event target to an Element. Clicks on link text yield a Text node
+ * (no `closest`); climb to `parentElement` so we can still find the `<a>`.
+ * Duck-typed for cross-realm iframe targets where `instanceof` is unreliable.
+ */
+export function eventTargetElement(target: EventTarget | null): Element | null {
+  if (!target || typeof target !== "object") return null;
+  const node = target as { nodeType?: number; parentElement?: Element | null; closest?: unknown };
+  // Node.ELEMENT_NODE === 1, Node.TEXT_NODE === 3
+  if (node.nodeType === 3) return node.parentElement ?? null;
+  if (typeof node.closest === "function") return target as Element;
+  return node.parentElement ?? null;
+}
+
+/**
  * Classify a click that landed on `target` inside an email body. Returns `null`
  * when the click isn't on a link (leave it alone); otherwise a
  * {@link FrameLinkAction}: openable schemes go to the OS browser, same-document
  * `#` anchors are left to scroll, and everything else (relative, same-origin,
  * `javascript:`) is blocked so the sandboxed frame can't navigate itself away
  * from the email. Walks up to the nearest `<a href>` so clicks on nested content
- * (e.g. `<a><img></a>`) resolve.
+ * (e.g. `<a><img></a>` or link text) resolve.
  *
  * The target comes from the iframe's own realm, whose `Element` differs from
  * this module's, so `instanceof Element` would always be false. We duck-type on
  * `closest` instead (absent on `document`/`window` targets) to stay realm-safe.
  */
 export function resolveFrameLink(target: EventTarget | null): FrameLinkAction | null {
-  const anchor = (target as Element | null)?.closest?.("a[href]");
+  // Prefer data-yerd-url (stamped by prepareHtmlBody) so we still open even if
+  // the visible href was rewritten or is a same-document fragment placeholder.
+  const el = eventTargetElement(target);
+  const anchor = el?.closest?.("a[href], a[data-yerd-url]") ?? null;
   if (!anchor) return null;
+  const stamped = anchor.getAttribute("data-yerd-url");
   const href = anchor.getAttribute("href");
-  const url = resolveExternalHref(href);
+  const url = resolveExternalHref(stamped) ?? resolveExternalHref(href);
   if (url) return { kind: "open", url };
   return isInPageFragment(href) ? { kind: "scroll" } : { kind: "block" };
+}
+
+/**
+ * Strip executable / navigable hazards from a captured HTML email before it is
+ * rendered in the host (Shadow DOM). Keeps inline styles and images so the
+ * message still looks like email; removes scripts, frames, and inline handlers.
+ */
+export function sanitizeMailHtml(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const strip = new Set(["script", "iframe", "object", "embed", "link", "meta", "base", "form"]);
+  for (const el of [...doc.body.querySelectorAll("*")]) {
+    if (strip.has(el.tagName.toLowerCase())) {
+      el.remove();
+      continue;
+    }
+    for (const attr of [...el.attributes]) {
+      const name = attr.name.toLowerCase();
+      if (name.startsWith("on") || name === "srcdoc") {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+      if (
+        (name === "href" || name === "src" || name === "xlink:href") &&
+        /^\s*javascript:/i.test(attr.value)
+      ) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+  return doc.body.innerHTML;
+}
+
+/**
+ * Stamp openable `<a href>` tags with `data-yerd-url` before rendering.
+ * The host click listener reads that attribute to open links in the OS browser.
+ */
+export function prepareHtmlBody(html: string): string {
+  const doc = new DOMParser().parseFromString(sanitizeMailHtml(html), "text/html");
+  for (const a of doc.querySelectorAll("a[href]")) {
+    const url = resolveExternalHref(a.getAttribute("href"));
+    if (!url) continue;
+    a.setAttribute("data-yerd-url", url);
+  }
+  return doc.body?.innerHTML ?? html;
 }

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -133,58 +133,125 @@ export function resolveFrameLink(target: EventTarget | null): FrameLinkAction | 
   return isInPageFragment(href) ? { kind: "scroll" } : { kind: "block" };
 }
 
+/** Child-document CSP for the sandboxed mail iframe (paired with `buildMailFrameDocument`). */
+export const MAIL_FRAME_CSP =
+  "default-src 'none'; script-src 'unsafe-inline'; img-src data: http: https:; style-src 'unsafe-inline' http: https:";
+
+const STRIP_TAGS = new Set([
+  "script",
+  "iframe",
+  "object",
+  "embed",
+  "base",
+  "form",
+  "map",
+  "area",
+]);
+
 /**
- * Strip executable / navigable hazards from captured HTML before it enters the
- * sandboxed iframe. Keeps inline styles and images; removes scripts, frames,
- * image maps, forms, and inline handlers. Primary isolation is still the iframe
- * sandbox + child CSP; this is defense in depth.
+ * Trusted bootstrap script injected into the iframe `head` (not from email).
+ * Forwards openable link clicks to the host via `postMessage` so link routing
+ * works on WKWebView where parent `contentDocument` listeners are unreliable.
+ * Email scripts remain blocked by sanitization + CSP `default-src 'none'`.
  */
-export function sanitizeMailHtml(html: string): string {
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  const strip = new Set([
-    "script",
-    "iframe",
-    "object",
-    "embed",
-    "link",
-    "meta",
-    "base",
-    "form",
-    "map",
-    "area",
-  ]);
-  for (const el of [...doc.body.querySelectorAll("*")]) {
-    if (strip.has(el.tagName.toLowerCase())) {
-      el.remove();
-      continue;
+export const MAIL_FRAME_CLICK_BRIDGE = `<script>
+document.addEventListener("click",function(e){
+  var el=e.target;
+  if(el&&el.nodeType===3)el=el.parentElement;
+  while(el){
+    var a=el.closest&&el.closest("a[href],a[data-yerd-url]");
+    if(a){
+      var stamped=a.getAttribute("data-yerd-url");
+      var href=a.getAttribute("href")||"";
+      var raw=(stamped||href).trim();
+      if(/^(https?:|mailto:|tel:)/i.test(raw)){
+        e.preventDefault();
+        parent.postMessage({type:"yerd-mail-link",url:raw},"*");
+        return;
+      }
+      if(href.trim().charAt(0)==="#")return;
+      e.preventDefault();
+      return;
     }
-    for (const attr of [...el.attributes]) {
-      const name = attr.name.toLowerCase();
-      if (name.startsWith("on") || name === "srcdoc") {
-        el.removeAttribute(attr.name);
+    el=el.parentElement;
+  }
+},true);
+</script>`;
+
+function sanitizeMailDocument(doc: Document): void {
+  const roots: Element[] = [];
+  if (doc.head) roots.push(doc.head);
+  if (doc.body) roots.push(doc.body);
+  for (const root of roots) {
+    for (const el of [...root.querySelectorAll("*")]) {
+      const tag = el.tagName.toLowerCase();
+      if (tag === "link") {
+        const rel = el.getAttribute("rel")?.toLowerCase() ?? "";
+        if (!rel.includes("stylesheet")) el.remove();
         continue;
       }
-      if (
-        (name === "href" || name === "src" || name === "xlink:href") &&
-        /^\s*javascript:/i.test(attr.value)
-      ) {
-        el.removeAttribute(attr.name);
+      if (tag === "meta") {
+        const equiv = el.getAttribute("http-equiv")?.toLowerCase() ?? "";
+        if (equiv === "refresh" || equiv === "set-cookie") el.remove();
+        continue;
+      }
+      if (STRIP_TAGS.has(tag)) {
+        el.remove();
+        continue;
+      }
+      for (const attr of [...el.attributes]) {
+        const name = attr.name.toLowerCase();
+        if (name.startsWith("on") || name === "srcdoc") {
+          el.removeAttribute(attr.name);
+          continue;
+        }
+        if (
+          (name === "href" || name === "src" || name === "xlink:href") &&
+          /^\s*javascript:/i.test(attr.value)
+        ) {
+          el.removeAttribute(attr.name);
+        }
       }
     }
   }
-  return doc.body.innerHTML;
 }
 
 /**
- * Stamp openable `<a href>` tags with `data-yerd-url` before the iframe srcdoc.
- * The frame click listener reads that attribute to open links in the OS browser.
+ * Sanitize a captured HTML email and stamp openable anchors with `data-yerd-url`.
+ * Preserves `<head>` styles / stylesheet links so marketing emails keep their CSS.
+ */
+export function buildMailFrameDocument(html: string): { head: string; body: string } {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  sanitizeMailDocument(doc);
+  for (const a of doc.querySelectorAll("a[href]")) {
+    const url = resolveExternalHref(a.getAttribute("href"));
+    if (url) a.setAttribute("data-yerd-url", url);
+  }
+  return {
+    head: doc.head?.innerHTML ?? "",
+    body: doc.body?.innerHTML ?? "",
+  };
+}
+
+/**
+ * Strip executable / navigable hazards from captured HTML (body fragment).
+ * Prefer {@link buildMailFrameDocument} for iframe rendering so `<head>` styles survive.
+ */
+export function sanitizeMailHtml(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  sanitizeMailDocument(doc);
+  return doc.body?.innerHTML ?? html;
+}
+
+/**
+ * Stamp openable `<a href>` tags with `data-yerd-url` (body HTML only).
+ * @deprecated Prefer {@link buildMailFrameDocument} for the mail iframe.
  */
 export function prepareHtmlBody(html: string): string {
   const doc = new DOMParser().parseFromString(sanitizeMailHtml(html), "text/html");
   for (const a of doc.querySelectorAll("a[href]")) {
     const url = resolveExternalHref(a.getAttribute("href"));
-    if (!url) continue;
-    a.setAttribute("data-yerd-url", url);
+    if (url) a.setAttribute("data-yerd-url", url);
   }
   return doc.body?.innerHTML ?? html;
 }

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FileDown, Inbox, Paperclip, Trash2 } from "lucide-vue-next";
-import { computed, nextTick, onUnmounted, ref, watch } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
@@ -26,9 +26,13 @@ import { linkifyText, prepareHtmlBody, resolveFrameLink } from "@/lib/mailLinks"
 import { humaniseBytes } from "@/lib/utils";
 import type { MailAttachment, MailDetail, MailSummary } from "@/ipc/types";
 
-// HTML emails are rendered in a Shadow DOM (style isolation, no email scripts).
-// WKWebView never delivered click events from a sandboxed srcdoc iframe to
-// parent-attached listeners, so the host Shadow root owns the click path.
+// HTML emails run in a sandboxed srcdoc iframe: no `allow-scripts`, child CSP
+// `default-src 'none'`. `allow-same-origin` lets the host attach a click
+// listener on the frame document (`interceptFrameLinks`) and route openable links
+// to the OS browser; scripts stay disabled so message content can't abuse that
+// access. CSP allows images over data:/http/https (inline cid: and remote logos).
+const CHILD_CSP =
+  "default-src 'none'; img-src data: http: https:; style-src 'unsafe-inline'";
 
 const toast = useToast();
 
@@ -47,7 +51,6 @@ const clearOpen = ref(false);
 const clearing = ref(false);
 const selectedApp = ref<string>("");
 
-const htmlHost = ref<HTMLElement | null>(null);
 let lastOpenedLink = "";
 let lastOpenedAt = 0;
 
@@ -159,56 +162,36 @@ async function confirmDelete(close: () => void): Promise<void> {
   }
 }
 
-function onHtmlLinkClick(ev: Event): void {
-  const action = resolveFrameLink(ev.target);
-  if (!action || action.kind === "scroll") return;
-  ev.preventDefault();
-  ev.stopPropagation();
-  if (action.kind !== "open") return;
-  const now = Date.now();
-  if (action.url === lastOpenedLink && now - lastOpenedAt < 750) return;
-  lastOpenedLink = action.url;
-  lastOpenedAt = now;
-  void openInBrowser(action.url).catch((e) => {
-    toast.error("Couldn't open link", (e as IpcError).message || action.url);
+function frameSrcdoc(html: string): string {
+  const body = prepareHtmlBody(html);
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${CHILD_CSP}"></head><body>${body}</body></html>`;
+}
+
+const linkedDocs = new WeakSet<Document>();
+
+/**
+ * Route link clicks inside the sandboxed email frame. On each `@load` attach one
+ * listener to `contentDocument`; classify via {@link resolveFrameLink} and
+ * either open in the OS browser, let `#` anchors scroll, or block navigation.
+ */
+function interceptFrameLinks(e: Event): void {
+  const doc = (e.target as HTMLIFrameElement).contentDocument;
+  if (!doc || linkedDocs.has(doc)) return;
+  linkedDocs.add(doc);
+  doc.addEventListener("click", (ev) => {
+    const action = resolveFrameLink(ev.target);
+    if (!action || action.kind === "scroll") return;
+    ev.preventDefault();
+    if (action.kind !== "open") return;
+    const now = Date.now();
+    if (action.url === lastOpenedLink && now - lastOpenedAt < 750) return;
+    lastOpenedLink = action.url;
+    lastOpenedAt = now;
+    void openInBrowser(action.url).catch((err) => {
+      toast.error("Couldn't open link", (err as IpcError).message || action.url);
+    });
   });
 }
-
-function renderHtmlBody(html: string): void {
-  const host = htmlHost.value;
-  if (!host) return;
-  const root = host.shadowRoot ?? host.attachShadow({ mode: "open" });
-  root.innerHTML = `<style>
-:host { display: block; }
-.yerd-mail-body {
-  padding: 1.25rem;
-  box-sizing: border-box;
-  color: #111;
-  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-.yerd-mail-body img, .yerd-mail-body table { max-width: 100%; }
-.yerd-mail-body a { cursor: pointer; }
-</style><div class="yerd-mail-body">${prepareHtmlBody(html)}</div>`;
-  root.addEventListener("click", onHtmlLinkClick, true);
-}
-
-function clearHtmlBody(): void {
-  const host = htmlHost.value;
-  if (!host?.shadowRoot) return;
-  host.shadowRoot.innerHTML = "";
-}
-
-watch(
-  [() => detail.value?.html_body, loadingDetail, htmlHost],
-  ([html, loading]) => {
-    if (loading) return;
-    if (!html) {
-      clearHtmlBody();
-      return;
-    }
-    void nextTick(() => renderHtmlBody(html));
-  },
-);
 
 function handleTextLinkClick(ev: MouseEvent): void {
   const action = resolveFrameLink(ev.target);
@@ -336,13 +319,13 @@ function formatDate(epoch: number): string {
             </p>
           </div>
 
-          <!-- HTML body in Shadow DOM (WKWebView iframe clicks never fired) -->
-          <div
+          <iframe
             v-if="detail.html_body"
-            ref="htmlHost"
-            class="min-h-0 flex-1 overflow-y-auto bg-white"
-            role="article"
-            aria-label="Email body"
+            :srcdoc="frameSrcdoc(detail.html_body)"
+            sandbox="allow-same-origin"
+            class="min-h-0 flex-1 bg-white"
+            title="Email body"
+            @load="interceptFrameLinks"
           />
 
           <!-- Plain-text body with linkified URLs -->

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FileDown, Inbox, Paperclip, Trash2 } from "lucide-vue-next";
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
@@ -25,19 +25,15 @@ import {
 import {
   buildMailFrameDocument,
   linkifyText,
-  MAIL_FRAME_CLICK_BRIDGE,
-  MAIL_FRAME_CSP,
   resolveExternalHref,
   resolveFrameLink,
 } from "@/lib/mailLinks";
 import { humaniseBytes } from "@/lib/utils";
 import type { MailAttachment, MailDetail, MailSummary } from "@/ipc/types";
 
-// Sandboxed srcdoc iframe + child CSP. `allow-scripts` is only for our trusted
-// click-bridge script in the frame head; email scripts are stripped and CSP
-// `default-src 'none'` blocks message content from running script. Link opens
-// are delivered to the host via `postMessage` (WKWebView is unreliable with
-// parent `contentDocument` listeners).
+// HTML mail is sanitized with DOMPurify, then rendered in a host Shadow DOM so
+// link clicks are handled in-process (WKWebView does not reliably deliver
+// sandboxed iframe clicks / postMessage). Opens are scheme-allowlisted.
 
 const toast = useToast();
 
@@ -164,10 +160,7 @@ async function confirmDelete(close: () => void): Promise<void> {
   }
 }
 
-function frameSrcdoc(html: string): string {
-  const { head, body } = buildMailFrameDocument(html);
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${MAIL_FRAME_CSP}">${MAIL_FRAME_CLICK_BRIDGE}${head}</head><body>${body}</body></html>`;
-}
+const htmlHost = ref<HTMLElement | null>(null);
 
 function openMailLink(url: string): void {
   const resolved = resolveExternalHref(url);
@@ -181,25 +174,63 @@ function openMailLink(url: string): void {
   });
 }
 
-function onMailFrameMessage(ev: MessageEvent): void {
-  const data = ev.data as { type?: string; url?: string } | null;
-  if (!data || data.type !== "yerd-mail-link" || typeof data.url !== "string") return;
-  openMailLink(data.url);
+function onHtmlLinkClick(ev: Event): void {
+  const action = resolveFrameLink(ev.target);
+  if (!action || action.kind === "scroll") return;
+  ev.preventDefault();
+  ev.stopPropagation();
+  if (action.kind !== "open") return;
+  openMailLink(action.url);
 }
 
-onMounted(() => window.addEventListener("message", onMailFrameMessage));
+function renderHtmlBody(html: string): void {
+  const host = htmlHost.value;
+  if (!host) return;
+  const { head, body } = buildMailFrameDocument(html);
+  let root = host.shadowRoot;
+  if (!root) {
+    root = host.attachShadow({ mode: "open" });
+    root.addEventListener("click", onHtmlLinkClick, true);
+  }
+  root.innerHTML = `<style>
+:host { display: block; }
+.yerd-mail-body {
+  padding: 1.25rem;
+  box-sizing: border-box;
+  color: #111;
+  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.yerd-mail-body img, .yerd-mail-body table { max-width: 100%; }
+.yerd-mail-body a { cursor: pointer; }
+</style>${head}<div class="yerd-mail-body">${body}</div>`;
+}
+
+function clearHtmlBody(): void {
+  const root = htmlHost.value?.shadowRoot;
+  if (root) root.innerHTML = "";
+}
+
+watch(
+  [() => detail.value?.html_body, loadingDetail, htmlHost],
+  ([html, loading]) => {
+    if (loading) return;
+    if (!html) {
+      clearHtmlBody();
+      return;
+    }
+    void nextTick(() => renderHtmlBody(html));
+  },
+);
+
 onUnmounted(() => {
   unregisterViewActions();
-  window.removeEventListener("message", onMailFrameMessage);
 });
 
 function handleTextLinkClick(ev: MouseEvent): void {
   const action = resolveFrameLink(ev.target);
   if (!action || action.kind !== "open") return;
   ev.preventDefault();
-  void openInBrowser(action.url).catch((e) =>
-    toast.error("Couldn't open link", (e as IpcError).message || action.url),
-  );
+  openMailLink(action.url);
 }
 
 const attachments = computed<MailAttachment[]>(
@@ -303,28 +334,10 @@ function formatDate(epoch: number): string {
           <Spinner class="size-6" />
         </div>
         <template v-else-if="detail">
-          <!-- Message header strip -->
-          <div class="shrink-0 border-b px-5 py-3">
-            <h2 class="text-base font-semibold">
-              {{ detail.subject || "(no subject)" }}
-            </h2>
-            <p class="mt-1 text-xs text-muted-foreground">
-              <strong>From:</strong> {{ detail.from }}
-            </p>
-            <p class="text-xs text-muted-foreground">
-              <strong>To:</strong> {{ detail.to.join(", ") }}
-            </p>
-            <p class="text-xs text-muted-foreground">
-              {{ formatDate(detail.date_epoch) }}
-            </p>
-          </div>
-
-          <iframe
+          <div
             v-if="detail.html_body"
-            :srcdoc="frameSrcdoc(detail.html_body)"
-            sandbox="allow-scripts allow-same-origin"
-            class="min-h-0 flex-1 bg-white"
-            title="Email body"
+            ref="htmlHost"
+            class="min-h-0 flex-1 overflow-auto bg-white"
           />
 
           <!-- Plain-text body with linkified URLs -->

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FileDown, Inbox, Paperclip, Trash2 } from "lucide-vue-next";
-import { computed, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
@@ -22,26 +22,28 @@ import {
   openInBrowser,
   saveMailAttachment,
 } from "@/ipc/client";
-import { linkifyText, prepareHtmlBody, resolveFrameLink } from "@/lib/mailLinks";
+import {
+  buildMailFrameDocument,
+  linkifyText,
+  MAIL_FRAME_CLICK_BRIDGE,
+  MAIL_FRAME_CSP,
+  resolveExternalHref,
+  resolveFrameLink,
+} from "@/lib/mailLinks";
 import { humaniseBytes } from "@/lib/utils";
 import type { MailAttachment, MailDetail, MailSummary } from "@/ipc/types";
 
-// HTML emails run in a sandboxed srcdoc iframe: no `allow-scripts`, child CSP
-// `default-src 'none'`. `allow-same-origin` lets the host attach a click
-// listener on the frame document (`interceptFrameLinks`) and route openable links
-// to the OS browser; scripts stay disabled so message content can't abuse that
-// access. CSP allows images over data:/http/https (inline cid: and remote logos).
-const CHILD_CSP =
-  "default-src 'none'; img-src data: http: https:; style-src 'unsafe-inline'";
+// Sandboxed srcdoc iframe + child CSP. `allow-scripts` is only for our trusted
+// click-bridge script in the frame head; email scripts are stripped and CSP
+// `default-src 'none'` blocks message content from running script. Link opens
+// are delivered to the host via `postMessage` (WKWebView is unreliable with
+// parent `contentDocument` listeners).
 
 const toast = useToast();
 
 const { data: mails, refresh } = usePoll<MailSummary[]>(listMails, 4000);
 
 const unregisterViewActions = registerViewActions({ refresh: () => void refresh() });
-onUnmounted(() => {
-  unregisterViewActions();
-});
 
 const selectedId = ref<string | null>(null);
 const detail = ref<MailDetail | null>(null);
@@ -163,35 +165,33 @@ async function confirmDelete(close: () => void): Promise<void> {
 }
 
 function frameSrcdoc(html: string): string {
-  const body = prepareHtmlBody(html);
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${CHILD_CSP}"></head><body>${body}</body></html>`;
+  const { head, body } = buildMailFrameDocument(html);
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${MAIL_FRAME_CSP}">${MAIL_FRAME_CLICK_BRIDGE}${head}</head><body>${body}</body></html>`;
 }
 
-const linkedDocs = new WeakSet<Document>();
-
-/**
- * Route link clicks inside the sandboxed email frame. On each `@load` attach one
- * listener to `contentDocument`; classify via {@link resolveFrameLink} and
- * either open in the OS browser, let `#` anchors scroll, or block navigation.
- */
-function interceptFrameLinks(e: Event): void {
-  const doc = (e.target as HTMLIFrameElement).contentDocument;
-  if (!doc || linkedDocs.has(doc)) return;
-  linkedDocs.add(doc);
-  doc.addEventListener("click", (ev) => {
-    const action = resolveFrameLink(ev.target);
-    if (!action || action.kind === "scroll") return;
-    ev.preventDefault();
-    if (action.kind !== "open") return;
-    const now = Date.now();
-    if (action.url === lastOpenedLink && now - lastOpenedAt < 750) return;
-    lastOpenedLink = action.url;
-    lastOpenedAt = now;
-    void openInBrowser(action.url).catch((err) => {
-      toast.error("Couldn't open link", (err as IpcError).message || action.url);
-    });
+function openMailLink(url: string): void {
+  const resolved = resolveExternalHref(url);
+  if (!resolved) return;
+  const now = Date.now();
+  if (resolved === lastOpenedLink && now - lastOpenedAt < 750) return;
+  lastOpenedLink = resolved;
+  lastOpenedAt = now;
+  void openInBrowser(resolved).catch((err) => {
+    toast.error("Couldn't open link", (err as IpcError).message || resolved);
   });
 }
+
+function onMailFrameMessage(ev: MessageEvent): void {
+  const data = ev.data as { type?: string; url?: string } | null;
+  if (!data || data.type !== "yerd-mail-link" || typeof data.url !== "string") return;
+  openMailLink(data.url);
+}
+
+onMounted(() => window.addEventListener("message", onMailFrameMessage));
+onUnmounted(() => {
+  unregisterViewActions();
+  window.removeEventListener("message", onMailFrameMessage);
+});
 
 function handleTextLinkClick(ev: MouseEvent): void {
   const action = resolveFrameLink(ev.target);
@@ -322,10 +322,9 @@ function formatDate(epoch: number): string {
           <iframe
             v-if="detail.html_body"
             :srcdoc="frameSrcdoc(detail.html_body)"
-            sandbox="allow-same-origin"
+            sandbox="allow-scripts allow-same-origin"
             class="min-h-0 flex-1 bg-white"
             title="Email body"
-            @load="interceptFrameLinks"
           />
 
           <!-- Plain-text body with linkified URLs -->

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
-import { FileDown, Inbox, Paperclip, Trash2 } from "lucide-vue-next";
+import { FileDown, Globe, Inbox, Paperclip, Trash2 } from "lucide-vue-next";
 import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import Modal from "@/components/ui/Modal.vue";
 import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
@@ -25,8 +32,10 @@ import {
 import {
   buildMailFrameDocument,
   linkifyText,
+  listRemoteContentUrls,
   resolveExternalHref,
   resolveFrameLink,
+  type RemoteContentKind,
 } from "@/lib/mailLinks";
 import { humaniseBytes } from "@/lib/utils";
 import type { MailAttachment, MailDetail, MailSummary } from "@/ipc/types";
@@ -45,9 +54,12 @@ const selectedId = ref<string | null>(null);
 const detail = ref<MailDetail | null>(null);
 const loadingDetail = ref(false);
 let selectSeq = 0;
-const clearOpen = ref(false);
+const deleteOpen = ref(false);
+const deleteMode = ref<"selected" | "all">("selected");
 const clearing = ref(false);
 const selectedApp = ref<string>("");
+/** Opt-in: remote images / stylesheets phone home; off until the user asks. */
+const loadRemoteContent = ref(false);
 
 let lastOpenedLink = "";
 let lastOpenedAt = 0;
@@ -92,6 +104,7 @@ watch(
     if (items.length === 0) {
       selectedId.value = null;
       detail.value = null;
+      loadRemoteContent.value = false;
       return;
     }
     if (!selectedId.value || !items.some((m) => m.id === selectedId.value)) {
@@ -104,6 +117,7 @@ watch(
 async function select(id: string, fromUser: boolean): Promise<void> {
   const seq = ++selectSeq;
   selectedId.value = id;
+  loadRemoteContent.value = false;
   loadingDetail.value = true;
   try {
     const mail = await getMail(id);
@@ -134,25 +148,51 @@ async function markRead(id: string): Promise<void> {
   }
 }
 
-const deleteScopeLabel = computed(() =>
-  selectedApp.value
-    ? `all ${filteredList.value.length} email(s) from "${selectedApp.value}"`
-    : "every captured email",
+function openDelete(mode: "selected" | "all"): void {
+  if (mode === "selected" && !selectedId.value) return;
+  if (mode === "all" && list.value.length === 0) return;
+  deleteMode.value = mode;
+  deleteOpen.value = true;
+}
+
+const deleteTitle = computed(() =>
+  deleteMode.value === "selected" ? "Delete this message?" : "Clear all mails?",
+);
+
+const deleteBody = computed(() => {
+  if (deleteMode.value === "selected") {
+    const subject = detail.value?.subject?.trim() || "(no subject)";
+    return `This permanently deletes "${subject}". This cannot be undone.`;
+  }
+  return `This permanently deletes every captured email (${list.value.length}). This cannot be undone.`;
+});
+
+const deleteConfirmLabel = computed(() =>
+  deleteMode.value === "selected" ? "Delete message" : "Delete all",
 );
 
 async function confirmDelete(close: () => void): Promise<void> {
   clearing.value = true;
   try {
-    if (selectedApp.value) {
-      await deleteMails(filteredList.value.map((m) => m.id));
-    } else {
-      await clearMails();
+    if (deleteMode.value === "selected") {
+      const id = selectedId.value;
+      if (!id) return;
+      await deleteMails([id]);
+      selectedId.value = null;
+      detail.value = null;
+      loadRemoteContent.value = false;
+      close();
+      await refresh();
+      toast.success("Message deleted");
+      return;
     }
+    await clearMails();
     selectedId.value = null;
     detail.value = null;
+    loadRemoteContent.value = false;
     close();
     await refresh();
-    toast.success(selectedApp.value ? "Emails deleted" : "Mailbox cleared");
+    toast.success("Mailbox cleared");
   } catch (e) {
     toast.error("Couldn't delete emails", (e as IpcError).message);
   } finally {
@@ -186,7 +226,9 @@ function onHtmlLinkClick(ev: Event): void {
 function renderHtmlBody(html: string): void {
   const host = htmlHost.value;
   if (!host) return;
-  const { head, body } = buildMailFrameDocument(html);
+  const { head, body } = buildMailFrameDocument(html, {
+    loadRemoteContent: loadRemoteContent.value,
+  });
   let root = host.shadowRoot;
   if (!root) {
     root = host.attachShadow({ mode: "open" });
@@ -211,7 +253,7 @@ function clearHtmlBody(): void {
 }
 
 watch(
-  [() => detail.value?.html_body, loadingDetail, htmlHost],
+  [() => detail.value?.html_body, loadingDetail, htmlHost, loadRemoteContent],
   ([html, loading]) => {
     if (loading) return;
     if (!html) {
@@ -236,6 +278,17 @@ function handleTextLinkClick(ev: MouseEvent): void {
 const attachments = computed<MailAttachment[]>(
   () => detail.value?.attachments ?? [],
 );
+
+const remoteContent = computed(() => {
+  const html = detail.value?.html_body;
+  return html ? listRemoteContentUrls(html) : [];
+});
+
+function remoteKindLabel(kind: RemoteContentKind): string {
+  if (kind === "stylesheet") return "Stylesheet";
+  if (kind === "css-url") return "CSS image";
+  return "Image";
+}
 
 async function openAttachment(att: MailAttachment): Promise<void> {
   try {
@@ -271,17 +324,33 @@ function formatDate(epoch: number): string {
           aria-label="Filter by application"
           class="!h-6 max-w-44 text-xs"
         />
-        <!-- Plain button (not the icon-variant Button) so it sits cleanly in the
-             32px titlebar without overflowing it. -->
-        <button
-          type="button"
-          class="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-          :disabled="filteredList.length === 0"
-          :aria-label="selectedApp ? 'Delete emails for this application' : 'Delete all emails'"
-          @click="clearOpen = true"
-        >
-          <Trash2 class="size-3.5" />
-        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger as-child>
+            <button
+              type="button"
+              class="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+              :disabled="list.length === 0"
+              aria-label="Delete emails"
+            >
+              <Trash2 class="size-3.5" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              :disabled="!selectedId"
+              @select="openDelete('selected')"
+            >
+              Delete selected message
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              class="text-destructive focus:bg-destructive/10 focus:text-destructive"
+              @select="openDelete('all')"
+            >
+              Clear all mails
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </template>
     </TitleBar>
 
@@ -400,15 +469,75 @@ function formatDate(epoch: number): string {
             <dd class="break-words text-muted-foreground">{{ h.value }}</dd>
           </div>
         </dl>
+
+        <section v-if="detail.html_body" class="mt-6">
+          <h3 class="mb-2 text-xs font-semibold uppercase text-muted-foreground">
+            Remote content
+          </h3>
+          <p class="mb-2 text-[11px] leading-snug text-muted-foreground">
+            External images and stylesheets are blocked until you load them.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            class="mb-3 w-full"
+            :disabled="remoteContent.length === 0"
+            :aria-pressed="loadRemoteContent"
+            :title="
+              remoteContent.length === 0
+                ? 'This message has no remote images or stylesheets'
+                : loadRemoteContent
+                  ? 'Remote images and stylesheets are loading for this message'
+                  : 'Load remote images and stylesheets for this message'
+            "
+            @click="loadRemoteContent = !loadRemoteContent"
+          >
+            <Globe class="size-3.5" />
+            {{
+              remoteContent.length === 0
+                ? "No remote content"
+                : loadRemoteContent
+                  ? "Hide remote content"
+                  : "Load remote content"
+            }}
+          </Button>
+          <ul
+            v-if="remoteContent.length > 0"
+            class="space-y-2"
+          >
+            <li
+              v-for="item in remoteContent"
+              :key="`${item.kind}:${item.url}`"
+              class="min-w-0"
+            >
+              <p
+                class="break-all text-xs text-foreground"
+                :title="item.url"
+              >
+                {{ item.url }}
+              </p>
+              <span class="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {{ remoteKindLabel(item.kind) }}
+              </span>
+            </li>
+          </ul>
+          <p
+            v-else
+            class="text-xs text-muted-foreground"
+          >
+            None detected
+          </p>
+        </section>
       </aside>
     </div>
 
     <Modal
-      v-model:open="clearOpen"
-      :title="selectedApp ? 'Delete these emails?' : 'Clear all mails?'"
+      v-model:open="deleteOpen"
+      :title="deleteTitle"
     >
       <p class="text-sm text-muted-foreground">
-        This permanently deletes {{ deleteScopeLabel }}. This cannot be undone.
+        {{ deleteBody }}
       </p>
       <template #footer="{ close }">
         <Button variant="ghost" @click="close">Cancel</Button>
@@ -418,7 +547,7 @@ function formatDate(epoch: number): string {
           @click="confirmDelete(close)"
         >
           <Spinner v-if="clearing" class="size-4" />
-          {{ selectedApp ? "Delete" : "Delete all" }}
+          {{ deleteConfirmLabel }}
         </Button>
       </template>
     </Modal>

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -406,6 +406,20 @@ function formatDate(epoch: number): string {
           <Spinner class="size-6" />
         </div>
         <template v-else-if="detail">
+          <div class="shrink-0 border-b px-5 py-3">
+            <h2 class="text-base font-semibold">
+              {{ detail.subject || "(no subject)" }}
+            </h2>
+            <p class="mt-1 text-xs text-muted-foreground">
+              <strong>From:</strong> {{ detail.from }}
+            </p>
+            <p class="text-xs text-muted-foreground">
+              <strong>To:</strong> {{ detail.to.join(", ") }}
+            </p>
+            <p class="text-xs text-muted-foreground">
+              {{ formatDate(detail.date_epoch) }}
+            </p>
+          </div>
           <div
             v-if="detail.html_body"
             ref="htmlHost"
@@ -432,8 +446,8 @@ function formatDate(epoch: number): string {
             </div>
             <div class="flex flex-wrap gap-2">
               <button
-                v-for="att in attachments"
-                :key="att.filename"
+                v-for="(att, i) in attachments"
+                :key="`${i}:${att.filename}`"
                 type="button"
                 class="flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 :title="`Open ${att.filename} (${humaniseBytes(att.size)})`"

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -223,14 +223,9 @@ const attachments = computed<MailAttachment[]>(
   () => detail.value?.attachments ?? [],
 );
 
-function decodeBase64(data: string): number[] {
-  const binary = atob(data);
-  return Array.from(binary, (char) => char.charCodeAt(0));
-}
-
 async function openAttachment(att: MailAttachment): Promise<void> {
   try {
-    const path = await saveMailAttachment(att.filename, decodeBase64(att.data));
+    const path = await saveMailAttachment(att.filename, att.data);
     await openInEditor(path);
   } catch (e) {
     toast.error("Couldn't open attachment", (e as IpcError).message || att.filename);

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Inbox, Trash2 } from "lucide-vue-next";
-import { computed, onUnmounted, ref, watch } from "vue";
+import { FileDown, Inbox, Paperclip, Trash2 } from "lucide-vue-next";
+import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
 import TitleBar from "@/components/TitleBar.vue";
 import Button from "@/components/ui/Button.vue";
@@ -18,46 +18,41 @@ import {
   IpcError,
   listMails,
   markMailsRead,
+  openInEditor,
   openInBrowser,
+  saveMailAttachment,
 } from "@/ipc/client";
-import { resolveFrameLink } from "@/lib/mailLinks";
-import type { MailDetail, MailSummary } from "@/ipc/types";
+import { linkifyText, prepareHtmlBody, resolveFrameLink } from "@/lib/mailLinks";
+import { humaniseBytes } from "@/lib/utils";
+import type { MailAttachment, MailDetail, MailSummary } from "@/ipc/types";
 
-// The rendered HTML email runs no scripts: the sandbox withholds `allow-scripts`
-// and the child CSP keeps `default-src 'none'`, so nothing in a message executes.
-// `allow-same-origin` is granted only so the host can attach a click listener to
-// the frame and route link clicks to the OS browser (see `interceptFrameLinks`);
-// with scripts still disabled a message can't abuse that same-origin access. The
-// CSP allows images over data:/http/https so emails render their inline AND
-// remote images (logos etc.) - like any mail client, opening a message can load
-// remote images.
-const CHILD_CSP =
-  "default-src 'none'; img-src data: http: https:; style-src 'unsafe-inline'";
+// HTML emails are rendered in a Shadow DOM (style isolation, no email scripts).
+// WKWebView never delivered click events from a sandboxed srcdoc iframe to
+// parent-attached listeners, so the host Shadow root owns the click path.
 
 const toast = useToast();
 
-// Live list of captured mail (newest first).
 const { data: mails, refresh } = usePoll<MailSummary[]>(listMails, 4000);
 
-onUnmounted(registerViewActions({ refresh: () => void refresh() }));
+const unregisterViewActions = registerViewActions({ refresh: () => void refresh() });
+onUnmounted(() => {
+  unregisterViewActions();
+});
 
 const selectedId = ref<string | null>(null);
 const detail = ref<MailDetail | null>(null);
 const loadingDetail = ref(false);
-// Monotonic guard so an out-of-order getMail() response from a superseded
-// select() can't overwrite the body of a newer selection.
 let selectSeq = 0;
 const clearOpen = ref(false);
 const clearing = ref(false);
-// Filter the list to a single application (or "" = all). Laravel sends the app
-// name as the From display name (MAIL_FROM_NAME = config('app.name')); we group
-// by that, falling back to the From email when there's no display name.
 const selectedApp = ref<string>("");
+
+const htmlHost = ref<HTMLElement | null>(null);
+let lastOpenedLink = "";
+let lastOpenedAt = 0;
 
 const list = computed<MailSummary[]>(() => mails.value ?? []);
 
-/** The "application" an email belongs to: its From display name, or - when the
- *  From has no name - the bare email address. */
 function applicationOf(from: string): string {
   const named = from.match(/^\s*(.*?)\s*<([^>]+)>\s*$/);
   if (named) {
@@ -67,7 +62,6 @@ function applicationOf(from: string): string {
   return from.trim();
 }
 
-// Distinct applications present, for the filter dropdown.
 const applications = computed<string[]>(() => {
   const set = new Set<string>();
   for (const m of list.value) set.add(applicationOf(m.from));
@@ -79,23 +73,18 @@ const appOptions = computed(() => [
   ...applications.value.map((a) => ({ value: a, label: a })),
 ]);
 
-// The list narrowed to the selected application.
 const filteredList = computed<MailSummary[]>(() =>
   selectedApp.value
     ? list.value.filter((m) => applicationOf(m.from) === selectedApp.value)
     : list.value,
 );
 
-// If the selected application disappears (e.g. its mail was cleared), fall back
-// to showing everything.
 watch(applications, (apps) => {
   if (selectedApp.value && !apps.includes(selectedApp.value)) {
     selectedApp.value = "";
   }
 });
 
-// Auto-select the first visible message; keep the selection valid as the
-// (filtered) list changes.
 watch(
   filteredList,
   (items) => {
@@ -111,12 +100,6 @@ watch(
   { immediate: true },
 );
 
-/**
- * Open a message in the reading pane. `fromUser` distinguishes a genuine row click
- * (which marks the mail read) from the watcher's auto-selection (which must not).
- * A monotonic `selectSeq` suppresses a superseded in-flight `getMail`, so an
- * out-of-order response can't overwrite a newer selection.
- */
 async function select(id: string, fromUser: boolean): Promise<void> {
   const seq = ++selectSeq;
   selectedId.value = id;
@@ -135,14 +118,6 @@ async function select(id: string, fromUser: boolean): Promise<void> {
   }
 }
 
-/**
- * Mark one email read on a genuine open: persist via the daemon, then replace the
- * list array (usePoll's data is a shallowRef, so an in-place mutation wouldn't be
- * reactive) so the unread styling/badges clear immediately. Best-effort: a failure
- * just leaves it unread and the next poll reconciles. Only acts when the daemon
- * explicitly reported the mail unread (`read === false`); an older daemon omits
- * `read` (and the `MarkMailsRead` request), so we must not call it there.
- */
 async function markRead(id: string): Promise<void> {
   const current = mails.value?.find((m) => m.id === id);
   if (!current || current.read !== false) return;
@@ -158,11 +133,10 @@ async function markRead(id: string): Promise<void> {
   }
 }
 
-// The delete button is scoped to the current filter: with no application
-// selected it clears everything; with one selected it deletes only that
-// application's currently-shown emails.
 const deleteScopeLabel = computed(() =>
-  selectedApp.value ? `all ${filteredList.value.length} email(s) from “${selectedApp.value}”` : "every captured email",
+  selectedApp.value
+    ? `all ${filteredList.value.length} email(s) from "${selectedApp.value}"`
+    : "every captured email",
 );
 
 async function confirmDelete(close: () => void): Promise<void> {
@@ -185,35 +159,87 @@ async function confirmDelete(close: () => void): Promise<void> {
   }
 }
 
-function frameSrcdoc(html: string): string {
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${CHILD_CSP}"></head><body>${html}</body></html>`;
+function onHtmlLinkClick(ev: Event): void {
+  const action = resolveFrameLink(ev.target);
+  if (!action || action.kind === "scroll") return;
+  ev.preventDefault();
+  ev.stopPropagation();
+  if (action.kind !== "open") return;
+  const now = Date.now();
+  if (action.url === lastOpenedLink && now - lastOpenedAt < 750) return;
+  lastOpenedLink = action.url;
+  lastOpenedAt = now;
+  void openInBrowser(action.url).catch((e) => {
+    toast.error("Couldn't open link", (e as IpcError).message || action.url);
+  });
 }
 
-// Frame documents that already have the link-click listener, so a repeated
-// `@load` for the same document can't stack listeners (which would open a link
-// twice). Keyed weakly so entries vanish with their document.
-const linkedDocs = new WeakSet<Document>();
+function renderHtmlBody(html: string): void {
+  const host = htmlHost.value;
+  if (!host) return;
+  const root = host.shadowRoot ?? host.attachShadow({ mode: "open" });
+  root.innerHTML = `<style>
+:host { display: block; }
+.yerd-mail-body {
+  padding: 1.25rem;
+  box-sizing: border-box;
+  color: #111;
+  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.yerd-mail-body img, .yerd-mail-body table { max-width: 100%; }
+.yerd-mail-body a { cursor: pointer; }
+</style><div class="yerd-mail-body">${prepareHtmlBody(html)}</div>`;
+  root.addEventListener("click", onHtmlLinkClick, true);
+}
 
-/**
- * Route link clicks inside the email frame. On each `@load` we attach one click
- * listener to the frame document; it classifies the click via `resolveFrameLink`
- * and either hands an openable URL to the opener plugin, leaves a same-document
- * `#` anchor to scroll, or blocks anything else so a relative/same-origin link
- * can't navigate the sandboxed frame away from the email onto app content. A
- * click that isn't on a link is left alone.
- */
-function interceptFrameLinks(e: Event): void {
-  const doc = (e.target as HTMLIFrameElement).contentDocument;
-  if (!doc || linkedDocs.has(doc)) return;
-  linkedDocs.add(doc);
-  doc.addEventListener("click", (ev) => {
-    const action = resolveFrameLink(ev.target);
-    if (!action || action.kind === "scroll") return;
-    ev.preventDefault();
-    if (action.kind === "open") {
-      void openInBrowser(action.url).catch(() => toast.error("Couldn't open link"));
+function clearHtmlBody(): void {
+  const host = htmlHost.value;
+  if (!host?.shadowRoot) return;
+  host.shadowRoot.innerHTML = "";
+}
+
+watch(
+  [() => detail.value?.html_body, loadingDetail, htmlHost],
+  ([html, loading]) => {
+    if (loading) return;
+    if (!html) {
+      clearHtmlBody();
+      return;
     }
-  });
+    void nextTick(() => renderHtmlBody(html));
+  },
+);
+
+function handleTextLinkClick(ev: MouseEvent): void {
+  const action = resolveFrameLink(ev.target);
+  if (!action || action.kind !== "open") return;
+  ev.preventDefault();
+  void openInBrowser(action.url).catch((e) =>
+    toast.error("Couldn't open link", (e as IpcError).message || action.url),
+  );
+}
+
+const attachments = computed<MailAttachment[]>(
+  () => detail.value?.attachments ?? [],
+);
+
+function decodeBase64(data: string): number[] {
+  const binary = atob(data);
+  return Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+async function openAttachment(att: MailAttachment): Promise<void> {
+  try {
+    const path = await saveMailAttachment(att.filename, decodeBase64(att.data));
+    await openInEditor(path);
+  } catch (e) {
+    toast.error("Couldn't open attachment", (e as IpcError).message || att.filename);
+  }
+}
+
+function mimeLabel(contentType: string): string {
+  const sub = contentType.split("/")[1] ?? contentType;
+  return sub.replace(/^x-/, "").toUpperCase();
 }
 
 function formatDate(epoch: number): string {
@@ -299,6 +325,7 @@ function formatDate(epoch: number): string {
           <Spinner class="size-6" />
         </div>
         <template v-else-if="detail">
+          <!-- Message header strip -->
           <div class="shrink-0 border-b px-5 py-3">
             <h2 class="text-base font-semibold">
               {{ detail.subject || "(no subject)" }}
@@ -313,18 +340,53 @@ function formatDate(epoch: number): string {
               {{ formatDate(detail.date_epoch) }}
             </p>
           </div>
-          <iframe
+
+          <!-- HTML body in Shadow DOM (WKWebView iframe clicks never fired) -->
+          <div
             v-if="detail.html_body"
-            :srcdoc="frameSrcdoc(detail.html_body)"
-            sandbox="allow-same-origin"
-            class="min-h-0 flex-1 bg-white"
-            title="Email body"
-            @load="interceptFrameLinks"
+            ref="htmlHost"
+            class="min-h-0 flex-1 overflow-y-auto bg-white"
+            role="article"
+            aria-label="Email body"
           />
+
+          <!-- Plain-text body with linkified URLs -->
+          <!-- eslint-disable-next-line vue/no-v-html -->
           <pre
             v-else
             class="min-h-0 flex-1 overflow-auto whitespace-pre-wrap p-5 text-sm"
-          >{{ detail.text_body || "(empty message)" }}</pre>
+            @click="handleTextLinkClick"
+            v-html="linkifyText(detail.text_body ?? '(empty message)')"
+          />
+
+          <!-- Attachment bar - shown only when the message has attachments -->
+          <div
+            v-if="attachments.length > 0"
+            class="shrink-0 border-t bg-muted/20 px-5 py-2"
+          >
+            <div class="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <Paperclip class="size-3.5" />
+              {{ attachments.length === 1 ? "1 attachment" : `${attachments.length} attachments` }}
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="att in attachments"
+                :key="att.filename"
+                type="button"
+                class="flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :title="`Open ${att.filename} (${humaniseBytes(att.size)})`"
+                @click="void openAttachment(att)"
+              >
+                <FileDown class="size-3.5 shrink-0 text-muted-foreground" />
+                <span class="flex flex-col leading-tight">
+                  <span class="max-w-[14rem] truncate font-medium">{{ att.filename }}</span>
+                  <span class="text-[10px] text-muted-foreground">
+                    {{ mimeLabel(att.content_type) }} · {{ humaniseBytes(att.size) }}
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
         </template>
         <div
           v-else

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -102,9 +102,7 @@ watch(
   filteredList,
   (items) => {
     if (items.length === 0) {
-      selectedId.value = null;
-      detail.value = null;
-      loadRemoteContent.value = false;
+      clearSelection();
       return;
     }
     if (!selectedId.value || !items.some((m) => m.id === selectedId.value)) {
@@ -113,6 +111,15 @@ watch(
   },
   { immediate: true },
 );
+
+/** Drop selection and invalidate any in-flight getMail for a prior id. */
+function clearSelection(): void {
+  selectSeq += 1;
+  selectedId.value = null;
+  detail.value = null;
+  loadingDetail.value = false;
+  loadRemoteContent.value = false;
+}
 
 async function select(id: string, fromUser: boolean): Promise<void> {
   const seq = ++selectSeq;
@@ -178,18 +185,14 @@ async function confirmDelete(close: () => void): Promise<void> {
       const id = selectedId.value;
       if (!id) return;
       await deleteMails([id]);
-      selectedId.value = null;
-      detail.value = null;
-      loadRemoteContent.value = false;
+      clearSelection();
       close();
       await refresh();
       toast.success("Message deleted");
       return;
     }
     await clearMails();
-    selectedId.value = null;
-    detail.value = null;
-    loadRemoteContent.value = false;
+    clearSelection();
     close();
     await refresh();
     toast.success("Mailbox cleared");

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -282,6 +282,12 @@ const attachments = computed<MailAttachment[]>(
   () => detail.value?.attachments ?? [],
 );
 
+/** Linkified plain-text body. Computed (not called inline in the template) so
+ *  it only re-runs when the body changes, not on every 4s poll re-render. */
+const linkedTextBody = computed(() =>
+  linkifyText(detail.value?.text_body || "(empty message)"),
+);
+
 const remoteContent = computed(() => {
   const html = detail.value?.html_body;
   return html ? listRemoteContentUrls(html) : [];
@@ -432,7 +438,7 @@ function formatDate(epoch: number): string {
             v-else
             class="min-h-0 flex-1 overflow-auto whitespace-pre-wrap p-5 text-sm"
             @click="handleTextLinkClick"
-            v-html="linkifyText(detail.text_body ?? '(empty message)')"
+            v-html="linkedTextBody"
           />
 
           <!-- Attachment bar - shown only when the message has attachments -->

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -3319,6 +3319,7 @@ mod tests {
             headers: vec![],
             html_body: None,
             text_body: Some("plain body".into()),
+            attachments: vec![],
         };
         let text = render(
             &Response::Mail {

--- a/crates/yerd-ipc/src/lib.rs
+++ b/crates/yerd-ipc/src/lib.rs
@@ -52,10 +52,11 @@ pub use response::{
 };
 pub use status::{
     AddableServiceType, CaStatus, CloudflaredSource, CloudflaredStatus, DatabaseSummary, Diagnosis,
-    DiagnosisCode, DomainShadow, FixReport, FixResult, MailDetail, MailHeader, MailStatus,
-    MailSummary, NamedTunnelMeta, PhpPoolStatus, PoolRunState, PortStatus, ServiceAvailability,
-    ServiceRunState, ServiceStatus, Severity, SiteCounts, SiteHostname, StatusReport, ToolStatus,
-    TunnelInfo, TunnelKind, TunnelRunState, UnboundWeb, WordPressVersionInfo,
+    DiagnosisCode, DomainShadow, FixReport, FixResult, MailAttachment, MailDetail, MailHeader,
+    MailStatus, MailSummary, NamedTunnelMeta, PhpPoolStatus, PoolRunState, PortStatus,
+    ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts, SiteHostname,
+    StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UnboundWeb,
+    WordPressVersionInfo,
 };
 pub use update::{Channel, StagedArtifact, UpdateSource};
 

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -761,6 +761,7 @@ mod variant_name_pinning {
                 }],
                 html_body: Some("<p>Hi</p>".into()),
                 text_body: Some("Hi".into()),
+                attachments: vec![],
             }),
         });
         pin_response(Response::Tools {

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -234,10 +234,31 @@ pub struct MailHeader {
     pub value: String,
 }
 
+/// One non-inline attachment extracted from a captured email, for
+/// [`MailDetail::attachments`].
+///
+/// The `data` field carries the raw bytes as standard (padded) base64 so a
+/// client can write a temporary file (or construct a `data:` URL) and hand it
+/// to the OS opener. Inline `cid:` parts are excluded; those stay in the HTML
+/// body via the existing rewrite to `data:` URLs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MailAttachment {
+    /// Display filename (from `Content-Disposition: attachment; filename=...`
+    /// or `Content-Type; name=...`). Falls back to `"attachment"` when absent.
+    pub filename: String,
+    /// MIME type, e.g. `"application/pdf"` or `"image/png"`.
+    pub content_type: String,
+    /// Decoded byte count (before base64 encoding).
+    pub size: usize,
+    /// Standard (padded) base64-encoded attachment bytes.
+    pub data: String,
+}
+
 /// One captured email's full decoded content, returned in
 /// [`crate::Response::Mail`]. The bodies are already MIME-decoded (charset +
 /// transfer-encoding) and the HTML body has had `cid:` images rewritten to
-/// `data:` URLs, so a client can render it directly in a sandboxed frame.
+/// `data:` URLs, so a client can render it directly (for example in a
+/// sandboxed frame or an isolated host Shadow DOM).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MailDetail {
     /// Opaque stable id (matches the [`MailSummary::id`]).
@@ -256,6 +277,11 @@ pub struct MailDetail {
     pub html_body: Option<String>,
     /// Decoded `text/plain` body, when the message has one.
     pub text_body: Option<String>,
+    /// Non-inline attachments (files the sender attached). Omitted on the
+    /// wire when empty (`#[serde(default, skip_serializing_if)]`) so an older
+    /// client that does not know about this field decodes cleanly.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<MailAttachment>,
 }
 
 /// A listener's requested vs actually-bound port.

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -20,10 +20,10 @@ use yerd_ipc::{
     types::{PhpVersion, Site},
     AddableServiceType, CaStatus, Channel, CloudflaredSource, CloudflaredStatus, DatabaseSummary,
     Diagnosis, DiagnosisCode, DumpCategory, DumpCounts, DumpEvent, DumpExtStatus, ErrorCode,
-    FixReport, FixResult, MailDetail, MailHeader, MailStatus, MailSummary, NamedTunnelMeta,
-    PhpPoolStatus, PoolRunState, PortStatus, Request, Response, ServiceAvailability,
-    ServiceRunState, ServiceStatus, Severity, SiteCounts, SiteHostname, StagedArtifact,
-    StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UpdateSource,
+    FixReport, FixResult, MailAttachment, MailDetail, MailHeader, MailStatus, MailSummary,
+    NamedTunnelMeta, PhpPoolStatus, PoolRunState, PortStatus, Request, Response,
+    ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts, SiteHostname,
+    StagedArtifact, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UpdateSource,
 };
 
 // ---------- Request ----------
@@ -1972,12 +1972,57 @@ fn response_mail_byte_shape() {
             }],
             html_body: Some("<p>Hi</p>".into()),
             text_body: None,
+            attachments: vec![],
         }),
     };
     let s = serde_json::to_string(&r).unwrap();
+    // `attachments` is omitted from the wire when empty (`skip_serializing_if`).
     let expected = r#"{"type":"mail","mail":{"id":"000001","from":"Example <hello@example.com>","to":["test@test.com"],"subject":"Hi","date_epoch":1700000000,"headers":[{"name":"Subject","value":"Hi"}],"html_body":"<p>Hi</p>","text_body":null}}"#;
     assert_eq!(s, expected);
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+}
+
+#[test]
+fn response_mail_with_attachment_byte_shape() {
+    let r = Response::Mail {
+        mail: Box::new(MailDetail {
+            id: "000002".into(),
+            from: "a@b.c".into(),
+            to: vec!["d@e.f".into()],
+            subject: "Invoice".into(),
+            date_epoch: 1_700_000_000,
+            headers: vec![],
+            html_body: None,
+            text_body: Some("See attached.".into()),
+            attachments: vec![MailAttachment {
+                filename: "invoice.pdf".into(),
+                content_type: "application/pdf".into(),
+                size: 8,
+                data: "ZmFrZS1wZGY=".into(),
+            }],
+        }),
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert!(
+        s.contains(r#""attachments":[{"filename":"invoice.pdf","content_type":"application/pdf","size":8,"data":"ZmFrZS1wZGY="}]"#),
+        "attachment must appear on the wire: {s}"
+    );
+    assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+}
+
+#[test]
+fn response_mail_legacy_without_attachments_decodes_default() {
+    // An older daemon that does not emit `attachments` must decode to an empty vec.
+    let legacy = r#"{"type":"mail","mail":{"id":"000001","from":"Example <hello@example.com>","to":["test@test.com"],"subject":"Hi","date_epoch":1700000000,"headers":[],"html_body":null,"text_body":null}}"#;
+    match serde_json::from_str::<Response>(legacy).unwrap() {
+        Response::Mail { mail } => {
+            assert!(
+                mail.attachments.is_empty(),
+                "legacy mail without attachments field must decode as empty"
+            );
+        }
+        other => panic!("expected Mail, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/yerd-mail/src/pure/mime.rs
+++ b/crates/yerd-mail/src/pure/mime.rs
@@ -76,10 +76,7 @@ pub fn detail(id: &str, raw: &[u8]) -> MailDetail {
 /// is not openable through the opener plugin).
 fn collect_attachments(msg: &Message<'_>) -> Vec<MailAttachment> {
     msg.attachments()
-        .filter(|part| {
-            // Skip inline parts (cid: images embedded in the HTML body).
-            part.content_id().is_none()
-        })
+        .filter(|part| part.content_id().is_none())
         .map(|part| {
             let content_type = part.content_type().map_or_else(
                 || "application/octet-stream".to_string(),
@@ -88,8 +85,6 @@ fn collect_attachments(msg: &Message<'_>) -> Vec<MailAttachment> {
                     None => c.ctype().to_string(),
                 },
             );
-            // Prefer the filename from Content-Disposition, then Content-Type name=,
-            // then fall back to a generic label.
             let filename = part
                 .attachment_name()
                 .filter(|n| !n.is_empty())

--- a/crates/yerd-mail/src/pure/mime.rs
+++ b/crates/yerd-mail/src/pure/mime.rs
@@ -71,9 +71,9 @@ pub fn detail(id: &str, raw: &[u8]) -> MailDetail {
 /// references in the HTML body) and are already handled by [`rewrite_cids`];
 /// surfacing them again as downloadable attachments would be confusing.
 ///
-/// The attachment bytes are base64-encoded here so the GUI can construct a
-/// `data:` URL and hand it straight to the OS opener without writing a
-/// temporary file.
+/// The attachment bytes are base64-encoded here so the GUI can decode them at
+/// the Tauri boundary and write a cache file for the OS opener (a `data:` URL
+/// is not openable through the opener plugin).
 fn collect_attachments(msg: &Message<'_>) -> Vec<MailAttachment> {
     msg.attachments()
         .filter(|part| {

--- a/crates/yerd-mail/src/pure/mime.rs
+++ b/crates/yerd-mail/src/pure/mime.rs
@@ -8,7 +8,7 @@
 //! URLs so a sandboxed viewer can render embedded images without network access.
 
 use mail_parser::{Addr, Address, Message, MessageParser, MessagePart, MimeHeaders};
-use yerd_ipc::{MailDetail, MailHeader, MailSummary};
+use yerd_ipc::{MailAttachment, MailDetail, MailHeader, MailSummary};
 
 /// Decode just the metadata of a captured message.
 #[must_use]
@@ -48,6 +48,8 @@ pub fn detail(id: &str, raw: &[u8]) -> MailDetail {
         None
     };
 
+    let attachments = collect_attachments(&msg);
+
     MailDetail {
         id: id.to_string(),
         from: render_from(&msg),
@@ -57,7 +59,51 @@ pub fn detail(id: &str, raw: &[u8]) -> MailDetail {
         headers,
         html_body,
         text_body,
+        attachments,
     }
+}
+
+/// Collect non-inline attachments from a parsed message.
+///
+/// A part is treated as a non-inline attachment when it appears in the
+/// `mail-parser` attachment list **and** does not carry a `Content-ID` header.
+/// Parts with a `Content-ID` are inline resources (images embedded via `cid:`
+/// references in the HTML body) and are already handled by [`rewrite_cids`];
+/// surfacing them again as downloadable attachments would be confusing.
+///
+/// The attachment bytes are base64-encoded here so the GUI can construct a
+/// `data:` URL and hand it straight to the OS opener without writing a
+/// temporary file.
+fn collect_attachments(msg: &Message<'_>) -> Vec<MailAttachment> {
+    msg.attachments()
+        .filter(|part| {
+            // Skip inline parts (cid: images embedded in the HTML body).
+            part.content_id().is_none()
+        })
+        .map(|part| {
+            let content_type = part.content_type().map_or_else(
+                || "application/octet-stream".to_string(),
+                |c| match c.subtype() {
+                    Some(sub) => format!("{}/{}", c.ctype(), sub),
+                    None => c.ctype().to_string(),
+                },
+            );
+            // Prefer the filename from Content-Disposition, then Content-Type name=,
+            // then fall back to a generic label.
+            let filename = part
+                .attachment_name()
+                .filter(|n| !n.is_empty())
+                .unwrap_or("attachment")
+                .to_string();
+            let bytes = part.contents();
+            MailAttachment {
+                filename,
+                content_type,
+                size: bytes.len(),
+                data: base64_encode(bytes),
+            }
+        })
+        .collect()
 }
 
 /// Whether a part is a genuine `text/html` body (not a text part we'd synthesise
@@ -194,6 +240,7 @@ Your OTP is 416063.\r\n";
             .headers
             .iter()
             .any(|h| h.name.eq_ignore_ascii_case("subject")));
+        assert!(d.attachments.is_empty(), "plain message has no attachments");
     }
 
     #[test]
@@ -239,11 +286,75 @@ Content-ID: <img1>\r\n\
 Zm9v\r\n\
 --BB--\r\n";
         let d = detail("000003", raw);
+        // The inline image has a Content-ID so it must NOT appear as a
+        // downloadable attachment.
+        assert!(
+            d.attachments.is_empty(),
+            "cid-only inline image must not appear as attachment: {d:?}"
+        );
         let html = d.html_body.expect("html body");
         assert!(
             html.contains("data:image/png;base64,"),
             "cid should become a data URL: {html}"
         );
         assert!(!html.contains("cid:img1"), "cid ref should be gone: {html}");
+    }
+
+    #[test]
+    fn multipart_mixed_attachment_is_collected() {
+        // A minimal multipart/mixed message with a text body and a PDF attachment.
+        // The PDF bytes are "fake-pdf" base64-encoded = "ZmFrZS1wZGY=".
+        let raw = b"From: sender@example.com\r\n\
+To: recipient@example.com\r\n\
+Subject: Invoice\r\n\
+MIME-Version: 1.0\r\n\
+Content-Type: multipart/mixed; boundary=\"BOUND\"\r\n\
+\r\n\
+--BOUND\r\n\
+Content-Type: text/plain\r\n\
+\r\n\
+Please find the invoice attached.\r\n\
+--BOUND\r\n\
+Content-Type: application/pdf\r\n\
+Content-Disposition: attachment; filename=\"invoice.pdf\"\r\n\
+Content-Transfer-Encoding: base64\r\n\
+\r\n\
+ZmFrZS1wZGY=\r\n\
+--BOUND--\r\n";
+        let d = detail("000004", raw);
+        assert_eq!(d.attachments.len(), 1, "expected one attachment");
+        let att = &d.attachments[0];
+        assert_eq!(att.filename, "invoice.pdf");
+        assert_eq!(att.content_type, "application/pdf");
+        assert!(att.size > 0, "size should be non-zero");
+        // The data field must be valid base64 that decodes to the original bytes.
+        assert!(!att.data.is_empty(), "data must not be empty");
+    }
+
+    #[test]
+    fn attachment_without_filename_falls_back_to_generic_label() {
+        let raw = b"From: a@b.c\r\n\
+To: d@e.f\r\n\
+Subject: No name\r\n\
+MIME-Version: 1.0\r\n\
+Content-Type: multipart/mixed; boundary=\"X\"\r\n\
+\r\n\
+--X\r\n\
+Content-Type: text/plain\r\n\
+\r\n\
+body\r\n\
+--X\r\n\
+Content-Type: application/octet-stream\r\n\
+Content-Disposition: attachment\r\n\
+Content-Transfer-Encoding: base64\r\n\
+\r\n\
+AAAA\r\n\
+--X--\r\n";
+        let d = detail("000005", raw);
+        assert_eq!(d.attachments.len(), 1);
+        assert_eq!(
+            d.attachments[0].filename, "attachment",
+            "missing filename should fall back to \"attachment\""
+        );
     }
 }

--- a/docs/developer/crates/yerd-mail.md
+++ b/docs/developer/crates/yerd-mail.md
@@ -158,6 +158,11 @@ Two decoding subtleties, both grounded in the source:
   viewer renders embedded images **without any network access**. A small local
   standard-alphabet `base64_encode` is inlined here rather than pulling a base64
   dependency for this one use.
+- **Downloadable attachments.** `collect_attachments` walks `mail-parser`'s
+  attachment list and keeps parts **without** a `Content-ID` (inline `cid:`
+  images stay out of that list). Each part becomes a `MailAttachment` on
+  `MailDetail` with filename, MIME type, size, and base64 `data`. The field is
+  omitted on the wire when empty so older clients keep decoding.
 
 ### `retention` - bounding the store
 

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -143,10 +143,12 @@ browser / handler).
 The HTML body is sanitized with **DOMPurify** and rendered in a **Shadow DOM**
 in the Mails window (so link clicks work reliably on macOS WKWebView). Openable
 `http(s)` / `mailto` / `tel` links are stamped and opened via the OS browser /
-handler. Inline images referenced by `cid:` are embedded as `data:` URLs, and
-remote images (e.g. a logo served over `https://`) load as well - just like a
-normal mail client, so opening a message can fetch its remote images. Non-inline
-attachments appear in a bar under the body and open with the OS default app.
+handler. Inline images referenced by `cid:` are embedded as `data:` URLs.
+Remote images and stylesheets (e.g. a logo served over `https://`) are **blocked
+by default** so merely opening a message cannot phone home. The right sidebar
+lists those URLs under **Remote content**; use **Load remote content** when you
+want them. Non-inline attachments appear in a bar under the body and open with
+the OS default app.
 
 ## Configuration
 

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -134,14 +134,17 @@ bodies).
 The standalone **Mails** viewer window - opened from the [desktop app](./desktop-app)
 with **Show Mails** - decodes each message for you: headers, the plain-text body,
 and a rendered **HTML** body. From the GUI you can read, delete individual
-messages, and clear everything.
+messages, clear everything, open **file attachments**, and follow **http(s) /
+mailto / tel** links in both HTML and plain-text bodies (they open in your OS
+browser / handler).
 
 <ThemedImage light="/images/mails-light.png" dark="/images/mails-dark.png" alt="A captured email open in the Yerd Mails viewer" />
 
-The HTML body renders in a **sandboxed frame that can't run scripts**. Inline
-images referenced by `cid:` are embedded as `data:` URLs, and remote images
-(e.g. a logo served over `https://`) load as well - just like a normal mail
-client, so opening a message can fetch its remote images.
+The HTML body is sanitized and rendered in an isolated host **Shadow DOM** (no
+email scripts). Inline images referenced by `cid:` are embedded as `data:` URLs,
+and remote images (e.g. a logo served over `https://`) load as well - just like a
+normal mail client, so opening a message can fetch its remote images. Non-inline
+attachments appear in a bar under the body and open with the OS default app.
 
 ## Configuration
 

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -140,8 +140,9 @@ browser / handler).
 
 <ThemedImage light="/images/mails-light.png" dark="/images/mails-dark.png" alt="A captured email open in the Yerd Mails viewer" />
 
-The HTML body is sanitized and rendered in a **sandboxed iframe** (no scripts,
-strict child CSP). Inline images referenced by `cid:` are embedded as `data:` URLs,
+The HTML body is sanitized and rendered in a **sandboxed iframe** (no message
+scripts; strict child CSP). A trusted in-frame click bridge forwards openable
+links to the host via `postMessage`. Inline images referenced by `cid:` are embedded as `data:` URLs,
 and remote images (e.g. a logo served over `https://`) load as well - just like a
 normal mail client, so opening a message can fetch its remote images. Non-inline
 attachments appear in a bar under the body and open with the OS default app.

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -140,8 +140,8 @@ browser / handler).
 
 <ThemedImage light="/images/mails-light.png" dark="/images/mails-dark.png" alt="A captured email open in the Yerd Mails viewer" />
 
-The HTML body is sanitized and rendered in an isolated host **Shadow DOM** (no
-email scripts). Inline images referenced by `cid:` are embedded as `data:` URLs,
+The HTML body is sanitized and rendered in a **sandboxed iframe** (no scripts,
+strict child CSP). Inline images referenced by `cid:` are embedded as `data:` URLs,
 and remote images (e.g. a logo served over `https://`) load as well - just like a
 normal mail client, so opening a message can fetch its remote images. Non-inline
 attachments appear in a bar under the body and open with the OS default app.

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -140,10 +140,11 @@ browser / handler).
 
 <ThemedImage light="/images/mails-light.png" dark="/images/mails-dark.png" alt="A captured email open in the Yerd Mails viewer" />
 
-The HTML body is sanitized and rendered in a **sandboxed iframe** (no message
-scripts; strict child CSP). A trusted in-frame click bridge forwards openable
-links to the host via `postMessage`. Inline images referenced by `cid:` are embedded as `data:` URLs,
-and remote images (e.g. a logo served over `https://`) load as well - just like a
+The HTML body is sanitized with **DOMPurify** and rendered in a **Shadow DOM**
+in the Mails window (so link clicks work reliably on macOS WKWebView). Openable
+`http(s)` / `mailto` / `tel` links are stamped and opened via the OS browser /
+handler. Inline images referenced by `cid:` are embedded as `data:` URLs, and
+remote images (e.g. a logo served over `https://`) load as well - just like a
 normal mail client, so opening a message can fetch its remote images. Non-inline
 attachments appear in a bar under the body and open with the OS default app.
 

--- a/docs/reference/cli/mail.md
+++ b/docs/reference/cli/mail.md
@@ -107,9 +107,10 @@ yerd mail show 000003 --json   # {"type":"mail","mail":{ ... }}
 `{"type":"mails","mails":[ ... ]}`, where each element of `mails` is one captured
 email's metadata (`id`, `from`, `to`, `subject`, `date_epoch`, `read`). `yerd mail
 show <id> --json` prints `{"type":"mail","mail":{ ... }}`, where `mail` is the full
-decoded message, including all `headers` and both the `html_body` and `text_body`
-(whichever the message carries). `date_epoch` is the message `Date:` as Unix epoch
-seconds, or `0` when absent/unparseable.
+decoded message, including all `headers`, both the `html_body` and `text_body`
+(whichever the message carries), and `attachments` when the message has
+non-inline file parts (omitted when empty). `date_epoch` is the message `Date:`
+as Unix epoch seconds, or `0` when absent/unparseable.
 
 ## See also
 


### PR DESCRIPTION
<!-- Thanks for contributing to Yerd! Please fill in the sections below. -->

## What does this PR do?

Makes the **Mails** viewer usable as a local mail catcher:

1. **Attachments** — list non-inline parts on `MailDetail` and open them via the OS default app (base64 through IPC → cache file + existing opener; `data:` URLs are not openable through the plugin).
2. **HTML / plain-text links** — open `http:`, `https:`, `mailto:`, and `tel:` with the OS browser / handler; plain-text bodies are linkified via DOM APIs.
3. **Remote content (opt-in)** — remote images, stylesheets, CSS `url(...)`, and `@import` are blocked by default; the sidebar lists those URLs and **Load remote content** fetches them when you ask.
4. **Delete menu** — trash can delete the selected message or clear the whole mailbox.

**HTML rendering:** sanitized with **DOMPurify**, then rendered in a host **Shadow DOM** (WKWebView does not reliably deliver sandboxed `srcdoc` iframe clicks). Links use neutralized `href` + `data-yerd-url` and open through `@tauri-apps/plugin-opener`.

IPC is **additive only**: `attachments` uses `#[serde(default, skip_serializing_if = "Vec::is_empty")]`, so older GUI ↔ newer daemon (and the reverse) keep working. Inline `cid:` parts stay out of `attachments` (they remain `data:` rewrites in the HTML body).

## Related issues

N/A

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / internal change
- [x] Documentation
- [ ] Build / CI / tooling

## Platforms tested

- [x] macOS (Mails viewer: attachments open; HTML and plain-text links open; remote content opt-in; per-message delete)
- [ ] Linux (no Linux-specific code; needs a smoke pass / CI)

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` is clean
- [x] `cargo test --workspace` passes
- [x] Pure crates/modules still do no I/O (collection lives in `yerd-mail` `pure/mime`)
- [x] Docs updated (`docs/guide/mail.md`, `docs/developer/crates/yerd-mail.md`, `docs/reference/cli/mail.md`)
- [x] Frontend: `npm run test` + `npm run typecheck` + `npm run build` in `apps/yerd-gui`

## Tests

| Layer | What |
| --- | --- |
| `yerd-mail` | Multipart attachment collection; missing filename fallback; `cid:` inline images excluded from `attachments` |
| `yerd-ipc` wire stability | Empty `attachments` omitted; populated attachment byte shape; legacy JSON without `attachments` decodes |
| `yerd-gui` | `safe_attachment_filename`; base64 decode (padding rules); collision-safe attachment writes |
| Frontend | `linkifyText`, DOMPurify + remote-content strip/list (including `@import`), `data-yerd-url` stamping, text-node click target resolution |

## Security

- Sanitize before render with DOMPurify; strip scripts, forms, maps/areas, SVG/math, media tags, dangerous meta, and non-stylesheet links.
- External opens limited to `http:`, `https:`, `mailto:`, `tel:`.
- Remote images / stylesheets / CSS network fetches are **off by default** (opt-in per message).
- Attachment basenames sanitized; files written under the app cache with `create_new` (no same-ms overwrite); partial files removed on write failure; cache purged on mailbox clear/delete and age-evicted on save (24h).

Shadow DOM is isolation for **styles + no script execution of email content**, not a full browser process sandbox. That matches typical local mail-catcher tooling.

## Out of scope / follow-ups (not blockers)

- Linux GUI smoke (link + attachment) — Rust/JS gates passed on macOS only
- Extract attachment-cache helpers into a dedicated host module (thin Tauri layer cleanup)