### PR TITLE
[Fix] Name release signatures .minisig so pacman -U no longer rejects Arch packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,8 @@ jobs:
         working-directory: dist
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          # Repo variable to close the legacy `.sig` transition window (see below).
+          RETIRE_LEGACY_SIG: ${{ vars.RETIRE_LEGACY_SIG }}
         run: |
           set -euo pipefail
           if [ -z "${MINISIGN_SECRET_KEY:-}" ]; then
@@ -209,10 +211,17 @@ jobs:
           done
           # Legacy `.sig` copies for the non-pacman kinds only (bounded transition
           # window). NEVER copy for *.pkg.tar.zst: a pacman `.sig` re-creates #157.
-          for f in *.app.tar.gz *.deb *.rpm; do
-            cp -- "$f.minisig" "$f.sig"
-            echo "legacy copy $f.minisig -> $f.sig"
-          done
+          # Closing the window is a deliberate, CI-controlled cutoff: set the repo
+          # variable RETIRE_LEGACY_SIG=true and no `.sig` is published thereafter.
+          # Default (unset) keeps the copies shipping through the transition.
+          if [ "${RETIRE_LEGACY_SIG:-}" = "true" ]; then
+            echo "RETIRE_LEGACY_SIG=true: transition window closed, publishing no legacy .sig copies"
+          else
+            for f in *.app.tar.gz *.deb *.rpm; do
+              cp -- "$f.minisig" "$f.sig"
+              echo "legacy copy $f.minisig -> $f.sig"
+            done
+          fi
 
       # Trust-anchor gate: prove the public key the daemon EMBEDS
       # (`yerd_update::UPDATE_PUBLIC_KEY`) actually verifies these signatures — so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,16 @@ jobs:
       # requires. PRECONDITION: provision `MINISIGN_SECRET_KEY` (generate an
       # *unencrypted* key with `minisign -G -W` to avoid a CI password prompt) and
       # set `UPDATE_PUBLIC_KEY` to its public half before this is load-bearing.
+      #
+      # The published signature is named `<artifact>.minisig`, not `<artifact>.sig`:
+      # pacman reserves `<pkg>.sig` for a detached OpenPGP signature, so a minisign
+      # file under that name makes `pacman -U` hard-fail even at the default
+      # `LocalFileSigLevel = Optional` (#157). For the NON-pacman kinds we also
+      # publish a byte-identical legacy `<artifact>.sig` copy so self-updaters
+      # shipped at v2.0.3 or earlier keep working; a detached minisign signature
+      # verifies the artifact bytes regardless of the sibling filename. That legacy
+      # copy is a bounded transition measure, to be retired once those clients have
+      # moved on; the pacman `.sig` is never re-published (see the guard below).
       - name: Sign update artifacts (minisign)
         working-directory: dist
         env:
@@ -194,8 +204,14 @@ jobs:
           umask 077; printf '%s\n' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/minisign.key"
           shopt -s nullglob
           for f in *.app.tar.gz *.deb *.pkg.tar.zst *.rpm; do
-            minisign -S -H -s "$RUNNER_TEMP/minisign.key" -m "$f" -x "$f.sig"
-            echo "signed $f -> $f.sig"
+            minisign -S -H -s "$RUNNER_TEMP/minisign.key" -m "$f" -x "$f.minisig"
+            echo "signed $f -> $f.minisig"
+          done
+          # Legacy `.sig` copies for the non-pacman kinds only (bounded transition
+          # window). NEVER copy for *.pkg.tar.zst: a pacman `.sig` re-creates #157.
+          for f in *.app.tar.gz *.deb *.rpm; do
+            cp -- "$f.minisig" "$f.sig"
+            echo "legacy copy $f.minisig -> $f.sig"
           done
 
       # Trust-anchor gate: prove the public key the daemon EMBEDS
@@ -217,10 +233,23 @@ jobs:
           fi
           shopt -s nullglob
           for f in *.app.tar.gz *.deb *.pkg.tar.zst *.rpm; do
-            minisign -V -H -P "$KEY" -m "$f" -x "$f.sig" \
-              || { echo "::error::embedded UPDATE_PUBLIC_KEY does not verify $f.sig (key/secret mismatch)"; exit 1; }
+            minisign -V -H -P "$KEY" -m "$f" -x "$f.minisig" \
+              || { echo "::error::embedded UPDATE_PUBLIC_KEY does not verify $f.minisig (key/secret mismatch)"; exit 1; }
             echo "verified $f against embedded key"
           done
+          # Also verify every legacy `.sig` copy against the same key, so a botched
+          # transition-window byte copy can't ship unverified.
+          for s in *.sig; do
+            minisign -V -H -P "$KEY" -m "${s%.sig}" -x "$s" \
+              || { echo "::error::embedded UPDATE_PUBLIC_KEY does not verify legacy $s (key/secret mismatch)"; exit 1; }
+            echo "verified legacy $s against embedded key"
+          done
+          # Regression guard for #157: a pacman `.sig` must never ship. pacman would
+          # mistake it for an OpenPGP signature and hard-fail `pacman -U`.
+          if compgen -G '*.pkg.tar.zst.sig' > /dev/null; then
+            echo "::error::refusing to publish: a *.pkg.tar.zst.sig exists in dist/ (re-creates #157)"
+            exit 1
+          fi
 
       - name: Generate SHA256SUMS
         working-directory: dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,6 +6284,7 @@ version = "2.0.3"
 dependencies = [
  "clap",
  "interprocess",
+ "minisign",
  "nix",
  "serde_json",
  "tempfile",

--- a/bin/yerd/Cargo.toml
+++ b/bin/yerd/Cargo.toml
@@ -37,6 +37,7 @@ nix            = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 yerdd          = { path = "../yerdd" }
+minisign       = { workspace = true }
 tokio          = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
 
 [lints]

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -260,19 +260,28 @@ pub fn run(
     }
 }
 
-/// Re-verify the staged artifact against its sibling `.sig` and the embedded key.
+/// Re-verify the staged artifact against its sibling `.minisig` and the embedded
+/// key.
 fn reverify(staged: &Path) -> Result<(), String> {
-    let bytes = std::fs::read(staged).map_err(|e| format!("reading staged artifact: {e}"))?;
-    let sig_path = sibling_sig(staged);
-    let sig = std::fs::read_to_string(&sig_path)
-        .map_err(|e| format!("reading signature {}: {e}", sig_path.display()))?;
-    verify_minisign(UPDATE_PUBLIC_KEY, &sig, &bytes).map_err(|e| e.to_string())
+    reverify_with_key(staged, UPDATE_PUBLIC_KEY)
 }
 
-/// `<artifact>.sig` beside the staged artifact.
-fn sibling_sig(staged: &Path) -> PathBuf {
+/// [`reverify`] against an explicit public key, so tests can exercise the sibling
+/// path + verification against a throwaway keypair (production passes
+/// [`UPDATE_PUBLIC_KEY`]).
+fn reverify_with_key(staged: &Path, public_key: &str) -> Result<(), String> {
+    let bytes = std::fs::read(staged).map_err(|e| format!("reading staged artifact: {e}"))?;
+    let sig_path = sibling_minisig(staged);
+    let sig = std::fs::read_to_string(&sig_path)
+        .map_err(|e| format!("reading signature {}: {e}", sig_path.display()))?;
+    verify_minisign(public_key, &sig, &bytes).map_err(|e| e.to_string())
+}
+
+/// `<artifact>.minisig` beside the staged artifact. `.minisig` (not `.sig`)
+/// because pacman reserves `<pkg>.sig` for `OpenPGP`; see issue #157.
+fn sibling_minisig(staged: &Path) -> PathBuf {
     let mut name = staged.file_name().unwrap_or_default().to_os_string();
-    name.push(".sig");
+    name.push(".minisig");
     staged.with_file_name(name)
 }
 
@@ -594,7 +603,7 @@ fn elevated_install_deb(staged: &Path) -> Result<(), String> {
         return Err("the elevated installer must run as root".to_owned());
     }
     let bytes = std::fs::read(staged).map_err(|e| format!("reading staged .deb: {e}"))?;
-    let sig_path = sibling_sig(staged);
+    let sig_path = sibling_minisig(staged);
     let sig = std::fs::read_to_string(&sig_path)
         .map_err(|e| format!("reading signature {}: {e}", sig_path.display()))?;
     verify_minisign(UPDATE_PUBLIC_KEY, &sig, &bytes).map_err(|e| e.to_string())?;
@@ -665,7 +674,7 @@ fn elevated_install_pacman(staged: &Path) -> Result<(), String> {
         return Err("the elevated installer must run as root".to_owned());
     }
     let bytes = std::fs::read(staged).map_err(|e| format!("reading staged .pkg.tar.zst: {e}"))?;
-    let sig_path = sibling_sig(staged);
+    let sig_path = sibling_minisig(staged);
     let sig = std::fs::read_to_string(&sig_path)
         .map_err(|e| format!("reading signature {}: {e}", sig_path.display()))?;
     verify_minisign(UPDATE_PUBLIC_KEY, &sig, &bytes).map_err(|e| e.to_string())?;
@@ -754,7 +763,7 @@ fn elevated_install_rpm(staged: &Path) -> Result<(), String> {
         return Err("the elevated installer must run as root".to_owned());
     }
     let bytes = std::fs::read(staged).map_err(|e| format!("reading staged .rpm: {e}"))?;
-    let sig_path = sibling_sig(staged);
+    let sig_path = sibling_minisig(staged);
     let sig = std::fs::read_to_string(&sig_path)
         .map_err(|e| format!("reading signature {}: {e}", sig_path.display()))?;
     verify_minisign(UPDATE_PUBLIC_KEY, &sig, &bytes).map_err(|e| e.to_string())?;
@@ -943,19 +952,19 @@ mod tests {
     }
 
     #[test]
-    fn sibling_sig_appends_sig_extension() {
+    fn sibling_minisig_appends_minisig_extension() {
         let p = Path::new("/cache/update/Yerd_MacOS_AppleSilicon_v2.app.tar.gz");
         assert_eq!(
-            sibling_sig(p),
-            Path::new("/cache/update/Yerd_MacOS_AppleSilicon_v2.app.tar.gz.sig")
+            sibling_minisig(p),
+            Path::new("/cache/update/Yerd_MacOS_AppleSilicon_v2.app.tar.gz.minisig")
         );
     }
 
     #[test]
-    fn sibling_sig_handles_bare_filename() {
+    fn sibling_minisig_handles_bare_filename() {
         assert_eq!(
-            sibling_sig(Path::new("update.deb")),
-            Path::new("update.deb.sig")
+            sibling_minisig(Path::new("update.deb")),
+            Path::new("update.deb.minisig")
         );
     }
 
@@ -998,5 +1007,35 @@ mod tests {
         std::fs::write(&staged, b"payload").unwrap();
         let err = reverify(&staged).unwrap_err();
         assert!(err.contains("reading signature"), "{err}");
+    }
+
+    /// Locks the reader side of the `.minisig` contract: a valid `.minisig`
+    /// sibling (named as `self_update::stage_update` writes it) reverifies against
+    /// the signing key, so a change to the reader's `.minisig` literal fails here.
+    /// The writer's literal is guarded by the ipc-server stage test, which asserts
+    /// the sibling the real `stage_update` writes is named `<artifact>.minisig`.
+    #[test]
+    fn reverify_succeeds_with_valid_minisig_sibling() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staged = tmp.path().join("Yerd_Linux_x86_64_v9.pkg.tar.zst");
+        let bytes: &[u8] = b"verified artifact bytes";
+        std::fs::write(&staged, bytes).unwrap();
+
+        let kp = minisign::KeyPair::generate_unencrypted_keypair().unwrap();
+        let sig = minisign::sign(
+            Some(&kp.pk),
+            &kp.sk,
+            std::io::Cursor::new(bytes),
+            Some("test artifact"),
+            Some("yerd test"),
+        )
+        .unwrap()
+        .into_string();
+
+        let name = staged.file_name().unwrap().to_string_lossy().into_owned();
+        let sibling = staged.with_file_name(format!("{name}.minisig"));
+        std::fs::write(&sibling, sig.as_bytes()).unwrap();
+
+        reverify_with_key(&staged, &kp.pk.to_base64()).unwrap();
     }
 }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -4163,6 +4163,8 @@ Subject: Captured\r\n\r\nhi\r\n";
         let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
         let pkg = "Yerd_Linux_x86_64_v99-0-1.pkg.tar.zst";
         let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
+        let rpm = "Yerd_Linux_x86_64_v99-0-1.rpm";
+        let rpm_arm = "Yerd_Linux_Arm64_v99-0-1.rpm";
         let releases = format!(
             r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
@@ -4175,15 +4177,23 @@ Subject: Captured\r\n\r\nhi\r\n";
                 {{"name":"{pkg}.minisig","browser_download_url":"https://h/{pkg}.minisig","size":1}},
                 {{"name":"{pkg_arm}","browser_download_url":"https://h/{pkg_arm}","size":4}},
                 {{"name":"{pkg_arm}.minisig","browser_download_url":"https://h/{pkg_arm}.minisig","size":1}},
+                {{"name":"{rpm}","browser_download_url":"https://h/{rpm}","size":4}},
+                {{"name":"{rpm}.minisig","browser_download_url":"https://h/{rpm}.minisig","size":1}},
+                {{"name":"{rpm_arm}","browser_download_url":"https://h/{rpm_arm}","size":4}},
+                {{"name":"{rpm_arm}.minisig","browser_download_url":"https://h/{rpm_arm}.minisig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
             ]}}]"#
         );
         let bad = "0".repeat(64);
-        let sums =
-            format!("{bad}  {mac}\n{bad}  {deb}\n{bad}  {arm}\n{bad}  {pkg}\n{bad}  {pkg_arm}\n");
+        let sums = format!(
+            "{bad}  {mac}\n{bad}  {deb}\n{bad}  {arm}\n{bad}  {pkg}\n{bad}  {pkg_arm}\n{bad}  {rpm}\n{bad}  {rpm_arm}\n"
+        );
         let dl = StageDl { releases, sums };
         match crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await {
-            Response::Error { .. } => {}
+            Response::Error { message, .. } => assert!(
+                message.contains("checksum verification failed"),
+                "expected a checksum verification failure, got: {message}"
+            ),
             other => panic!("expected Error on checksum mismatch, got {other:?}"),
         }
         assert!(
@@ -4191,7 +4201,9 @@ Subject: Captured\r\n\r\nhi\r\n";
                 && !state.dirs.cache.join("update").join(deb).exists()
                 && !state.dirs.cache.join("update").join(arm).exists()
                 && !state.dirs.cache.join("update").join(pkg).exists()
-                && !state.dirs.cache.join("update").join(pkg_arm).exists(),
+                && !state.dirs.cache.join("update").join(pkg_arm).exists()
+                && !state.dirs.cache.join("update").join(rpm).exists()
+                && !state.dirs.cache.join("update").join(rpm_arm).exists(),
             "must not write an artifact when verification fails"
         );
     }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -3957,7 +3957,8 @@ Subject: Captured\r\n\r\nhi\r\n";
 
     /// Fake downloader for the full stage flow. Serves the releases JSON for the
     /// API URL; the signed fixture bytes (`b"test"`) for any artifact URL; the
-    /// fixture signature for any `.sig` URL; and a matching `SHA256SUMS`.
+    /// fixture signature for any `.sig`/`.minisig` URL; and a matching
+    /// `SHA256SUMS`.
     struct StageDl {
         releases: String,
         sums: String,
@@ -3969,7 +3970,7 @@ Subject: Captured\r\n\r\nhi\r\n";
                 Ok(self.releases.clone().into_bytes())
             } else if url.ends_with("SHA256SUMS") {
                 Ok(self.sums.clone().into_bytes())
-            } else if url.ends_with(".sig") {
+            } else if url.ends_with(".minisig") || url.ends_with(".sig") {
                 Ok(SIG_FIXTURE.as_bytes().to_vec())
             } else {
                 Ok(b"test".to_vec())
@@ -3979,6 +3980,112 @@ Subject: Captured\r\n\r\nhi\r\n";
 
     #[tokio::test]
     async fn stage_update_downloads_verifies_and_writes_artifact() {
+        if !matches!(
+            yerd_update::Platform::current(),
+            yerd_update::Platform::MacOsAarch64
+                | yerd_update::Platform::LinuxX86_64
+                | yerd_update::Platform::LinuxAarch64
+        ) {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+
+        let mac = "Yerd_MacOS_AppleSilicon_v99-0-1.app.tar.gz";
+        let deb = "Yerd_Linux_x86_64_v99-0-1.deb";
+        let arm = "Yerd_Linux_Arm64_v99-0-1.deb";
+        let pkg = "Yerd_Linux_x86_64_v99-0-1.pkg.tar.zst";
+        let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
+        let rpm = "Yerd_Linux_x86_64_v99-0-1.rpm";
+        let rpm_arm = "Yerd_Linux_Arm64_v99-0-1.rpm";
+        let releases = format!(
+            r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
+                {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
+                {{"name":"{mac}.minisig","browser_download_url":"https://h/{mac}.minisig","size":1}},
+                {{"name":"{deb}","browser_download_url":"https://h/{deb}","size":4}},
+                {{"name":"{deb}.minisig","browser_download_url":"https://h/{deb}.minisig","size":1}},
+                {{"name":"{arm}","browser_download_url":"https://h/{arm}","size":4}},
+                {{"name":"{arm}.minisig","browser_download_url":"https://h/{arm}.minisig","size":1}},
+                {{"name":"{pkg}","browser_download_url":"https://h/{pkg}","size":4}},
+                {{"name":"{pkg}.minisig","browser_download_url":"https://h/{pkg}.minisig","size":1}},
+                {{"name":"{pkg_arm}","browser_download_url":"https://h/{pkg_arm}","size":4}},
+                {{"name":"{pkg_arm}.minisig","browser_download_url":"https://h/{pkg_arm}.minisig","size":1}},
+                {{"name":"{rpm}","browser_download_url":"https://h/{rpm}","size":4}},
+                {{"name":"{rpm}.minisig","browser_download_url":"https://h/{rpm}.minisig","size":1}},
+                {{"name":"{rpm_arm}","browser_download_url":"https://h/{rpm_arm}","size":4}},
+                {{"name":"{rpm_arm}.minisig","browser_download_url":"https://h/{rpm_arm}.minisig","size":1}},
+                {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
+            ]}}]"#
+        );
+        let h = yerd_update::sha256_hex(b"test");
+        let sums = format!(
+            "{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n{h}  {pkg}\n{h}  {pkg_arm}\n{h}  {rpm}\n{h}  {rpm_arm}\n"
+        );
+        let dl = StageDl { releases, sums };
+
+        let resp = crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await;
+        match resp {
+            Response::Staged {
+                path,
+                version,
+                kind,
+            } => {
+                assert_eq!(version, "99.0.1");
+                let p = std::path::Path::new(&path);
+                assert!(p.exists(), "staged file should exist at {path}");
+                assert_eq!(std::fs::read(p).unwrap(), b"test");
+                let sibling = p.with_file_name(format!(
+                    "{}.minisig",
+                    p.file_name().and_then(|n| n.to_str()).unwrap()
+                ));
+                assert!(
+                    sibling.exists(),
+                    "staged .minisig sibling should exist at {}",
+                    sibling.display()
+                );
+                let (expected_kind, expected_name) = match (
+                    yerd_update::Platform::current(),
+                    yerd_update::PkgFormat::current(),
+                ) {
+                    (yerd_update::Platform::MacOsAarch64, _) => {
+                        (yerd_ipc::StagedArtifact::AppTarGz, mac)
+                    }
+                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Deb) => {
+                        (yerd_ipc::StagedArtifact::Deb, deb)
+                    }
+                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Pacman) => {
+                        (yerd_ipc::StagedArtifact::Pacman, pkg)
+                    }
+                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Deb) => {
+                        (yerd_ipc::StagedArtifact::Deb, arm)
+                    }
+                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Pacman) => {
+                        (yerd_ipc::StagedArtifact::Pacman, pkg_arm)
+                    }
+                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Rpm) => {
+                        (yerd_ipc::StagedArtifact::Rpm, rpm)
+                    }
+                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Rpm) => {
+                        (yerd_ipc::StagedArtifact::Rpm, rpm_arm)
+                    }
+                    (other, _) => panic!("unexpected platform for fixture: {other:?}"),
+                };
+                assert_eq!(kind, expected_kind);
+                assert_eq!(
+                    p.file_name().and_then(|n| n.to_str()),
+                    Some(expected_name),
+                    "staged basename should be the current platform+format's asset"
+                );
+            }
+            other => panic!("expected Staged, got {other:?}"),
+        }
+    }
+
+    /// A pre-N release layout carries only `.sig` signatures. An N-built client
+    /// must still stage from it via the `select_asset` `.sig` fallback, and it
+    /// always writes the sibling under the new `.minisig` name.
+    #[tokio::test]
+    async fn stage_update_stages_from_legacy_sig_only_layout() {
         if !matches!(
             yerd_update::Platform::current(),
             yerd_update::Platform::MacOsAarch64
@@ -4022,52 +4129,20 @@ Subject: Captured\r\n\r\nhi\r\n";
         );
         let dl = StageDl { releases, sums };
 
-        let resp = crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await;
-        match resp {
-            Response::Staged {
-                path,
-                version,
-                kind,
-            } => {
-                assert_eq!(version, "99.0.1");
+        match crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await {
+            Response::Staged { path, .. } => {
                 let p = std::path::Path::new(&path);
                 assert!(p.exists(), "staged file should exist at {path}");
-                assert_eq!(std::fs::read(p).unwrap(), b"test");
-                let (expected_kind, expected_name) = match (
-                    yerd_update::Platform::current(),
-                    yerd_update::PkgFormat::current(),
-                ) {
-                    (yerd_update::Platform::MacOsAarch64, _) => {
-                        (yerd_ipc::StagedArtifact::AppTarGz, mac)
-                    }
-                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Deb) => {
-                        (yerd_ipc::StagedArtifact::Deb, deb)
-                    }
-                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Pacman) => {
-                        (yerd_ipc::StagedArtifact::Pacman, pkg)
-                    }
-                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Deb) => {
-                        (yerd_ipc::StagedArtifact::Deb, arm)
-                    }
-                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Pacman) => {
-                        (yerd_ipc::StagedArtifact::Pacman, pkg_arm)
-                    }
-                    (yerd_update::Platform::LinuxX86_64, yerd_update::PkgFormat::Rpm) => {
-                        (yerd_ipc::StagedArtifact::Rpm, rpm)
-                    }
-                    (yerd_update::Platform::LinuxAarch64, yerd_update::PkgFormat::Rpm) => {
-                        (yerd_ipc::StagedArtifact::Rpm, rpm_arm)
-                    }
-                    (other, _) => panic!("unexpected platform for fixture: {other:?}"),
-                };
-                assert_eq!(kind, expected_kind);
-                assert_eq!(
-                    p.file_name().and_then(|n| n.to_str()),
-                    Some(expected_name),
-                    "staged basename should be the current platform+format's asset"
+                let sibling = p.with_file_name(format!(
+                    "{}.minisig",
+                    p.file_name().and_then(|n| n.to_str()).unwrap()
+                ));
+                assert!(
+                    sibling.exists(),
+                    "staged sibling should be written as .minisig even from a .sig layout"
                 );
             }
-            other => panic!("expected Staged, got {other:?}"),
+            other => panic!("expected Staged from legacy .sig layout, got {other:?}"),
         }
     }
 
@@ -4091,15 +4166,15 @@ Subject: Captured\r\n\r\nhi\r\n";
         let releases = format!(
             r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
-                {{"name":"{mac}.sig","browser_download_url":"https://h/{mac}.sig","size":1}},
+                {{"name":"{mac}.minisig","browser_download_url":"https://h/{mac}.minisig","size":1}},
                 {{"name":"{deb}","browser_download_url":"https://h/{deb}","size":4}},
-                {{"name":"{deb}.sig","browser_download_url":"https://h/{deb}.sig","size":1}},
+                {{"name":"{deb}.minisig","browser_download_url":"https://h/{deb}.minisig","size":1}},
                 {{"name":"{arm}","browser_download_url":"https://h/{arm}","size":4}},
-                {{"name":"{arm}.sig","browser_download_url":"https://h/{arm}.sig","size":1}},
+                {{"name":"{arm}.minisig","browser_download_url":"https://h/{arm}.minisig","size":1}},
                 {{"name":"{pkg}","browser_download_url":"https://h/{pkg}","size":4}},
-                {{"name":"{pkg}.sig","browser_download_url":"https://h/{pkg}.sig","size":1}},
+                {{"name":"{pkg}.minisig","browser_download_url":"https://h/{pkg}.minisig","size":1}},
                 {{"name":"{pkg_arm}","browser_download_url":"https://h/{pkg_arm}","size":4}},
-                {{"name":"{pkg_arm}.sig","browser_download_url":"https://h/{pkg_arm}.sig","size":1}},
+                {{"name":"{pkg_arm}.minisig","browser_download_url":"https://h/{pkg_arm}.minisig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
             ]}}]"#
         );

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -421,7 +421,7 @@ pub async fn stage_update(
     if let Err(e) = tokio::fs::write(&path, &artifact).await {
         return internal(format!("could not write staged artifact: {e}"));
     }
-    let sig_path = dir.join(format!("{}.sig", sel.artifact.name));
+    let sig_path = dir.join(format!("{}.minisig", sel.artifact.name));
     if let Err(e) = tokio::fs::write(&sig_path, sig.as_bytes()).await {
         return internal(format!("could not write staged signature: {e}"));
     }

--- a/crates/yerd-update/src/artifact.rs
+++ b/crates/yerd-update/src/artifact.rs
@@ -2,8 +2,14 @@
 //!
 //! Given a resolved [`crate::ReleaseMeta`] and the running [`Platform`], pick the
 //! right downloadable artifact (the macOS `.app.tar.gz` or the Linux `.deb`),
-//! its detached minisign `.sig`, and the `SHA256SUMS` manifest. Verification is
+//! its detached minisign signature (`<artifact>.minisig`, with a legacy
+//! `<artifact>.sig` fallback), and the `SHA256SUMS` manifest. Verification is
 //! pure: it operates on already-downloaded bytes.
+//!
+//! The signature is named `.minisig` rather than `.sig` because pacman reserves
+//! `<pkg>.sig` for a detached `OpenPGP` signature and hard-fails `pacman -U` when a
+//! minisign file sits there (issue #157). The `.sig` fallback keeps clients built
+//! after that change able to consume older release layouts.
 
 use sha2::{Digest, Sha256};
 
@@ -136,7 +142,8 @@ impl PkgFormat {
 pub struct ArtifactSelection<'a> {
     /// The primary artifact (`.app.tar.gz` / `.deb`).
     pub artifact: &'a Asset,
-    /// The detached minisign signature (`<artifact>.sig`).
+    /// The detached minisign signature (`<artifact>.minisig`, with a legacy
+    /// `<artifact>.sig` fallback).
     pub signature: &'a Asset,
     /// The `SHA256SUMS` manifest covering the artifact.
     pub checksums: &'a Asset,
@@ -149,7 +156,8 @@ pub struct ArtifactSelection<'a> {
 pub enum AssetError {
     /// No artifact is published for this platform (e.g. Intel macOS, Windows).
     NoArtifactForPlatform(Platform),
-    /// The artifact is present but its `.sig` is missing.
+    /// The artifact is present but neither its `.minisig` nor its legacy `.sig`
+    /// is attached.
     MissingSignature(String),
     /// No `SHA256SUMS` manifest is attached to the release.
     MissingChecksums,
@@ -175,11 +183,16 @@ impl std::error::Error for AssetError {}
 /// Selection is by filename convention (the names the release workflow emits):
 /// the macOS artifact ends `.app.tar.gz` and is arch-tagged; the Linux artifact
 /// ends `.deb` (Debian), `.pkg.tar.zst` (Arch), or `.rpm` (Fedora) per `format`
-/// and is arch-tagged (`x86_64` or `arm64`); the signature is `<artifact>.sig`;
-/// the manifest is named `SHA256SUMS`. `format` resolves the deb-vs-pacman-vs-rpm
-/// ambiguity on Linux (a release carries all three) and is ignored on macOS. Intel
-/// macOS / unsupported platforms return [`AssetError::NoArtifactForPlatform`]
-/// rather than mis-selecting.
+/// and is arch-tagged (`x86_64` or `arm64`); the signature is `<artifact>.minisig`
+/// (with a legacy `<artifact>.sig` fallback); the manifest is named `SHA256SUMS`.
+/// `format` resolves the deb-vs-pacman-vs-rpm ambiguity on Linux (a release
+/// carries all three) and is ignored on macOS. Intel macOS / unsupported platforms
+/// return [`AssetError::NoArtifactForPlatform`] rather than mis-selecting.
+///
+/// The signature is `.minisig` (not `.sig`) because pacman reserves `<pkg>.sig` for
+/// a detached `OpenPGP` signature, which breaks `pacman -U` when a minisign file is
+/// there (issue #157). Transition releases carry both; `.minisig` is preferred so
+/// selection is identical before and after the legacy `.sig` copies are retired.
 pub fn select_asset(
     release: &ReleaseMeta,
     platform: Platform,
@@ -208,11 +221,13 @@ pub fn select_asset(
         .find(|a| matches(&a.name))
         .ok_or(AssetError::NoArtifactForPlatform(platform))?;
 
+    let minisig_name = format!("{}.minisig", artifact.name);
     let sig_name = format!("{}.sig", artifact.name);
     let signature = release
         .assets
         .iter()
-        .find(|a| a.name == sig_name)
+        .find(|a| a.name == minisig_name)
+        .or_else(|| release.assets.iter().find(|a| a.name == sig_name))
         .ok_or_else(|| AssetError::MissingSignature(artifact.name.clone()))?;
 
     let checksums = release
@@ -290,7 +305,7 @@ pub enum VerifyError {
     ChecksumMissing,
     /// The embedded public key string was not a valid minisign key.
     BadPublicKey,
-    /// The `.sig` content was not a valid minisign signature.
+    /// The signature content was not a valid minisign signature.
     BadSignature,
     /// The signature did not verify against the public key + bytes.
     SignatureMismatch,
@@ -397,14 +412,14 @@ mod tests {
     fn selects_macos_aarch64_app_tarball() {
         let r = release_with(&[
             "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz",
-            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz.sig",
+            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz.minisig",
             "Yerd_MacOS_AppleSilicon_v2-0-2.dmg",
             "SHA256SUMS",
         ]);
         let sel = select_asset(&r, Platform::MacOsAarch64, PkgFormat::Deb).unwrap();
         assert_eq!(sel.kind, ArtifactKind::AppTarGz);
         assert!(sel.artifact.name.ends_with(".app.tar.gz"));
-        assert!(sel.signature.name.ends_with(".app.tar.gz.sig"));
+        assert!(sel.signature.name.ends_with(".app.tar.gz.minisig"));
         assert_eq!(sel.checksums.name, "SHA256SUMS");
     }
 
@@ -412,7 +427,7 @@ mod tests {
     fn macos_selection_ignores_pkg_format() {
         let r = release_with(&[
             "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz",
-            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz.sig",
+            "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz.minisig",
             "SHA256SUMS",
         ]);
         let sel = select_asset(&r, Platform::MacOsAarch64, PkgFormat::Pacman).unwrap();
@@ -423,7 +438,7 @@ mod tests {
     fn selects_linux_x86_64_deb() {
         let r = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
-            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "Yerd_Linux_x86_64_v2-0-2.deb.minisig",
             "SHA256SUMS",
         ]);
         let sel = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb).unwrap();
@@ -435,7 +450,7 @@ mod tests {
     fn selects_linux_aarch64_deb() {
         let r = release_with(&[
             "Yerd_Linux_Arm64_v2-0-2.deb",
-            "Yerd_Linux_Arm64_v2-0-2.deb.sig",
+            "Yerd_Linux_Arm64_v2-0-2.deb.minisig",
             "SHA256SUMS",
         ]);
         let sel = select_asset(&r, Platform::LinuxAarch64, PkgFormat::Deb).unwrap();
@@ -447,33 +462,33 @@ mod tests {
     fn selects_linux_x86_64_pacman() {
         let r = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
-            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.minisig",
             "SHA256SUMS",
         ]);
         let sel = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Pacman).unwrap();
         assert_eq!(sel.kind, ArtifactKind::Pacman);
         assert!(sel.artifact.name.ends_with(".pkg.tar.zst"));
-        assert!(sel.signature.name.ends_with(".pkg.tar.zst.sig"));
+        assert!(sel.signature.name.ends_with(".pkg.tar.zst.minisig"));
     }
 
     #[test]
     fn selects_linux_x86_64_rpm() {
         let r = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.rpm",
-            "Yerd_Linux_x86_64_v2-0-2.rpm.sig",
+            "Yerd_Linux_x86_64_v2-0-2.rpm.minisig",
             "SHA256SUMS",
         ]);
         let sel = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Rpm).unwrap();
         assert_eq!(sel.kind, ArtifactKind::Rpm);
         assert!(sel.artifact.name.ends_with(".rpm"));
-        assert!(sel.signature.name.ends_with(".rpm.sig"));
+        assert!(sel.signature.name.ends_with(".rpm.minisig"));
     }
 
     #[test]
     fn selects_linux_aarch64_rpm() {
         let r = release_with(&[
             "Yerd_Linux_Arm64_v2-0-2.rpm",
-            "Yerd_Linux_Arm64_v2-0-2.rpm.sig",
+            "Yerd_Linux_Arm64_v2-0-2.rpm.minisig",
             "SHA256SUMS",
         ]);
         let sel = select_asset(&r, Platform::LinuxAarch64, PkgFormat::Rpm).unwrap();
@@ -485,11 +500,11 @@ mod tests {
     fn both_artifacts_present_resolves_per_format() {
         let r = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
-            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "Yerd_Linux_x86_64_v2-0-2.deb.minisig",
             "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
-            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.minisig",
             "Yerd_Linux_x86_64_v2-0-2.rpm",
-            "Yerd_Linux_x86_64_v2-0-2.rpm.sig",
+            "Yerd_Linux_x86_64_v2-0-2.rpm.minisig",
             "SHA256SUMS",
         ]);
         let deb = select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb).unwrap();
@@ -507,7 +522,7 @@ mod tests {
     fn linux_arch_matchers_are_disjoint() {
         let only_x86 = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
-            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "Yerd_Linux_x86_64_v2-0-2.deb.minisig",
             "SHA256SUMS",
         ]);
         assert_eq!(
@@ -516,7 +531,7 @@ mod tests {
         );
         let only_arm = release_with(&[
             "Yerd_Linux_Arm64_v2-0-2.deb",
-            "Yerd_Linux_Arm64_v2-0-2.deb.sig",
+            "Yerd_Linux_Arm64_v2-0-2.deb.minisig",
             "SHA256SUMS",
         ]);
         assert_eq!(
@@ -529,7 +544,7 @@ mod tests {
     fn pacman_matchers_are_disjoint_from_deb_and_across_arch() {
         let only_deb = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
-            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "Yerd_Linux_x86_64_v2-0-2.deb.minisig",
             "SHA256SUMS",
         ]);
         assert_eq!(
@@ -538,7 +553,7 @@ mod tests {
         );
         let only_pac = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
-            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.sig",
+            "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst.minisig",
             "SHA256SUMS",
         ]);
         assert_eq!(
@@ -547,7 +562,7 @@ mod tests {
         );
         let only_arm_pac = release_with(&[
             "Yerd_Linux_Arm64_v2-0-2.pkg.tar.zst",
-            "Yerd_Linux_Arm64_v2-0-2.pkg.tar.zst.sig",
+            "Yerd_Linux_Arm64_v2-0-2.pkg.tar.zst.minisig",
             "SHA256SUMS",
         ]);
         assert_eq!(
@@ -561,7 +576,7 @@ mod tests {
         // An rpm-only release resolves under Rpm but not Deb/Pacman.
         let only_rpm = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.rpm",
-            "Yerd_Linux_x86_64_v2-0-2.rpm.sig",
+            "Yerd_Linux_x86_64_v2-0-2.rpm.minisig",
             "SHA256SUMS",
         ]);
         assert_eq!(
@@ -575,7 +590,7 @@ mod tests {
         // A deb-only release does not resolve under Rpm.
         let only_deb = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
-            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "Yerd_Linux_x86_64_v2-0-2.deb.minisig",
             "SHA256SUMS",
         ]);
         assert_eq!(
@@ -607,11 +622,94 @@ mod tests {
         ));
     }
 
+    /// The signature-extension dimension: `.minisig` primary, legacy `.sig`
+    /// fallback, `.minisig` preferred when both are present, and an error when
+    /// neither is attached, exercised across every artifact kind.
+    #[test]
+    fn signature_extension_selection() {
+        struct Case {
+            artifact: &'static str,
+            platform: Platform,
+            format: PkgFormat,
+        }
+        let cases = [
+            Case {
+                artifact: "Yerd_MacOS_AppleSilicon_v2-0-2.app.tar.gz",
+                platform: Platform::MacOsAarch64,
+                format: PkgFormat::Deb,
+            },
+            Case {
+                artifact: "Yerd_Linux_x86_64_v2-0-2.deb",
+                platform: Platform::LinuxX86_64,
+                format: PkgFormat::Deb,
+            },
+            Case {
+                artifact: "Yerd_Linux_x86_64_v2-0-2.pkg.tar.zst",
+                platform: Platform::LinuxX86_64,
+                format: PkgFormat::Pacman,
+            },
+            Case {
+                artifact: "Yerd_Linux_x86_64_v2-0-2.rpm",
+                platform: Platform::LinuxX86_64,
+                format: PkgFormat::Rpm,
+            },
+        ];
+        for c in cases {
+            let minisig = format!("{}.minisig", c.artifact);
+            let sig = format!("{}.sig", c.artifact);
+
+            let minisig_only = release_with(&[c.artifact, &minisig, "SHA256SUMS"]);
+            let sel = select_asset(&minisig_only, c.platform, c.format).unwrap();
+            assert_eq!(sel.signature.name, minisig, "minisig-only: {}", c.artifact);
+
+            let sig_only = release_with(&[c.artifact, &sig, "SHA256SUMS"]);
+            let sel = select_asset(&sig_only, c.platform, c.format).unwrap();
+            assert_eq!(
+                sel.signature.name, sig,
+                "legacy sig fallback: {}",
+                c.artifact
+            );
+
+            let both = release_with(&[c.artifact, &sig, &minisig, "SHA256SUMS"]);
+            let sel = select_asset(&both, c.platform, c.format).unwrap();
+            assert_eq!(
+                sel.signature.name, minisig,
+                "both prefers minisig: {}",
+                c.artifact
+            );
+
+            let neither = release_with(&[c.artifact, "SHA256SUMS"]);
+            assert_eq!(
+                select_asset(&neither, c.platform, c.format),
+                Err(AssetError::MissingSignature(c.artifact.to_string())),
+                "neither present: {}",
+                c.artifact
+            );
+        }
+    }
+
+    /// A `.minisig` for a *different* artifact must not satisfy this one: matching
+    /// is by exact name, with no suffix sloppiness.
+    #[test]
+    fn foreign_minisig_does_not_satisfy() {
+        let r = release_with(&[
+            "Yerd_Linux_x86_64_v2-0-2.deb",
+            "Yerd_Linux_Arm64_v2-0-2.deb.minisig",
+            "SHA256SUMS",
+        ]);
+        assert_eq!(
+            select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb),
+            Err(AssetError::MissingSignature(
+                "Yerd_Linux_x86_64_v2-0-2.deb".to_string()
+            ))
+        );
+    }
+
     #[test]
     fn missing_checksums_is_an_error() {
         let r = release_with(&[
             "Yerd_Linux_x86_64_v2-0-2.deb",
-            "Yerd_Linux_x86_64_v2-0-2.deb.sig",
+            "Yerd_Linux_x86_64_v2-0-2.deb.minisig",
         ]);
         assert_eq!(
             select_asset(&r, Platform::LinuxX86_64, PkgFormat::Deb),

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -469,6 +469,18 @@ users should keep their system current. It also requires the default
 (Yerd verifies it itself with the embedded update key), so a hardened
 `LocalFileSigLevel = Required` rejects the local install.
 
+The Arch package's minisign signature is published as `<pkg>.pkg.tar.zst.minisig`,
+not `.sig`. pacman reserves `<pkg>.sig` for a detached OpenPGP signature and feeds
+any such sibling to GPGME, so a minisign file under that name hard-fails
+`pacman -U` even at `LocalFileSigLevel = Optional` (a missing signature is
+tolerated, a present-but-unparseable one is fatal) - this was
+[#157](https://github.com/forjedio/yerd/issues/157). The other artifact kinds
+(`.app.tar.gz`, `.deb`, `.rpm`) publish a byte-identical legacy `<artifact>.sig`
+copy alongside the `.minisig` for a bounded transition window, so self-updaters
+built at v2.0.3 or earlier keep resolving a signature; that copy is retired once
+those clients have moved on, and the pacman `.sig` is never re-published (the
+release workflow fails the publish if a `*.pkg.tar.zst.sig` is present).
+
 ### The Fedora package (`.rpm`)
 
 Unlike pacman, Tauri v2 **does** have an rpm bundler (pure-Rust, no `rpmbuild`),

--- a/docs/developer/crates/yerd-update.md
+++ b/docs/developer/crates/yerd-update.md
@@ -66,6 +66,15 @@ ends `.deb` or `.pkg.tar.zst` depending on [`PkgFormat`]. Intel macOS and any
 other [`Platform::Unsupported`] host get `AssetError::NoArtifactForPlatform`
 rather than a mis-selected file.
 
+The detached signature is named `<artifact>.minisig` (minisign's own default),
+with a legacy `<artifact>.sig` accepted as a fallback for releases published
+before the rename. When both names are present `select_asset` prefers
+`.minisig`, so behaviour is identical during and after the transition window;
+if neither is attached the artifact is treated as unsigned and
+`AssetError::MissingSignature` is returned. The rename exists because pacman
+reserves `<pkg>.sig` for a detached OpenPGP signature, so publishing a minisign
+`.sig` beside the Arch package broke `pacman -U` (#157).
+
 Verification is two independent checks, both pure functions over
 already-downloaded bytes:
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -46,6 +46,13 @@ Grab the latest **stable release** from the
 Remove any leftover `/usr/bin/yerd` from the old v1 (Go) project first - pacman
 won't install over a file it doesn't own - and `pacman -Syu` before installing so
 the bundled GUI's WebKit/GTK libraries match your system.
+
+If you are upgrading from Yerd v2.0.3 or earlier, in-app update cannot see this
+release, so reinstall once by hand with the same
+`sudo pacman -U ./Yerd_Linux_x86_64_v<ver>.pkg.tar.zst` command from the
+[releases page](https://github.com/forjedio/yerd/releases); your settings and
+sites are preserved, since it is a normal package upgrade, and in-app updates
+work again from this version on.
 :::
 
 <ThemedImage light="/images/dmg-install.png" dark="/images/dmg-install.png" alt="macOS .dmg installer window: drag Yerd into the Applications folder" />

--- a/docs/reference/cli/update.md
+++ b/docs/reference/cli/update.md
@@ -48,7 +48,8 @@ automated downgrade isn't implemented yet - it currently just says so.
    artifact (`Request::StageUpdate`): the daemon fetches the platform-specific
    asset (macOS `.app.tar.gz`, Linux `.deb`/`.pkg.tar.zst`/`.rpm`), checks its
    SHA-256 against the release's `SHA256SUMS` manifest, and verifies a
-   detached minisign signature against an embedded public key.
+   detached minisign signature (the `<artifact>.minisig` asset, with a legacy
+   `<artifact>.sig` accepted as a fallback) against an embedded public key.
 4. Re-verifies the signature a second time locally (closing the window
    between the daemon's verify and the install), then installs the artifact
    and restarts the daemon so it comes back up on the new version.


### PR DESCRIPTION
## What does this PR do?

Renames the published minisign signature from <artifact>.sig to <artifact>.minisig (with a legacy .sig fallback in select_asset and a bounded dual-publish window for non-pacman kinds) so it no longer collides with the filename pacman reserves for OpenPGP signatures, unbreaking pacman -U on Arch.

## Related issues

closes #157 

## Type of change

- [x] Bug fix
- [x] Refactor / internal change
- [x] Build / CI / tooling

## Platforms tested

- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [ ] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Self-updates now prefer detached `*.minisig` signature assets (with automatic fallback to legacy `*.sig` when needed).
  * Release publishing and verification were updated to avoid misidentification of Arch package signatures.
  * A release-time guard prevents publishing `*.pkg.tar.zst.sig` assets, and legacy `*.sig` copies can be retired via a repository setting.

* **Documentation**
  * Updated developer and CLI docs to reflect the `*.minisig`/legacy `*.sig` behavior.
  * Added an Arch upgrade note for users moving from Yerd v2.0.3 or earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->