### PR TITLE
[Feat] Preload TimescaleDB for Postgres installs that bundle it

### DIFF
--- a/crates/yerd-services/src/config_render.rs
+++ b/crates/yerd-services/src/config_render.rs
@@ -131,10 +131,19 @@ pub fn render_my_bootstrap_sql() -> &'static str {
 ///   populated with `--auth=trust`, so passwordless loopback auth holds even
 ///   though this config file lives outside the datadir (`-c config_file=`).
 ///   `data_directory` itself comes from the `-D` command-line flag.
+///
+/// `preload_libraries` become a single `shared_preload_libraries` line, in the
+/// given order (the caller lists `TimescaleDB` first, per upstream guidance), and
+/// only when the slice is non-empty - a preload entry naming a library the
+/// install does not ship makes the postmaster fail to start. The manager probes
+/// the install tree and passes the resolved list; this file is regenerated in
+/// full on every start (the whole config is Yerd-owned via `-c config_file=`),
+/// so the line never duplicates or accumulates.
 #[must_use]
-pub fn render_postgresql_conf(port: u16, datadir: &Path) -> String {
+pub fn render_postgresql_conf(port: u16, datadir: &Path, preload_libraries: &[&str]) -> String {
     let hba = quote_pg_string(&datadir.join("pg_hba.conf").display().to_string());
     let ident = quote_pg_string(&datadir.join("pg_ident.conf").display().to_string());
+    let preload = render_preload_line(preload_libraries);
     format!(
         "# Managed by Yerd — do not edit by hand.\n\
          # Local development database (PostgreSQL).\n\
@@ -142,9 +151,21 @@ pub fn render_postgresql_conf(port: u16, datadir: &Path) -> String {
          port = {port}\n\
          unix_socket_directories = ''\n\
          logging_collector = off\n\
+         {preload}\
          hba_file = {hba}\n\
          ident_file = {ident}\n"
     )
+}
+
+/// The `shared_preload_libraries` line for the given libraries (comma-joined,
+/// order preserved), or the empty string when there are none so no line is
+/// emitted at all.
+fn render_preload_line(libraries: &[&str]) -> String {
+    if libraries.is_empty() {
+        return String::new();
+    }
+    let value = quote_pg_string(&libraries.join(","));
+    format!("shared_preload_libraries = {value}\n")
 }
 
 /// Single-quote a string for a `postgresql.conf` value, escaping embedded single
@@ -270,7 +291,7 @@ mod tests {
 
     #[test]
     fn postgresql_conf_is_loopback_tcp_only() {
-        let conf = render_postgresql_conf(5432, &PathBuf::from("/data/pg/data-17"));
+        let conf = render_postgresql_conf(5432, &PathBuf::from("/data/pg/data-17"), &[]);
         assert!(conf.contains("listen_addresses = '127.0.0.1'"));
         assert!(!conf.contains("0.0.0.0"));
         assert!(conf.contains("port = 5432"));
@@ -282,10 +303,42 @@ mod tests {
 
     #[test]
     fn postgresql_conf_escapes_single_quotes_in_paths() {
-        let conf = render_postgresql_conf(5432, &PathBuf::from("/data/o'brien/data-17"));
+        let conf = render_postgresql_conf(5432, &PathBuf::from("/data/o'brien/data-17"), &[]);
         assert!(
             conf.contains("hba_file = '/data/o''brien/data-17/pg_hba.conf'"),
             "single quote must be doubled: {conf}"
+        );
+    }
+
+    #[test]
+    fn postgresql_conf_omits_preload_line_when_no_libraries() {
+        let conf = render_postgresql_conf(5432, &PathBuf::from("/data/pg/data-17"), &[]);
+        assert!(
+            !conf.contains("shared_preload_libraries"),
+            "base install must get no preload line: {conf}"
+        );
+    }
+
+    #[test]
+    fn postgresql_conf_emits_preload_line_when_libraries_present() {
+        let conf =
+            render_postgresql_conf(5432, &PathBuf::from("/data/pg/data-17"), &["timescaledb"]);
+        assert!(
+            conf.contains("shared_preload_libraries = 'timescaledb'"),
+            "preload line must be present and quoted: {conf}"
+        );
+    }
+
+    #[test]
+    fn postgresql_conf_joins_preload_libraries_in_order() {
+        let conf = render_postgresql_conf(
+            5432,
+            &PathBuf::from("/data/pg/data-17"),
+            &["timescaledb", "pg_stat_statements"],
+        );
+        assert!(
+            conf.contains("shared_preload_libraries = 'timescaledb,pg_stat_statements'"),
+            "libraries must be comma-joined in order: {conf}"
         );
     }
 }

--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -186,7 +186,7 @@ where
         self.preflight_port(wire_id, port)?;
         let listen = Listen::TcpLoopback(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port));
 
-        if let Some((_, datadir)) = versioned.as_ref() {
+        if let Some((v, datadir)) = versioned.as_ref() {
             Self::prepare_dirs(
                 def.as_ref(),
                 wire_id,
@@ -204,7 +204,14 @@ where
                     }
                 })?;
             }
-            if let Some(rendered) = def.render_config(port, datadir, &socket, &log_path, &init_file)
+            let preload = if def.preloads_bundled_extensions() {
+                let install_dir = version::install_dir(&self.dirs, id, v);
+                postgres_preload_libraries(&install_dir)
+            } else {
+                Vec::new()
+            };
+            if let Some(rendered) =
+                def.render_config(port, datadir, &socket, &log_path, &init_file, &preload)
             {
                 std::fs::write(&config_path, rendered.as_bytes()).map_err(|source| {
                     ServiceError::ConfigWrite {
@@ -970,6 +977,71 @@ fn geo_data_env(
     env
 }
 
+/// The extensions a postgres install needs listed in `shared_preload_libraries`,
+/// probed from the install tree. `TimescaleDB` FATAL-errors on `CREATE EXTENSION`
+/// unless it is preloaded at postmaster start (a reload is too late), so when the
+/// install ships it the library must be named here, with `timescaledb` first per
+/// upstream guidance. Only the Linux/macOS `full` build bundles it (the Windows
+/// `full` build ships `PostGIS` but not `TimescaleDB`), so this probes the tree
+/// rather than keying off the `-full` label. Empty when absent, so a base install
+/// never gets a preload line (naming a missing library stops the postmaster
+/// starting).
+fn postgres_preload_libraries(install_dir: &std::path::Path) -> Vec<&'static str> {
+    if timescaledb_present(install_dir) {
+        vec!["timescaledb"]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Whether a postgres install ships `TimescaleDB`: its `timescaledb.control` file
+/// under `share/` or a `timescaledb*.so`/`.dylib` under `lib/`. Fast path checks
+/// the standard `share/postgresql/extension/` location, then falls back to a
+/// symlink-safe depth-first walk (mirroring [`find_geo_data_dirs`]).
+fn timescaledb_present(install_dir: &std::path::Path) -> bool {
+    let standard = install_dir
+        .join("share")
+        .join("postgresql")
+        .join("extension")
+        .join("timescaledb.control");
+    if standard.is_file() {
+        return true;
+    }
+    let mut stack = vec![install_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() && is_timescaledb_file(&entry.file_name()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Whether a file name marks a bundled `TimescaleDB`: the extension control file,
+/// or a versioned shared object (`timescaledb-2.17.so`, `timescaledb.dylib`, …).
+fn is_timescaledb_file(name: &std::ffi::OsStr) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    if name == "timescaledb.control" {
+        return true;
+    }
+    name.starts_with("timescaledb")
+        && std::path::Path::new(name)
+            .extension()
+            .and_then(std::ffi::OsStr::to_str)
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("so") || ext.eq_ignore_ascii_case("dylib"))
+}
+
 /// The directories holding `proj.db` (PROJ) and `gdalvrt.xsd` (GDAL) inside a
 /// variant install. Fast path probes `share/proj` / `share/gdal` directly, then
 /// falls back to a depth-first walk. `DirEntry::file_type()` does not follow
@@ -1310,6 +1382,54 @@ mod tests {
             find_geo_data_dirs(tmp.path()),
             (Some(proj_dir), Some(gdal_dir))
         );
+    }
+
+    /// Stage the standard extension dir and drop `timescaledb.control` into it.
+    fn stage_timescaledb_control(root: &std::path::Path) {
+        let dir = root.join("share").join("postgresql").join("extension");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("timescaledb.control"), b"").unwrap();
+    }
+
+    #[test]
+    fn preload_libraries_empty_without_timescaledb() {
+        let tmp = tempfile::tempdir().unwrap();
+        stage_geo_install(tmp.path(), true, true);
+        assert!(postgres_preload_libraries(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn preload_libraries_lists_timescaledb_when_control_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        stage_timescaledb_control(tmp.path());
+        assert_eq!(postgres_preload_libraries(tmp.path()), vec!["timescaledb"]);
+    }
+
+    #[test]
+    fn timescaledb_present_detects_a_versioned_shared_object() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("lib").join("postgresql");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("timescaledb-2.17.so"), b"").unwrap();
+        assert!(timescaledb_present(tmp.path()));
+    }
+
+    #[test]
+    fn timescaledb_present_detects_a_dylib() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("timescaledb.dylib"), b"").unwrap();
+        assert!(timescaledb_present(tmp.path()));
+    }
+
+    #[test]
+    fn timescaledb_present_false_for_bare_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("postgis.so"), b"").unwrap();
+        assert!(!timescaledb_present(tmp.path()));
     }
 
     #[test]

--- a/crates/yerd-services/src/service.rs
+++ b/crates/yerd-services/src/service.rs
@@ -225,6 +225,14 @@ pub trait ServiceDefinition: Send + Sync + 'static {
         false
     }
 
+    /// Whether the manager should probe the install tree for bundled extensions
+    /// that must appear in `shared_preload_libraries` at postmaster start
+    /// (`TimescaleDB`). True only for Postgres; the probe (not the label) decides
+    /// whether any entry is actually written.
+    fn preloads_bundled_extensions(&self) -> bool {
+        false
+    }
+
     /// One-time init-tool arguments populating the fresh `staging` datadir.
     /// Empty for a type with no init step.
     fn init_args(&self, staging: &std::path::Path) -> Vec<OsString> {
@@ -246,7 +254,9 @@ pub trait ServiceDefinition: Send + Sync + 'static {
     }
 
     /// Render this type's server config text, or `None` for a type with no config
-    /// file (app servers).
+    /// file (app servers). `preload_libraries` is the manager-resolved
+    /// `shared_preload_libraries` list (empty except for a Postgres install that
+    /// ships a preload-required extension).
     fn render_config(
         &self,
         port: u16,
@@ -254,8 +264,16 @@ pub trait ServiceDefinition: Send + Sync + 'static {
         socket: &std::path::Path,
         log_path: &std::path::Path,
         init_file: &std::path::Path,
+        preload_libraries: &[&str],
     ) -> Option<String> {
-        let _ = (port, datadir, socket, log_path, init_file);
+        let _ = (
+            port,
+            datadir,
+            socket,
+            log_path,
+            init_file,
+            preload_libraries,
+        );
         None
     }
 
@@ -365,6 +383,7 @@ impl ServiceDefinition for Redis {
         _socket: &std::path::Path,
         log_path: &std::path::Path,
         _init_file: &std::path::Path,
+        _preload_libraries: &[&str],
     ) -> Option<String> {
         Some(config_render::render_redis_conf(port, datadir, log_path))
     }
@@ -442,6 +461,7 @@ impl ServiceDefinition for MySql {
         socket: &std::path::Path,
         log_path: &std::path::Path,
         init_file: &std::path::Path,
+        _preload_libraries: &[&str],
     ) -> Option<String> {
         Some(config_render::render_my_cnf(
             port, datadir, socket, log_path, init_file,
@@ -516,6 +536,7 @@ impl ServiceDefinition for MariaDb {
         socket: &std::path::Path,
         log_path: &std::path::Path,
         init_file: &std::path::Path,
+        _preload_libraries: &[&str],
     ) -> Option<String> {
         Some(config_render::render_my_cnf(
             port, datadir, socket, log_path, init_file,
@@ -572,6 +593,9 @@ impl ServiceDefinition for Postgres {
     fn injects_geo_data(&self) -> bool {
         true
     }
+    fn preloads_bundled_extensions(&self) -> bool {
+        true
+    }
     fn init_args(&self, staging: &std::path::Path) -> Vec<OsString> {
         vec![
             OsString::from("-D"),
@@ -593,8 +617,13 @@ impl ServiceDefinition for Postgres {
         _socket: &std::path::Path,
         _log_path: &std::path::Path,
         _init_file: &std::path::Path,
+        preload_libraries: &[&str],
     ) -> Option<String> {
-        Some(config_render::render_postgresql_conf(port, datadir))
+        Some(config_render::render_postgresql_conf(
+            port,
+            datadir,
+            preload_libraries,
+        ))
     }
     fn plan_launch(&self, ctx: &LaunchContext<'_>) -> Result<LaunchPlan, ServiceError> {
         let mut command = base_command(ctx);
@@ -823,6 +852,14 @@ mod tests {
     }
 
     #[test]
+    fn only_postgres_preloads_bundled_extensions() {
+        assert!(reg().get("postgres").unwrap().preloads_bundled_extensions());
+        for id in ["redis", "mysql", "mariadb"] {
+            assert!(!reg().get(id).unwrap().preloads_bundled_extensions());
+        }
+    }
+
+    #[test]
     fn plan_launch_redis_passes_only_the_config_path() {
         let program = std::path::Path::new("/b/valkey-server");
         let config = std::path::Path::new("/c/redis.conf");
@@ -967,7 +1004,9 @@ mod tests {
         let init = std::path::Path::new("/i/x-init.sql");
         for id in ["redis", "mysql", "mariadb", "postgres"] {
             let d = reg().get(id).unwrap();
-            let rendered = d.render_config(6543, datadir, socket, log, init).unwrap();
+            let rendered = d
+                .render_config(6543, datadir, socket, log, init, &[])
+                .unwrap();
             assert!(rendered.contains("6543"), "{id} config missing port");
         }
     }


### PR DESCRIPTION
## What does this PR do?

The daemon now probes each Postgres install tree for TimescaleDB and, when present, writes shared_preload_libraries = 'timescaledb' into postgresql.conf before the postmaster starts - so CREATE EXTENSION timescaledb works out of the box, while base installs correctly get no preload line.

## Related issues

n/a

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL configurations now automatically enable bundled TimescaleDB extensions when detected.
  * Preload libraries are rendered in the correct PostgreSQL configuration format and order.
  * Services can identify whether bundled extensions require startup-time loading.

* **Bug Fixes**
  * Improved detection of TimescaleDB installations across supported library formats.
  * Prevented unnecessary preload configuration when TimescaleDB is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->