### PR TITLE
[Feat] Legacy PHP version support (7.4 / 8.0 / 8.1) with guardrails

### DIFF
--- a/apps/yerd-gui/package-lock.json
+++ b/apps/yerd-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yerd-gui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yerd-gui",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.2.0",

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -211,16 +211,31 @@ pub async fn available_php() -> Result<Response, GuiError> {
 }
 
 #[tauri::command]
-pub async fn install_php(version: PhpVersion) -> Result<Response, GuiError> {
-    finish(exchange(&Request::InstallPhp { version }).await?)
+pub async fn install_php(version: PhpVersion, confirm_legacy: bool) -> Result<Response, GuiError> {
+    finish(
+        exchange(&Request::InstallPhp {
+            version,
+            confirm_legacy,
+        })
+        .await?,
+    )
 }
 
 /// Start a streamed PHP install; replies `JobStarted` for the client to poll via
 /// `job_status`. The non-blocking sibling of `install_php`, used by the GUI so a
 /// multi-minute download streams progress instead of spinning a single request.
 #[tauri::command]
-pub async fn install_php_streamed(version: PhpVersion) -> Result<Response, GuiError> {
-    finish(exchange(&Request::InstallPhpStreamed { version }).await?)
+pub async fn install_php_streamed(
+    version: PhpVersion,
+    confirm_legacy: bool,
+) -> Result<Response, GuiError> {
+    finish(
+        exchange(&Request::InstallPhpStreamed {
+            version,
+            confirm_legacy,
+        })
+        .await?,
+    )
 }
 
 #[tauri::command]

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -282,13 +282,16 @@ export async function availablePhp(): Promise<AvailablePhpResponse> {
   return ensureOk(await call<Response>("available_php")) as AvailablePhpResponse;
 }
 
-export async function installPhp(version: PhpVersion): Promise<void> {
-  ensureOk(await call<Response>("install_php", { version }));
+export async function installPhp(version: PhpVersion, confirmLegacy = false): Promise<void> {
+  ensureOk(await call<Response>("install_php", { version, confirmLegacy }));
 }
 
 /** Start a streamed PHP install as a background job; returns the job id to poll. */
-export async function installPhpStreamed(version: PhpVersion): Promise<string> {
-  const r = ensureOk(await call<Response>("install_php_streamed", { version }));
+export async function installPhpStreamed(
+  version: PhpVersion,
+  confirmLegacy = false,
+): Promise<string> {
+  const r = ensureOk(await call<Response>("install_php_streamed", { version, confirmLegacy }));
   if (r.type !== "job_started") throw new IpcError("unexpected response to install_php_streamed");
   return r.job_id;
 }
@@ -297,13 +300,15 @@ export async function installPhpStreamed(version: PhpVersion): Promise<string> {
  * Install a PHP version as a streamed job, delivering progress lines via
  * `onProgress`, and resolving only when it finishes. Throws (toast-worthy) on a
  * failed/cancelled job, so callers keep their existing try/catch around a
- * single awaited install.
+ * single awaited install. Pass `confirmLegacy` for an out-of-support legacy
+ * minor (< 8.2); the daemon refuses a legacy install without it.
  */
 export async function installPhpWithProgress(
   version: PhpVersion,
   onProgress?: (lines: string[]) => void,
+  confirmLegacy = false,
 ): Promise<void> {
-  const jobId = await installPhpStreamed(version);
+  const jobId = await installPhpStreamed(version, confirmLegacy);
   const final = await pollJobToEnd(jobId, (lines) => onProgress?.(lines));
   if (final.state !== "succeeded") {
     throw new IpcError(final.error || `PHP ${version} install ${final.state}`);

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -470,6 +470,7 @@ export type ErrorCode =
   | "invalid_path"
   | "port_in_use"
   | "extension_load_failed"
+  | "legacy_restricted"
   | "internal";
 
 /** One whole-host reverse proxy (`{name}.{tld}` → `target`). Reply element of a

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -373,6 +373,8 @@ export interface DumpCounts {
 export interface DumpExtStatus {
   version: PhpVersion;
   present: boolean;
+  /** True for legacy (< 8.2) versions, which never capture dumps. */
+  legacy?: boolean;
 }
 
 // ── site creation (create.rs) ───────────────────────────────────────────────
@@ -532,6 +534,8 @@ export type Response =
       type: "available_php";
       available: PhpVersion[];
       installed: PhpVersion[];
+      /** Installable legacy (< 8.2) minors from php-legacy.json; omitted when none. */
+      legacy?: PhpVersion[];
     }
   | {
       type: "php_extensions";

--- a/apps/yerd-gui/src/lib/phpVersion.test.ts
+++ b/apps/yerd-gui/src/lib/phpVersion.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { comparePhpVersions, phpVersionInRange } from "./phpVersion";
+import { comparePhpVersions, isLegacyVersion, phpVersionInRange } from "./phpVersion";
 
 describe("comparePhpVersions", () => {
   it.each([
@@ -17,6 +17,20 @@ describe("comparePhpVersions", () => {
   ])("comparePhpVersions(%s, %s) has the sign of %i", (a, b, expectedSign) => {
     const result = comparePhpVersions(a, b);
     expect(Math.sign(result)).toBe(expectedSign);
+  });
+});
+
+describe("isLegacyVersion", () => {
+  it.each([
+    ["7.4", true],
+    ["8.0", true],
+    ["8.1", true],
+    ["8.2", false],
+    ["8.3", false],
+    ["8.5", false],
+    ["8.10", false],
+  ] as const)("isLegacyVersion(%s) === %s", (php, expected) => {
+    expect(isLegacyVersion(php)).toBe(expected);
   });
 });
 

--- a/apps/yerd-gui/src/lib/phpVersion.ts
+++ b/apps/yerd-gui/src/lib/phpVersion.ts
@@ -15,3 +15,13 @@ export function comparePhpVersions(a: PhpVersion, b: PhpVersion): number {
 export function phpVersionInRange(php: PhpVersion, minPhp: PhpVersion, maxPhp: PhpVersion): boolean {
   return comparePhpVersions(php, minPhp) >= 0 && comparePhpVersions(php, maxPhp) <= 0;
 }
+
+/**
+ * Whether `php` is an out-of-support legacy version (< 8.2): no coverage, no
+ * dumps, and never eligible as the global default. Mirrors the authoritative
+ * cutoff in `yerd_core::PhpVersion::is_legacy` (FIRST_SUPPORTED_MINOR = 8.2);
+ * the daemon remains the real gate, so this is a UI convenience only.
+ */
+export function isLegacyVersion(php: PhpVersion): boolean {
+  return comparePhpVersions(php, "8.2") < 0;
+}

--- a/apps/yerd-gui/src/views/LaravelDumpsView.spec.ts
+++ b/apps/yerd-gui/src/views/LaravelDumpsView.spec.ts
@@ -1,0 +1,71 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import LaravelDumpsView from "./LaravelDumpsView.vue";
+import { resetResourceCache } from "@/composables/useResource";
+import type { DumpExtStatus } from "@/ipc/types";
+
+function stubIpc(extensions: DumpExtStatus[]) {
+  invokeMock.mockImplementation((cmd: string) => {
+    switch (cmd) {
+      case "dumps_status":
+        return Promise.resolve({
+          type: "dumps_status",
+          enabled: true,
+          port: 2304,
+          running: true,
+          persist: false,
+          extensions,
+          counts: {},
+          features: {},
+        });
+      default:
+        return Promise.reject(new Error(`unexpected invoke ${cmd}`));
+    }
+  });
+}
+
+const mounted: { unmount: () => void }[] = [];
+
+async function mountView() {
+  const wrapper = mount(LaravelDumpsView, {
+    global: { stubs: { teleport: true, RouterLink: true } },
+  });
+  mounted.push(wrapper);
+  await flushPromises();
+  return wrapper;
+}
+
+describe("LaravelDumpsView legacy handling", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    resetResourceCache();
+  });
+
+  afterEach(() => {
+    mounted.forEach((w) => w.unmount());
+    mounted.length = 0;
+  });
+
+  it("shows the legacy banner and Unsupported badge when a legacy version is present", async () => {
+    stubIpc([
+      { version: "7.4", present: false, legacy: true },
+      { version: "8.4", present: true },
+    ]);
+    const wrapper = await mountView();
+    expect(wrapper.find('[data-testid="dumps-legacy-banner"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain("Unsupported (no dumps)");
+  });
+
+  it("shows neither banner nor Unsupported badge when only supported versions are present", async () => {
+    stubIpc([{ version: "8.4", present: true }]);
+    const wrapper = await mountView();
+    expect(wrapper.find('[data-testid="dumps-legacy-banner"]').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("Unsupported (no dumps)");
+  });
+});

--- a/apps/yerd-gui/src/views/LaravelDumpsView.vue
+++ b/apps/yerd-gui/src/views/LaravelDumpsView.vue
@@ -43,6 +43,7 @@ const FEATURES: { key: string; label: string }[] = [
 const running = computed(() => status.value?.running ?? false);
 const enabled = computed(() => status.value?.enabled ?? false);
 const extensions = computed(() => status.value?.extensions ?? []);
+const hasLegacy = computed(() => extensions.value.some((e) => e.legacy));
 
 // The dump server *port* is now edited centrally on Settings ▸ Application Ports;
 // this page shows it read-only via `status.port`.
@@ -175,13 +176,24 @@ async function openViewer(): Promise<void> {
         </CardContent>
       </Card>
 
+      <!-- Legacy PHP warning -->
+      <div
+        v-if="hasLegacy"
+        data-testid="dumps-legacy-banner"
+        class="rounded-md border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-warning-foreground"
+      >
+        One or more installed PHP versions are legacy (&lt; 8.2). Dumps are never captured for
+        legacy versions - the <code>yerd-dump</code> extension isn't built for out-of-support PHP.
+      </div>
+
       <!-- Extension presence -->
       <Card>
         <CardHeader>
           <CardTitle>PHP extension</CardTitle>
           <CardDescription>
             Telemetry is captured by the <code>yerd-dump</code> extension, installed per PHP
-            version. Versions without it simply produce no dumps.
+            version. Versions without it simply produce no dumps. Legacy PHP versions (&lt; 8.2)
+            never capture dumps - the extension isn't built for them.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -197,7 +209,8 @@ async function openViewer(): Promise<void> {
               >
                 <td class="py-2 font-mono">PHP {{ ext.version }}</td>
                 <td class="py-2 text-right">
-                  <Badge :variant="ext.present ? 'success' : 'warning'">
+                  <Badge v-if="ext.legacy" variant="warning">Unsupported (no dumps)</Badge>
+                  <Badge v-else :variant="ext.present ? 'success' : 'warning'">
                     {{ ext.present ? "Installed" : "Not installed" }}
                   </Badge>
                 </td>

--- a/apps/yerd-gui/src/views/PhpView.spec.ts
+++ b/apps/yerd-gui/src/views/PhpView.spec.ts
@@ -108,4 +108,27 @@ describe("PhpView legacy handling", () => {
     const streamed = invokeMock.mock.calls.find((c) => c[0] === "install_php_streamed");
     expect(streamed?.[1]).toMatchObject({ confirmLegacy: true });
   });
+
+  it("keeps the stable install available while the legacy disclosure is open", async () => {
+    stubIpc({});
+    const wrapper = await mountView();
+
+    const openBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Install") && b.attributes("disabled") === undefined);
+    await openBtn!.trigger("click");
+    await flushPromises();
+
+    await wrapper.find('[data-testid="toggle-legacy"]').trigger("click");
+    await flushPromises();
+
+    const stableBtn = wrapper.find('[data-testid="install-stable"]');
+    expect(stableBtn.exists()).toBe(true);
+    expect(stableBtn.attributes("disabled")).toBeUndefined();
+
+    await stableBtn.trigger("click");
+    await flushPromises();
+    const streamed = invokeMock.mock.calls.find((c) => c[0] === "install_php_streamed");
+    expect(streamed?.[1]).toMatchObject({ confirmLegacy: false });
+  });
 });

--- a/apps/yerd-gui/src/views/PhpView.spec.ts
+++ b/apps/yerd-gui/src/views/PhpView.spec.ts
@@ -1,0 +1,111 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import PhpView from "./PhpView.vue";
+import { useDaemon } from "@/composables/useDaemon";
+import { resetResourceCache } from "@/composables/useResource";
+import type { PhpVersion } from "@/ipc/types";
+
+/** A default mock: installed 8.4 + legacy 8.1, an available list with a legacy
+ *  8.0, `ok` for mutations, and a loud reject for anything unexpected. */
+function stubIpc(opts: { installed?: PhpVersion[]; available?: PhpVersion[]; legacy?: PhpVersion[] }) {
+  const installed = opts.installed ?? ["8.1", "8.4"];
+  const available = opts.available ?? ["8.5"];
+  const legacy = opts.legacy ?? ["7.4", "8.0"];
+  invokeMock.mockImplementation((cmd: string) => {
+    switch (cmd) {
+      case "list_php":
+        return Promise.resolve({
+          type: "php_versions",
+          installed,
+          default: "8.4",
+          updates: [],
+          settings: {},
+          version_settings: {},
+        });
+      case "list_php_extensions":
+        return Promise.resolve({ type: "php_extensions", by_version: {} });
+      case "available_php":
+        return Promise.resolve({ type: "available_php", available, installed, legacy });
+      case "install_php_streamed":
+        return Promise.resolve({ type: "job_started", job_id: "j1" });
+      default:
+        return Promise.reject(new Error(`unexpected invoke ${cmd}`));
+    }
+  });
+}
+
+const mounted: { unmount: () => void }[] = [];
+
+async function mountView() {
+  const wrapper = mount(PhpView, {
+    global: { stubs: { teleport: true, RouterLink: true } },
+  });
+  mounted.push(wrapper);
+  await flushPromises();
+  return wrapper;
+}
+
+describe("PhpView legacy handling", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    resetResourceCache();
+    useDaemon().report.value = null;
+  });
+
+  afterEach(() => {
+    mounted.forEach((w) => w.unmount());
+    mounted.length = 0;
+  });
+
+  it("tags an installed legacy version with a legacy badge", async () => {
+    stubIpc({ installed: ["8.1", "8.4"] });
+    const wrapper = await mountView();
+    expect(wrapper.text()).toContain("legacy");
+  });
+
+  it("gates the legacy install behind a confirmation checkbox", async () => {
+    stubIpc({});
+    const wrapper = await mountView();
+
+    // Open the install modal.
+    const openBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Install") && b.attributes("disabled") === undefined);
+    expect(openBtn).toBeTruthy();
+    await openBtn!.trigger("click");
+    await flushPromises();
+
+    // The legacy disclosure is present; reveal it.
+    const toggle = wrapper.find('[data-testid="toggle-legacy"]');
+    expect(toggle.exists()).toBe(true);
+    await toggle.trigger("click");
+    await flushPromises();
+    expect(wrapper.find('[data-testid="legacy-warning"]').exists()).toBe(true);
+
+    // The footer "Install legacy version" button is disabled until confirmed.
+    const installBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Install legacy version"));
+    expect(installBtn).toBeTruthy();
+    expect(installBtn!.attributes("disabled")).toBeDefined();
+
+    // Tick the confirmation switch → enabled, and installing streams the flag.
+    await wrapper.find('button[aria-label="Confirm legacy install"]').trigger("click");
+    await flushPromises();
+    const enabled = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Install legacy version"));
+    expect(enabled!.attributes("disabled")).toBeUndefined();
+
+    await enabled!.trigger("click");
+    await flushPromises();
+    const streamed = invokeMock.mock.calls.find((c) => c[0] === "install_php_streamed");
+    expect(streamed?.[1]).toMatchObject({ confirmLegacy: true });
+  });
+});

--- a/apps/yerd-gui/src/views/PhpView.vue
+++ b/apps/yerd-gui/src/views/PhpView.vue
@@ -392,12 +392,9 @@ const legacyOptions = ref<{ value: PhpVersion; label: string }[]>([]);
 const selectedLegacy = ref<PhpVersion>("");
 const showLegacy = ref(false);
 const confirmLegacy = ref(false);
-// Whether the install button acts on a legacy version (the disclosure is open).
-const legacyMode = computed(() => showLegacy.value);
-const canInstall = computed(() =>
-  legacyMode.value
-    ? !!selectedLegacy.value && confirmLegacy.value
-    : !!selectedVersion.value,
+const canInstallStable = computed(() => !!selectedVersion.value);
+const canInstallLegacy = computed(
+  () => !!selectedLegacy.value && confirmLegacy.value,
 );
 
 // ── install-progress dialog ──
@@ -449,8 +446,7 @@ async function openInstall(): Promise<void> {
  * version list AND the status poll so the new row shows its patch + "idle" state
  * immediately rather than on the next 4s tick.
  */
-async function confirmInstall(closePicker: () => void): Promise<void> {
-  const legacy = legacyMode.value;
+async function confirmInstall(legacy: boolean): Promise<void> {
   const v = legacy ? selectedLegacy.value : selectedVersion.value;
   if (!v || installing.value) return;
   if (legacy && !confirmLegacy.value) return;
@@ -459,7 +455,7 @@ async function confirmInstall(closePicker: () => void): Promise<void> {
   installPhase.value = "running";
   installError.value = "";
   operations.begin({ id: opId, kind: "php-install", label: `Installing PHP ${v}` });
-  closePicker();
+  installOpen.value = false;
   installProgressOpen.value = true;
   try {
     await installPhpWithProgress(
@@ -895,6 +891,13 @@ onUnmounted(
               <Switch v-model="confirmLegacy" aria-label="Confirm legacy install" />
               I understand and want to install this legacy version anyway.
             </label>
+            <Button
+              class="w-full"
+              :disabled="!canInstallLegacy || installing"
+              @click="confirmInstall(true)"
+            >
+              Install legacy version
+            </Button>
           </div>
         </div>
       </template>
@@ -904,8 +907,13 @@ onUnmounted(
       </p>
       <template #footer="{ close }">
         <Button variant="ghost" @click="close">Cancel</Button>
-        <Button :disabled="!canInstall || installing" @click="confirmInstall(close)">
-          {{ legacyMode ? "Install legacy version" : "Install" }}
+        <Button
+          v-if="installOptions.length"
+          :disabled="!canInstallStable || installing"
+          data-testid="install-stable"
+          @click="confirmInstall(false)"
+        >
+          Install
         </Button>
       </template>
     </Modal>

--- a/apps/yerd-gui/src/views/PhpView.vue
+++ b/apps/yerd-gui/src/views/PhpView.vue
@@ -67,6 +67,7 @@ import {
   DISPLAY_ERRORS_OPTIONS,
   TEXT_SETTINGS,
 } from "@/lib/phpSettings";
+import { isLegacyVersion } from "@/lib/phpVersion";
 import { humaniseBytes, poolStateLabel, poolStateTone } from "@/lib/utils";
 
 const toast = useToast();
@@ -386,6 +387,18 @@ const installOpen = ref(false);
 const installLoading = ref(false);
 const installOptions = ref<{ value: PhpVersion; label: string }[]>([]);
 const selectedVersion = ref<PhpVersion>("");
+// Legacy (< 8.2) versions are offered behind an explicit, warned opt-in.
+const legacyOptions = ref<{ value: PhpVersion; label: string }[]>([]);
+const selectedLegacy = ref<PhpVersion>("");
+const showLegacy = ref(false);
+const confirmLegacy = ref(false);
+// Whether the install button acts on a legacy version (the disclosure is open).
+const legacyMode = computed(() => showLegacy.value);
+const canInstall = computed(() =>
+  legacyMode.value
+    ? !!selectedLegacy.value && confirmLegacy.value
+    : !!selectedVersion.value,
+);
 
 // ── install-progress dialog ──
 // A blocking, non-dismissible dialog owns the install's status (spinner + the
@@ -403,15 +416,24 @@ async function openInstall(): Promise<void> {
   installOpen.value = true;
   installLoading.value = true;
   installOptions.value = [];
+  legacyOptions.value = [];
   selectedVersion.value = "";
+  selectedLegacy.value = "";
+  showLegacy.value = false;
+  confirmLegacy.value = false;
   try {
     const r = await availablePhp();
     const installedSet = new Set(r.installed);
     installOptions.value = r.available
       .filter((v) => !installedSet.has(v))
       .map((v) => ({ value: v, label: `PHP ${v}` }));
+    legacyOptions.value = (r.legacy ?? [])
+      .filter((v) => !installedSet.has(v))
+      .map((v) => ({ value: v, label: `PHP ${v}` }));
     const opts = installOptions.value;
     selectedVersion.value = opts[opts.length - 1]?.value ?? "";
+    const legacyOpts = legacyOptions.value;
+    selectedLegacy.value = legacyOpts[legacyOpts.length - 1]?.value ?? "";
   } catch (e) {
     toast.error("Couldn't load installable versions", (e as IpcError).message);
   } finally {
@@ -428,8 +450,10 @@ async function openInstall(): Promise<void> {
  * immediately rather than on the next 4s tick.
  */
 async function confirmInstall(closePicker: () => void): Promise<void> {
-  const v = selectedVersion.value;
+  const legacy = legacyMode.value;
+  const v = legacy ? selectedLegacy.value : selectedVersion.value;
   if (!v || installing.value) return;
+  if (legacy && !confirmLegacy.value) return;
   const opId = `php-install:${v}`;
   installTarget.value = v;
   installPhase.value = "running";
@@ -438,10 +462,14 @@ async function confirmInstall(closePicker: () => void): Promise<void> {
   closePicker();
   installProgressOpen.value = true;
   try {
-    await installPhpWithProgress(v, (lines) => {
-      const latest = lines[lines.length - 1];
-      if (latest) operations.update(opId, { detail: latest });
-    });
+    await installPhpWithProgress(
+      v,
+      (lines) => {
+        const latest = lines[lines.length - 1];
+        if (latest) operations.update(opId, { detail: latest });
+      },
+      legacy,
+    );
     installPhase.value = "done";
     toast.success(`Installed PHP ${v}`);
     await Promise.all([reloadPhp({ force: true }), refresh()]);
@@ -542,6 +570,7 @@ onUnmounted(
                 <Badge v-if="v === defaultVersion" variant="secondary">
                   <Star class="size-3" /> default
                 </Badge>
+                <Badge v-if="isLegacyVersion(v)" variant="warning">legacy</Badge>
               </div>
             </td>
             <td class="py-3 pr-4">
@@ -578,7 +607,10 @@ onUnmounted(
                     <DropdownMenuItem :disabled="!updateByVersion[v]" @select="doUpdate(v)">
                       <Download class="size-4" /> Update
                     </DropdownMenuItem>
-                    <DropdownMenuItem :disabled="v === defaultVersion" @select="makeDefault(v)">
+                    <DropdownMenuItem
+                      :disabled="v === defaultVersion || isLegacyVersion(v)"
+                      @select="makeDefault(v)"
+                    >
                       <Star class="size-4" /> Set default
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
@@ -812,21 +844,59 @@ onUnmounted(
       <div v-if="installLoading" class="flex justify-center py-6">
         <Spinner class="size-5" />
       </div>
-      <template v-else-if="installOptions.length">
-        <span class="text-sm font-medium">Version</span>
-        <div class="mt-2">
-          <Select
-            class="w-full"
-            :model-value="selectedVersion"
-            :options="installOptions"
-            aria-label="PHP version to install"
-            @update:model-value="(v: PhpVersion) => (selectedVersion = v)"
-          />
+      <template v-else-if="installOptions.length || legacyOptions.length">
+        <template v-if="installOptions.length">
+          <span class="text-sm font-medium">Version</span>
+          <div class="mt-2">
+            <Select
+              class="w-full"
+              :model-value="selectedVersion"
+              :options="installOptions"
+              aria-label="PHP version to install"
+              @update:model-value="(v: PhpVersion) => (selectedVersion = v)"
+            />
+          </div>
+          <p class="mt-2 text-xs text-muted-foreground">
+            Downloads a prebuilt static build; this can take a few minutes. A
+            dialog shows live progress and can be closed once it finishes.
+          </p>
+        </template>
+
+        <div v-if="legacyOptions.length" class="mt-4 border-t pt-3">
+          <button
+            type="button"
+            class="text-sm text-muted-foreground underline-offset-2 hover:underline"
+            data-testid="toggle-legacy"
+            @click="showLegacy = !showLegacy"
+          >
+            {{ showLegacy ? "Hide" : "Show" }} legacy versions (7.4 / 8.0 / 8.1)
+          </button>
+
+          <div v-if="showLegacy" class="mt-3 space-y-3">
+            <div
+              class="flex gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-xs text-warning-foreground"
+              data-testid="legacy-warning"
+            >
+              <TriangleAlert class="mt-0.5 size-4 shrink-0" />
+              <span>
+                Legacy PHP versions are out of support and may contain unpatched security
+                vulnerabilities. They have no code coverage (phpcover), no yerd-dumps capture, and
+                cannot be set as the default PHP version. Use only for maintaining old projects.
+              </span>
+            </div>
+            <Select
+              class="w-full"
+              :model-value="selectedLegacy"
+              :options="legacyOptions"
+              aria-label="Legacy PHP version to install"
+              @update:model-value="(v: PhpVersion) => (selectedLegacy = v)"
+            />
+            <label class="flex items-center gap-2 text-sm">
+              <Switch v-model="confirmLegacy" aria-label="Confirm legacy install" />
+              I understand and want to install this legacy version anyway.
+            </label>
+          </div>
         </div>
-        <p class="mt-2 text-xs text-muted-foreground">
-          Downloads a prebuilt static build; this can take a few minutes. A
-          dialog shows live progress and can be closed once it finishes.
-        </p>
       </template>
       <p v-else class="py-2 text-sm text-muted-foreground">
         No installable versions to add - every version offered by the
@@ -834,11 +904,8 @@ onUnmounted(
       </p>
       <template #footer="{ close }">
         <Button variant="ghost" @click="close">Cancel</Button>
-        <Button
-          :disabled="!installOptions.length || !selectedVersion || installing"
-          @click="confirmInstall(close)"
-        >
-          Install
+        <Button :disabled="!canInstall || installing" @click="confirmInstall(close)">
+          {{ legacyMode ? "Install legacy version" : "Install" }}
         </Button>
       </template>
     </Modal>

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -682,6 +682,11 @@ pub enum InstallTarget {
     Php {
         /// PHP version, e.g. `8.5`.
         version: String,
+        /// Confirm you want an out-of-support legacy version (7.4 / 8.0 / 8.1).
+        /// Required for legacy minors: they get no security support, no code
+        /// coverage (phpcover), and no yerd-dumps, and cannot be the default.
+        #[arg(long)]
+        legacy: bool,
     },
     /// Install a dev tool (`composer`, `node`, `bun`, `laravel`, `wp-cli`) at
     /// its latest release.

--- a/bin/yerd/src/cli_shim.rs
+++ b/bin/yerd/src/cli_shim.rs
@@ -100,8 +100,9 @@ fn resolve_target(
                 ))
             }
         }
-        CliSpec::Default => resolve_default_php(dirs)
-            .ok_or_else(|| "no PHP installed — run `yerd install php <version>`".to_owned()),
+        CliSpec::Default => {
+            resolve_default_php(dirs).ok_or_else(|| crate::shim::no_default_php_message(dirs))
+        }
     }
 }
 

--- a/bin/yerd/src/composer_shim.rs
+++ b/bin/yerd/src/composer_shim.rs
@@ -33,7 +33,7 @@ fn run() -> ExitCode {
     };
 
     let Some((php_bin, _minor)) = resolve_default_php(&dirs) else {
-        return fail("no PHP installed — run `yerd install php <version>`".to_owned());
+        return fail(crate::shim::no_default_php_message(&dirs));
     };
 
     let phar = dirs

--- a/bin/yerd/src/cover_shim.rs
+++ b/bin/yerd/src/cover_shim.rs
@@ -17,7 +17,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
-use yerd_core::php_settings;
+use yerd_core::{php_settings, PhpVersion};
 use yerd_platform::{ActivePaths, Paths, PlatformDirs};
 
 use crate::shim::{cli_binary, fail, resolve_default_php};
@@ -137,6 +137,12 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 fn resolve_target(dirs: &PlatformDirs, spec: &CoverSpec) -> Result<(PathBuf, String), String> {
     match spec {
         CoverSpec::Version(maj, min) => {
+            if PhpVersion::new(*maj, *min).is_legacy() {
+                return Err(format!(
+                    "code coverage is not available for PHP {maj}.{min}: pcov is not built for \
+                     out-of-support legacy versions (< 8.2). Use a supported PHP version."
+                ));
+            }
             let minor = format!("{maj}.{min}");
             let php = cli_binary(dirs, &minor);
             if php.is_file() {
@@ -147,12 +153,14 @@ fn resolve_target(dirs: &PlatformDirs, spec: &CoverSpec) -> Result<(PathBuf, Str
                 ))
             }
         }
-        CoverSpec::Default => resolve_default_php(dirs)
-            .ok_or_else(|| "no PHP installed — run `yerd install php <version>`".to_owned()),
+        CoverSpec::Default => {
+            resolve_default_php(dirs).ok_or_else(|| crate::shim::no_default_php_message(dirs))
+        }
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
 
@@ -175,5 +183,26 @@ mod tests {
         assert!(parse_cover_name("phpunit").is_none());
         assert!(parse_cover_name("php8.cover").is_none());
         assert!(parse_cover_name("phpx.4cover").is_none());
+    }
+
+    #[test]
+    fn resolve_target_rejects_legacy_before_checking_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = PlatformDirs {
+            config: tmp.path().join("c"),
+            data: tmp.path().join("d"),
+            state: tmp.path().join("s"),
+            cache: tmp.path().join("ca"),
+            runtime: tmp.path().join("r"),
+        };
+        // No 7.4 installed, yet the legacy gate fires first with a pcov message,
+        // not "not installed".
+        match resolve_target(&dirs, &CoverSpec::Version(7, 4)) {
+            Err(msg) => {
+                assert!(msg.contains("pcov"), "got {msg}");
+                assert!(msg.contains("legacy"), "got {msg}");
+            }
+            Ok(_) => panic!("expected legacy rejection"),
+        }
     }
 }

--- a/bin/yerd/src/laravel_shim.rs
+++ b/bin/yerd/src/laravel_shim.rs
@@ -35,7 +35,7 @@ fn run() -> ExitCode {
     };
 
     let Some((php_bin, _minor)) = resolve_default_php(&dirs) else {
-        return fail("no PHP installed — run `yerd install php <version>`".to_owned());
+        return fail(crate::shim::no_default_php_message(&dirs));
     };
 
     let installer = dirs

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -35,9 +35,17 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
         Command::Use {
             first,
             version: None,
-        } => Request::SetDefaultPhp {
-            version: parse_php(first)?,
-        },
+        } => {
+            let version = parse_php(first)?;
+            if version.is_legacy() {
+                return Err(ClientError::Usage(format!(
+                    "PHP {version} is an out-of-support legacy version and cannot be the global \
+                     default (`yerd use`). It can still serve individual sites (`yerd use <site> \
+                     {version}`) and run via `php{version}`."
+                )));
+            }
+            Request::SetDefaultPhp { version }
+        }
         Command::Use {
             first,
             version: Some(version),
@@ -83,10 +91,22 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
             action: crate::cli::PhpAction::Ext { action },
         } => php_ext_to_request(action)?,
         Command::Install {
-            target: crate::cli::InstallTarget::Php { version },
-        } => Request::InstallPhp {
-            version: parse_php(version)?,
-        },
+            target: crate::cli::InstallTarget::Php { version, legacy },
+        } => {
+            let parsed = parse_php(version)?;
+            if parsed.is_legacy() && !*legacy {
+                return Err(ClientError::Usage(format!(
+                    "PHP {parsed} is an out-of-support legacy version. It may contain unpatched \
+                     security vulnerabilities, has no code coverage (phpcover) and no yerd-dumps, \
+                     and cannot be set as the default. Re-run with `--legacy` to install it \
+                     anyway: `yerd install php {parsed} --legacy`."
+                )));
+            }
+            Request::InstallPhp {
+                version: parsed,
+                confirm_legacy: *legacy,
+            }
+        }
         Command::Install {
             target: crate::cli::InstallTarget::Tool { id },
         } => Request::InstallTool { tool: id.clone() },
@@ -769,7 +789,8 @@ pub fn render(resp: &Response, json: bool) -> Rendered {
         Response::AvailablePhp {
             available,
             installed,
-        } => Rendered::ok(format_available_php(available, installed)),
+            legacy,
+        } => Rendered::ok(format_available_php(available, installed, legacy)),
         Response::PhpExtensions { by_version } => Rendered::ok(format_php_extensions(by_version)),
         Response::Error { code: c, message } => Rendered::err(format!("error ({c:?}): {message}")),
         Response::Status { report } => Rendered {
@@ -1208,22 +1229,33 @@ fn global_of(settings: &std::collections::BTreeMap<String, String>, key: &str) -
         .map_or_else(|| "PHP default".to_owned(), |v| format!("global {v}"))
 }
 
-/// Render the installable versions, tagging the ones already installed.
-fn format_available_php(available: &[PhpVersion], installed: &[PhpVersion]) -> String {
-    if available.is_empty() {
+/// Render the installable versions, tagging the ones already installed. Legacy
+/// (< 8.2) versions, when offered, are listed in a separate, clearly-warned
+/// section below the supported ones.
+fn format_available_php(
+    available: &[PhpVersion],
+    installed: &[PhpVersion],
+    legacy: &[PhpVersion],
+) -> String {
+    if available.is_empty() && legacy.is_empty() {
         return "no installable PHP versions found for this platform".to_owned();
     }
-    available
-        .iter()
-        .map(|v| {
-            if installed.contains(v) {
-                format!("{v} (installed)")
-            } else {
-                v.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+    let tag = |v: &PhpVersion| {
+        if installed.contains(v) {
+            format!("{v} (installed)")
+        } else {
+            v.to_string()
+        }
+    };
+    let mut out = available.iter().map(&tag).collect::<Vec<_>>().join("\n");
+    if !legacy.is_empty() {
+        if !out.is_empty() {
+            out.push_str("\n\n");
+        }
+        out.push_str("Legacy (out of support - no coverage, no dumps, cannot be default):\n");
+        out.push_str(&legacy.iter().map(&tag).collect::<Vec<_>>().join("\n"));
+    }
+    out
 }
 
 /// Render the custom-extension registry, grouped by version, tagging any entry
@@ -1616,12 +1648,14 @@ mod tests {
         assert_eq!(
             to_request(&Command::Install {
                 target: crate::cli::InstallTarget::Php {
-                    version: "8.5".into()
+                    version: "8.5".into(),
+                    legacy: false,
                 }
             })
             .unwrap(),
             Request::InstallPhp {
-                version: PhpVersion::new(8, 5)
+                version: PhpVersion::new(8, 5),
+                confirm_legacy: false,
             }
         );
         assert_eq!(
@@ -2298,6 +2332,7 @@ mod tests {
                     PhpVersion::new(8, 5),
                 ],
                 installed: vec![PhpVersion::new(8, 4)],
+                legacy: vec![],
             },
             false,
         );
@@ -2306,15 +2341,70 @@ mod tests {
         assert!(r.stdout.contains("\n8.3") || r.stdout.starts_with("8.3"));
         assert!(!r.stdout.contains("8.3 (installed)"));
         assert!(!r.stdout.contains("8.5 (installed)"));
+        assert!(!r.stdout.contains("Legacy"), "no legacy section when empty");
 
         let empty = render(
             &Response::AvailablePhp {
                 available: vec![],
                 installed: vec![],
+                legacy: vec![],
             },
             false,
         );
         assert!(empty.stdout.contains("no installable PHP versions"));
+    }
+
+    #[test]
+    fn renders_available_php_legacy_section() {
+        let r = render(
+            &Response::AvailablePhp {
+                available: vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)],
+                installed: vec![PhpVersion::new(8, 1)],
+                legacy: vec![PhpVersion::new(7, 4), PhpVersion::new(8, 1)],
+            },
+            false,
+        );
+        assert_eq!(r.code, 0);
+        assert!(r.stdout.contains("Legacy (out of support"));
+        assert!(r.stdout.contains("7.4"));
+        assert!(r.stdout.contains("8.1 (installed)"));
+    }
+
+    #[test]
+    fn use_rejects_legacy_default() {
+        match to_request(&Command::Use {
+            first: "7.4".into(),
+            version: None,
+        }) {
+            Err(ClientError::Usage(msg)) => assert!(msg.contains("legacy")),
+            other => panic!("expected Usage error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn install_legacy_requires_flag() {
+        match to_request(&Command::Install {
+            target: crate::cli::InstallTarget::Php {
+                version: "7.4".into(),
+                legacy: false,
+            },
+        }) {
+            Err(ClientError::Usage(msg)) => assert!(msg.contains("--legacy")),
+            other => panic!("expected Usage error, got {other:?}"),
+        }
+        assert_eq!(
+            to_request(&Command::Install {
+                target: crate::cli::InstallTarget::Php {
+                    version: "7.4".into(),
+                    legacy: true,
+                },
+            })
+            .unwrap(),
+            Request::InstallPhp {
+                version: PhpVersion::new(7, 4),
+                confirm_legacy: true,
+            }
+        );
     }
 
     #[test]
@@ -3010,6 +3100,7 @@ mod tests {
         match to_request(&Command::Install {
             target: crate::cli::InstallTarget::Php {
                 version: "not-a-version".into(),
+                legacy: false,
             },
         }) {
             Err(ClientError::Usage(_)) => {}

--- a/bin/yerd/src/shim.rs
+++ b/bin/yerd/src/shim.rs
@@ -6,7 +6,14 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+use yerd_core::PhpVersion;
 use yerd_platform::PlatformDirs;
+
+/// Whether a `"major.minor"` minor string names a legacy version (< 8.2). A
+/// minor that doesn't parse is treated as non-legacy (it will fail elsewhere).
+fn minor_is_legacy(minor: &str) -> bool {
+    minor.parse::<PhpVersion>().is_ok_and(PhpVersion::is_legacy)
+}
 
 /// `{data}/php/php-<minor>/bin/php`.
 #[must_use]
@@ -29,6 +36,9 @@ pub(crate) fn cli_binary(dirs: &PlatformDirs, minor: &str) -> PathBuf {
 pub(crate) fn default_from_shim(dirs: &PlatformDirs) -> Option<(PathBuf, String)> {
     let target = std::fs::read_link(dirs.data.join("bin").join("php")).ok()?;
     let minor = minor_from_php_path(&target)?;
+    if minor_is_legacy(&minor) {
+        return None;
+    }
     let php = cli_binary(dirs, &minor);
     php.is_file().then_some((php, minor))
 }
@@ -43,6 +53,9 @@ pub(crate) fn default_from_shim(dirs: &PlatformDirs) -> Option<(PathBuf, String)
 pub(crate) fn default_from_config(dirs: &PlatformDirs) -> Option<(PathBuf, String)> {
     let cfg = yerd_config::Config::load(&dirs.config.join("yerd.toml")).ok()?;
     let v = cfg.php.default;
+    if v.is_legacy() {
+        return None;
+    }
     let minor = format!("{}.{}", v.major, v.minor);
     let php = cli_binary(dirs, &minor);
     php.is_file().then_some((php, minor))
@@ -80,7 +93,47 @@ pub(crate) fn minor_from_php_path(p: &Path) -> Option<String> {
     })
 }
 
-/// Highest installed minor under `{data}/php` whose CLI binary exists.
+/// Whether any PHP version is installed under `{data}/php` (legacy included) -
+/// used to distinguish "nothing installed" from "only legacy installed" in the
+/// no-default message.
+#[must_use]
+pub(crate) fn any_installed(dirs: &PlatformDirs) -> bool {
+    let root = dirs.data.join("php");
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let fname = entry.file_name();
+        let Some(name) = fname.to_str() else { continue };
+        let Some(rest) = name.strip_prefix("php-") else {
+            continue;
+        };
+        if cli_binary(dirs, rest).is_file() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Message for when [`resolve_default_php`] returns `None`: distinguishes
+/// "nothing installed" from "only legacy installed" so the guidance is accurate.
+/// Shared by every shim that resolves the default PHP (`php`, `phpcover`,
+/// `composer`, `laravel`, `wp`).
+#[must_use]
+pub(crate) fn no_default_php_message(dirs: &PlatformDirs) -> String {
+    if any_installed(dirs) {
+        "No supported default PHP version. Legacy versions (7.4 / 8.0 / 8.1) can't be the \
+         default - install a supported version (e.g. `yerd install php 8.4`), or invoke a \
+         legacy version explicitly, e.g. `php7.4`."
+            .to_owned()
+    } else {
+        "no PHP installed - run `yerd install php <version>`".to_owned()
+    }
+}
+
+/// Highest installed **non-legacy** minor under `{data}/php` whose CLI binary
+/// exists. Legacy minors (< 8.2) are skipped so bare `php` never resolves to a
+/// legacy interpreter.
 #[must_use]
 pub(crate) fn highest_installed(dirs: &PlatformDirs) -> Option<(PathBuf, String)> {
     let root = dirs.data.join("php");
@@ -97,6 +150,9 @@ pub(crate) fn highest_installed(dirs: &PlatformDirs) -> Option<(PathBuf, String)
         let (Ok(maj), Ok(min)) = (maj.parse::<u8>(), min.parse::<u8>()) else {
             continue;
         };
+        if PhpVersion::new(maj, min).is_legacy() {
+            continue;
+        }
         if !cli_binary(dirs, rest).is_file() {
             continue;
         }
@@ -111,7 +167,10 @@ pub(crate) fn highest_installed(dirs: &PlatformDirs) -> Option<(PathBuf, String)
 
 /// Resolve the default PHP `(binary, "major.minor")`: the config default first
 /// (authoritative), then a legacy direct-symlink `php` shim target, then the
-/// highest installed version. `None` when no PHP is installed.
+/// highest installed version. Every fallback excludes legacy (< 8.2) versions,
+/// so bare `php` never runs a legacy interpreter. `None` when no *supported* PHP
+/// is installed (even if a legacy version is) - callers render
+/// [`no_default_php_message`] to explain.
 #[must_use]
 pub(crate) fn resolve_default_php(dirs: &PlatformDirs) -> Option<(PathBuf, String)> {
     default_from_config(dirs)
@@ -129,6 +188,69 @@ pub(crate) fn fail(msg: String) -> ExitCode {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    fn dirs_at(tmp: &Path) -> PlatformDirs {
+        PlatformDirs {
+            config: tmp.join("c"),
+            data: tmp.join("d"),
+            state: tmp.join("s"),
+            cache: tmp.join("ca"),
+            runtime: tmp.join("r"),
+        }
+    }
+
+    fn fake_cli(dirs: &PlatformDirs, minor: &str) {
+        let base = dirs
+            .data
+            .join("php")
+            .join(format!("php-{minor}"))
+            .join("bin");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("php"), b"x").unwrap();
+    }
+
+    #[test]
+    fn highest_installed_skips_legacy_versions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        fake_cli(&dirs, "8.0");
+        fake_cli(&dirs, "8.2");
+        assert_eq!(
+            highest_installed(&dirs).map(|(_, m)| m),
+            Some("8.2".to_owned()),
+            "legacy 8.0 is skipped; 8.2 wins"
+        );
+    }
+
+    #[test]
+    fn highest_installed_none_when_only_legacy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        fake_cli(&dirs, "7.4");
+        assert_eq!(highest_installed(&dirs), None);
+        assert!(any_installed(&dirs), "7.4 is still installed");
+    }
+
+    #[test]
+    fn no_default_message_distinguishes_legacy_only_from_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        std::fs::create_dir_all(dirs.data.join("php")).unwrap();
+        assert!(no_default_php_message(&dirs).contains("no PHP installed"));
+        fake_cli(&dirs, "7.4");
+        let msg = no_default_php_message(&dirs);
+        assert!(msg.contains("supported"));
+        assert!(msg.contains("php7.4"));
+    }
+
+    #[test]
+    fn minor_is_legacy_splits_at_floor() {
+        assert!(minor_is_legacy("7.4"));
+        assert!(minor_is_legacy("8.1"));
+        assert!(!minor_is_legacy("8.2"));
+        assert!(!minor_is_legacy("8.5"));
+        assert!(!minor_is_legacy("garbage"));
+    }
 
     #[test]
     fn minor_from_php_path_extracts_dotted_minor() {

--- a/bin/yerd/src/wp_shim.rs
+++ b/bin/yerd/src/wp_shim.rs
@@ -116,7 +116,7 @@ fn run() -> ExitCode {
         }
         ScopeResolution::NoScope => match resolve_default_php(&dirs) {
             Some((php, minor)) => (php, minor, None),
-            None => return fail("no PHP installed — run `yerd install php <version>`".to_owned()),
+            None => return fail(crate::shim::no_default_php_message(&dirs)),
         },
     };
 

--- a/bin/yerd/tests/cover_shim_e2e.rs
+++ b/bin/yerd/tests/cover_shim_e2e.rs
@@ -120,6 +120,63 @@ mod tests {
         assert!(expected_phprc.is_file(), "cover.ini must have been written");
     }
 
+    /// Build a faked layout whose ONLY installed PHP is legacy 7.4 (stub CLI at
+    /// `php-7.4/bin/php`). Returns `(tempdir, home)`.
+    fn faked_legacy_only_layout() -> (tempfile::TempDir, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).expect("mkdir home");
+        let dirs = PlatformDirs::for_user(&home, 0);
+        let php_bin_dir = dirs.data.join("php").join("php-7.4").join("bin");
+        fs::create_dir_all(&php_bin_dir).expect("mkdir php bin");
+        let php_bin = php_bin_dir.join("php");
+        fs::write(&php_bin, STUB_PHP).expect("write stub php");
+        fs::set_permissions(&php_bin, fs::Permissions::from_mode(0o755)).expect("chmod +x");
+        (tmp, home)
+    }
+
+    #[test]
+    fn php74cover_errors_on_legacy() {
+        let (tmp, home) = faked_legacy_only_layout();
+        let cover_shim_bin = tmp.path().join("php7.4cover");
+        symlink(env!("CARGO_BIN_EXE_yerd"), &cover_shim_bin).expect("symlink cover shim");
+
+        let output = run_in_home(&cover_shim_bin, &["artisan", "test"], &home);
+        assert!(!output.status.success(), "php7.4cover must fail on legacy");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("pcov") && stderr.contains("legacy"),
+            "stderr should explain pcov/legacy, got: {stderr}"
+        );
+    }
+
+    #[test]
+    fn bare_php_errors_when_only_legacy_installed_but_versioned_shim_runs() {
+        let (tmp, home) = faked_legacy_only_layout();
+
+        let php_shim = tmp.path().join("php");
+        symlink(env!("CARGO_BIN_EXE_yerd"), &php_shim).expect("symlink php shim");
+        let bare = run_in_home(&php_shim, &["--version"], &home);
+        assert!(
+            !bare.status.success(),
+            "bare php must not run a legacy interpreter"
+        );
+        let stderr = String::from_utf8_lossy(&bare.stderr);
+        assert!(
+            stderr.contains("supported") && stderr.contains("php7.4"),
+            "stderr should steer to a supported version, got: {stderr}"
+        );
+
+        let php74_shim = tmp.path().join("php7.4");
+        symlink(env!("CARGO_BIN_EXE_yerd"), &php74_shim).expect("symlink php7.4 shim");
+        let versioned = run_in_home(&php74_shim, &["--version"], &home);
+        assert!(
+            versioned.status.success(),
+            "php7.4 must still run the legacy interpreter: {}",
+            String::from_utf8_lossy(&versioned.stderr)
+        );
+    }
+
     #[test]
     fn phprc_survives_a_re_exec_grandchild_hop() {
         let (tmp, home, expected_phprc) = faked_php_8_4_layout();

--- a/bin/yerdd/src/dump_server.rs
+++ b/bin/yerdd/src/dump_server.rs
@@ -552,6 +552,7 @@ fn extension_presence(dirs: &PlatformDirs) -> Vec<DumpExtStatus> {
         .map(|version| DumpExtStatus {
             version,
             present: crate::ext_install::so_path(dirs, version).is_file(),
+            legacy: version.is_legacy(),
         })
         .collect();
     out.sort_by_key(|s| (s.version.major, s.version.minor));

--- a/bin/yerdd/src/ext_install.rs
+++ b/bin/yerdd/src/ext_install.rs
@@ -115,7 +115,10 @@ pub async fn ensure_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader) {
 /// which is fine: pcov is ABI-stable per PHP minor and any *missing* `.so` still
 /// forces a full manifest fetch + re-verify.)
 pub async fn ensure_pcov_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader) {
-    let versions = installed_versions(dirs);
+    let versions: Vec<PhpVersion> = installed_versions(dirs)
+        .into_iter()
+        .filter(|v| !v.is_legacy())
+        .collect();
     if versions.is_empty() || versions.iter().all(|v| pcov_so_path(dirs, *v).is_file()) {
         return;
     }
@@ -124,12 +127,17 @@ pub async fn ensure_pcov_for_installed(dirs: &PlatformDirs, dl: &dyn Downloader)
 
 /// Shared fetch loop: resolve the host triple in `spec`'s manifest for each
 /// installed PHP minor, sha-verify, and atomically place the `.so`. Best-effort.
+/// Legacy minors (< 8.2) are skipped: `forjedio/yerd-php-ext` builds neither
+/// `pcov` nor `yerd-dump` for EOL PHP, so a fetch would only 404-log per poll.
 async fn ensure_for_installed_spec(dirs: &PlatformDirs, dl: &dyn Downloader, spec: &ExtSpec) {
     let Some(manifest) = fetch_manifest(dl, spec.manifest_name, spec.label).await else {
         return;
     };
     let (os, arch) = host_os_arch();
-    for v in installed_versions(dirs) {
+    for v in installed_versions(dirs)
+        .into_iter()
+        .filter(|v| !v.is_legacy())
+    {
         let minor = v.to_string();
         let Some(file) = manifest
             .files
@@ -374,6 +382,30 @@ mod tests {
             dl.call_count(),
             0,
             "no PHP installed: must not hit the network"
+        );
+    }
+
+    fn fake_install(dirs: &PlatformDirs, v: PhpVersion) {
+        let base = dirs.data.join("php").join(format!("php-{v}")).join("sbin");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("php-fpm"), b"x").unwrap();
+    }
+
+    #[tokio::test]
+    async fn ensure_pcov_skips_network_when_only_missing_is_legacy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        fake_install(&dirs, PhpVersion::new(8, 4));
+        fake_install(&dirs, PhpVersion::new(7, 4));
+        let pcov = pcov_so_path(&dirs, PhpVersion::new(8, 4));
+        std::fs::create_dir_all(pcov.parent().unwrap()).unwrap();
+        std::fs::write(&pcov, b"so").unwrap();
+        let dl = FakeDownloader::new(std::collections::HashMap::new());
+        ensure_pcov_for_installed(&dirs, &dl).await;
+        assert_eq!(
+            dl.call_count(),
+            0,
+            "the only version without pcov is legacy (7.4), which is skipped — no fetch"
         );
     }
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -4110,6 +4110,26 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
     }
 
+    /// Serves a valid legacy `php-legacy.json` but errors on every stable
+    /// `php.json` request, modelling a reachable legacy manifest behind an
+    /// unreachable stable one.
+    struct LegacyOnlyDl {
+        legacy: ListingDl,
+    }
+    #[async_trait::async_trait]
+    impl yerd_php::Downloader for LegacyOnlyDl {
+        async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
+            if url.contains("php-legacy.json") {
+                self.legacy.download(url).await
+            } else {
+                Err(yerd_php::DownloadError::Transport {
+                    url: url.to_owned(),
+                    reason: "stable unreachable".into(),
+                })
+            }
+        }
+    }
+
     #[tokio::test]
     async fn poll_and_refresh_populates_cache_from_listing() {
         let tmp = tempfile::tempdir().unwrap();
@@ -4188,6 +4208,61 @@ Subject: Captured\r\n\r\nhi\r\n";
         assert!(
             !cache.contains_key(&PhpVersion::new(7, 4)),
             "legacy minor is skipped, not errored"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_and_refresh_preserves_cached_legacy_update_when_legacy_fetch_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
+        fake_install_build(&state.dirs, PhpVersion::new(7, 4), "7.4.20", 1);
+        state
+            .php_updates
+            .write()
+            .await
+            .insert(PhpVersion::new(7, 4), ("7.4.33".to_owned(), 1));
+        // Legacy is signed with a different key than the poll is given, so its
+        // fetch degrades to `None`; the stable manifest is valid.
+        let stable = signed_listing(&[("8.5.9", "8.5", 1)]);
+        let legacy = signed_listing(&[("7.4.40", "7.4", 1)]);
+        let dl = TwoChannelDl {
+            stable: ListingDl::new(&stable),
+            legacy: ListingDl::new(&legacy),
+        };
+
+        crate::php_updates::poll_and_refresh(&state, &dl, &stable.public_key).await;
+
+        let cache = state.php_updates.read().await;
+        assert_eq!(
+            cache.get(&PhpVersion::new(8, 5)).cloned(),
+            Some(("8.5.9".to_owned(), 1)),
+            "stable minor is refreshed"
+        );
+        assert_eq!(
+            cache.get(&PhpVersion::new(7, 4)).cloned(),
+            Some(("7.4.33".to_owned(), 1)),
+            "a legacy fetch failure preserves the previously-cached legacy update"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_and_refresh_checks_legacy_when_stable_is_unreachable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        fake_install_build(&state.dirs, PhpVersion::new(7, 4), "7.4.20", 1);
+        let legacy = signed_listing(&[("7.4.33", "7.4", 1)]);
+        let dl = LegacyOnlyDl {
+            legacy: ListingDl::new(&legacy),
+        };
+
+        crate::php_updates::poll_and_refresh(&state, &dl, &legacy.public_key).await;
+
+        let cache = state.php_updates.read().await;
+        assert_eq!(
+            cache.get(&PhpVersion::new(7, 4)).cloned(),
+            Some(("7.4.33".to_owned(), 1)),
+            "a legacy-only install still gets update checks when stable is unreachable"
         );
     }
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -68,9 +68,10 @@ async fn handle_client(stream: IpcStream, state: Arc<DaemonState>) {
                 crate::tunnel::install_cloudflared_streamed(state.clone()).await
             }
             Request::CloudflaredLogin => crate::tunnel::named::login_streamed(state.clone()).await,
-            Request::InstallPhpStreamed { version } => {
-                install_php_streamed(version, state.clone()).await
-            }
+            Request::InstallPhpStreamed {
+                version,
+                confirm_legacy,
+            } => install_php_streamed(version, confirm_legacy, state.clone()).await,
             Request::JobStatus { job_id, cursor } => state.jobs.poll(&job_id, cursor).await,
             Request::JobCancel { job_id } => state.jobs.cancel(&job_id).await,
             other => dispatch(other, &state).await,
@@ -192,7 +193,10 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         | Request::SetSiteGroup { .. }
         | Request::RenameGroup { .. } => handle_group_mutation(req, state).await,
         Request::ListPhp => php_versions_response(state).await,
-        Request::InstallPhp { version } => install_php(version, state).await,
+        Request::InstallPhp {
+            version,
+            confirm_legacy,
+        } => install_php(version, confirm_legacy, state).await,
         Request::SetDefaultPhp { version } => set_default_php(version, state).await,
         Request::CheckPhpUpdates => {
             let dl = crate::php_install::ReqwestDownloader::new();
@@ -503,13 +507,23 @@ async fn available_php_with(
             }
         }
     };
-    let listing = match crate::php_install::fetch_verified_listing(dl, public_key).await {
-        Ok(body) => body,
-        Err(e) => return internal(format!("couldn't load the PHP listing: {e}")),
-    };
+    let listing =
+        match crate::php_install::fetch_verified_listing(dl, public_key, yerd_php::Channel::Stable)
+            .await
+        {
+            Ok(body) => body,
+            Err(e) => return internal(format!("couldn't load the PHP listing: {e}")),
+        };
+    let legacy =
+        crate::php_install::fetch_verified_listing(dl, public_key, yerd_php::Channel::Legacy)
+            .await
+            .ok()
+            .map(|body| yerd_php::available_minors(&body, os, arch, yerd_php::Channel::Legacy))
+            .unwrap_or_default();
     Response::AvailablePhp {
-        available: yerd_php::available_minors(&listing, os, arch),
+        available: yerd_php::available_minors(&listing, os, arch, yerd_php::Channel::Stable),
         installed: installed_versions(state),
+        legacy,
     }
 }
 
@@ -918,6 +932,7 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
 /// Holds `php_mutate` across the install loop so it can't race
 /// `install_php`/`install_php_streamed` over the same per-version staging dir.
 /// Not re-entrant: dispatched directly, never while `php_mutate` is already held.
+#[allow(clippy::too_many_lines)]
 async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState) -> Response {
     let dl = crate::php_install::ReqwestDownloader::new();
     let (os, arch) = match yerd_php::current_os_arch() {
@@ -941,13 +956,25 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
         }
         None => crate::php_updates::installed_minors(state),
     };
-    let listing =
-        match crate::php_install::fetch_verified_listing(&dl, yerd_update::PHP_LISTING_PUBLIC_KEY)
-            .await
+    let key = yerd_update::PHP_LISTING_PUBLIC_KEY;
+    let has_stable = targets.iter().any(|v| !v.is_legacy());
+    let has_legacy = targets.iter().any(|v| v.is_legacy());
+    let stable = if has_stable {
+        match crate::php_install::fetch_verified_listing(&dl, key, yerd_php::Channel::Stable).await
         {
-            Ok(body) => body,
+            Ok(body) => Some(body),
             Err(e) => return internal(format!("listing fetch/verify failed: {e}")),
-        };
+        }
+    } else {
+        None
+    };
+    let legacy = if has_legacy {
+        crate::php_install::fetch_verified_listing(&dl, key, yerd_php::Channel::Legacy)
+            .await
+            .ok()
+    } else {
+        None
+    };
     let _guard = state.php_mutate.lock().await;
     let mut updated: Vec<yerd_core::PhpVersion> = Vec::new();
     let mut pending_error: Option<yerd_php::PhpError> = None;
@@ -956,7 +983,20 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
             continue;
         };
         let installed_rev = crate::php_install::installed_revision(&state.dirs, minor);
-        let artifact = match yerd_php::resolve_from_listing(&listing, minor, os, arch) {
+        let channel = yerd_php::Channel::of(minor);
+        let listing = match channel {
+            yerd_php::Channel::Stable => stable.as_deref().unwrap_or_default(),
+            yerd_php::Channel::Legacy => match legacy.as_deref() {
+                Some(body) => body,
+                None if version.is_some() => {
+                    return internal(
+                        "couldn't load the legacy PHP listing; try again later".to_owned(),
+                    )
+                }
+                None => continue,
+            },
+        };
+        let artifact = match yerd_php::resolve_from_listing(listing, minor, os, arch, channel) {
             Ok(a) => a,
             Err(yerd_php::PhpError::VersionUnavailable { .. }) if version.is_none() => continue,
             Err(e) => {
@@ -1044,7 +1084,33 @@ fn pools_needing_restart(
 /// version + pid, so concurrent installs of the same version would clobber each
 /// other). A failure is logged as the only durable record of it (the line the
 /// GUI diagnostics / About > Logs panel tails).
-async fn install_php(version: yerd_core::PhpVersion, state: &DaemonState) -> Response {
+/// Reject an install of an out-of-support legacy minor (< 8.2) that did not
+/// carry the explicit `confirm_legacy` opt-in. Defence-in-depth behind the CLI
+/// `--legacy` flag / GUI confirmation checkbox: the daemon never installs a
+/// legacy version "by accident". `None` means the install may proceed.
+fn legacy_install_gate(version: yerd_core::PhpVersion, confirm_legacy: bool) -> Option<Response> {
+    if version.is_legacy() && !confirm_legacy {
+        return Some(Response::Error {
+            code: ErrorCode::LegacyRestricted,
+            message: format!(
+                "PHP {version} is an out-of-support legacy version. Re-run with explicit \
+                 confirmation (CLI `--legacy`, or tick the confirmation box in the GUI). \
+                 Legacy versions get no security support, no code coverage (phpcover), and \
+                 no yerd-dumps, and cannot be set as the default."
+            ),
+        });
+    }
+    None
+}
+
+async fn install_php(
+    version: yerd_core::PhpVersion,
+    confirm_legacy: bool,
+    state: &DaemonState,
+) -> Response {
+    if let Some(rejection) = legacy_install_gate(version, confirm_legacy) {
+        return rejection;
+    }
     let dl = crate::php_install::ReqwestDownloader::new();
     let _guard = state.php_mutate.lock().await;
     match crate::php_install::install(
@@ -1100,8 +1166,12 @@ async fn finalize_php_install(version: yerd_core::PhpVersion, state: &DaemonStat
 /// line is lost.
 pub(crate) async fn install_php_streamed(
     version: yerd_core::PhpVersion,
+    confirm_legacy: bool,
     state: Arc<DaemonState>,
 ) -> Response {
+    if let Some(rejection) = legacy_install_gate(version, confirm_legacy) {
+        return rejection;
+    }
     let (job_id, mut cancel) = state.jobs.create().await;
     let id = job_id.clone();
     tokio::spawn(async move {
@@ -1183,6 +1253,9 @@ pub(crate) async fn install_php_streamed(
 /// Best-effort (the install already succeeded) and does NOT reconcile shims -
 /// the caller's `refresh_pcov_and_shims` reconciles against the updated default.
 async fn adopt_default_if_unset(version: yerd_core::PhpVersion, state: &DaemonState) {
+    if version.is_legacy() {
+        return;
+    }
     let mut cfg_guard = state.config.lock().await;
     if crate::php_install::cli_binary_path(&state.dirs, cfg_guard.php.default).exists() {
         return;
@@ -1592,6 +1665,15 @@ async fn uninstall_php(version: yerd_core::PhpVersion, state: &DaemonState) -> R
 /// `use <ver>` (global) - require the version installed, set the live default +
 /// site fallback (`config.php.default`), persist, and repoint the `php` shim.
 async fn set_default_php(version: yerd_core::PhpVersion, state: &DaemonState) -> Response {
+    if version.is_legacy() {
+        return Response::Error {
+            code: ErrorCode::LegacyRestricted,
+            message: format!(
+                "PHP {version} is an out-of-support legacy version and cannot be the global \
+                 default. It can still serve individual sites and run via `php{version}`."
+            ),
+        };
+    }
     if !crate::php_install::cli_binary_path(&state.dirs, version).exists() {
         return Response::Error {
             code: ErrorCode::NotFound,
@@ -3954,7 +4036,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
             if url.ends_with(".minisig") {
                 Ok(self.minisig.clone().into_bytes())
-            } else if url.ends_with("php.json") {
+            } else if url.contains(".json") {
                 Ok(self.manifest.clone().into_bytes())
             } else {
                 Err(yerd_php::DownloadError::Transport {
@@ -3965,10 +4047,10 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
     }
 
-    /// Build + sign a `php.json` with the given `(php, minor, revision)` builds
-    /// for the host platform. Tarball shas are placeholders (`"00"`) - the poll /
+    /// A `php.json` body with the given `(php, minor, revision)` builds for the
+    /// host platform. Tarball shas are placeholders (`"00"`) - the poll /
     /// available paths never download tarballs.
-    fn signed_listing(builds: &[(&str, &str, u32)]) -> crate::test_support::SignedManifest {
+    fn listing_body(builds: &[(&str, &str, u32)]) -> String {
         let (os, arch) = yerd_php::current_os_arch().unwrap();
         let entries: Vec<String> = builds
             .iter()
@@ -3982,8 +4064,29 @@ Subject: Captured\r\n\r\nhi\r\n";
                 )
             })
             .collect();
-        let manifest = format!("{{ \"schema\": 1, \"builds\": [{}] }}", entries.join(","));
-        crate::test_support::sign_manifest(&manifest)
+        format!("{{ \"schema\": 1, \"builds\": [{}] }}", entries.join(","))
+    }
+
+    /// Build + sign a `php.json` for the host platform (see [`listing_body`]).
+    fn signed_listing(builds: &[(&str, &str, u32)]) -> crate::test_support::SignedManifest {
+        crate::test_support::sign_manifest(&listing_body(builds))
+    }
+
+    /// Routes stable `php.json` to `stable` and legacy `php-legacy.json` to
+    /// `legacy`, so `available_php_with` sees a distinct manifest per channel.
+    struct TwoChannelDl {
+        stable: ListingDl,
+        legacy: ListingDl,
+    }
+    #[async_trait::async_trait]
+    impl yerd_php::Downloader for TwoChannelDl {
+        async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
+            if url.contains("php-legacy.json") {
+                self.legacy.download(url).await
+            } else {
+                self.stable.download(url).await
+            }
+        }
     }
 
     /// Like `fake_install_patch` but also writes the `.yerd-revision` marker.
@@ -4538,12 +4641,44 @@ Subject: Captured\r\n\r\nhi\r\n";
             Response::AvailablePhp {
                 available,
                 installed,
+                legacy,
             } => {
                 assert_eq!(
                     available,
                     vec![PhpVersion::new(8, 3), PhpVersion::new(8, 5)]
                 );
                 assert_eq!(installed, vec![PhpVersion::new(8, 5)]);
+                assert!(
+                    legacy.is_empty(),
+                    "legacy manifest unreachable via ListingDl → empty"
+                );
+            }
+            other => panic!("expected AvailablePhp, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn available_php_lists_legacy_from_second_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        let (stable, legacy) = crate::test_support::sign_manifest_pair(
+            &listing_body(&[("8.4.21", "8.4", 1), ("8.5.9", "8.5", 1)]),
+            &listing_body(&[("7.4.33", "7.4", 1), ("8.1.33", "8.1", 1)]),
+        );
+        let dl = TwoChannelDl {
+            stable: ListingDl::new(&stable),
+            legacy: ListingDl::new(&legacy),
+        };
+
+        match available_php_with(&state, &dl, &stable.public_key).await {
+            Response::AvailablePhp {
+                available, legacy, ..
+            } => {
+                assert_eq!(
+                    available,
+                    vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)]
+                );
+                assert_eq!(legacy, vec![PhpVersion::new(7, 4), PhpVersion::new(8, 1)]);
             }
             other => panic!("expected AvailablePhp, got {other:?}"),
         }
@@ -4558,6 +4693,57 @@ Subject: Captured\r\n\r\nhi\r\n";
             Response::Error { code, .. } => assert_eq!(code, ErrorCode::Internal),
             other => panic!("expected Error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn legacy_install_gate_blocks_only_unconfirmed_legacy() {
+        assert!(legacy_install_gate(PhpVersion::new(8, 5), false).is_none());
+        assert!(legacy_install_gate(PhpVersion::new(7, 4), true).is_none());
+        match legacy_install_gate(PhpVersion::new(7, 4), false) {
+            Some(Response::Error { code, .. }) => assert_eq!(code, ErrorCode::LegacyRestricted),
+            other => panic!("expected LegacyRestricted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn install_php_legacy_without_confirm_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        match install_php(PhpVersion::new(7, 4), false, &state).await {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::LegacyRestricted),
+            other => panic!("expected LegacyRestricted, got {other:?}"),
+        }
+        assert!(!state.dirs.data.join("php").join("php-7.4").exists());
+    }
+
+    #[tokio::test]
+    async fn install_php_streamed_legacy_without_confirm_creates_no_job() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(state_in(tmp.path()));
+        match install_php_streamed(PhpVersion::new(8, 0), false, state.clone()).await {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::LegacyRestricted),
+            other => panic!("expected synchronous LegacyRestricted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_default_php_rejects_legacy_even_when_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        fake_install_patch(&state.dirs, PhpVersion::new(7, 4), "7.4.33");
+        match set_default_php(PhpVersion::new(7, 4), &state).await {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::LegacyRestricted),
+            other => panic!("expected LegacyRestricted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn adopt_default_if_unset_never_adopts_legacy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        let before = state.config.lock().await.php.default;
+        adopt_default_if_unset(PhpVersion::new(7, 4), &state).await;
+        assert_eq!(state.config.lock().await.php.default, before);
     }
 
     // ---------- pure helpers ----------

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -4132,6 +4132,66 @@ Subject: Captured\r\n\r\nhi\r\n";
     }
 
     #[tokio::test]
+    async fn poll_and_refresh_is_channel_aware_for_legacy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
+        fake_install_build(&state.dirs, PhpVersion::new(7, 4), "7.4.20", 1);
+        let (stable, legacy) = crate::test_support::sign_manifest_pair(
+            &listing_body(&[("8.5.9", "8.5", 1)]),
+            &listing_body(&[("7.4.33", "7.4", 1)]),
+        );
+        let dl = TwoChannelDl {
+            stable: ListingDl::new(&stable),
+            legacy: ListingDl::new(&legacy),
+        };
+
+        crate::php_updates::poll_and_refresh(&state, &dl, &stable.public_key).await;
+
+        let cache = state.php_updates.read().await;
+        assert_eq!(
+            cache.get(&PhpVersion::new(8, 5)).cloned(),
+            Some(("8.5.9".to_owned(), 1)),
+            "stable minor resolved from php.json"
+        );
+        assert_eq!(
+            cache.get(&PhpVersion::new(7, 4)).cloned(),
+            Some(("7.4.33".to_owned(), 1)),
+            "legacy minor resolved from php-legacy.json"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_and_refresh_tolerates_untrusted_legacy_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        fake_install_build(&state.dirs, PhpVersion::new(8, 5), "8.5.6", 1);
+        fake_install_build(&state.dirs, PhpVersion::new(7, 4), "7.4.20", 1);
+        // The legacy manifest is signed with a DIFFERENT key, so its signature
+        // fails verification against the stable key the poll is given - the
+        // legacy fetch degrades to `None` and 7.4 is skipped, not errored.
+        let stable = signed_listing(&[("8.5.9", "8.5", 1)]);
+        let legacy = signed_listing(&[("7.4.33", "7.4", 1)]);
+        let dl = TwoChannelDl {
+            stable: ListingDl::new(&stable),
+            legacy: ListingDl::new(&legacy),
+        };
+
+        crate::php_updates::poll_and_refresh(&state, &dl, &stable.public_key).await;
+
+        let cache = state.php_updates.read().await;
+        assert_eq!(
+            cache.get(&PhpVersion::new(8, 5)).cloned(),
+            Some(("8.5.9".to_owned(), 1)),
+            "stable minor still refreshed when the legacy manifest is unreachable"
+        );
+        assert!(
+            !cache.contains_key(&PhpVersion::new(7, 4)),
+            "legacy minor is skipped, not errored"
+        );
+    }
+
+    #[tokio::test]
     async fn poll_and_refresh_is_failure_tolerant() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -155,12 +155,13 @@ fn note(progress: Option<&ProgressTx>, msg: impl Into<String>) {
 pub(crate) async fn fetch_verified_listing(
     dl: &dyn Downloader,
     public_key: &str,
+    channel: yerd_php::Channel,
 ) -> Result<String, PhpError> {
-    let body = dl.download(&listing_url()).await?;
-    let sig = dl.download(&listing_sig_url()).await?;
+    let body = dl.download(&listing_url(channel)).await?;
+    let sig = dl.download(&listing_sig_url(channel)).await?;
     let sig = String::from_utf8_lossy(&sig);
     yerd_update::verify_minisign(public_key, &sig, &body).map_err(|e| {
-        tracing::warn!(error = %e, "php.json signature verification failed");
+        tracing::warn!(error = %e, "php listing signature verification failed");
         PhpError::ListingUntrusted
     })?;
     String::from_utf8(body).map_err(|e| PhpError::ListingParse {
@@ -187,9 +188,10 @@ pub async fn install(
     progress: Option<&ProgressTx>,
 ) -> Result<(), PhpError> {
     let (os, arch) = current_os_arch()?;
+    let channel = yerd_php::Channel::of(version);
     note(progress, format!("Resolving PHP {version}…"));
-    let listing = fetch_verified_listing(dl, public_key).await?;
-    let artifact = yerd_php::resolve_from_listing(&listing, version, os, arch)?;
+    let listing = fetch_verified_listing(dl, public_key, channel).await?;
+    let artifact = yerd_php::resolve_from_listing(&listing, version, os, arch, channel)?;
     tracing::info!(%version, patch = %artifact.full_version, revision = artifact.revision, "resolved PHP build; downloading");
     note(
         progress,
@@ -812,9 +814,10 @@ mod tests {
         }
     }
 
-    /// URL-keyed fake: `php.json.minisig` → signature; `php.json` → manifest;
-    /// `-cli-`/`-fpm-` → the respective tarball. Missing tarballs (empty) still
-    /// answer so a resolve-then-download path can run.
+    /// URL-keyed fake: any `*.json.minisig` → signature; any `*.json` (stable
+    /// `php.json` or legacy `php-legacy.json`) → the single `manifest`;
+    /// `-cli-`/`-fpm-` → the respective tarball. Each test drives one channel, so
+    /// serving the same manifest for whichever `.json` is requested is enough.
     struct FakeDownloader {
         manifest: String,
         minisig: String,
@@ -827,7 +830,7 @@ mod tests {
         async fn download(&self, url: &str) -> Result<Vec<u8>, DownloadError> {
             if url.ends_with(".minisig") {
                 Ok(self.minisig.clone().into_bytes())
-            } else if url.ends_with("php.json") {
+            } else if url.contains(".json") {
                 Ok(self.manifest.clone().into_bytes())
             } else if url.contains("-cli-") {
                 Ok(self.cli.clone())
@@ -973,10 +976,37 @@ mod tests {
             cli,
             fpm,
         };
-        let err = fetch_verified_listing(&dl, &signed.public_key)
+        let err = fetch_verified_listing(&dl, &signed.public_key, yerd_php::Channel::Stable)
             .await
             .unwrap_err();
         assert!(matches!(err, PhpError::ListingUntrusted), "got {err:?}");
+    }
+
+    /// A legacy (7.4) build installs from the `php-legacy.json` channel into
+    /// `php-7.4/bin/php`, exercising the channel-aware `install` path.
+    #[tokio::test]
+    async fn install_legacy_version_lands_in_versioned_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let cli = gzip_tar_single("php", b"LEGACY-CLI", 0o755);
+        let fpm = gzip_tar_single("php-fpm", b"LEGACY-FPM", 0o755);
+        let signed = signed_manifest_for("7.4.33", "7.4", 1, &cli, &fpm);
+        let dl = FakeDownloader {
+            manifest: signed.manifest.clone(),
+            minisig: signed.minisig.clone(),
+            cli,
+            fpm,
+        };
+        install(PhpVersion::new(7, 4), &dirs, &dl, &signed.public_key, None)
+            .await
+            .unwrap();
+        assert!(dirs
+            .data
+            .join("php")
+            .join("php-7.4")
+            .join("bin")
+            .join("php")
+            .exists());
     }
 
     #[tokio::test]

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -644,7 +644,12 @@ pub fn reconcile_shims(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<(), PhpEr
 
     for &v in &installed {
         place_symlink(&bin.join(versioned_shim_name(v, false)), yerd_bin)?;
-        place_symlink(&bin.join(versioned_shim_name(v, true)), yerd_bin)?;
+        // No cover shim for legacy (< 8.2): pcov is never built for it, so
+        // `php<ver>cover` could only error. The gate in `cover_shim` still
+        // rejects it, but not creating the shim keeps `{data}/bin` honest.
+        if !v.is_legacy() {
+            place_symlink(&bin.join(versioned_shim_name(v, true)), yerd_bin)?;
+        }
     }
     place_symlink(&bin.join("phpcover"), yerd_bin)?;
 
@@ -669,7 +674,11 @@ pub fn reconcile_shims(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<(), PhpEr
         let Some(v) = managed_shim_version(name) else {
             continue;
         };
-        if installed.contains(&v) {
+        // Keep a shim only if its version is installed - except a legacy cover
+        // shim (`php7.4cover`), which must be pruned even when 7.4 is installed,
+        // since pcov is never built for legacy.
+        let stale_legacy_cover = name.ends_with("cover") && v.is_legacy();
+        if installed.contains(&v) && !stale_legacy_cover {
             continue;
         }
         let path = entry.path();
@@ -1130,6 +1139,46 @@ mod tests {
         assert_eq!(std::fs::read_link(bin.join("php")).unwrap(), yerd_bin);
         assert!(!bin.join("php8.2cover").exists());
         assert!(bin.join("keep.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_gives_legacy_a_version_shim_but_no_cover_shim() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let yerd_bin = tmp.path().join("yerd");
+        std::fs::write(&yerd_bin, b"#!fake").unwrap();
+
+        let mk = |v: PhpVersion| {
+            let base = dirs
+                .data
+                .join("php")
+                .join(format!("php-{}.{}", v.major, v.minor));
+            std::fs::create_dir_all(base.join("bin")).unwrap();
+            std::fs::create_dir_all(base.join("sbin")).unwrap();
+            std::fs::write(base.join("bin").join("php"), b"cli").unwrap();
+            std::fs::write(base.join("sbin").join("php-fpm"), b"fpm").unwrap();
+        };
+        mk(PhpVersion::new(7, 4));
+        mk(PhpVersion::new(8, 4));
+
+        let bin = shim_dir(&dirs);
+        std::fs::create_dir_all(&bin).unwrap();
+        // A stale legacy cover shim (from an older yerd) must be pruned even
+        // though 7.4 is installed.
+        std::os::unix::fs::symlink(&yerd_bin, bin.join("php7.4cover")).unwrap();
+
+        reconcile_shims(&dirs, &yerd_bin).unwrap();
+
+        assert!(
+            bin.join("php7.4").exists(),
+            "legacy version shim is created"
+        );
+        assert!(
+            !bin.join("php7.4cover").exists(),
+            "no cover shim for a legacy version, and a stale one is pruned"
+        );
+        assert!(bin.join("php8.4cover").exists(), "stable cover shim stays");
     }
 
     #[cfg(unix)]

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -616,12 +616,16 @@ fn managed_shim_version(name: &str) -> Option<PhpVersion> {
 /// `yerd_bin`): the wrapper reads `argv[0]`, resolves the target PHP + minor, and
 /// points `PHPRC` at that version's generated ini before `exec`ing PHP. So:
 ///
-/// * for each installed `v`: `php<v>` → `yerd_bin`, `php<v>cover` → `yerd_bin`;
+/// * for each installed `v`: `php<v>` → `yerd_bin`, and `php<v>cover` → `yerd_bin`
+///   except for legacy (`< 8.2`) versions, which get no cover shim because pcov is
+///   never built for them (`cover_shim` rejects them regardless, so the shim keeps
+///   `{data}/bin` honest);
 /// * `phpcover` → `yerd_bin`;
 /// * `php` → `yerd_bin` when at least one version is installed (the wrapper
 ///   resolves the default from `config.php.default` at run time);
 /// * prune managed `php<X.Y>`/`php<X.Y>cover` symlinks whose version is no longer
-///   installed.
+///   installed, plus any legacy cover shim (e.g. `php7.4cover`) left by an older
+///   Yerd, which must go even when that legacy version is still installed.
 ///
 /// A **single** `discover_bundled` snapshot drives both create and prune. Callers
 /// must serialize invocations (the daemon holds a dedicated mutex) so the
@@ -644,9 +648,6 @@ pub fn reconcile_shims(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<(), PhpEr
 
     for &v in &installed {
         place_symlink(&bin.join(versioned_shim_name(v, false)), yerd_bin)?;
-        // No cover shim for legacy (< 8.2): pcov is never built for it, so
-        // `php<ver>cover` could only error. The gate in `cover_shim` still
-        // rejects it, but not creating the shim keeps `{data}/bin` honest.
         if !v.is_legacy() {
             place_symlink(&bin.join(versioned_shim_name(v, true)), yerd_bin)?;
         }
@@ -674,9 +675,6 @@ pub fn reconcile_shims(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<(), PhpEr
         let Some(v) = managed_shim_version(name) else {
             continue;
         };
-        // Keep a shim only if its version is installed - except a legacy cover
-        // shim (`php7.4cover`), which must be pruned even when 7.4 is installed,
-        // since pcov is never built for legacy.
         let stale_legacy_cover = name.ends_with("cover") && v.is_legacy();
         if installed.contains(&v) && !stale_legacy_cover {
             continue;
@@ -1164,8 +1162,6 @@ mod tests {
 
         let bin = shim_dir(&dirs);
         std::fs::create_dir_all(&bin).unwrap();
-        // A stale legacy cover shim (from an older yerd) must be pruned even
-        // though 7.4 is installed.
         std::os::unix::fs::symlink(&yerd_bin, bin.join("php7.4cover")).unwrap();
 
         reconcile_shims(&dirs, &yerd_bin).unwrap();

--- a/bin/yerdd/src/php_updates.rs
+++ b/bin/yerdd/src/php_updates.rs
@@ -28,11 +28,28 @@ pub(crate) fn installed_minors(state: &DaemonState) -> Vec<PhpVersion> {
         .collect()
 }
 
+/// Fetch and verify one channel's listing, degrading a fetch/verify failure to
+/// `None` with a `debug` log. Returning `None` (rather than aborting the whole
+/// poll) lets one unreachable channel be skipped while the other still refreshes,
+/// and lets the caller preserve the failed channel's previously-cached updates.
+async fn fetch_channel(dl: &dyn Downloader, public_key: &str, channel: Channel) -> Option<String> {
+    match fetch_verified_listing(dl, public_key, channel).await {
+        Ok(body) => Some(body),
+        Err(e) => {
+            tracing::debug!(error = %e, ?channel, "php update poll: listing fetch/verify failed, keeping cached updates for this channel");
+            None
+        }
+    }
+}
+
 /// Poll the manifest once, refresh `state.php_updates`, and log (notify-only)
-/// any installed minor with a newer build. **Failure-tolerant**: network,
-/// signature, and platform errors are logged at `debug` and leave the cache
-/// untouched. `public_key` is the minisign key the manifest is verified against
-/// (prod passes [`yerd_update::PHP_LISTING_PUBLIC_KEY`]).
+/// any installed minor with a newer build. **Failure-tolerant**: platform errors
+/// and a manifest that parses but is unusable leave the cache untouched, and a
+/// fetch/verify failure for one channel is logged at `debug` and carries that
+/// channel's previously-cached updates forward while the other channel still
+/// refreshes. Only channels with an installed minor are fetched. `public_key` is
+/// the minisign key the manifest is verified against (prod passes
+/// [`yerd_update::PHP_LISTING_PUBLIC_KEY`]).
 pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader, public_key: &str) {
     let minors = installed_minors(state);
     if minors.is_empty() {
@@ -45,30 +62,30 @@ pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader, public_k
             return;
         }
     };
-    let stable = match fetch_verified_listing(dl, public_key, Channel::Stable).await {
-        Ok(body) => body,
-        Err(e) => {
-            tracing::debug!(error = %e, "php update poll skipped: listing fetch/verify failed");
-            return;
-        }
+    let stable = if minors.iter().any(|v| !v.is_legacy()) {
+        fetch_channel(dl, public_key, Channel::Stable).await
+    } else {
+        None
     };
     let legacy = if minors.iter().any(|v| v.is_legacy()) {
-        fetch_verified_listing(dl, public_key, Channel::Legacy)
-            .await
-            .ok()
+        fetch_channel(dl, public_key, Channel::Legacy).await
     } else {
         None
     };
 
+    let previous = state.php_updates.read().await.clone();
     let mut latest: HashMap<PhpVersion, (String, u32)> = HashMap::new();
     for minor in minors {
         let channel = Channel::of(minor);
         let listing = match channel {
-            Channel::Stable => stable.as_str(),
-            Channel::Legacy => match legacy.as_deref() {
-                Some(body) => body,
-                None => continue,
-            },
+            Channel::Stable => stable.as_deref(),
+            Channel::Legacy => legacy.as_deref(),
+        };
+        let Some(listing) = listing else {
+            if let Some(prev) = previous.get(&minor) {
+                latest.insert(minor, prev.clone());
+            }
+            continue;
         };
         let artifact = match resolve_from_listing(listing, minor, os, arch, channel) {
             Ok(a) => a,

--- a/bin/yerdd/src/php_updates.rs
+++ b/bin/yerdd/src/php_updates.rs
@@ -13,7 +13,7 @@ use yerd_core::PhpVersion;
 use yerd_ipc::PhpUpdate;
 use yerd_php::{
     current_os_arch, discover_bundled, display_build, is_newer_build, resolve_from_listing,
-    Downloader,
+    Channel, Downloader,
 };
 
 use crate::php_install::{fetch_verified_listing, installed_patch, installed_revision};
@@ -45,17 +45,32 @@ pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader, public_k
             return;
         }
     };
-    let listing = match fetch_verified_listing(dl, public_key).await {
+    let stable = match fetch_verified_listing(dl, public_key, Channel::Stable).await {
         Ok(body) => body,
         Err(e) => {
             tracing::debug!(error = %e, "php update poll skipped: listing fetch/verify failed");
             return;
         }
     };
+    let legacy = if minors.iter().any(|v| v.is_legacy()) {
+        fetch_verified_listing(dl, public_key, Channel::Legacy)
+            .await
+            .ok()
+    } else {
+        None
+    };
 
     let mut latest: HashMap<PhpVersion, (String, u32)> = HashMap::new();
     for minor in minors {
-        let artifact = match resolve_from_listing(&listing, minor, os, arch) {
+        let channel = Channel::of(minor);
+        let listing = match channel {
+            Channel::Stable => stable.as_str(),
+            Channel::Legacy => match legacy.as_deref() {
+                Some(body) => body,
+                None => continue,
+            },
+        };
+        let artifact = match resolve_from_listing(listing, minor, os, arch, channel) {
             Ok(a) => a,
             Err(yerd_php::PhpError::VersionUnavailable { .. }) => continue,
             Err(e) => {

--- a/bin/yerdd/src/test_support.rs
+++ b/bin/yerdd/src/test_support.rs
@@ -148,6 +148,35 @@ pub fn sign_manifest(manifest: &str) -> SignedManifest {
     out
 }
 
+/// Sign two manifest bodies with a **single** freshly generated keypair, so both
+/// share one public key - mirroring production, where `php.json` and
+/// `php-legacy.json` are signed with the same embedded key. Returns the two
+/// [`SignedManifest`]s (their `public_key` fields are identical).
+#[must_use]
+pub fn sign_manifest_pair(first: &str, second: &str) -> (SignedManifest, SignedManifest) {
+    let kp = minisign::KeyPair::generate_unencrypted_keypair().unwrap();
+    let public_key = kp.pk.to_base64();
+    let sign_one = |body: &str| {
+        let sig_box = minisign::sign(
+            Some(&kp.pk),
+            &kp.sk,
+            std::io::Cursor::new(body.as_bytes()),
+            Some("test manifest"),
+            Some("yerd test"),
+        )
+        .unwrap();
+        let out = SignedManifest {
+            public_key: public_key.clone(),
+            manifest: body.to_owned(),
+            minisig: sig_box.into_string(),
+        };
+        yerd_update::verify_minisign(&out.public_key, &out.minisig, out.manifest.as_bytes())
+            .expect("freshly signed manifest must verify with the production verifier");
+        out
+    };
+    (sign_one(first), sign_one(second))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/yerd-core/src/lib.rs
+++ b/crates/yerd-core/src/lib.rs
@@ -45,7 +45,7 @@ pub use error::{
     CoreError, DomainErrorReason, PhpVersionErrorReason, ProxyRuleErrorReason, SiteNameErrorReason,
     TldErrorReason, UpstreamTargetErrorReason,
 };
-pub use php::PhpVersion;
+pub use php::{PhpVersion, FIRST_SUPPORTED_MINOR};
 pub use php_extensions::{ExtError, NameErrorReason, PathErrorReason};
 pub use php_settings::{PhpSettingError, ValueErrorReason};
 pub use proxy::{match_rule, ProxyRule, ProxySite, UpstreamTarget};

--- a/crates/yerd-core/src/php.rs
+++ b/crates/yerd-core/src/php.rs
@@ -23,12 +23,30 @@ pub struct PhpVersion {
     pub minor: u8,
 }
 
+/// The lowest PHP minor Yerd considers "supported". The bundled `pcov` and
+/// `yerd-dump` extensions are only built for 8.2+, so anything below this is a
+/// legacy version: installable, but with no coverage, no dumps, and never
+/// eligible as the global default. This is the single authority every legacy
+/// guardrail keys on; see [`PhpVersion::is_legacy`].
+pub const FIRST_SUPPORTED_MINOR: PhpVersion = PhpVersion::new(8, 2);
+
 impl PhpVersion {
     /// Constructs without validation. Use [`PhpVersion::from_str`] for input
     /// from users or config files.
     #[must_use]
     pub const fn new(major: u8, minor: u8) -> Self {
         Self { major, minor }
+    }
+
+    /// True for out-of-support legacy minors (below [`FIRST_SUPPORTED_MINOR`]):
+    /// no pcov/coverage, no yerd-dump capture, and rejected as the global
+    /// default. The single authority every guardrail keys on (cover shim,
+    /// set-default, dumps warning, GUI).
+    #[must_use]
+    pub const fn is_legacy(self) -> bool {
+        self.major < FIRST_SUPPORTED_MINOR.major
+            || (self.major == FIRST_SUPPORTED_MINOR.major
+                && self.minor < FIRST_SUPPORTED_MINOR.minor)
     }
 }
 
@@ -318,6 +336,23 @@ mod tests {
             "(8,9) < (8,10) — guards numeric (not lex) ordering"
         );
         assert!(php8_dot_10 < php899);
+    }
+
+    #[test]
+    fn is_legacy_splits_at_first_supported_minor() {
+        for (m, n) in [(5, 6), (7, 0), (7, 4), (8, 0), (8, 1)] {
+            assert!(
+                PhpVersion::new(m, n).is_legacy(),
+                "{m}.{n} should be legacy"
+            );
+        }
+        for (m, n) in [(8, 2), (8, 3), (8, 4), (8, 5), (9, 0)] {
+            assert!(
+                !PhpVersion::new(m, n).is_legacy(),
+                "{m}.{n} should not be legacy"
+            );
+        }
+        assert!(!FIRST_SUPPORTED_MINOR.is_legacy());
     }
 
     #[test]

--- a/crates/yerd-ipc/src/dump.rs
+++ b/crates/yerd-ipc/src/dump.rs
@@ -110,4 +110,9 @@ pub struct DumpExtStatus {
     pub version: yerd_core::PhpVersion,
     /// Whether a matching extension artifact is present for it.
     pub present: bool,
+    /// True for legacy (< 8.2) versions, for which `yerd-dump` is never built
+    /// and dumps are never captured. Additive: omitted (false) for supported
+    /// versions and older daemons.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub legacy: bool,
 }

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -153,6 +153,13 @@ pub enum Request {
     InstallPhp {
         /// The major.minor version to install (resolved to a pinned patch).
         version: PhpVersion,
+        /// Explicit opt-in to install an out-of-support legacy minor (< 8.2).
+        /// The daemon refuses a legacy install unless this is `true`. Defaults
+        /// to `false` so older clients (which omit it) can never trigger a
+        /// legacy install; skipped-when-false so the existing stable wire
+        /// literal stays byte-identical.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        confirm_legacy: bool,
     },
     /// Install a PHP version as a streamed background job. The daemon replies
     /// [`super::Response::JobStarted`] immediately; phase + byte-count progress is
@@ -161,6 +168,10 @@ pub enum Request {
     InstallPhpStreamed {
         /// The major.minor version to install (resolved to a pinned patch).
         version: PhpVersion,
+        /// Explicit opt-in to install a legacy minor; see the `InstallPhp`
+        /// variant's `confirm_legacy` for the full contract.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        confirm_legacy: bool,
     },
     /// Set the global default PHP version (terminal `php` shim + site fallback).
     SetDefaultPhp {
@@ -907,6 +918,7 @@ mod variant_name_pinning {
         pin(Request::DaemonInfo);
         pin(Request::InstallPhp {
             version: PhpVersion::new(8, 5),
+            confirm_legacy: false,
         });
         pin(Request::SetDefaultPhp {
             version: PhpVersion::new(8, 5),

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -867,6 +867,7 @@ mod variant_name_pinning {
             ErrorCode::SiteNotLaravel,
             ErrorCode::UnknownServiceType,
             ErrorCode::InstanceAlreadyExists,
+            ErrorCode::LegacyRestricted,
             ErrorCode::Internal,
         ] {
             pin_code(c);

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -524,8 +524,10 @@ pub enum ErrorCode {
     InstanceAlreadyExists,
     /// A legacy (< 8.2) PHP version was used where it is not allowed: as the
     /// global default, or installed without the explicit `confirm_legacy`
-    /// opt-in. Returned only for the new legacy flows, so older clients (which
-    /// never install legacy) cannot receive it.
+    /// opt-in. Reachable from the pre-existing `InstallPhp` / `SetDefaultPhp`
+    /// requests, so a pre-legacy client that names a legacy version can still
+    /// provoke it and, lacking the variant, will surface it as an
+    /// `IpcError::Decode` rather than a typed error.
     LegacyRestricted,
     /// Catch-all for daemon-side failures that don't fit a typed code.
     /// Expand this enum rather than overloading `Internal`.

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -122,11 +122,17 @@ pub enum Response {
     },
     /// Reply to [`crate::Request::AvailablePhp`].
     AvailablePhp {
-        /// Installable major.minor versions from the distribution, ascending.
+        /// Installable **stable** major.minor versions from `php.json`, ascending.
         available: Vec<PhpVersion>,
         /// Currently installed versions, ascending, so clients can hide (GUI
         /// dropdown) or tag (CLI) them.
         installed: Vec<PhpVersion>,
+        /// Installable **legacy** minors (< 8.2) from the separately-signed
+        /// `php-legacy.json`, ascending. Empty (and omitted on the wire) when the
+        /// legacy manifest is unreachable or a client is talking to an older
+        /// daemon, so the wire stays byte-identical for the stable-only case.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        legacy: Vec<PhpVersion>,
     },
     /// Reply to [`crate::Request::ListPhpExtensions`] - registered custom
     /// extensions keyed by PHP version (ascending), each tagged with whether its
@@ -516,6 +522,11 @@ pub enum ErrorCode {
     /// A single-instance service type already has its one instance, or a per-site
     /// instance already exists for the chosen site.
     InstanceAlreadyExists,
+    /// A legacy (< 8.2) PHP version was used where it is not allowed: as the
+    /// global default, or installed without the explicit `confirm_legacy`
+    /// opt-in. Returned only for the new legacy flows, so older clients (which
+    /// never install legacy) cannot receive it.
+    LegacyRestricted,
     /// Catch-all for daemon-side failures that don't fit a typed code.
     /// Expand this enum rather than overloading `Internal`.
     Internal,
@@ -588,6 +599,7 @@ mod variant_name_pinning {
             ErrorCode::SiteNotLaravel => {}
             ErrorCode::UnknownServiceType => {}
             ErrorCode::InstanceAlreadyExists => {}
+            ErrorCode::LegacyRestricted => {}
             ErrorCode::Internal => {}
         }
     }
@@ -626,6 +638,7 @@ mod variant_name_pinning {
         pin_response(Response::AvailablePhp {
             available: vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)],
             installed: vec![PhpVersion::new(8, 5)],
+            legacy: vec![],
         });
         pin_response(Response::PhpExtensions {
             by_version: BTreeMap::from([(

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -58,6 +58,7 @@ fn encode_then_decode_request_roundtrip() {
     assert_request_roundtrips(Request::DaemonInfo);
     assert_request_roundtrips(Request::InstallPhp {
         version: PhpVersion::new(8, 5),
+        confirm_legacy: false,
     });
     assert_request_roundtrips(Request::SetDefaultPhp {
         version: PhpVersion::new(8, 4),

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -204,6 +204,7 @@ fn request_daemon_info_byte_shape() {
 fn request_install_php_byte_shape() {
     let r = Request::InstallPhp {
         version: PhpVersion::new(8, 5),
+        confirm_legacy: false,
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(s, r#"{"type":"install_php","version":"8.5"}"#);
@@ -211,12 +212,53 @@ fn request_install_php_byte_shape() {
 }
 
 #[test]
+fn request_install_php_legacy_byte_shape() {
+    let r = Request::InstallPhp {
+        version: PhpVersion::new(7, 4),
+        confirm_legacy: true,
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"install_php","version":"7.4","confirm_legacy":true}"#
+    );
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
+fn request_install_php_old_payload_decodes_without_confirm_legacy() {
+    let back: Request = serde_json::from_str(r#"{"type":"install_php","version":"8.5"}"#).unwrap();
+    assert_eq!(
+        back,
+        Request::InstallPhp {
+            version: PhpVersion::new(8, 5),
+            confirm_legacy: false,
+        }
+    );
+}
+
+#[test]
 fn request_install_php_streamed_byte_shape() {
     let r = Request::InstallPhpStreamed {
         version: PhpVersion::new(8, 5),
+        confirm_legacy: false,
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(s, r#"{"type":"install_php_streamed","version":"8.5"}"#);
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
+fn request_install_php_streamed_legacy_byte_shape() {
+    let r = Request::InstallPhpStreamed {
+        version: PhpVersion::new(8, 1),
+        confirm_legacy: true,
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"install_php_streamed","version":"8.1","confirm_legacy":true}"#
+    );
     assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
 }
 
@@ -757,11 +799,27 @@ fn response_available_php_byte_shape() {
     let r = Response::AvailablePhp {
         available: vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)],
         installed: vec![PhpVersion::new(8, 5)],
+        legacy: vec![],
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
         s,
         r#"{"type":"available_php","available":["8.4","8.5"],"installed":["8.5"]}"#
+    );
+    assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
+}
+
+#[test]
+fn response_available_php_with_legacy_byte_shape() {
+    let r = Response::AvailablePhp {
+        available: vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)],
+        installed: vec![PhpVersion::new(8, 5)],
+        legacy: vec![PhpVersion::new(7, 4), PhpVersion::new(8, 1)],
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"available_php","available":["8.4","8.5"],"installed":["8.5"],"legacy":["7.4","8.1"]}"#
     );
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
 }
@@ -774,6 +832,7 @@ fn response_error_each_code_byte_shape() {
         (ErrorCode::InvalidPath, "invalid_path"),
         (ErrorCode::PortInUse, "port_in_use"),
         (ErrorCode::ExtensionLoadFailed, "extension_load_failed"),
+        (ErrorCode::LegacyRestricted, "legacy_restricted"),
         (ErrorCode::Internal, "internal"),
     ] {
         let r = Response::Error {
@@ -1114,6 +1173,7 @@ fn error_code_each_variant_byte_shape() {
             ErrorCode::InstanceAlreadyExists,
             r#""instance_already_exists""#,
         ),
+        (ErrorCode::LegacyRestricted, r#""legacy_restricted""#),
         (ErrorCode::Internal, r#""internal""#),
     ];
     for (code, expected) in cases {
@@ -1771,9 +1831,22 @@ fn dump_ext_status_byte_shape() {
     let x = DumpExtStatus {
         version: PhpVersion::new(8, 3),
         present: true,
+        legacy: false,
     };
     let s = serde_json::to_string(&x).unwrap();
     assert_eq!(s, r#"{"version":"8.3","present":true}"#);
+    assert_eq!(serde_json::from_str::<DumpExtStatus>(&s).unwrap(), x);
+}
+
+#[test]
+fn dump_ext_status_legacy_byte_shape() {
+    let x = DumpExtStatus {
+        version: PhpVersion::new(7, 4),
+        present: false,
+        legacy: true,
+    };
+    let s = serde_json::to_string(&x).unwrap();
+    assert_eq!(s, r#"{"version":"7.4","present":false,"legacy":true}"#);
     assert_eq!(serde_json::from_str::<DumpExtStatus>(&s).unwrap(), x);
 }
 
@@ -1957,6 +2030,7 @@ fn response_dumps_status_byte_shape() {
         extensions: vec![DumpExtStatus {
             version: PhpVersion::new(8, 3),
             present: false,
+            legacy: false,
         }],
         counts: DumpCounts::default(),
         features,

--- a/crates/yerd-mcp/src/tools.rs
+++ b/crates/yerd-mcp/src/tools.rs
@@ -249,6 +249,7 @@ fn build_request(name: &'static str, args: &Value) -> Result<Request, ArgError> 
         "list_available_php" => Request::AvailablePhp,
         "install_php" => Request::InstallPhpStreamed {
             version: req_php(args, "version")?,
+            confirm_legacy: false,
         },
         "set_default_php" => Request::SetDefaultPhp {
             version: req_php(args, "version")?,

--- a/crates/yerd-mcp/tests/tools.rs
+++ b/crates/yerd-mcp/tests/tools.rs
@@ -600,6 +600,7 @@ fn php_tools_map_to_their_requests() {
         built("install_php", json!({ "version": "8.5" })),
         Request::InstallPhpStreamed {
             version: PhpVersion::new(8, 5),
+            confirm_legacy: false,
         },
         "install_php uses the streamed (job) variant so the call returns at once"
     );

--- a/crates/yerd-php/src/lib.rs
+++ b/crates/yerd-php/src/lib.rs
@@ -26,8 +26,8 @@ pub use pure::ext_probe::{interpret_probe, ExtLoadError};
 pub use real::{SystemClock, TokioChild, TokioProcessSpawner};
 pub use release::{
     available_minors, current_os_arch, display_build, is_newer_build, is_safe_member,
-    listing_sig_url, listing_url, patch_of, resolve_from_listing, Arch, Artifact, BinaryKind, Os,
-    PHP_LISTING_BASE_URL, PHP_LISTING_SCHEMA,
+    listing_sig_url, listing_url, patch_of, resolve_from_listing, Arch, Artifact, BinaryKind,
+    Channel, Os, MIN_SUPPORTED, PHP_LISTING_BASE_URL, PHP_LISTING_SCHEMA,
 };
 pub use traits::{ChildHandle, Clock, Downloader, HealthProbe, ProcessSpawner};
 pub use version::discover_bundled;

--- a/crates/yerd-php/src/release.rs
+++ b/crates/yerd-php/src/release.rs
@@ -37,11 +37,45 @@ use yerd_core::PhpVersion;
 
 use crate::error::PhpError;
 
-/// Lowest PHP minor Yerd supports installing. The bundled `pcov` / `yerd-dump`
-/// extensions are only built for 8.2+, so older minors are filtered out of the
-/// installable list and rejected at resolve time even when the manifest still
-/// publishes them.
-pub const MIN_SUPPORTED: PhpVersion = PhpVersion::new(8, 2);
+/// Lowest PHP minor on the **stable** channel. The bundled `pcov` / `yerd-dump`
+/// extensions are only built for 8.2+, so older minors are served from the
+/// separate [`Channel::Legacy`] manifest and never resolve off the stable one.
+/// Tied to the single core cutoff [`yerd_core::FIRST_SUPPORTED_MINOR`] so there
+/// is exactly one boundary in the codebase.
+pub const MIN_SUPPORTED: PhpVersion = yerd_core::FIRST_SUPPORTED_MINOR;
+
+/// Which signed PHP distribution manifest a version is sourced from. Stable is
+/// the supported channel (8.2+, `php.json`); Legacy carries out-of-support
+/// minors (< 8.2) from a separately-signed `php-legacy.json` with the SAME
+/// embedded minisign key and the SAME per-tarball SHA-256 verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    /// Supported minors (>= [`MIN_SUPPORTED`]) from `php.json`.
+    Stable,
+    /// Out-of-support legacy minors (< [`MIN_SUPPORTED`]) from `php-legacy.json`.
+    Legacy,
+}
+
+impl Channel {
+    /// The channel a version is sourced from, via the pure core cutoff
+    /// [`PhpVersion::is_legacy`].
+    #[must_use]
+    pub fn of(version: PhpVersion) -> Self {
+        if version.is_legacy() {
+            Channel::Legacy
+        } else {
+            Channel::Stable
+        }
+    }
+
+    /// Manifest basename for this channel (`php` or `php-legacy`).
+    const fn manifest_stem(self) -> &'static str {
+        match self {
+            Channel::Stable => "php",
+            Channel::Legacy => "php-legacy",
+        }
+    }
+}
 
 /// The `php.json` schema version this build understands. A producer-side bump
 /// signals an incompatible format change (additive changes do not bump it).
@@ -203,17 +237,22 @@ pub struct Artifact {
     pub fpm_sha256: String,
 }
 
-/// URL of the signed `php.json` manifest (the daemon fetches this, verifies its
-/// signature, then hands the body to [`resolve_from_listing`]).
+/// URL of the signed manifest for `channel` (the daemon fetches this, verifies
+/// its signature, then hands the body to [`resolve_from_listing`]). Stable is
+/// `php.json`; Legacy is `php-legacy.json`.
 #[must_use]
-pub fn listing_url() -> String {
-    format!("{PHP_LISTING_BASE_URL}/php.json")
+pub fn listing_url(channel: Channel) -> String {
+    format!("{PHP_LISTING_BASE_URL}/{}.json", channel.manifest_stem())
 }
 
-/// URL of the detached minisign signature over [`listing_url`]'s `php.json`.
+/// URL of the detached minisign signature over [`listing_url`]'s manifest for
+/// `channel`.
 #[must_use]
-pub fn listing_sig_url() -> String {
-    format!("{PHP_LISTING_BASE_URL}/php.json.minisig")
+pub fn listing_sig_url(channel: Channel) -> String {
+    format!(
+        "{PHP_LISTING_BASE_URL}/{}.json.minisig",
+        channel.manifest_stem()
+    )
 }
 
 /// Resolve a requested major.minor version + platform to an [`Artifact`] from
@@ -230,8 +269,9 @@ pub fn resolve_from_listing(
     version: PhpVersion,
     os: Os,
     arch: Arch,
+    channel: Channel,
 ) -> Result<Artifact, PhpError> {
-    if version < MIN_SUPPORTED {
+    if Channel::of(version) != channel {
         return Err(PhpError::VersionUnavailable { version });
     }
     let parsed = parse_listing(listing)?;
@@ -275,7 +315,7 @@ pub fn resolve_from_listing(
 /// treats PHP as uninstallable rather than erroring); use
 /// [`resolve_from_listing`] when a hard error is wanted.
 #[must_use]
-pub fn available_minors(listing: &str, os: Os, arch: Arch) -> Vec<PhpVersion> {
+pub fn available_minors(listing: &str, os: Os, arch: Arch, channel: Channel) -> Vec<PhpVersion> {
     let Ok(parsed) = parse_listing(listing) else {
         return Vec::new();
     };
@@ -284,7 +324,7 @@ pub fn available_minors(listing: &str, os: Os, arch: Arch) -> Vec<PhpVersion> {
         .iter()
         .filter(|b| b.os == os.as_str() && b.arch == arch.as_str())
         .filter_map(|b| parse_minor(&b.minor))
-        .filter(|v| *v >= MIN_SUPPORTED)
+        .filter(|v| Channel::of(*v) == channel)
         .collect();
     out.sort_unstable();
     out.dedup();
@@ -403,10 +443,37 @@ mod tests {
         ]
     }"#;
 
+    /// A `php-legacy.json` body spanning the three legacy minors across the four
+    /// targets, shaped like the real manifest.
+    const LEGACY_LISTING: &str = r#"{
+        "schema": 1,
+        "generated_at": "2026-07-01T00:00:00Z",
+        "builds": [
+            { "php": "7.4.33", "minor": "7.4", "os": "linux", "arch": "x86_64", "revision": 1,
+              "cli": { "file": "php-7.4.33-1-cli-linux-x86_64.tar.gz", "sha256": "aa", "size": 1 },
+              "fpm": { "file": "php-7.4.33-1-fpm-linux-x86_64.tar.gz", "sha256": "bb", "size": 1 } },
+            { "php": "8.0.30", "minor": "8.0", "os": "linux", "arch": "x86_64", "revision": 1,
+              "cli": { "file": "php-8.0.30-1-cli-linux-x86_64.tar.gz", "sha256": "cc", "size": 1 },
+              "fpm": { "file": "php-8.0.30-1-fpm-linux-x86_64.tar.gz", "sha256": "dd", "size": 1 } },
+            { "php": "8.1.33", "minor": "8.1", "os": "linux", "arch": "x86_64", "revision": 1,
+              "cli": { "file": "php-8.1.33-1-cli-linux-x86_64.tar.gz", "sha256": "ee", "size": 1 },
+              "fpm": { "file": "php-8.1.33-1-fpm-linux-x86_64.tar.gz", "sha256": "ff", "size": 1 } },
+            { "php": "8.1.33", "minor": "8.1", "os": "macos", "arch": "aarch64", "revision": 1,
+              "cli": { "file": "php-8.1.33-1-cli-macos-aarch64.tar.gz", "sha256": "11", "size": 1 },
+              "fpm": { "file": "php-8.1.33-1-fpm-macos-aarch64.tar.gz", "sha256": "22", "size": 1 } }
+        ]
+    }"#;
+
     #[test]
     fn resolve_from_listing_selects_entry_and_builds_urls() {
-        let a =
-            resolve_from_listing(LISTING, PhpVersion::new(8, 5), Os::Linux, Arch::X86_64).unwrap();
+        let a = resolve_from_listing(
+            LISTING,
+            PhpVersion::new(8, 5),
+            Os::Linux,
+            Arch::X86_64,
+            Channel::Stable,
+        )
+        .unwrap();
         assert_eq!(a.full_version, "8.5.7");
         assert_eq!(a.revision, 2);
         assert_eq!(a.install_dir_name, "php-8.5");
@@ -425,26 +492,56 @@ mod tests {
     #[test]
     fn listing_urls_point_at_the_signed_manifest() {
         assert_eq!(
-            listing_url(),
+            listing_url(Channel::Stable),
             "https://github.com/forjedio/yerd-php/releases/download/php/php.json"
         );
         assert_eq!(
-            listing_sig_url(),
+            listing_sig_url(Channel::Stable),
             "https://github.com/forjedio/yerd-php/releases/download/php/php.json.minisig"
+        );
+        assert_eq!(
+            listing_url(Channel::Legacy),
+            "https://github.com/forjedio/yerd-php/releases/download/php/php-legacy.json"
+        );
+        assert_eq!(
+            listing_sig_url(Channel::Legacy),
+            "https://github.com/forjedio/yerd-php/releases/download/php/php-legacy.json.minisig"
         );
     }
 
     #[test]
+    fn channel_of_splits_at_the_floor() {
+        for (m, n) in [(7, 4), (8, 0), (8, 1)] {
+            assert_eq!(Channel::of(PhpVersion::new(m, n)), Channel::Legacy);
+        }
+        for (m, n) in [(8, 2), (8, 3), (8, 4), (8, 5)] {
+            assert_eq!(Channel::of(PhpVersion::new(m, n)), Channel::Stable);
+        }
+    }
+
+    #[test]
     fn resolve_from_listing_anchors_arch() {
-        let a =
-            resolve_from_listing(LISTING, PhpVersion::new(8, 5), Os::Linux, Arch::Aarch64).unwrap();
+        let a = resolve_from_listing(
+            LISTING,
+            PhpVersion::new(8, 5),
+            Os::Linux,
+            Arch::Aarch64,
+            Channel::Stable,
+        )
+        .unwrap();
         assert!(a.cli_url.contains("linux-aarch64"));
         assert_eq!(a.cli_sha256, "11");
     }
 
     #[test]
     fn resolve_from_listing_unknown_minor_errors() {
-        match resolve_from_listing(LISTING, PhpVersion::new(8, 3), Os::Linux, Arch::X86_64) {
+        match resolve_from_listing(
+            LISTING,
+            PhpVersion::new(8, 3),
+            Os::Linux,
+            Arch::X86_64,
+            Channel::Stable,
+        ) {
             Err(PhpError::VersionUnavailable { version }) => {
                 assert_eq!(version, PhpVersion::new(8, 3));
             }
@@ -455,7 +552,13 @@ mod tests {
     #[test]
     fn resolve_rejects_unknown_schema() {
         let bad = r#"{ "schema": 99, "builds": [] }"#;
-        match resolve_from_listing(bad, PhpVersion::new(8, 5), Os::Linux, Arch::X86_64) {
+        match resolve_from_listing(
+            bad,
+            PhpVersion::new(8, 5),
+            Os::Linux,
+            Arch::X86_64,
+            Channel::Stable,
+        ) {
             Err(PhpError::UnsupportedListingSchema { found, supported }) => {
                 assert_eq!(found, 99);
                 assert_eq!(supported, PHP_LISTING_SCHEMA);
@@ -466,7 +569,13 @@ mod tests {
 
     #[test]
     fn resolve_reports_parse_error_on_garbage() {
-        match resolve_from_listing("not json", PhpVersion::new(8, 5), Os::Linux, Arch::X86_64) {
+        match resolve_from_listing(
+            "not json",
+            PhpVersion::new(8, 5),
+            Os::Linux,
+            Arch::X86_64,
+            Channel::Stable,
+        ) {
             Err(PhpError::ListingParse { .. }) => {}
             other => panic!("expected ListingParse, got {other:?}"),
         }
@@ -479,7 +588,13 @@ mod tests {
               "cli": { "file": "c.tar.gz", "sha256": "aa", "size": 1 },
               "fpm": { "file": "f.tar.gz", "sha256": "bb", "size": 1 } }
         ] }"#;
-        match resolve_from_listing(bad, PhpVersion::new(8, 5), Os::Linux, Arch::X86_64) {
+        match resolve_from_listing(
+            bad,
+            PhpVersion::new(8, 5),
+            Os::Linux,
+            Arch::X86_64,
+            Channel::Stable,
+        ) {
             Err(PhpError::ListingParse { .. }) => {}
             other => panic!("expected ListingParse for revision 0, got {other:?}"),
         }
@@ -487,9 +602,15 @@ mod tests {
 
     #[test]
     fn min_supported_floor_drops_below_8_2() {
-        let got = available_minors(LISTING, Os::Linux, Arch::X86_64);
+        let got = available_minors(LISTING, Os::Linux, Arch::X86_64, Channel::Stable);
         assert_eq!(got, vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)]);
-        match resolve_from_listing(LISTING, PhpVersion::new(8, 1), Os::Linux, Arch::X86_64) {
+        match resolve_from_listing(
+            LISTING,
+            PhpVersion::new(8, 1),
+            Os::Linux,
+            Arch::X86_64,
+            Channel::Stable,
+        ) {
             Err(PhpError::VersionUnavailable { version }) => {
                 assert_eq!(version, PhpVersion::new(8, 1));
             }
@@ -498,23 +619,79 @@ mod tests {
     }
 
     #[test]
+    fn legacy_channel_resolves_legacy_minors_and_rejects_cross_channel() {
+        let a = resolve_from_listing(
+            LEGACY_LISTING,
+            PhpVersion::new(7, 4),
+            Os::Linux,
+            Arch::X86_64,
+            Channel::Legacy,
+        )
+        .unwrap();
+        assert_eq!(a.full_version, "7.4.33");
+        assert_eq!(a.install_dir_name, "php-7.4");
+        assert_eq!(
+            a.cli_url,
+            "https://github.com/forjedio/yerd-php/releases/download/php/php-7.4.33-1-cli-linux-x86_64.tar.gz"
+        );
+
+        assert!(matches!(
+            resolve_from_listing(
+                LEGACY_LISTING,
+                PhpVersion::new(8, 5),
+                Os::Linux,
+                Arch::X86_64,
+                Channel::Legacy,
+            ),
+            Err(PhpError::VersionUnavailable { .. })
+        ));
+        assert!(matches!(
+            resolve_from_listing(
+                LISTING,
+                PhpVersion::new(8, 5),
+                Os::Linux,
+                Arch::X86_64,
+                Channel::Legacy,
+            ),
+            Err(PhpError::VersionUnavailable { .. })
+        ));
+    }
+
+    #[test]
+    fn available_minors_partitions_by_channel() {
+        assert_eq!(
+            available_minors(LEGACY_LISTING, Os::Linux, Arch::X86_64, Channel::Legacy),
+            vec![
+                PhpVersion::new(7, 4),
+                PhpVersion::new(8, 0),
+                PhpVersion::new(8, 1)
+            ]
+        );
+        assert!(
+            available_minors(LEGACY_LISTING, Os::Linux, Arch::X86_64, Channel::Stable).is_empty()
+        );
+    }
+
+    #[test]
     fn available_minors_anchors_platform() {
         assert_eq!(
-            available_minors(LISTING, Os::Macos, Arch::Aarch64),
+            available_minors(LISTING, Os::Macos, Arch::Aarch64, Channel::Stable),
             vec![PhpVersion::new(8, 5)]
         );
         assert_eq!(
-            available_minors(LISTING, Os::Linux, Arch::Aarch64),
+            available_minors(LISTING, Os::Linux, Arch::Aarch64, Channel::Stable),
             vec![PhpVersion::new(8, 5)]
         );
     }
 
     #[test]
     fn available_minors_malformed_listing_is_empty() {
-        assert!(available_minors("", Os::Linux, Arch::X86_64).is_empty());
-        assert!(available_minors("not json", Os::Linux, Arch::X86_64).is_empty());
+        assert!(available_minors("", Os::Linux, Arch::X86_64, Channel::Stable).is_empty());
+        assert!(available_minors("not json", Os::Linux, Arch::X86_64, Channel::Stable).is_empty());
         let unknown_schema = r#"{ "schema": 2, "builds": [] }"#;
-        assert!(available_minors(unknown_schema, Os::Linux, Arch::X86_64).is_empty());
+        assert!(
+            available_minors(unknown_schema, Os::Linux, Arch::X86_64, Channel::Stable).is_empty()
+        );
     }
 
     #[test]

--- a/docs/developer/crates/yerd-php.md
+++ b/docs/developer/crates/yerd-php.md
@@ -359,6 +359,21 @@ Yerd does not ship PHP. It downloads prebuilt, statically-linked PHP builds that
 
 Supported versions come from Yerd's signed `php.json` manifest. The daemon fetches `php.json` + its detached `php.json.minisig`, **verifies the minisign signature** (at the I/O edge, against the embedded `PHP_LISTING_PUBLIC_KEY`), then hands the trusted JSON body to the pure functions here. Each build also carries a per-tarball SHA-256 (verified after download) and a `revision` (`-N`) counter:
 
+::: info Legacy channel: a second, independently-signed manifest
+A `Channel { Stable, Legacy }` enum picks which manifest a version is sourced
+from: `Channel::of(version)` derives it from `PhpVersion::is_legacy` (the same
+`< 8.2` cutoff as `MIN_SUPPORTED` / `yerd_core::FIRST_SUPPORTED_MINOR`), so there
+is exactly one boundary in the codebase. `Channel::Stable` maps to `php.json`;
+`Channel::Legacy` maps to a second manifest, `php-legacy.json`, hosted alongside
+it on the same rolling release with the **same schema**, the **same** embedded
+minisign key, and the **same** per-tarball SHA-256 verification - only the
+listing URL differs (`listing_url` / `listing_sig_url` now take a `Channel`).
+`resolve_from_listing` and `available_minors` filter their input listing by
+`Channel::of(version) == channel`, so a legacy minor never resolves off the
+stable manifest and vice versa. See the [PHP Versions guide](../../guide/php-versions#legacy-php-versions)
+for the user-facing restrictions this backs.
+:::
+
 | Function | Purpose |
 | --- | --- |
 | `resolve_from_listing(listing, version, os, arch)` | Selects the single `(minor, os, arch)` build and returns an `Artifact` with `cli_url`/`fpm_url`, their `sha256`s, and the `revision`. Errors `VersionUnavailable` if none match, or `UnsupportedListingSchema` / `ListingParse` on a bad manifest. |

--- a/docs/developer/crates/yerd-php.md
+++ b/docs/developer/crates/yerd-php.md
@@ -376,9 +376,9 @@ for the user-facing restrictions this backs.
 
 | Function | Purpose |
 | --- | --- |
-| `resolve_from_listing(listing, version, os, arch)` | Selects the single `(minor, os, arch)` build and returns an `Artifact` with `cli_url`/`fpm_url`, their `sha256`s, and the `revision`. Errors `VersionUnavailable` if none match, or `UnsupportedListingSchema` / `ListingParse` on a bad manifest. |
-| `available_minors(listing, os, arch)` | Every distinct major.minor with a build for the platform, sorted + deduped. Feeds the GUI dropdown / `yerd list php`. |
-| `listing_url()` / `listing_sig_url()` | URLs of the `php.json` manifest and its detached signature. |
+| `resolve_from_listing(listing, version, os, arch, channel)` | Selects the single `(minor, os, arch)` build and returns an `Artifact` with `cli_url`/`fpm_url`, their `sha256`s, and the `revision`. Errors `VersionUnavailable` if none match (including when `Channel::of(version) != channel`), or `UnsupportedListingSchema` / `ListingParse` on a bad manifest. |
+| `available_minors(listing, os, arch, channel)` | Every distinct major.minor with a build for the platform whose channel matches, sorted + deduped. Feeds the GUI dropdown / `yerd list php`. |
+| `listing_url(channel)` / `listing_sig_url(channel)` | URLs of the channel's manifest (`Channel::Stable` → `php.json`, `Channel::Legacy` → `php-legacy.json`) and its detached signature. |
 | `is_safe_member(name)` | Zip-slip guard: a tar member is trusted only if relative with no `..`, root, or prefix components. |
 | `is_newer_build` / `patch_of` / `display_build` | Build-level `(patch, revision)` comparison for update checks, and the `<patch>-<revision>` display string. |
 

--- a/docs/developer/ipc-protocol.md
+++ b/docs/developer/ipc-protocol.md
@@ -164,8 +164,8 @@ The variant set is the daemon's whole RPC surface - liveness, site management, P
 | `RemoveDomain { name, domain }` | `{"type":"remove_domain","name":"foo","domain":"api.foo.test"}` (refused for a site's last exact domain) |
 | `SetPrimaryDomain { name, domain }` | `{"type":"set_primary_domain","name":"foo","domain":"corp.foo.test"}` (exact host only, never a wildcard; auto-added if absent) |
 | `ResetDomains { name }` | `{"type":"reset_domains","name":"foo"}` (back to apex only) |
-| `InstallPhp { version }` | `{"type":"install_php","version":"8.5"}` |
-| `InstallPhpStreamed { version }` | `{"type":"install_php_streamed","version":"8.5"}` (replies `JobStarted`; poll `JobStatus`) |
+| `InstallPhp { version, confirm_legacy }` | `{"type":"install_php","version":"8.5"}` (`confirm_legacy` defaults `false` and is skipped on the wire; `{"type":"install_php","version":"7.4","confirm_legacy":true}` to install a legacy minor) |
+| `InstallPhpStreamed { version, confirm_legacy }` | `{"type":"install_php_streamed","version":"8.5"}` (same `confirm_legacy` convention; replies `JobStarted`; poll `JobStatus`) |
 | `UpdatePhp { version: Option }` | `{"type":"update_php","version":"8.5"}` or `…,"version":null` |
 | `SetPhpSettings { settings }` | `{"type":"set_php_settings","settings":{…}}` |
 | `SetPhpVersionSettings { version, settings }` | `{"type":"set_php_version_settings","version":"8.3","settings":{…}}` (per-version overrides; `""` removes → falls back to global) |
@@ -213,6 +213,17 @@ The variant set is the daemon's whole RPC surface - liveness, site management, P
 
 Note `Unpark { path: String }` deliberately uses a `String`, not `PathBuf`: clients echo a value straight back from `Response::Parked`, and an exact-identity match avoids lossy path normalisation (the daemon does not canonicalise it).
 
+::: info Legacy PHP support: an additive `confirm_legacy` field
+`InstallPhp` and `InstallPhpStreamed` both gained `confirm_legacy: bool`
+(`#[serde(default, skip_serializing_if = "std::ops::Not::not")]`, last field):
+`false` is the default and is skipped on the wire, so an install of a supported
+version is byte-identical to before the field existed, and an old client's
+payload (missing the field entirely) decodes with `confirm_legacy: false`. The
+daemon requires `confirm_legacy: true` to install an out-of-support [legacy
+version](../guide/php-versions#legacy-php-versions) (7.4 / 8.0 / 8.1) and
+otherwise replies `Response::Error { code: ErrorCode::LegacyRestricted, .. }`.
+:::
+
 `CreateSite { spec: CreateSiteSpec }` is the wizard's entry point (both Laravel and WordPress): `CreateSiteSpec` carries the shared fields (`name`, `parent_dir`, `php`, `secure`) plus a `framework: Framework` enum internally tagged on `"framework"` (`"laravel"` with `LaravelOptions`, `"wordpress"` with `WordPressOptions` - core version, locale, admin credentials, database engine/name/table-prefix). It replies `JobStarted { job_id }` immediately; the caller polls `Request::JobStatus { job_id }` (streamed via `Response::JobProgress`) the same way `InstallPhpStreamed`/`InstallToolStreamed` do. See [`yerdd`'s WordPress support section](./binaries/yerdd#wordpress-support) for what runs behind the job.
 
 ### Response (daemon → client)
@@ -228,7 +239,7 @@ pub enum Response {
     Parked { paths: Vec<String> },
     Info { dns_addr, tld, ca_path, ca_fingerprint, http_port, https_port },
     PhpVersions { installed, default, updates, settings },
-    AvailablePhp { available, installed },
+    AvailablePhp { available, installed, legacy },
     PhpExtensions { by_version },                  // version → [PhpExtInfo{name,path,zend,present}]
     Status { report: Box<StatusReport> },         // boxed: large payload
     Diagnoses { items: Vec<Diagnosis> },
@@ -282,6 +293,17 @@ The multi-domain feature adds three more `SiteEntry` fields alongside `is_wordpr
 For read/unread tracking, `MailSummary` gained a `read: bool` (last field) and `MailStatus` gained an `unread: u32` (last field), both `#[serde(default)]`. A missing key decodes to `false`/`0`, so old daemons and old clients interoperate without a `PROTOCOL_VERSION` bump; the goldens grew a `,"read":false` / `,"unread":0` suffix. The matching mutator is the additive `Request::MarkMailsRead { ids }`.
 :::
 
+::: info `AvailablePhp` and `DumpExtStatus` gained a `legacy` field additively
+`Response::AvailablePhp` gained `legacy: Vec<PhpVersion>` (last field,
+`#[serde(default)]`, skipped when empty) - the installable [legacy](../guide/php-versions#legacy-php-versions)
+minors from `php-legacy.json`, ascending. Separately, `dump.rs`'s `DumpExtStatus`
+gained `legacy: bool` (same `#[serde(default, skip_serializing_if = "std::ops::Not::not")]`
+convention, `false`/omitted for supported versions and older daemons) marking
+whether a PHP version's extension-presence row is a legacy version, so the Dumps
+view can flag it as unsupported without a second round-trip. Same additive,
+no-`PROTOCOL_VERSION`-bump pattern as `web_subpath`.
+:::
+
 ::: info Reverse proxies are additive requests plus their own response variant
 The proxy feature adds four mutators - `AddProxy { name, url }`, `RemoveProxy { name }`, `AddProxyRule { site, prefix, url }`, `RemoveProxyRule { site, prefix }` (all reply with the generic `Ok`) - and one query, `ListProxies`. Because a whole-host proxy is **not** a `Site`, it can't ride `Response::Sites`/`SiteEntry`; `ListProxies` gets a dedicated `Response::Proxies { proxies: Vec<ProxyEntry>, rules: Vec<ProxyRuleEntry> }` instead, where `ProxyEntry { name, target, secure }` and `ProxyRuleEntry { site, prefix, target }` are all `String`/`bool` so the `Response` `Eq` derive holds. New variants are additive by serde tag, so existing pins are byte-identical and no `PROTOCOL_VERSION` bump is needed. `url` stays a `String` on the wire; the daemon parses and validates it (returning a typed error) rather than the client.
 :::
@@ -299,9 +321,14 @@ pub enum ErrorCode {
     InvalidPath,          // "invalid_path"
     PortInUse,            // "port_in_use"
     ExtensionLoadFailed,  // "extension_load_failed" - a valid path whose .so failed its load-probe
+    LegacyRestricted,     // "legacy_restricted" - a legacy version used somewhere it's disallowed
     Internal,             // "internal" - catch-all; expand the enum, don't overload this
 }
 ```
+
+`LegacyRestricted` is returned when a request tries to do something an [out-of-support legacy version](../guide/php-versions#legacy-php-versions)
+(7.4 / 8.0 / 8.1) can't: setting it as the global default, or installing it
+without `confirm_legacy: true`.
 
 There is deliberately **no `#[serde(other)]` catch-all**. An unknown code from a newer daemon fails closed as `IpcError::Decode` rather than silently downgrading - the same signal as an unknown `type` tag, and the placeholder for a real version mismatch until a handshake lands.
 

--- a/docs/guide/code-coverage.md
+++ b/docs/guide/code-coverage.md
@@ -87,6 +87,12 @@ installed for that version rather than running without coverage. The fetch is
 best-effort and never blocks a PHP install.
 :::
 
+::: warning No coverage on legacy PHP
+pcov isn't built for [legacy versions](./php-versions#legacy-php-versions) (7.4 /
+8.0 / 8.1, PHP < 8.2). `phpcover`, `php7.4cover` / `php8.0cover` / `php8.1cover`,
+and `yerd coverage` all **error** on a legacy version rather than run.
+:::
+
 ::: warning Unix only
 Cover shims are created on macOS and Linux only. They are not generated on other
 platforms.

--- a/docs/guide/laravel-dumps.md
+++ b/docs/guide/laravel-dumps.md
@@ -84,6 +84,13 @@ The download is **best-effort**: a network or verification failure is logged and
 leaves your sites running normally, just without capture.
 :::
 
+::: warning No dumps on legacy PHP
+[Legacy PHP versions](./php-versions#legacy-php-versions) (7.4 / 8.0 / 8.1) never
+capture dumps - the `yerd-dump` extension isn't built for out-of-support PHP. The
+Dumps view flags legacy rows as **"Unsupported (no dumps)"** and shows a warning
+banner when a legacy version is installed.
+:::
+
 ::: tip Toggling is cheap after the first enable
 The extension reads a small state file at the start of every request and
 self-disables when capture is off, so turning capture (or an individual category)

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -9,9 +9,9 @@ The fastest way to manage PHP is the **PHP** page (under the **Environment** gro
 <ThemedImage light="/images/php-light.png" dark="/images/php-dark.png" alt="The PHP page in the Yerd desktop app" />
 
 - A table of installed versions shows live FPM pool state, patch level, pool memory (RSS), and whether an update is available.
-- **Install** opens a picker of installable versions (already-installed ones are hidden); progress streams live next to the Install button as the prebuilt static build downloads.
+- **Install** opens a picker of installable versions (already-installed ones are hidden); progress streams live next to the Install button as the prebuilt static build downloads. A **Show legacy versions** disclosure reveals [legacy minors](#legacy-php-versions) (7.4 / 8.0 / 8.1) behind a warning block and a mandatory confirmation checkbox.
 - **Refresh** re-checks for updates and **Update all** updates every version with one pending - [updates are notify-only](#updates-are-notify-only).
-- Each row's `⋯` menu offers **Restart**, **Set default** (marks it with a star), **Update** (when available), and **Uninstall**; **Restart all** restarts every running pool.
+- Each row's `⋯` menu offers **Restart**, **Set default** (marks it with a star; disabled for legacy rows, which are tagged with a `legacy` badge), **Update** (when available), and **Uninstall**; **Restart all** restarts every running pool.
 - A **Default settings** card edits the [global ini defaults](#tuning-php-settings) applied to every version; leave a field blank to use PHP's built-in default, and saving restarts running pools to apply.
 - A **Per-version configuration** card holds one expandable panel per installed version: the same settings form scoped to that version (empty fields inherit the defaults; see [Per-version configuration](#per-version-configuration)). Saving restarts only that version's pool.
 - A **Custom extensions** card registers extra `.so` extensions per version (see [Custom extensions](#custom-extensions)); each is load-probed before it's saved, and broken registrations are flagged.
@@ -35,6 +35,41 @@ A "PHP version" means a `major.minor` pair like `8.5`, never a full patch like `
 ::: info Downloads are signed and hash-verified
 The `php.json` manifest is signed with a dedicated minisign key whose public half is embedded in Yerd; the daemon verifies that signature before trusting the manifest, then verifies each downloaded tarball against the SHA-256 the manifest lists. Because PHP runs as you, this verification is on the install critical path, not just updates.
 :::
+
+### Legacy PHP versions
+
+Yerd also serves three **out-of-support** minors - **7.4**, **8.0**, and **8.1** -
+from a separate, independently-signed `php-legacy.json` manifest. It's the same
+minisign key and the same per-tarball SHA-256 verification as `php.json`, just a
+different listing.
+
+These versions are past their upstream end of life and may contain **unpatched
+security vulnerabilities**, so installing one requires an explicit opt-in:
+
+```sh
+yerd install php 7.4 --legacy
+```
+
+Running `yerd install php 7.4` without `--legacy` refuses and prints an
+out-of-support warning instead of installing. In the desktop app, the Install
+picker's **Show legacy versions** disclosure opens a warning block and a
+mandatory confirmation checkbox ("I understand and want to install this legacy
+version anyway.") before the Install button is enabled.
+
+A legacy version carries hard restrictions once installed:
+
+- **Cannot be the global default.** `yerd use 7.4` is refused; the desktop app
+  disables **Set default** for legacy rows.
+- **No code coverage.** `phpcover`, `php7.4cover` / `php8.0cover` / `php8.1cover`,
+  and `yerd coverage` all error rather than run - see [Code Coverage](./code-coverage).
+- **No yerd-dumps capture.** The Dumps view flags legacy rows as unsupported -
+  see [Laravel Dumps](./laravel-dumps).
+- **No `pcov` or `yerd-dump` `.so` builds.** Neither extension is built for EOL
+  PHP, which is why coverage and dumps don't work on legacy versions.
+
+A legacy version **can** still be assigned to an individual site
+(`yerd use my-app 7.4`), just not as the global default. See
+[Per-site versions](#per-site-versions).
 
 ### Bundled extensions
 
@@ -132,6 +167,83 @@ on 8.4, as noted.
 Need something not in this set? Register your own with
 [`yerd php ext`](#custom-extensions).
 
+[Legacy versions](#legacy-php-versions) (7.4 / 8.0 / 8.1) ship a smaller, uniform
+extension set built once across all three EOL minors, dropping a few extensions
+that need PHP 8.0+ or a newer `swoole` than 7.4 can run.
+
+<details>
+<summary><b>Legacy build extension list</b> (7.4 / 8.0 / 8.1 - identical across all three)</summary>
+
+| Extension | What it does |
+| --- | --- |
+| `apcu` | In-process shared-memory cache (APCu) for storing user data across a pool's requests. |
+| `bcmath` | Arbitrary-precision decimal arithmetic for money and other exact-math needs. |
+| `bz2` | bzip2 stream compression and decompression. |
+| `calendar` | Conversions between calendar systems (Julian day count, Gregorian, Jewish, French). |
+| `ctype` | Fast character-class checks such as `ctype_digit()` and `ctype_alpha()`. |
+| `curl` | Network transfers via libcurl (HTTP/S, FTP, and more); the default backend for Guzzle. |
+| `dba` | Key/value database abstraction over dbm-style engines (GDBM and friends). |
+| `dom` | Tree-based DOM API for reading and manipulating XML and HTML documents. |
+| `event` | libevent bindings for event-driven, non-blocking I/O loops. |
+| `exif` | Reads EXIF metadata (camera, orientation, GPS) embedded in image files. |
+| `fileinfo` | Detects a file's MIME type from its contents rather than its name. |
+| `filter` | Validates and sanitizes data with `filter_var()` (emails, URLs, ints, …). |
+| `ftp` | Client-side FTP protocol support. |
+| `gd` | Image creation and manipulation: resize, crop, draw, and convert common formats. |
+| `gmp` | Arbitrary-precision integer arithmetic via GNU MP, faster than `bcmath` for big integers. |
+| `iconv` | Character-set conversion between text encodings. |
+| `imagick` | ImageMagick bindings for advanced image processing and a wide range of formats. |
+| `imap` | Access to IMAP, POP3, and NNTP mailboxes. |
+| `intl` | Unicode/ICU internationalization: number and date formatting, collation, transliteration. |
+| `mbregex` | Multibyte-aware regular expressions (the `mb_ereg*` functions). |
+| `mbstring` | Multibyte-safe string functions for UTF-8 and other encodings. |
+| `mysqli` | The improved, feature-complete MySQL/MariaDB driver. |
+| `mysqlnd` | The native driver backend that `mysqli` and PDO's MySQL driver run on. |
+| `opcache` | Caches compiled PHP bytecode in shared memory so scripts aren't re-parsed each request. |
+| `openssl` | TLS, symmetric/asymmetric encryption, signatures, and X.509 certificate handling. |
+| `pcntl` | Unix process control (fork, signals, `waitpid`) for CLI worker processes. |
+| `pdo` | The database-access abstraction layer. |
+| `pdo_mysql` | PDO driver for MySQL/MariaDB. |
+| `pdo_pgsql` | PDO driver for PostgreSQL. |
+| `pdo_sqlite` | PDO driver for SQLite. |
+| `pgsql` | Native PostgreSQL client library (libpq-backed `pg_*` functions). |
+| `phar` | PHP Archive support: bundle a whole application into one distributable file. |
+| `posix` | POSIX system-call bindings (users, groups, process info) on Unix. |
+| `protobuf` | Google Protocol Buffers runtime for compact, fast binary (de)serialization. |
+| `readline` | Interactive line editing and history for CLI and REPL programs. |
+| `redis` | Client for the Redis / Valkey in-memory data store (phpredis). |
+| `session` | Server-side session state management. |
+| `shmop` | Direct read/write access to shared-memory segments. |
+| `simplexml` | Simple object-oriented access to XML documents. |
+| `soap` | SOAP client and server for XML web services. |
+| `sockets` | Low-level BSD sockets API for building custom network protocols. |
+| `sodium` | Modern libsodium cryptography: authenticated encryption, signing, and hashing. |
+| `sqlite3` | The self-contained, embedded SQLite database engine. |
+| `sysvmsg` | System V message-queue inter-process communication. |
+| `sysvsem` | System V semaphores for coordinating processes. |
+| `sysvshm` | System V shared-memory inter-process communication. |
+| `tokenizer` | Tokenizes PHP source code; used by linters and static analysis tools. |
+| `xml` | Event-based (SAX/Expat) XML parsing. |
+| `xmlreader` | Pull-based streaming reader for large XML documents. |
+| `xmlwriter` | Streaming writer for generating XML. |
+| `xsl` | XSLT 1.0 stylesheet transformations over the DOM. |
+| `zip` | Reading and writing ZIP archives. |
+| `zlib` | gzip / deflate stream compression. |
+
+Dropped versus the stable builds:
+
+- **`opentelemetry`** - requires PHP 8.0+, which breaks the 7.4 build outright.
+- **`swoole`** - the pinned `swoole` build needs a newer PHP than 7.4 and would
+  fragment across the three EOL minors, so it's dropped to keep one uniform
+  legacy set.
+- **`swoole-hook-mysql`** - depends on `swoole`.
+- **`pcov` and `yerd-dump`** - the external `.so` partners from
+  [`forjedio/yerd-php-ext`](https://github.com/forjedio/yerd-php-ext) aren't
+  built for EOL PHP, which is why [coverage](./code-coverage) and
+  [dumps](./laravel-dumps) don't work on legacy versions.
+
+</details>
+
 ### Custom extensions
 
 When you need an extension Yerd's builds don't ship (a PECL module like `scrypt`,
@@ -190,6 +302,13 @@ yerd use 8.5
 ```
 
 A fresh config defaults to **PHP 8.3**, but you'll usually set your own right after installing.
+
+::: warning Legacy versions can't be the default
+A [legacy version](#legacy-php-versions) (7.4 / 8.0 / 8.1) is ineligible as the
+global default - `yerd use 7.4` is refused client-side, and the desktop app
+disables **Set default** for legacy rows. It can still be pinned to an
+individual site.
+:::
 
 ::: tip Add the shim dir to your PATH
 Put `{data}/bin` (Yerd prints the exact path) on your `PATH` so a bare `php` matches the version your sites run. The bare `php` shim resolves the current default at run time, so `yerd use` takes effect immediately with nothing to re-point.

--- a/docs/reference/cli/coverage.md
+++ b/docs/reference/cli/coverage.md
@@ -58,6 +58,10 @@ belong to your script or test runner, not to `yerd`:
   architecture yet, `yerd coverage` reports that pcov isn't installed for that
   version rather than running without coverage. The background fetch is
   best-effort and never blocks a PHP install.
+- **No legacy support.** pcov is not built for [legacy PHP versions](../../guide/php-versions#legacy-php-versions)
+  (7.4 / 8.0 / 8.1, PHP < 8.2). `yerd coverage`, `phpcover`, and the versioned
+  `php7.4cover` / `php8.0cover` / `php8.1cover` shims all error on a legacy
+  version rather than run.
 - **Unix only.** Coverage is available on macOS and Linux; it is not generated on
   other platforms.
 

--- a/docs/reference/cli/php.md
+++ b/docs/reference/cli/php.md
@@ -18,11 +18,17 @@ yerd use blog 8.3     # pin one site to 8.3
 
 After a successful global `yerd use <version>` (human output only), `yerd` prints a hint telling you which directory holds the managed `php` shim and warns if a different `php` is found earlier on your `PATH` and would shadow it.
 
+::: warning `yerd use` refuses a legacy version as the default
+`yerd use <VERSION>` is refused for an out-of-support [legacy version](../../guide/php-versions#legacy-php-versions)
+(7.4 / 8.0 / 8.1) - legacy versions can't be the global default. `yerd use <SITE> <VERSION>`
+still accepts one, pinning it to that site only.
+:::
+
 ## Managing installed versions
 
 | Command | Description | Example |
 | --- | --- | --- |
-| `yerd install php <VERSION>` | Install a PHP version (downloads a prebuilt static build). | `yerd install php 8.5` |
+| `yerd install php <VERSION> [--legacy]` | Install a PHP version (downloads a prebuilt static build). | `yerd install php 8.5` |
 | `yerd uninstall php <VERSION>` | Uninstall a PHP version (removes its files; blocked if in use). | `yerd uninstall php 8.3` |
 | `yerd update php [VERSION]` | Update a PHP version to the latest release. Omit the version to update every installed version. | `yerd update php` |
 | `yerd restart php [VERSION]` | Restart a PHP FPM pool. Omit the version to restart every running pool. | `yerd restart php 8.5` |
@@ -35,6 +41,19 @@ yerd update php 8.5       # update just 8.5
 yerd restart php          # restart every running pool
 yerd uninstall php 8.3    # remove 8.3 (refused if a site still uses it)
 ```
+
+### The `--legacy` flag
+
+`7.4`, `8.0`, and `8.1` are out-of-support [legacy versions](../../guide/php-versions#legacy-php-versions)
+served from a separate manifest. Installing one requires the explicit `--legacy` flag:
+
+```sh
+yerd install php 7.4 --legacy
+```
+
+Without `--legacy`, `yerd install php 7.4` prints an out-of-support warning and
+refuses to install. `--legacy` is a no-op (accepted but unnecessary) for a
+supported version.
 
 ### `yerd list php` flags
 
@@ -50,6 +69,11 @@ yerd list php --available     # everything installable, tagging what you have
 ```
 
 Installed versions are printed one per line; the current default is marked `(default)`, and any version with a newer release shows `update available: <installed> -> <latest>`. If nothing is installed, `yerd list php` suggests `yerd install php <default>`.
+
+`yerd list php --available` also prints a trailing **Legacy (out of support - no
+coverage, no dumps, cannot be default)** section listing the installable
+[legacy versions](../../guide/php-versions#legacy-php-versions), tagging any
+already installed - the section is omitted when there are none.
 
 ## Global PHP ini settings
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in legacy PHP channel sourced from a separately-signed php-legacy.json manifest, letting users install EOL versions 7.4/8.0/8.1 while enforcing that they can never be the CLI default, produce no code coverage (phpcover) or yerd-dumps, and require an explicit confirmation in both the CLI (--legacy) and GUI (checkbox + warning).

## Related issues

closes #148

## Type of change

- [x] New feature
- [x] Documentation

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets` is clean
- [ ] `cargo test` passes
- [ ] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [ ] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit opt-in to install legacy PHP versions (7.4, 8.0, 8.1) via the desktop app and CLI (`--legacy`), including confirmation before starting installs.
  * Legacy-aware “available PHP” listings and install progress for legacy versions.
* **Bug Fixes**
  * Prevented code coverage and dump capture for legacy PHP; tightened messaging and default selection so legacy cannot be used as the global default.
* **Documentation**
  * Updated CLI and guide docs to describe legacy restrictions, warnings, and install rules.
* **Tests**
  * Added and expanded IPC, unit, and UI tests to cover legacy install gating and legacy UI/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->