### PR TITLE
[Feat] Per-version custom PHP ini directives

### DIFF
--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -368,6 +368,20 @@ pub async fn set_php_version_settings(
 }
 
 #[tauri::command]
+pub async fn set_php_directives(
+    version: PhpVersion,
+    directives: std::collections::BTreeMap<String, String>,
+) -> Result<Response, GuiError> {
+    finish(
+        exchange(&Request::SetPhpDirectives {
+            version,
+            directives,
+        })
+        .await?,
+    )
+}
+
+#[tauri::command]
 pub async fn list_php_extensions() -> Result<Response, GuiError> {
     finish(exchange(&Request::ListPhpExtensions).await?)
 }

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -90,6 +90,7 @@ fn main() {
             commands::apply_update,
             commands::set_php_settings,
             commands::set_php_version_settings,
+            commands::set_php_directives,
             commands::list_php_extensions,
             commands::add_php_extension,
             commands::remove_php_extension,

--- a/apps/yerd-gui/src/components/PhpVersionConfig.test.ts
+++ b/apps/yerd-gui/src/components/PhpVersionConfig.test.ts
@@ -1,0 +1,83 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import PhpVersionConfig from "./PhpVersionConfig.vue";
+
+const setPhpDirectives = vi.hoisted(() => vi.fn());
+
+vi.mock("@/ipc/client", () => ({
+  IpcError: class IpcError extends Error {},
+  setPhpDirectives,
+  setPhpVersionSettings: vi.fn(),
+}));
+
+const refreshed = {
+  installed: ["8.3"],
+  default: "8.3",
+  directives: { "8.3": { "xdebug.mode": "off" } },
+};
+
+async function mountOpen() {
+  const w = mount(PhpVersionConfig, {
+    props: {
+      version: "8.3",
+      globalSettings: {},
+      overrides: {},
+      directives: { "xdebug.mode": "debug" },
+    },
+  });
+  await w.find("button[aria-expanded]").trigger("click");
+  return w;
+}
+
+function button(w: Awaited<ReturnType<typeof mountOpen>>, label: string) {
+  return w.find(`button[aria-label="${label}"]`);
+}
+
+describe("PhpVersionConfig directive editing", () => {
+  beforeEach(() => {
+    setPhpDirectives.mockReset();
+    setPhpDirectives.mockResolvedValue(refreshed);
+  });
+
+  it("edits a directive's value in place and reports the refreshed list", async () => {
+    const w = await mountOpen();
+    expect(w.text()).toContain("xdebug.mode = debug");
+
+    await button(w, "Edit xdebug.mode").trigger("click");
+    const input = w.find('input[aria-label="New value for xdebug.mode"]');
+    expect((input.element as HTMLInputElement).value).toBe("debug");
+
+    await input.setValue("off");
+    await button(w, "Save xdebug.mode").trigger("click");
+    await vi.waitFor(() => expect(setPhpDirectives).toHaveBeenCalled());
+
+    expect(setPhpDirectives).toHaveBeenCalledWith("8.3", { "xdebug.mode": "off" });
+    expect(w.emitted("updated")?.[0]).toEqual([refreshed]);
+    expect(w.find('input[aria-label="New value for xdebug.mode"]').exists()).toBe(false);
+  });
+
+  it("cancels an edit without saving", async () => {
+    const w = await mountOpen();
+    await button(w, "Edit xdebug.mode").trigger("click");
+    await w.find('input[aria-label="New value for xdebug.mode"]').setValue("off");
+    await button(w, "Cancel editing xdebug.mode").trigger("click");
+
+    expect(setPhpDirectives).not.toHaveBeenCalled();
+    expect(w.text()).toContain("xdebug.mode = debug");
+  });
+
+  it("blocks saving an invalid or empty value", async () => {
+    const w = await mountOpen();
+    await button(w, "Edit xdebug.mode").trigger("click");
+    const input = w.find('input[aria-label="New value for xdebug.mode"]');
+
+    await input.setValue("a;b");
+    expect(button(w, "Save xdebug.mode").attributes("disabled")).toBeDefined();
+    expect(w.text()).toContain("values can't contain");
+
+    await input.setValue("");
+    expect(button(w, "Save xdebug.mode").attributes("disabled")).toBeDefined();
+    expect(setPhpDirectives).not.toHaveBeenCalled();
+  });
+});

--- a/apps/yerd-gui/src/components/PhpVersionConfig.vue
+++ b/apps/yerd-gui/src/components/PhpVersionConfig.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { ChevronDown, Info } from "lucide-vue-next";
+import { ChevronDown, Info, Plus, Trash2 } from "lucide-vue-next";
 
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
@@ -14,10 +14,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useToast } from "@/composables/useToast";
-import { IpcError, setPhpVersionSettings } from "@/ipc/client";
+import { IpcError, setPhpDirectives, setPhpVersionSettings } from "@/ipc/client";
 import type { PhpVersion, PhpVersionsResponse } from "@/ipc/types";
 import {
   DISPLAY_ERRORS_HINT,
+  directiveNameProblem,
+  directiveValueProblem,
   effectiveValue,
   overrideCount,
   SETTING_KEYS,
@@ -30,16 +32,18 @@ const props = defineProps<{
   globalSettings: Record<string, string>;
   /** This version's sparse setting overrides (may be empty). */
   overrides: Record<string, string>;
+  /** This version's free-form ini directives (may be empty). */
+  directives: Record<string, string>;
 }>();
 
 const emit = defineEmits<{
-  /** Fired with the daemon's refreshed version list after a successful save. */
+  /** Fired with the daemon's refreshed version list after any successful save. */
   (e: "updated", r: PhpVersionsResponse): void;
 }>();
 
 const toast = useToast();
 const open = ref(false);
-const busy = ref(false);
+const busy = ref<string | null>(null);
 
 // ── per-version settings form ──
 // Fields hold only the override value; an empty field means "inherit" (the
@@ -69,6 +73,9 @@ watch(
 );
 
 const badgeCount = computed(() => overrideCount(props.overrides));
+const directiveEntries = computed(() =>
+  Object.entries(props.directives).sort(([a], [b]) => a.localeCompare(b)),
+);
 
 function inheritedLabel(key: string, fallback: string): string {
   const inherited = effectiveValue(props.globalSettings, {}, key);
@@ -85,8 +92,9 @@ const displayErrorsOptions = computed(() => {
 });
 
 async function saveSettings(): Promise<void> {
-  busy.value = true;
+  busy.value = "settings";
   try {
+    // Send every field; blank values remove the override (inherit again).
     const r = await setPhpVersionSettings(props.version, { ...form.value });
     seed(r.version_settings?.[props.version] ?? {});
     toast.success(
@@ -97,7 +105,51 @@ async function saveSettings(): Promise<void> {
   } catch (e) {
     toast.error(`Couldn't update PHP ${props.version} settings`, (e as IpcError).message);
   } finally {
-    busy.value = false;
+    busy.value = null;
+  }
+}
+
+// ── custom ini directives ──
+const dirName = ref("");
+const dirValue = ref("");
+
+// Inline hint while typing; the daemon remains the authority on save.
+const dirProblem = computed(() => {
+  if (!dirName.value && !dirValue.value) return null;
+  return directiveNameProblem(dirName.value) ?? directiveValueProblem(dirValue.value);
+});
+
+async function addDirective(): Promise<void> {
+  const name = dirName.value.trim();
+  const value = dirValue.value.trim();
+  if (directiveNameProblem(name) || directiveValueProblem(value)) {
+    toast.error("Invalid directive", dirProblem.value ?? "check the name and value");
+    return;
+  }
+  busy.value = "dir-add";
+  try {
+    const r = await setPhpDirectives(props.version, { [name]: value });
+    dirName.value = "";
+    dirValue.value = "";
+    toast.success(`Set ${name} for PHP ${props.version}`);
+    emit("updated", r);
+  } catch (e) {
+    toast.error("Couldn't set the directive", (e as IpcError).message);
+  } finally {
+    busy.value = null;
+  }
+}
+
+async function removeDirective(name: string): Promise<void> {
+  busy.value = `dir-remove:${name}`;
+  try {
+    const r = await setPhpDirectives(props.version, { [name]: "" });
+    toast.success(`Removed ${name} for PHP ${props.version}`);
+    emit("updated", r);
+  } catch (e) {
+    toast.error("Couldn't remove the directive", (e as IpcError).message);
+  } finally {
+    busy.value = null;
   }
 }
 </script>
@@ -114,6 +166,9 @@ async function saveSettings(): Promise<void> {
         <span class="font-mono text-sm font-medium">PHP {{ version }}</span>
         <Badge v-if="badgeCount" variant="secondary">
           {{ badgeCount }} override{{ badgeCount === 1 ? "" : "s" }}
+        </Badge>
+        <Badge v-if="directiveEntries.length" variant="secondary">
+          {{ directiveEntries.length }} directive{{ directiveEntries.length === 1 ? "" : "s" }}
         </Badge>
       </span>
       <ChevronDown class="size-4 transition-transform" :class="{ 'rotate-180': open }" />
@@ -172,10 +227,76 @@ async function saveSettings(): Promise<void> {
         <span class="text-xs text-muted-foreground">
           Empty fields inherit the default settings above.
         </span>
-        <Button size="sm" :disabled="busy" @click="saveSettings">
-          <Spinner v-if="busy" class="size-4" />
-          {{ busy ? "Applying…" : "Save" }}
+        <Button size="sm" :disabled="busy === 'settings'" @click="saveSettings">
+          <Spinner v-if="busy === 'settings'" class="size-4" />
+          {{ busy === "settings" ? "Applying…" : "Save" }}
         </Button>
+      </div>
+
+      <div class="mt-5 border-t border-border pt-4">
+        <div class="flex items-center gap-1">
+          <span class="text-xs font-medium">Custom ini directives</span>
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <span class="inline-flex cursor-help text-muted-foreground">
+                <Info class="size-3.5" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              Free-form directives for this version, e.g. xdebug.mode = debug.
+              Names and values are checked for safety; whether a directive means
+              anything is up to PHP and its extensions.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        <div v-if="directiveEntries.length" class="mt-2 flex flex-col gap-2">
+          <div
+            v-for="[name, value] in directiveEntries"
+            :key="name"
+            class="flex items-center justify-between rounded-md border border-border px-3 py-1.5"
+          >
+            <code class="truncate text-xs">{{ name }} = {{ value }}</code>
+            <Button
+              variant="ghost"
+              size="sm"
+              :disabled="busy === `dir-remove:${name}`"
+              :aria-label="`Remove ${name}`"
+              @click="removeDirective(name)"
+            >
+              <Spinner v-if="busy === `dir-remove:${name}`" class="size-4" />
+              <Trash2 v-else class="size-4" />
+            </Button>
+          </div>
+        </div>
+        <p v-else class="mt-2 text-xs text-muted-foreground">
+          No custom directives for this version yet.
+        </p>
+
+        <div class="mt-3 flex items-start gap-2">
+          <Input
+            v-model="dirName"
+            placeholder="xdebug.mode"
+            class="flex-1"
+            :aria-label="`Directive name for PHP ${version}`"
+          />
+          <Input
+            v-model="dirValue"
+            placeholder="debug"
+            class="flex-1"
+            :aria-label="`Directive value for PHP ${version}`"
+          />
+          <Button
+            size="sm"
+            :disabled="busy === 'dir-add' || !!dirProblem || !dirName || !dirValue"
+            @click="addDirective"
+          >
+            <Spinner v-if="busy === 'dir-add'" class="size-4" />
+            <Plus v-else class="size-4" />
+            Add
+          </Button>
+        </div>
+        <p v-if="dirProblem" class="mt-1 text-xs text-destructive">{{ dirProblem }}</p>
       </div>
     </div>
   </div>

--- a/apps/yerd-gui/src/components/PhpVersionConfig.vue
+++ b/apps/yerd-gui/src/components/PhpVersionConfig.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { ChevronDown, Info, Plus, Trash2 } from "lucide-vue-next";
+import { Check, ChevronDown, Info, Pencil, Plus, Trash2, X } from "lucide-vue-next";
 
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
@@ -140,6 +140,45 @@ async function addDirective(): Promise<void> {
   }
 }
 
+// Inline editing of one directive's value. The name stays fixed; renaming is
+// remove + add. Saving reuses the set path, which upserts on the daemon.
+const editName = ref<string | null>(null);
+const editValue = ref("");
+
+const editProblem = computed(() =>
+  editName.value === null || editValue.value === ""
+    ? null
+    : directiveValueProblem(editValue.value),
+);
+
+function startEdit(name: string, value: string): void {
+  editName.value = name;
+  editValue.value = value;
+}
+
+function cancelEdit(): void {
+  editName.value = null;
+  editValue.value = "";
+}
+
+async function saveEdit(): Promise<void> {
+  const name = editName.value;
+  if (name === null) return;
+  const value = editValue.value.trim();
+  if (value === "" || directiveValueProblem(value)) return;
+  busy.value = `dir-edit:${name}`;
+  try {
+    const r = await setPhpDirectives(props.version, { [name]: value });
+    cancelEdit();
+    toast.success(`Updated ${name} for PHP ${props.version}`);
+    emit("updated", r);
+  } catch (e) {
+    toast.error("Couldn't update the directive", (e as IpcError).message);
+  } finally {
+    busy.value = null;
+  }
+}
+
 async function removeDirective(name: string): Promise<void> {
   busy.value = `dir-remove:${name}`;
   try {
@@ -236,38 +275,83 @@ async function removeDirective(name: string): Promise<void> {
       <div class="mt-5 border-t border-border pt-4">
         <div class="flex items-center gap-1">
           <span class="text-xs font-medium">Custom ini directives</span>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <span class="inline-flex cursor-help text-muted-foreground">
-                <Info class="size-3.5" />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="top">
-              Free-form directives for this version, e.g. xdebug.mode = debug.
-              Names and values are checked for safety; whether a directive means
-              anything is up to PHP and its extensions.
-            </TooltipContent>
-          </Tooltip>
+          <TooltipProvider :delay-duration="0">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <span class="inline-flex cursor-help text-muted-foreground">
+                  <Info class="size-3.5" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                Free-form directives for this version, e.g. xdebug.mode = debug.
+                Names and values are checked for safety; whether a directive means
+                anything is up to PHP and its extensions.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
 
         <div v-if="directiveEntries.length" class="mt-2 flex flex-col gap-2">
-          <div
-            v-for="[name, value] in directiveEntries"
-            :key="name"
-            class="flex items-center justify-between rounded-md border border-border px-3 py-1.5"
-          >
-            <code class="truncate text-xs">{{ name }} = {{ value }}</code>
-            <Button
-              variant="ghost"
-              size="sm"
-              :disabled="busy === `dir-remove:${name}`"
-              :aria-label="`Remove ${name}`"
-              @click="removeDirective(name)"
+          <template v-for="[name, value] in directiveEntries" :key="name">
+            <div
+              class="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-1.5"
             >
-              <Spinner v-if="busy === `dir-remove:${name}`" class="size-4" />
-              <Trash2 v-else class="size-4" />
-            </Button>
-          </div>
+              <template v-if="editName === name">
+                <code class="shrink-0 text-xs">{{ name }} =</code>
+                <Input
+                  v-model="editValue"
+                  class="flex-1"
+                  :aria-label="`New value for ${name}`"
+                  @keydown.enter="saveEdit"
+                  @keydown.esc="cancelEdit"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  :disabled="busy === `dir-edit:${name}` || !!editProblem || !editValue"
+                  :aria-label="`Save ${name}`"
+                  @click="saveEdit"
+                >
+                  <Spinner v-if="busy === `dir-edit:${name}`" class="size-4" />
+                  <Check v-else class="size-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  :aria-label="`Cancel editing ${name}`"
+                  @click="cancelEdit"
+                >
+                  <X class="size-4" />
+                </Button>
+              </template>
+              <template v-else>
+                <code class="truncate text-xs">{{ name }} = {{ value }}</code>
+                <span class="flex items-center">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    :aria-label="`Edit ${name}`"
+                    @click="startEdit(name, value)"
+                  >
+                    <Pencil class="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    :disabled="busy === `dir-remove:${name}`"
+                    :aria-label="`Remove ${name}`"
+                    @click="removeDirective(name)"
+                  >
+                    <Spinner v-if="busy === `dir-remove:${name}`" class="size-4" />
+                    <Trash2 v-else class="size-4" />
+                  </Button>
+                </span>
+              </template>
+            </div>
+            <p v-if="editName === name && editProblem" class="text-xs text-destructive">
+              {{ editProblem }}
+            </p>
+          </template>
         </div>
         <p v-else class="mt-2 text-xs text-muted-foreground">
           No custom directives for this version yet.
@@ -276,13 +360,13 @@ async function removeDirective(name: string): Promise<void> {
         <div class="mt-3 flex items-start gap-2">
           <Input
             v-model="dirName"
-            placeholder="xdebug.mode"
+            placeholder="Directive name"
             class="flex-1"
             :aria-label="`Directive name for PHP ${version}`"
           />
           <Input
             v-model="dirValue"
-            placeholder="debug"
+            placeholder="Value"
             class="flex-1"
             :aria-label="`Directive value for PHP ${version}`"
           />

--- a/apps/yerd-gui/src/ipc/client.test.ts
+++ b/apps/yerd-gui/src/ipc/client.test.ts
@@ -20,6 +20,7 @@ import {
   setFrontController,
   setMailEnabled,
   setMailPort,
+  setPhpDirectives,
   setPhpVersionSettings,
   setPrimaryDomain,
   setSymlinkProtection,
@@ -186,6 +187,21 @@ describe("client → command mapping", () => {
       settings: { memory_limit: "1G" },
     });
     expect(r.version_settings?.["8.3"]?.memory_limit).toBe("1G");
+  });
+
+  it("setPhpDirectives sends the version and directives map", async () => {
+    invokeMock.mockResolvedValue({
+      type: "php_versions",
+      installed: ["8.3"],
+      default: "8.3",
+      directives: { "8.3": { "xdebug.mode": "debug" } },
+    });
+    const r = await setPhpDirectives("8.3", { "xdebug.mode": "debug" });
+    expect(invokeMock).toHaveBeenCalledWith("set_php_directives", {
+      version: "8.3",
+      directives: { "xdebug.mode": "debug" },
+    });
+    expect(r.directives?.["8.3"]?.["xdebug.mode"]).toBe("debug");
   });
 
   it("resetDomains sends just the name", async () => {

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -415,6 +415,21 @@ export async function setPhpVersionSettings(
   ) as PhpVersionsResponse;
 }
 
+/**
+ * Merge free-form ini directives (e.g. `xdebug.mode`) for one installed
+ * version. An empty-string value removes the directive. The daemon validates
+ * names/values and rejects directives Yerd manages elsewhere. Returns the
+ * refreshed version list.
+ */
+export async function setPhpDirectives(
+  version: PhpVersion,
+  directives: Record<string, string>,
+): Promise<PhpVersionsResponse> {
+  return ensureOk(
+    await call<Response>("set_php_directives", { version, directives }),
+  ) as PhpVersionsResponse;
+}
+
 // ── php extensions ───────────────────────────────────────────────────────────
 
 /** Registered custom extensions, keyed by version string (e.g. `"8.5"`). */

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -530,6 +530,9 @@ export type Response =
       /** Sparse per-version overrides of `settings`, keyed by version string
        *  (e.g. `"8.3"`). Absent when no overrides are set / older daemon. */
       version_settings?: Record<PhpVersion, Record<string, string>>;
+      /** Free-form per-version ini directives keyed by version string. Absent
+       *  when none are set / older daemon. */
+      directives?: Record<PhpVersion, Record<string, string>>;
     }
   | {
       type: "available_php";

--- a/apps/yerd-gui/src/lib/phpSettings.test.ts
+++ b/apps/yerd-gui/src/lib/phpSettings.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { effectiveValue, overrideCount, SETTING_KEYS } from "./phpSettings";
+import {
+  directiveNameProblem,
+  directiveValueProblem,
+  effectiveValue,
+  overrideCount,
+  SETTING_KEYS,
+} from "./phpSettings";
 
 describe("effectiveValue", () => {
   const global = { memory_limit: "512M", max_execution_time: "60" };
@@ -34,5 +40,39 @@ describe("overrideCount", () => {
   it("SETTING_KEYS covers the 8 allowlisted settings", () => {
     expect(SETTING_KEYS).toHaveLength(8);
     expect(SETTING_KEYS).toContain("display_errors");
+  });
+});
+
+describe("directiveNameProblem", () => {
+  it("accepts real extension directive names", () => {
+    for (const name of ["xdebug.mode", "opcache.enable", "zend.assertions", "_x"]) {
+      expect(directiveNameProblem(name)).toBeNull();
+    }
+  });
+
+  it("flags allowlisted settings and reserved names", () => {
+    expect(directiveNameProblem("memory_limit")).toMatch(/settings form/);
+    expect(directiveNameProblem("extension")).toMatch(/extensions/);
+    expect(directiveNameProblem("openssl.cafile")).toMatch(/CA bundle/);
+  });
+
+  it("flags malformed names", () => {
+    for (const name of ["", "1st", ".dot", "has space", "semi;colon"]) {
+      expect(directiveNameProblem(name)).not.toBeNull();
+    }
+  });
+});
+
+describe("directiveValueProblem", () => {
+  it("accepts ordinary values", () => {
+    for (const value of ["debug", "develop,debug", "1", "256M", "/a/b c.log"]) {
+      expect(directiveValueProblem(value)).toBeNull();
+    }
+  });
+
+  it("flags empty values and injection metacharacters", () => {
+    for (const value of ["", "  ", "a;b", "a#b", "a=b", "a[b", "a]b", "a\nb"]) {
+      expect(directiveValueProblem(value)).not.toBeNull();
+    }
   });
 });

--- a/apps/yerd-gui/src/lib/phpSettings.ts
+++ b/apps/yerd-gui/src/lib/phpSettings.ts
@@ -85,3 +85,44 @@ export function effectiveValue(
 export function overrideCount(overrides: Record<string, string>): number {
   return SETTING_KEYS.filter((k) => (overrides[k] ?? "") !== "").length;
 }
+
+/** Directive names Yerd manages elsewhere, with a hint pointing at that path. */
+const RESERVED_DIRECTIVES: Record<string, string> = {
+  extension: "extensions are managed in the Custom extensions panel",
+  zend_extension: "extensions are managed in the Custom extensions panel",
+  "openssl.cafile": "Yerd manages the CA bundle for this",
+  "curl.cainfo": "Yerd manages the CA bundle for this",
+};
+
+/**
+ * Client-side hint for an invalid or reserved custom-directive name; `null`
+ * when it looks fine. Mirrors the daemon's `yerd-core` rules loosely - the
+ * daemon remains the authority.
+ */
+export function directiveNameProblem(name: string): string | null {
+  if (name === "") return "enter a directive name";
+  if (SETTING_KEYS.includes(name)) {
+    return "this setting has its own field in the settings form above";
+  }
+  const reserved = RESERVED_DIRECTIVES[name];
+  if (reserved) return reserved;
+  if (!/^[A-Za-z_][A-Za-z0-9._-]*$/.test(name) || name.length > 128) {
+    return "names start with a letter or _ and use letters, digits, '.', '_' or '-'";
+  }
+  return null;
+}
+
+/**
+ * Client-side hint for an invalid custom-directive value; `null` when it looks
+ * fine. Rejects the ini/FPM metacharacters and control characters the daemon
+ * refuses.
+ */
+export function directiveValueProblem(value: string): string | null {
+  if (value.trim() === "") return "enter a value";
+  if (value.length > 256) return "value is too long";
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f[\]=;#]/.test(value)) {
+    return "values can't contain [ ] = ; # or control characters";
+  }
+  return null;
+}

--- a/apps/yerd-gui/src/views/PhpView.vue
+++ b/apps/yerd-gui/src/views/PhpView.vue
@@ -169,8 +169,8 @@ async function saveSettings(): Promise<void> {
 
 // ── per-version configuration ──
 // Each installed version gets a collapsible panel (PhpVersionConfig) holding
-// its setting overrides. The panel does its own saves and hands back the
-// daemon's refreshed version list.
+// its setting overrides and free-form ini directives. The panel does its own
+// saves and hands back the daemon's refreshed version list.
 function onVersionConfigUpdated(r: PhpVersionsResponse): void {
   mutate(() => r);
   void reloadPhp({ force: true });
@@ -708,14 +708,14 @@ onUnmounted(
         </CardContent>
       </Card>
 
-      <!-- Per-version setting overrides. -->
+      <!-- Per-version setting overrides + free-form ini directives. -->
       <Card v-if="!loading && installed.length" class="mt-8">
         <CardHeader>
           <CardTitle>Per-version configuration</CardTitle>
           <CardDescription>
-            Override the default settings for a single version; empty fields
-            inherit the defaults above. Saving restarts only that version's
-            pool.
+            Override the default settings for a single version, or add custom
+            ini directives (e.g. xdebug.mode) for extensions registered below.
+            Saving restarts only that version's pool.
           </CardDescription>
         </CardHeader>
         <CardContent class="flex flex-col gap-3">
@@ -725,6 +725,7 @@ onUnmounted(
             :version="v"
             :global-settings="data?.settings ?? {}"
             :overrides="data?.version_settings?.[v] ?? {}"
+            :directives="data?.directives?.[v] ?? {}"
             @updated="onVersionConfigUpdated"
           />
         </CardContent>

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -586,6 +586,37 @@ pub enum PhpAction {
         #[command(subcommand)]
         action: PhpExtAction,
     },
+    /// Manage free-form per-version ini directives (e.g. `xdebug.mode`),
+    /// applied to that version's web (FPM) pool and CLI.
+    Ini {
+        /// The ini directive action.
+        #[command(subcommand)]
+        action: PhpIniAction,
+    },
+}
+
+/// Action of `yerd php ini`.
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum PhpIniAction {
+    /// Set an ini directive for one installed PHP version. The name and value
+    /// are shape-validated; whether the directive means anything is up to PHP.
+    Set {
+        /// PHP version, e.g. `8.3`.
+        version: String,
+        /// Directive name, e.g. `xdebug.mode`.
+        name: String,
+        /// Directive value, e.g. `debug`.
+        value: String,
+    },
+    /// Remove an ini directive for one installed PHP version.
+    Unset {
+        /// PHP version, e.g. `8.3`.
+        version: String,
+        /// Directive name, e.g. `xdebug.mode`.
+        name: String,
+    },
+    /// List per-version settings overrides and custom ini directives.
+    List,
 }
 
 /// Action of `yerd php ext`.

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -90,6 +90,9 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
         Command::Php {
             action: crate::cli::PhpAction::Ext { action },
         } => php_ext_to_request(action)?,
+        Command::Php {
+            action: crate::cli::PhpAction::Ini { action },
+        } => php_ini_to_request(action)?,
         Command::Install {
             target: crate::cli::InstallTarget::Php { version, legacy },
         } => {
@@ -556,6 +559,50 @@ fn php_ext_to_request(action: &crate::cli::PhpExtAction) -> Result<Request, Clie
     })
 }
 
+/// Map a `yerd php ini` action to its wire request, validating the version,
+/// directive name, and value client-side so a bad argument fails before
+/// connect. The daemon re-validates (it is the authority).
+fn php_ini_to_request(action: &crate::cli::PhpIniAction) -> Result<Request, ClientError> {
+    use crate::cli::PhpIniAction;
+    let validate_directive = |name: &str, value: Option<&str>| -> Result<(), ClientError> {
+        yerd_core::php_directives::validate_name(name)
+            .map_err(|e| ClientError::Usage(e.to_string()))?;
+        if let Some(hint) = yerd_core::php_directives::reserved(name) {
+            return Err(ClientError::Usage(format!(
+                "{name} is managed by Yerd: {hint}"
+            )));
+        }
+        if let Some(v) = value {
+            yerd_core::php_directives::validate_value(v)
+                .map_err(|e| ClientError::Usage(e.to_string()))?;
+        }
+        Ok(())
+    };
+    Ok(match action {
+        PhpIniAction::Set {
+            version,
+            name,
+            value,
+        } => {
+            let v = parse_php(version)?;
+            validate_directive(name, Some(value))?;
+            Request::SetPhpDirectives {
+                version: v,
+                directives: std::collections::BTreeMap::from([(name.clone(), value.clone())]),
+            }
+        }
+        PhpIniAction::Unset { version, name } => {
+            let v = parse_php(version)?;
+            validate_directive(name, None)?;
+            Request::SetPhpDirectives {
+                version: v,
+                directives: std::collections::BTreeMap::from([(name.clone(), String::new())]),
+            }
+        }
+        PhpIniAction::List => Request::ListPhp,
+    })
+}
+
 /// The channel override for a self-update check, from the `--edge`/`--stable`
 /// flags (mutually exclusive at the clap layer). `None` = use the saved default.
 #[must_use]
@@ -779,12 +826,14 @@ pub fn render(resp: &Response, json: bool) -> Rendered {
             updates,
             settings,
             version_settings,
+            directives,
         } => Rendered::ok(format_php_versions(
             installed,
             *default,
             updates,
             settings,
             version_settings,
+            directives,
         )),
         Response::AvailablePhp {
             available,
@@ -1178,6 +1227,7 @@ fn format_php_versions(
         PhpVersion,
         std::collections::BTreeMap<String, String>,
     >,
+    directives: &std::collections::BTreeMap<PhpVersion, std::collections::BTreeMap<String, String>>,
 ) -> String {
     let versions = if installed.is_empty() {
         format!("no PHP versions installed (default: {default}) - `yerd install php {default}`")
@@ -1206,16 +1256,25 @@ fn format_php_versions(
         }
     }
     for v in installed {
-        let Some(map) = version_settings.get(v) else {
+        let overrides = version_settings.get(v);
+        let dirs = directives.get(v);
+        if overrides.is_none() && dirs.is_none() {
             continue;
-        };
+        }
         let _ = write!(out, "\n\nPHP {v}:");
-        for (k, val) in map {
-            let _ = write!(
-                out,
-                "\n  {k} = {val}  (overrides {})",
-                global_of(settings, k)
-            );
+        if let Some(map) = overrides {
+            for (k, val) in map {
+                let _ = write!(
+                    out,
+                    "\n  {k} = {val}  (overrides {})",
+                    global_of(settings, k)
+                );
+            }
+        }
+        if let Some(map) = dirs {
+            for (k, val) in map {
+                let _ = write!(out, "\n  {k} = {val}");
+            }
         }
     }
     out
@@ -1948,6 +2007,76 @@ mod tests {
     }
 
     #[test]
+    fn php_ini_actions_map_and_validate() {
+        assert_eq!(
+            to_request(&Command::Php {
+                action: crate::cli::PhpAction::Ini {
+                    action: crate::cli::PhpIniAction::Set {
+                        version: "8.3".into(),
+                        name: "xdebug.mode".into(),
+                        value: "debug".into(),
+                    }
+                }
+            })
+            .unwrap(),
+            Request::SetPhpDirectives {
+                version: PhpVersion::new(8, 3),
+                directives: std::collections::BTreeMap::from([(
+                    "xdebug.mode".to_string(),
+                    "debug".to_string()
+                )])
+            }
+        );
+        assert_eq!(
+            to_request(&Command::Php {
+                action: crate::cli::PhpAction::Ini {
+                    action: crate::cli::PhpIniAction::Unset {
+                        version: "8.3".into(),
+                        name: "xdebug.mode".into(),
+                    }
+                }
+            })
+            .unwrap(),
+            Request::SetPhpDirectives {
+                version: PhpVersion::new(8, 3),
+                directives: std::collections::BTreeMap::from([(
+                    "xdebug.mode".to_string(),
+                    String::new()
+                )])
+            }
+        );
+        assert_eq!(
+            to_request(&Command::Php {
+                action: crate::cli::PhpAction::Ini {
+                    action: crate::cli::PhpIniAction::List
+                }
+            })
+            .unwrap(),
+            Request::ListPhp
+        );
+
+        for (name, value) in [
+            ("memory_limit", "1G"),
+            ("extension", "/evil.so"),
+            ("1bad", "x"),
+            ("xdebug.mode", "debug; evil"),
+        ] {
+            match to_request(&Command::Php {
+                action: crate::cli::PhpAction::Ini {
+                    action: crate::cli::PhpIniAction::Set {
+                        version: "8.3".into(),
+                        name: name.into(),
+                        value: value.into(),
+                    },
+                },
+            }) {
+                Err(ClientError::Usage(_)) => {}
+                other => panic!("expected Usage error for {name}={value}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn renders_update_status_with_all_rows() {
         let resp = Response::UpdateStatus {
             current: "2.0.0".into(),
@@ -2129,6 +2258,7 @@ mod tests {
                 }],
                 settings: std::collections::BTreeMap::new(),
                 version_settings: Box::new(std::collections::BTreeMap::new()),
+                directives: Box::new(std::collections::BTreeMap::new()),
             },
             false,
         );
@@ -2146,6 +2276,7 @@ mod tests {
                 updates: vec![],
                 settings: std::collections::BTreeMap::new(),
                 version_settings: Box::new(std::collections::BTreeMap::new()),
+                directives: Box::new(std::collections::BTreeMap::new()),
             },
             false,
         );
@@ -2153,7 +2284,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_php_versions_with_per_version_overrides() {
+    fn renders_php_versions_with_per_version_overrides_and_directives() {
         let v83 = PhpVersion::new(8, 3);
         let r = render(
             &Response::PhpVersions {
@@ -2171,6 +2302,13 @@ mod tests {
                         ("display_errors".to_string(), "Off".to_string()),
                     ]),
                 )])),
+                directives: Box::new(std::collections::BTreeMap::from([(
+                    v83,
+                    std::collections::BTreeMap::from([(
+                        "xdebug.mode".to_string(),
+                        "debug".to_string(),
+                    )]),
+                )])),
             },
             false,
         );
@@ -2185,6 +2323,11 @@ mod tests {
         assert!(
             r.stdout
                 .contains("display_errors = Off  (overrides PHP default)"),
+            "got: {}",
+            r.stdout
+        );
+        assert!(
+            r.stdout.contains("xdebug.mode = debug"),
             "got: {}",
             r.stdout
         );
@@ -2313,6 +2456,7 @@ mod tests {
                     ("display_errors".to_string(), "On".to_string()),
                 ]),
                 version_settings: Box::new(std::collections::BTreeMap::new()),
+                directives: Box::new(std::collections::BTreeMap::new()),
             },
             false,
         );

--- a/bin/yerd/tests/cli_e2e.rs
+++ b/bin/yerd/tests/cli_e2e.rs
@@ -506,9 +506,9 @@ mod tests {
         drop(keep_alive);
     }
 
-    /// Per-version PHP config over the socket: `yerd set php ... --only 8.3`
-    /// and the `NotFound` guard for an uninstalled version. PHP 8.3 is faked
-    /// on disk (binaries only; no pool is running).
+    /// Per-version PHP config over the socket: `yerd set php ... --only 8.3`,
+    /// `yerd php ini set/unset`, and the `NotFound` guard for an uninstalled
+    /// version. PHP 8.3 is faked on disk (binaries only; no pool is running).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[allow(clippy::too_many_lines)]
     async fn php_version_config_round_trips_against_daemon() {
@@ -583,17 +583,58 @@ mod tests {
             other => panic!("expected NotFound, got {other:?}"),
         }
 
+        let ini_set = Command::Php {
+            action: yerd::cli::PhpAction::Ini {
+                action: yerd::cli::PhpIniAction::Set {
+                    version: "8.3".into(),
+                    name: "xdebug.mode".into(),
+                    value: "debug".into(),
+                },
+            },
+        };
+        match send(&sock, &ini_set).await {
+            Response::PhpVersions { directives, .. } => {
+                assert_eq!(
+                    directives
+                        .get(&v83)
+                        .and_then(|m| m.get("xdebug.mode"))
+                        .map(String::as_str),
+                    Some("debug")
+                );
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+
         let per_version_ini =
             std::fs::read_to_string(dirs.data.join("php-cli-8.3.ini")).expect("per-version ini");
         assert!(per_version_ini.contains("memory_limit = 1G\n"));
+        assert!(per_version_ini.contains("xdebug.mode = debug\n"));
         let base_ini = std::fs::read_to_string(dirs.data.join("php-cli.ini")).expect("base ini");
         assert!(!base_ini.contains("1G"));
+        assert!(!base_ini.contains("xdebug.mode"));
 
         let on_disk = std::fs::read_to_string(&cfg_path).expect("config written");
         assert!(
             on_disk.contains("[php.version_settings.\"8.3\"]"),
             "{on_disk}"
         );
+        assert!(on_disk.contains("[php.directives.\"8.3\"]"), "{on_disk}");
+
+        let ini_unset = Command::Php {
+            action: yerd::cli::PhpAction::Ini {
+                action: yerd::cli::PhpIniAction::Unset {
+                    version: "8.3".into(),
+                    name: "xdebug.mode".into(),
+                },
+            },
+        };
+        match send(&sock, &ini_unset).await {
+            Response::PhpVersions { directives, .. } => {
+                assert!(!directives.contains_key(&v83));
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+
         match send(
             &sock,
             &Command::Unset {

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -210,6 +210,10 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         Request::SetPhpVersionSettings { version, settings } => {
             set_php_version_settings(version, settings, state).await
         }
+        Request::SetPhpDirectives {
+            version,
+            directives,
+        } => set_php_directives(version, directives, state).await,
         Request::AddPhpExtension {
             version,
             path,
@@ -464,12 +468,13 @@ fn installed_versions(state: &DaemonState) -> Vec<yerd_core::PhpVersion> {
 /// Build the `PhpVersions` reply: installed versions, the live global default,
 /// cached update annotations, and the global ini settings. Read-only; no network.
 async fn php_versions_response(state: &DaemonState) -> Response {
-    let (default, settings, version_settings) = {
+    let (default, settings, version_settings, directives) = {
         let cfg = state.config.lock().await;
         (
             cfg.php.default,
             cfg.php.settings.clone(),
             cfg.php.version_settings.clone(),
+            cfg.php.directives.clone(),
         )
     };
     Response::PhpVersions {
@@ -478,6 +483,7 @@ async fn php_versions_response(state: &DaemonState) -> Response {
         updates: crate::php_updates::cached_updates(state).await,
         settings,
         version_settings: Box::new(version_settings),
+        directives: Box::new(directives),
     }
 }
 
@@ -1366,12 +1372,13 @@ fn bundle_contains_ca(ca_pem: &str, bundle_pem: &str) -> bool {
 }
 
 pub(crate) async fn write_cli_ini_now(state: &DaemonState) {
-    let (settings, extensions, version_settings) = {
+    let (settings, extensions, version_settings, directives) = {
         let cfg = state.config.lock().await;
         (
             cfg.php.settings.clone(),
             cfg.php.extensions.clone(),
             cfg.php.version_settings.clone(),
+            cfg.php.directives.clone(),
         )
     };
     if let Err(e) = crate::php_install::write_cli_ini(
@@ -1380,6 +1387,7 @@ pub(crate) async fn write_cli_ini_now(state: &DaemonState) {
         state.php_ca_bundle.as_deref(),
         &extensions,
         &version_settings,
+        &directives,
     ) {
         tracing::warn!(error = %e, "failed to write CLI php.ini");
     }
@@ -1959,6 +1967,82 @@ async fn set_php_version_settings(
     php_versions_response(state).await
 }
 
+/// `yerd php ini set/unset` - merge free-form per-version ini directives into
+/// the config and apply them to that version's FPM pool and CLI ini. An
+/// empty-string value removes the directive. Reserved names (allowlisted
+/// settings, extension loading, the CA bundle) are refused with a pointer to
+/// the typed path. Same lock order and `php_settings_mutate` discipline as
+/// [`set_php_settings`], but only the affected version's pool restarts.
+async fn set_php_directives(
+    version: yerd_core::PhpVersion,
+    directives: std::collections::BTreeMap<String, String>,
+    state: &DaemonState,
+) -> Response {
+    if let Some(resp) = require_installed(version, state) {
+        return resp;
+    }
+    let _mutate_guard = state.php_settings_mutate.lock().await;
+    let mut cfg_guard = state.config.lock().await;
+    let mut new = cfg_guard.clone();
+    for (key, value) in directives {
+        if let Err(e) = yerd_core::php_directives::validate_name(&key) {
+            return Response::Error {
+                code: ErrorCode::InvalidPath,
+                message: e.to_string(),
+            };
+        }
+        if let Some(hint) = yerd_core::php_directives::reserved(&key) {
+            return Response::Error {
+                code: ErrorCode::InvalidPath,
+                message: format!("{key} is managed by Yerd: {hint}"),
+            };
+        }
+        if value.is_empty() {
+            if let Some(map) = new.php.directives.get_mut(&version) {
+                map.remove(&key);
+            }
+            continue;
+        }
+        if let Err(e) = yerd_core::php_directives::validate_value(&value) {
+            return Response::Error {
+                code: ErrorCode::InvalidPath,
+                message: e.to_string(),
+            };
+        }
+        new.php
+            .directives
+            .entry(version)
+            .or_default()
+            .insert(key, value.trim().to_owned());
+    }
+    if new
+        .php
+        .directives
+        .get(&version)
+        .is_some_and(std::collections::BTreeMap::is_empty)
+    {
+        new.php.directives.remove(&version);
+    }
+
+    if new.php.directives == cfg_guard.php.directives {
+        drop(cfg_guard);
+        return php_versions_response(state).await;
+    }
+
+    if let Err(e) = new.validate() {
+        return internal(format!("config validation failed: {e}"));
+    }
+    if let Err(e) = new.save(&state.config_path) {
+        return internal(format!("config save failed: {e}"));
+    }
+    *cfg_guard = new;
+    drop(cfg_guard);
+
+    apply_version_php_config(state, version).await;
+    tracing::info!(version = %version, "applied per-version PHP ini directives");
+    php_versions_response(state).await
+}
+
 /// `NotFound` error when `version` has no installed CLI binary, else `None`.
 /// Per-version config only makes sense for an installed version (mirrors
 /// `add_php_extension`).
@@ -1973,20 +2057,21 @@ fn require_installed(version: yerd_core::PhpVersion, state: &DaemonState) -> Opt
     })
 }
 
-/// Push the config's per-version settings overrides into the
+/// Push the config's per-version settings overrides and directives into the
 /// live `PhpManager`, restart the affected version's pool if it is currently
 /// running, and rewrite the per-version CLI inis. Follows `set_php_settings`'s
 /// lock discipline: the config lock is released before the manager lock is
 /// taken. Runs under the caller's `php_settings_mutate` guard, which is what
 /// keeps the config re-read here from racing a concurrent settings mutation.
 async fn apply_version_php_config(state: &DaemonState, affected: yerd_core::PhpVersion) {
-    let version_settings = {
+    let (version_settings, directives) = {
         let cfg = state.config.lock().await;
-        cfg.php.version_settings.clone()
+        (cfg.php.version_settings.clone(), cfg.php.directives.clone())
     };
     {
         let mut mgr = state.php_manager.lock().await;
         mgr.set_ini_overrides(version_settings);
+        mgr.set_directives(directives);
         if mgr.snapshots().iter().any(|s| s.version == affected) {
             if let Err(e) = mgr.restart(affected).await {
                 tracing::warn!(version = %affected, error = %e, "failed to restart FPM pool after per-version PHP config change");
@@ -3764,6 +3849,26 @@ Subject: Captured\r\n\r\nhi\r\n";
         .await
     }
 
+    /// Dispatch a single-entry `SetPhpDirectives` request.
+    async fn set_directive(
+        state: &DaemonState,
+        version: PhpVersion,
+        name: &str,
+        value: &str,
+    ) -> Response {
+        dispatch(
+            Request::SetPhpDirectives {
+                version,
+                directives: std::collections::BTreeMap::from([(
+                    name.to_string(),
+                    value.to_string(),
+                )]),
+            },
+            state,
+        )
+        .await
+    }
+
     #[tokio::test]
     async fn set_php_version_settings_persists_canonicalises_and_falls_back() {
         let tmp = tempfile::tempdir().unwrap();
@@ -3820,6 +3925,77 @@ Subject: Captured\r\n\r\nhi\r\n";
                 assert!(
                     !version_settings.contains_key(&v83),
                     "emptied override map must drop the version key"
+                );
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_php_directives_persists_rejects_reserved_and_removes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        let v83 = PhpVersion::new(8, 3);
+        fake_install(&state.dirs, v83);
+
+        assert!(matches!(
+            set_directive(&state, PhpVersion::new(8, 5), "xdebug.mode", "debug").await,
+            Response::Error {
+                code: ErrorCode::NotFound,
+                ..
+            }
+        ));
+
+        match set_directive(&state, v83, "xdebug.mode", "debug").await {
+            Response::PhpVersions { directives, .. } => {
+                assert_eq!(
+                    directives
+                        .get(&v83)
+                        .and_then(|m| m.get("xdebug.mode"))
+                        .map(String::as_str),
+                    Some("debug")
+                );
+            }
+            other => panic!("expected PhpVersions, got {other:?}"),
+        }
+
+        for (name, value) in [
+            ("memory_limit", "1G"),
+            ("extension", "/evil.so"),
+            ("zend_extension", "/evil.so"),
+            ("openssl.cafile", "/evil.pem"),
+            ("1bad", "x"),
+            ("bad name", "x"),
+            ("xdebug.mode", "debug; evil"),
+        ] {
+            assert!(
+                matches!(
+                    set_directive(&state, v83, name, value).await,
+                    Response::Error {
+                        code: ErrorCode::InvalidPath,
+                        ..
+                    }
+                ),
+                "{name}={value} should be rejected"
+            );
+        }
+        assert_eq!(
+            state
+                .config
+                .lock()
+                .await
+                .php
+                .directives
+                .get(&v83)
+                .map(std::collections::BTreeMap::len),
+            Some(1)
+        );
+
+        match set_directive(&state, v83, "xdebug.mode", "").await {
+            Response::PhpVersions { directives, .. } => {
+                assert!(
+                    !directives.contains_key(&v83),
+                    "emptied directive map must drop the version key"
                 );
             }
             other => panic!("expected PhpVersions, got {other:?}"),

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -233,11 +233,11 @@ pub async fn install(
 ///   per-version entries), kept for the shell-profile `PHPRC` export and any
 ///   non-shim `php`;
 /// - one `{data}/php-cli-<minor>.ini` per **installed** version, rendering that
-///   version's *effective* settings (global merged with its sparse overrides)
-///   and its registered extensions. Writing per *installed* version (not per
-///   config key) is load-bearing: a version whose last extension/override was
-///   just removed still gets its file rewritten back to base-only, rather than
-///   left stale.
+///   version's *effective* settings (global merged with its sparse overrides),
+///   its registered extensions, and its free-form directives. Writing per
+///   *installed* version (not per config key) is load-bearing: a version whose
+///   last extension/override was just removed still gets its file rewritten back
+///   to base-only, rather than left stale.
 ///
 /// Always rewrites (idempotent).
 pub fn write_cli_ini(
@@ -249,6 +249,7 @@ pub fn write_cli_ini(
         PhpVersion,
         std::collections::BTreeMap<String, String>,
     >,
+    directives: &std::collections::BTreeMap<PhpVersion, std::collections::BTreeMap<String, String>>,
 ) -> std::io::Result<()> {
     std::fs::create_dir_all(&dirs.data)?;
     let base = decorate_cli_ini(
@@ -274,7 +275,10 @@ pub fn write_cli_ini(
             settings,
             version_settings.get(&v).unwrap_or(&no_overrides),
         );
-        let body = yerd_core::php_settings::render_cli_ini_with_ext(&effective, &refs);
+        let mut body = yerd_core::php_settings::render_cli_ini_with_ext(&effective, &refs);
+        if let Some(dirs_for_v) = directives.get(&v) {
+            body.push_str(&yerd_core::php_directives::render_ini_lines(dirs_for_v));
+        }
         let contents = decorate_cli_ini(&body, ca_bundle);
         let name = format!("php-cli-{}.{}.ini", v.major, v.minor);
         yerd_php::io::atomic_write::write(&dirs.data.join(name), contents.as_bytes())?;
@@ -741,19 +745,28 @@ mod tests {
 
         let exts = std::collections::BTreeMap::new();
         let no_vs = std::collections::BTreeMap::new();
-        write_cli_ini(&dirs, &settings, None, &exts, &no_vs).unwrap();
+        let no_dirs = std::collections::BTreeMap::new();
+        write_cli_ini(&dirs, &settings, None, &exts, &no_vs, &no_dirs).unwrap();
         let without = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
         assert!(!without.contains("openssl.cafile"));
         assert!(!without.contains("curl.cainfo"));
 
         let bundle = dirs.data.join("cacert.pem");
-        write_cli_ini(&dirs, &settings, Some(&bundle), &exts, &no_vs).unwrap();
+        write_cli_ini(&dirs, &settings, Some(&bundle), &exts, &no_vs, &no_dirs).unwrap();
         let with = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
         assert!(with.contains(&format!("openssl.cafile = {}\n", bundle.display())));
         assert!(with.contains(&format!("curl.cainfo = {}\n", bundle.display())));
 
         for bad in ["/d/ca\ncert.pem", "/d/ca;cert.pem", "/d/ca#cert.pem"] {
-            write_cli_ini(&dirs, &settings, Some(Path::new(bad)), &exts, &no_vs).unwrap();
+            write_cli_ini(
+                &dirs,
+                &settings,
+                Some(Path::new(bad)),
+                &exts,
+                &no_vs,
+                &no_dirs,
+            )
+            .unwrap();
             let injected = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
             assert!(
                 !injected.contains("openssl.cafile"),
@@ -765,7 +778,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn write_cli_ini_scopes_overrides_to_the_version_file() {
+    fn write_cli_ini_scopes_overrides_and_directives_to_the_version_file() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
         let fpm_dir = dirs.data.join("php").join("php-8.3").join("sbin");
@@ -780,15 +793,32 @@ mod tests {
             v83,
             std::collections::BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
         )]);
-        write_cli_ini(&dirs, &settings, None, &exts, &version_settings).unwrap();
+        let directives = std::collections::BTreeMap::from([(
+            v83,
+            std::collections::BTreeMap::from([("xdebug.mode".to_string(), "debug".to_string())]),
+        )]);
+        write_cli_ini(
+            &dirs,
+            &settings,
+            None,
+            &exts,
+            &version_settings,
+            &directives,
+        )
+        .unwrap();
 
         let base = std::fs::read_to_string(dirs.data.join("php-cli.ini")).unwrap();
         assert!(base.contains("memory_limit = 512M\n"), "got: {base}");
         assert!(!base.contains("1G"), "override leaked into base: {base}");
+        assert!(
+            !base.contains("xdebug.mode"),
+            "directive leaked into base: {base}"
+        );
 
         let per = std::fs::read_to_string(dirs.data.join("php-cli-8.3.ini")).unwrap();
         assert!(per.contains("memory_limit = 1G\n"), "got: {per}");
         assert!(!per.contains("512M"), "global shadowed override: {per}");
+        assert!(per.contains("xdebug.mode = debug\n"), "got: {per}");
     }
 
     #[test]

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -200,6 +200,7 @@ pub async fn bring_up_with_dirs(
     );
     php_manager.set_ini_settings(config.php.settings.clone());
     php_manager.set_ini_overrides(config.php.version_settings.clone());
+    php_manager.set_directives(config.php.directives.clone());
     php_manager.set_dump_ext(Some(yerd_php::DumpExtSettings {
         so_dir: dirs.data.join("php-ext"),
         ini_defines: vec![(

--- a/crates/yerd-config/src/lib.rs
+++ b/crates/yerd-config/src/lib.rs
@@ -86,8 +86,10 @@ pub use schema::{
 /// PHP settings. It defaults (empty) when absent, so v15→v16 is a bare
 /// version bump. v17 added the top-level `mcp_enabled` scalar
 /// ([`Config::mcp_enabled`]) gating the MCP server for AI agents (defaults to off
-/// when absent), also a bare bump.
+/// when absent), also a bare bump. v18 added the optional `[php.directives]`
+/// table ([`PhpSection::directives`]) for free-form per-version ini
+/// directives; it defaults (empty) when absent, so v17→v18 is a bare bump.
 ///
 /// The per-version detail, including how to hand-edit a file back down for an
 /// older binary, lives in `docs/developer/config-schema-history.md`.
-pub const CURRENT_VERSION: u32 = 17;
+pub const CURRENT_VERSION: u32 = 18;

--- a/crates/yerd-config/src/migrate.rs
+++ b/crates/yerd-config/src/migrate.rs
@@ -19,7 +19,7 @@ pub(crate) type MigrationStep = fn(&mut Value) -> Result<(), ConfigError>;
 /// Forward-migration steps, indexed so that **`STEPS[N]` walks `vN → v(N+1)`**.
 /// This matches [`up`], which indexes `STEPS[current]` (== the version being
 /// migrated *from*). Example: a v1 file is migrated by `STEPS[1]`. When
-/// `CURRENT_VERSION == 17`, `STEPS = [v0→v1, …, v15→v16, v16→v17]`, length 17.
+/// `CURRENT_VERSION == 18`, `STEPS = [v0→v1, …, v16→v17, v17→v18]`, length 18.
 ///
 /// `STEPS[0]` (v0→v1) is only reachable via a hand-crafted `version = 0` file -
 /// v0 was never written to disk - but it must exist so that `STEPS[1]` does.
@@ -41,6 +41,7 @@ pub(crate) const STEPS: &[MigrationStep] = &[
     migrate_v14_to_v15,
     migrate_v15_to_v16,
     migrate_v16_to_v17,
+    migrate_v17_to_v18,
 ];
 
 /// `v0 → v1`: bump the version. v0 predates any shipped config, so there is no
@@ -194,6 +195,15 @@ fn migrate_v16_to_v17(value: &mut Value) -> Result<(), ConfigError> {
     set_version(value, 17)
 }
 
+/// `v17 → v18`: bump the version. v18 added the optional `[php.directives]`
+/// table, which defaults (empty) when absent, so an in-place version bump is
+/// the entire migration. Installed versions are discovered from disk,
+/// invisible to this pure step, so per-version tables cannot (and need not)
+/// be seeded here.
+fn migrate_v17_to_v18(value: &mut Value) -> Result<(), ConfigError> {
+    set_version(value, 18)
+}
+
 /// Set the top-level `version` key, erroring if the root is not a table.
 fn set_version(value: &mut Value, n: i64) -> Result<(), ConfigError> {
     let table = value.as_table_mut().ok_or(ConfigError::Migration {
@@ -263,7 +273,7 @@ mod tests {
 
     #[test]
     fn current_version_pinned() {
-        assert_eq!(crate::CURRENT_VERSION, 17);
+        assert_eq!(crate::CURRENT_VERSION, 18);
     }
 
     #[test]
@@ -271,6 +281,13 @@ mod tests {
         let mut v: Value = toml::from_str("version = 16\n").unwrap();
         migrate_v16_to_v17(&mut v).unwrap();
         assert_eq!(read_version(&v).unwrap(), 17);
+    }
+
+    #[test]
+    fn v17_to_v18_is_a_bare_version_bump() {
+        let mut v: Value = toml::from_str("version = 17\n").unwrap();
+        migrate_v17_to_v18(&mut v).unwrap();
+        assert_eq!(read_version(&v).unwrap(), 18);
     }
 
     #[test]

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -285,6 +285,9 @@ struct PhpSectionWire {
     // version string like `extensions`. Additive: pre-v16 files omit it.
     #[serde(default)]
     version_settings: BTreeMap<String, BTreeMap<String, String>>,
+    // v16: free-form per-version ini directives, keyed by version string.
+    #[serde(default)]
+    directives: BTreeMap<String, BTreeMap<String, String>>,
 }
 
 impl Default for PhpSectionWire {
@@ -294,6 +297,7 @@ impl Default for PhpSectionWire {
             settings: BTreeMap::new(),
             extensions: BTreeMap::new(),
             version_settings: BTreeMap::new(),
+            directives: BTreeMap::new(),
         }
     }
 }
@@ -467,6 +471,7 @@ impl TryFrom<Wire> for Config {
             settings: w.php.settings,
             extensions: convert_extensions(w.php.extensions)?,
             version_settings: convert_version_settings(w.php.version_settings)?,
+            directives: convert_directives(w.php.directives)?,
         };
         let ports = Ports {
             http: w.ports.http,
@@ -699,6 +704,32 @@ fn convert_version_settings(
         let kept: BTreeMap<String, String> = entries
             .into_iter()
             .filter(|(k, val)| yerd_core::php_settings::validate_value(k, val).is_ok())
+            .collect();
+        if !kept.is_empty() {
+            out.insert(v, kept);
+        }
+    }
+    Ok(out)
+}
+
+/// Convert the raw wire per-version directives map into the typed
+/// [`PhpSection::directives`] shape. Same policy as
+/// [`convert_version_settings`]: a bad version key errors, while an entry with
+/// an invalid or reserved name, or an invalid value, is dropped leniently.
+fn convert_directives(
+    wire: BTreeMap<String, BTreeMap<String, String>>,
+) -> Result<BTreeMap<yerd_core::PhpVersion, BTreeMap<String, String>>, ConfigError> {
+    use yerd_core::php_directives;
+    let mut out = BTreeMap::new();
+    for (ver, entries) in wire {
+        let v = yerd_core::PhpVersion::from_str(&ver)?;
+        let kept: BTreeMap<String, String> = entries
+            .into_iter()
+            .filter(|(k, val)| {
+                php_directives::validate_name(k).is_ok()
+                    && php_directives::validate_value(val).is_ok()
+                    && php_directives::reserved(k).is_none()
+            })
             .collect();
         if !kept.is_empty() {
             out.insert(v, kept);
@@ -1140,7 +1171,7 @@ mod tests {
         match Config::from_toml("version = 99\n") {
             Err(ConfigError::UnsupportedVersion {
                 found: 99,
-                current: 17,
+                current: 18,
             }) => {}
             other => panic!("expected UnsupportedVersion, got {other:?}"),
         }
@@ -2239,9 +2270,10 @@ php = "not-a-version"
     }
 
     #[test]
-    fn version_settings_round_trip() {
-        let s = "version = 16\n[php]\ndefault = \"8.3\"\n\
-                 [php.version_settings.\"8.3\"]\nmemory_limit = \"1G\"\n";
+    fn version_settings_and_directives_round_trip() {
+        let s = "version = 18\n[php]\ndefault = \"8.3\"\n\
+                 [php.version_settings.\"8.3\"]\nmemory_limit = \"1G\"\n\
+                 [php.directives.\"8.3\"]\n\"xdebug.mode\" = \"debug\"\n";
         let c = Config::from_toml(s).unwrap();
         let v83 = yerd_core::PhpVersion::new(8, 3);
         assert_eq!(
@@ -2252,40 +2284,62 @@ php = "not-a-version"
                 .map(String::as_str),
             Some("1G")
         );
+        assert_eq!(
+            c.php
+                .directives
+                .get(&v83)
+                .and_then(|m| m.get("xdebug.mode"))
+                .map(String::as_str),
+            Some("debug")
+        );
         let back = Config::from_toml(&c.to_toml().unwrap()).unwrap();
         assert_eq!(back, c);
     }
 
-    /// Load-time leniency: invalid entries inside the v16 table are dropped
-    /// without failing the load, while valid siblings survive. Strictness
-    /// lives at set time (CLI/daemon), not here - a bad hand-edit must never
-    /// stop the daemon.
+    /// Load-time leniency: invalid or reserved entries inside the per-version
+    /// tables are dropped without failing the load, while valid siblings
+    /// survive. Strictness lives at set time (CLI/daemon), not here - a bad
+    /// hand-edit must never stop the daemon.
     #[test]
-    fn invalid_version_settings_entries_are_dropped_leniently() {
+    fn invalid_version_settings_and_directives_entries_are_dropped_leniently() {
         let s = "version = 16\n[php]\ndefault = \"8.3\"\n\
                  [php.version_settings.\"8.3\"]\n\
                  memory_limit = \"1G\"\n\
                  allow_url_fopen = \"1\"\n\
-                 max_execution_time = \"bogus\"\n";
+                 max_execution_time = \"bogus\"\n\
+                 [php.directives.\"8.3\"]\n\
+                 \"xdebug.mode\" = \"debug\"\n\
+                 \"1bad\" = \"x\"\n\
+                 \"opcache.bad\" = \"a;b\"\n\
+                 extension = \"/evil.so\"\n\
+                 memory_limit = \"2G\"\n";
         let c = Config::from_toml(s).unwrap();
         let v83 = yerd_core::PhpVersion::new(8, 3);
         let vs = c.php.version_settings.get(&v83).unwrap();
         assert_eq!(vs.len(), 1);
         assert_eq!(vs.get("memory_limit").map(String::as_str), Some("1G"));
+        let dirs = c.php.directives.get(&v83).unwrap();
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs.get("xdebug.mode").map(String::as_str), Some("debug"));
     }
 
     /// A table whose entries are all dropped disappears entirely, and a bad
     /// version key still errors (matching `convert_extensions`).
     #[test]
-    fn fully_invalid_version_settings_table_vanishes_and_bad_version_key_errors() {
+    fn fully_invalid_version_tables_vanish_and_bad_version_key_errors() {
         let s = "version = 16\n[php]\ndefault = \"8.3\"\n\
-                 [php.version_settings.\"8.3\"]\nallow_url_fopen = \"1\"\n";
+                 [php.version_settings.\"8.3\"]\nallow_url_fopen = \"1\"\n\
+                 [php.directives.\"8.3\"]\nextension = \"/evil.so\"\n";
         let c = Config::from_toml(s).unwrap();
         assert!(c.php.version_settings.is_empty());
+        assert!(c.php.directives.is_empty());
 
         let bad = "version = 16\n[php]\ndefault = \"8.3\"\n\
                    [php.version_settings.\"eight\"]\nmemory_limit = \"1G\"\n";
         assert!(Config::from_toml(bad).is_err());
+        let bad2 = "version = 16\n[php]\ndefault = \"8.3\"\n\
+                    [php.directives.\"eight\"]\n\"xdebug.mode\" = \"debug\"\n";
+        assert!(Config::from_toml(bad2).is_err());
     }
 
     #[test]

--- a/crates/yerd-config/src/schema.rs
+++ b/crates/yerd-config/src/schema.rs
@@ -426,6 +426,13 @@ pub struct PhpSection {
     /// Entries are validated leniently at load time: an invalid or
     /// unsupported entry is dropped rather than failing the load.
     pub version_settings: BTreeMap<PhpVersion, BTreeMap<String, String>>,
+    /// Free-form per-version ini directives (e.g. `"xdebug.mode" -> "debug"`),
+    /// applied to that version's FPM pool and CLI ini alongside the typed
+    /// settings. Shape-validated by [`yerd_core::php_directives`] (the
+    /// injection boundary); reserved names are refused at set time and
+    /// dropped leniently at load time. Empty by default, so
+    /// `[php.directives.*]` tables are omitted from a default config.
+    pub directives: BTreeMap<PhpVersion, BTreeMap<String, String>>,
 }
 
 /// One registered custom PHP extension (see [`PhpSection::extensions`]).
@@ -451,6 +458,7 @@ impl Default for PhpSection {
                 .collect(),
             extensions: BTreeMap::new(),
             version_settings: BTreeMap::new(),
+            directives: BTreeMap::new(),
         }
     }
 }

--- a/crates/yerd-config/src/serialize.rs
+++ b/crates/yerd-config/src/serialize.rs
@@ -182,6 +182,10 @@ struct PhpSectionSer<'a> {
     // Placed after `settings`, before `extensions`.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     version_settings: BTreeMap<String, &'a BTreeMap<String, String>>,
+    // Sub-tables keyed by version string (`[php.directives."8.3"]`). Skipped
+    // when empty for the same byte-stability reason.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    directives: BTreeMap<String, &'a BTreeMap<String, String>>,
     // Array-of-tables keyed by version string (`[[php.extensions."8.5"]]`).
     // Skipped when empty so a default config emits no `[php.extensions]` region
     // (byte-shape goldens assume no extra tables). A trailing sub-table region,
@@ -271,6 +275,12 @@ pub(crate) fn to_toml(c: &Config) -> Result<String, ConfigError> {
             version_settings: c
                 .php
                 .version_settings
+                .iter()
+                .map(|(v, m)| (v.to_string(), m))
+                .collect(),
+            directives: c
+                .php
+                .directives
                 .iter()
                 .map(|(v, m)| (v.to_string(), m))
                 .collect(),
@@ -453,8 +463,8 @@ mod tests {
     fn default_to_toml_starts_with_version_line() {
         let s = to_toml(&Config::default()).unwrap();
         assert!(
-            s.starts_with("version = 17\n"),
-            "expected `version = 17` first line; got: {s}"
+            s.starts_with("version = 18\n"),
+            "expected `version = 18` first line; got: {s}"
         );
     }
 

--- a/crates/yerd-config/tests/io.rs
+++ b/crates/yerd-config/tests/io.rs
@@ -24,6 +24,7 @@ fn save_then_load_round_trip() {
         settings: std::collections::BTreeMap::new(),
         extensions: std::collections::BTreeMap::new(),
         version_settings: std::collections::BTreeMap::new(),
+        directives: std::collections::BTreeMap::new(),
     };
     original.parked.paths.insert("/srv/sites".to_string());
     original

--- a/crates/yerd-config/tests/roundtrip.rs
+++ b/crates/yerd-config/tests/roundtrip.rs
@@ -56,6 +56,7 @@ fn populated_expected() -> Config {
         settings: std::collections::BTreeMap::new(),
         extensions: std::collections::BTreeMap::new(),
         version_settings: std::collections::BTreeMap::new(),
+        directives: std::collections::BTreeMap::new(),
     };
     c.parked.paths.insert("docroot-a".to_string());
     c.parked.paths.insert("docroot-b".to_string());

--- a/crates/yerd-config/tests/toml_byte_shape.rs
+++ b/crates/yerd-config/tests/toml_byte_shape.rs
@@ -61,8 +61,8 @@ fn populated() -> Config {
 fn default_config_starts_with_version_line() {
     let s = Config::default().to_toml().unwrap();
     assert!(
-        s.starts_with("version = 17\n"),
-        "expected first line `version = 17`; got: {s}"
+        s.starts_with("version = 18\n"),
+        "expected first line `version = 18`; got: {s}"
     );
 }
 
@@ -372,21 +372,29 @@ fn populated_php_settings_emit_subtable_after_default_and_round_trip() {
 }
 
 #[test]
-fn default_config_emits_no_version_settings_table() {
+fn default_config_emits_no_version_settings_or_directives_tables() {
     let s = Config::default().to_toml().unwrap();
     assert!(
         !s.contains("[php.version_settings"),
         "default config must omit version_settings; got: {s}"
     );
+    assert!(
+        !s.contains("[php.directives"),
+        "default config must omit directives; got: {s}"
+    );
 }
 
 #[test]
-fn populated_version_settings_emit_between_settings_and_extensions() {
+fn populated_version_settings_and_directives_emit_between_settings_and_extensions() {
     let mut c = Config::default();
     let v83 = PhpVersion::new(8, 3);
     c.php.version_settings.insert(
         v83,
         std::collections::BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
+    );
+    c.php.directives.insert(
+        v83,
+        std::collections::BTreeMap::from([("xdebug.mode".to_string(), "debug".to_string())]),
     );
     c.php.extensions.insert(
         v83,
@@ -402,16 +410,22 @@ fn populated_version_settings_emit_between_settings_and_extensions() {
         s.contains("[php.version_settings.\"8.3\"]"),
         "missing version_settings table; got: {s}"
     );
+    assert!(
+        s.contains("[php.directives.\"8.3\"]"),
+        "missing directives table; got: {s}"
+    );
     assert!(s.contains("memory_limit = \"1G\""), "got: {s}");
+    assert!(s.contains("\"xdebug.mode\" = \"debug\""), "got: {s}");
 
     let settings_at = s.find("[php.settings]").expect("[php.settings] present");
     let vs_at = s
         .find("[php.version_settings.")
         .expect("version_settings present");
+    let dir_at = s.find("[php.directives.").expect("directives present");
     let ext_at = s.find("[[php.extensions.").expect("extensions present");
     assert!(
-        settings_at < vs_at && vs_at < ext_at,
-        "expected settings < version_settings < extensions; got: {s}"
+        settings_at < vs_at && vs_at < dir_at && dir_at < ext_at,
+        "expected settings < version_settings < directives < extensions; got: {s}"
     );
 
     let back = Config::from_toml(&s).unwrap();

--- a/crates/yerd-core/src/lib.rs
+++ b/crates/yerd-core/src/lib.rs
@@ -12,6 +12,7 @@ mod domain;
 mod error;
 mod host;
 mod php;
+pub mod php_directives;
 pub mod php_extensions;
 pub mod php_settings;
 mod proxy;
@@ -46,6 +47,7 @@ pub use error::{
     TldErrorReason, UpstreamTargetErrorReason,
 };
 pub use php::{PhpVersion, FIRST_SUPPORTED_MINOR};
+pub use php_directives::{DirectiveError, DirectiveNameErrorReason};
 pub use php_extensions::{ExtError, NameErrorReason, PathErrorReason};
 pub use php_settings::{PhpSettingError, ValueErrorReason};
 pub use proxy::{match_rule, ProxyRule, ProxySite, UpstreamTarget};

--- a/crates/yerd-core/src/php_directives.rs
+++ b/crates/yerd-core/src/php_directives.rs
@@ -1,0 +1,326 @@
+//! Pure validation for free-form per-version PHP ini directives.
+//!
+//! Beyond the fixed allowlist in [`crate::php_settings`], Yerd lets users set
+//! arbitrary ini directives per installed PHP version (`xdebug.mode`,
+//! `opcache.enable`, …). These are not typed: Yerd cannot know the shape of
+//! every extension's directives, so a valid-shaped but nonsensical entry is
+//! PHP's problem, not Yerd's. What this module does guarantee is that a
+//! directive can never corrupt a generated FPM pool config or CLI ini:
+//! [`validate_name`] and [`validate_value`] are the **injection boundary**,
+//! run when a directive is set (CLI + daemon), when the config is loaded from
+//! disk (`yerd-config`, leniently: bad entries are dropped), and again
+//! defensively at render time (`yerd-php`, `bin/yerdd`).
+//!
+//! A small denylist ([`reserved`]) keeps free-form entries from colliding with
+//! directives Yerd manages through typed paths (the settings allowlist,
+//! `yerd php ext`, the CA bundle).
+//!
+//! This module is pure: string validation and rendering only, hand-rolled
+//! (no `regex` dependency).
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::php_settings;
+
+/// Longest accepted directive name, in bytes. Real ini directive names are
+/// short (`opcache.jit_buffer_size` is 23 bytes); 128 is a generous bound.
+const MAX_NAME_LEN: usize = 128;
+
+/// Longest accepted directive value, in bytes. Matches the allowlisted
+/// settings' cap in [`crate::php_settings`].
+const MAX_VALUE_LEN: usize = 256;
+
+/// Denylisted directive names Yerd manages through a typed path, paired with a
+/// human-readable hint pointing at that path.
+const RESERVED: &[(&str, &str)] = &[
+    (
+        "extension",
+        "extensions are managed with `yerd php ext` (or the GUI extensions panel)",
+    ),
+    (
+        "zend_extension",
+        "extensions are managed with `yerd php ext` (or the GUI extensions panel)",
+    ),
+    ("openssl.cafile", "Yerd manages the CA bundle for this"),
+    ("curl.cainfo", "Yerd manages the CA bundle for this"),
+];
+
+/// If `name` is a directive Yerd manages elsewhere, the human-readable hint
+/// explaining where; `None` when the name is free for custom use.
+///
+/// Covers the typed settings allowlist (use `yerd set php <name>` /
+/// `yerd unset php <name>`, optionally with `--only <version>`), extension
+/// loading, and the CA bundle paths.
+#[must_use]
+pub fn reserved(name: &str) -> Option<&'static str> {
+    if php_settings::is_supported(name) {
+        return Some("this setting is managed with `yerd set php` (add --only <version> for a per-version value)");
+    }
+    RESERVED
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, hint)| *hint)
+}
+
+/// Validate a free-form directive name: non-empty, bounded, first character
+/// `[A-Za-z_]`, remaining characters `[A-Za-z0-9._-]`. This is strict enough
+/// to keep a name safe on the left side of an unescaped `php_value[name]` /
+/// `name =` line while accepting every real ini directive shape
+/// (`xdebug.mode`, `opcache.jit_buffer_size`, `zend.assertions`).
+///
+/// Reserved names ([`reserved`]) are not rejected here; callers on the set
+/// path check that separately so they can surface the specific hint.
+///
+/// # Errors
+/// [`DirectiveError::Name`] with the specific [`DirectiveNameErrorReason`].
+pub fn validate_name(name: &str) -> Result<(), DirectiveError> {
+    let err = |reason| Err(DirectiveError::Name { reason });
+    let Some(first) = name.chars().next() else {
+        return err(DirectiveNameErrorReason::Empty);
+    };
+    if name.len() > MAX_NAME_LEN {
+        return err(DirectiveNameErrorReason::TooLong);
+    }
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return err(DirectiveNameErrorReason::IllegalStart);
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+    {
+        return err(DirectiveNameErrorReason::IllegalCharacter);
+    }
+    Ok(())
+}
+
+/// Validate a free-form directive value: non-empty, not all-whitespace,
+/// `≤ MAX_VALUE_LEN`, no control characters, none of the FPM/ini
+/// metacharacters `[ ] = ; #`. This is the same charset discipline as
+/// [`php_settings::validate_value`] without the per-kind typing: it keeps the
+/// value from breaking out of its config line, and leaves semantic sanity to
+/// PHP.
+///
+/// # Errors
+/// [`DirectiveError::Value`] with the specific
+/// [`php_settings::ValueErrorReason`].
+pub fn validate_value(value: &str) -> Result<(), DirectiveError> {
+    use php_settings::ValueErrorReason;
+    let err = |reason| Err(DirectiveError::Value { reason });
+    if value.is_empty() || value.chars().all(char::is_whitespace) {
+        return err(ValueErrorReason::Empty);
+    }
+    if value.len() > MAX_VALUE_LEN {
+        return err(ValueErrorReason::TooLong);
+    }
+    if value
+        .chars()
+        .any(|c| c.is_control() || matches!(c, '[' | ']' | '=' | ';' | '#'))
+    {
+        return err(ValueErrorReason::IllegalCharacter);
+    }
+    Ok(())
+}
+
+/// Render a directives map as `name = value` ini lines for a CLI `php.ini`,
+/// in map (alphabetical) order. Entries failing [`validate_name`] /
+/// [`validate_value`] or naming a [`reserved`] directive are skipped
+/// defensively - this renderer runs after the set-time and load-time checks,
+/// so nothing malformed can reach a generated file even if a bad entry slips
+/// through. Values are trimmed; empty when nothing renders.
+#[must_use]
+pub fn render_ini_lines(directives: &BTreeMap<String, String>) -> String {
+    let mut out = String::new();
+    for (name, value) in directives {
+        if validate_name(name).is_err()
+            || validate_value(value).is_err()
+            || reserved(name).is_some()
+        {
+            continue;
+        }
+        out.push_str(name);
+        out.push_str(" = ");
+        out.push_str(value.trim());
+        out.push('\n');
+    }
+    out
+}
+
+/// Failure to validate a free-form ini directive.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DirectiveError {
+    /// The directive name was rejected.
+    #[error("invalid ini directive name: {reason}")]
+    Name {
+        /// Why the name was rejected.
+        reason: DirectiveNameErrorReason,
+    },
+    /// The directive value was rejected.
+    #[error("invalid ini directive value: {reason}")]
+    Value {
+        /// Why the value was rejected.
+        reason: php_settings::ValueErrorReason,
+    },
+}
+
+/// Specific failure modes for a directive name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DirectiveNameErrorReason {
+    /// Empty string.
+    Empty,
+    /// Longer than the accepted maximum.
+    TooLong,
+    /// First character was not a letter or underscore.
+    IllegalStart,
+    /// Contained a character outside `[A-Za-z0-9._-]`.
+    IllegalCharacter,
+}
+
+impl fmt::Display for DirectiveNameErrorReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            Self::Empty => "name must not be empty",
+            Self::TooLong => "name is too long",
+            Self::IllegalStart => "name must start with a letter or '_'",
+            Self::IllegalCharacter => "name may only contain letters, digits, '.', '_' and '-'",
+        };
+        f.write_str(msg)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_names_pass() {
+        for name in [
+            "xdebug.mode",
+            "opcache.enable",
+            "opcache.jit_buffer_size",
+            "zend.assertions",
+            "_private",
+            "short_open_tag",
+            "a",
+        ] {
+            assert!(validate_name(name).is_ok(), "{name}");
+        }
+    }
+
+    #[test]
+    fn invalid_names_are_rejected() {
+        let cases: &[(&str, DirectiveNameErrorReason)] = &[
+            ("", DirectiveNameErrorReason::Empty),
+            ("1st", DirectiveNameErrorReason::IllegalStart),
+            (".dot", DirectiveNameErrorReason::IllegalStart),
+            ("-dash", DirectiveNameErrorReason::IllegalStart),
+            ("has space", DirectiveNameErrorReason::IllegalCharacter),
+            ("semi;colon", DirectiveNameErrorReason::IllegalCharacter),
+            ("brack[et", DirectiveNameErrorReason::IllegalCharacter),
+            ("eq=uals", DirectiveNameErrorReason::IllegalCharacter),
+            ("new\nline", DirectiveNameErrorReason::IllegalCharacter),
+        ];
+        for (name, want) in cases {
+            assert!(
+                matches!(validate_name(name), Err(DirectiveError::Name { reason }) if reason == *want),
+                "{name:?}"
+            );
+        }
+        assert!(matches!(
+            validate_name(&"x".repeat(MAX_NAME_LEN + 1)),
+            Err(DirectiveError::Name {
+                reason: DirectiveNameErrorReason::TooLong
+            })
+        ));
+    }
+
+    #[test]
+    fn valid_values_pass() {
+        for value in ["debug", "1", "off", "develop,debug", "256M", "/a/b c.log"] {
+            assert!(validate_value(value).is_ok(), "{value}");
+        }
+    }
+
+    #[test]
+    fn invalid_values_are_rejected() {
+        use crate::php_settings::ValueErrorReason;
+        let cases: &[(&str, ValueErrorReason)] = &[
+            ("", ValueErrorReason::Empty),
+            ("   ", ValueErrorReason::Empty),
+            ("a\nb", ValueErrorReason::IllegalCharacter),
+            ("a;b", ValueErrorReason::IllegalCharacter),
+            ("a#b", ValueErrorReason::IllegalCharacter),
+            ("a=b", ValueErrorReason::IllegalCharacter),
+            ("a[b", ValueErrorReason::IllegalCharacter),
+            ("a]b", ValueErrorReason::IllegalCharacter),
+        ];
+        for (value, want) in cases {
+            assert!(
+                matches!(validate_value(value), Err(DirectiveError::Value { reason }) if reason == *want),
+                "{value:?}"
+            );
+        }
+        assert!(matches!(
+            validate_value(&"9".repeat(MAX_VALUE_LEN + 1)),
+            Err(DirectiveError::Value {
+                reason: ValueErrorReason::TooLong
+            })
+        ));
+    }
+
+    #[test]
+    fn every_reserved_name_has_a_hint() {
+        for name in [
+            "extension",
+            "zend_extension",
+            "openssl.cafile",
+            "curl.cainfo",
+            "memory_limit",
+            "max_execution_time",
+            "max_input_time",
+            "max_file_uploads",
+            "upload_max_filesize",
+            "post_max_size",
+            "display_errors",
+            "error_reporting",
+        ] {
+            assert!(reserved(name).is_some(), "{name}");
+        }
+        assert!(reserved("xdebug.mode").is_none());
+        assert!(reserved("opcache.enable").is_none());
+    }
+
+    #[test]
+    fn render_skips_invalid_and_reserved_entries() {
+        let directives = BTreeMap::from([
+            ("xdebug.mode".to_owned(), "debug".to_owned()),
+            ("opcache.enable".to_owned(), " 1 ".to_owned()),
+            ("bad name".to_owned(), "x".to_owned()),
+            ("bad.value".to_owned(), "a;b".to_owned()),
+            ("extension".to_owned(), "/evil.so".to_owned()),
+            ("memory_limit".to_owned(), "1G".to_owned()),
+        ]);
+        assert_eq!(
+            render_ini_lines(&directives),
+            "opcache.enable = 1\nxdebug.mode = debug\n"
+        );
+        assert_eq!(render_ini_lines(&BTreeMap::new()), "");
+    }
+
+    #[test]
+    fn error_display_non_empty() {
+        for r in [
+            DirectiveNameErrorReason::Empty,
+            DirectiveNameErrorReason::TooLong,
+            DirectiveNameErrorReason::IllegalStart,
+            DirectiveNameErrorReason::IllegalCharacter,
+        ] {
+            assert!(!r.to_string().is_empty());
+        }
+    }
+}

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -209,6 +209,15 @@ pub enum Request {
         /// the per-version override so the global default falls through.
         settings: BTreeMap<String, String>,
     },
+    /// Merge free-form per-version ini directives (e.g. `"xdebug.mode" ->
+    /// "debug"`) into the config and apply them to that version's FPM pool and
+    /// CLI ini. An empty-string value removes the directive.
+    SetPhpDirectives {
+        /// The installed PHP version the directives apply to.
+        version: PhpVersion,
+        /// Directive name → value; `""` removes the directive.
+        directives: BTreeMap<String, String>,
+    },
     /// Register a custom PHP extension for a version: the daemon validates and
     /// load-probes the `.so`, persists it, and loads it into that version's FPM
     /// pool and CLI ini.
@@ -784,6 +793,7 @@ mod variant_name_pinning {
             Request::AvailablePhp => {}
             Request::SetPhpSettings { .. } => {}
             Request::SetPhpVersionSettings { .. } => {}
+            Request::SetPhpDirectives { .. } => {}
             Request::AddPhpExtension { .. } => {}
             Request::RemovePhpExtension { .. } => {}
             Request::ListPhpExtensions => {}

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -119,6 +119,12 @@ pub enum Response {
         /// [`Self::Status`]); `Box<T>` serializes transparently.
         #[serde(default, skip_serializing_if = "boxed_version_map_is_empty")]
         version_settings: Box<BTreeMap<PhpVersion, BTreeMap<String, String>>>,
+        /// Free-form per-version ini directives (`"xdebug.mode" -> "debug"`),
+        /// keyed by version. Empty when none are set; `#[serde(default)]`
+        /// keeps older daemons (which omit it) decodable. Boxed like
+        /// `version_settings`.
+        #[serde(default, skip_serializing_if = "boxed_version_map_is_empty")]
+        directives: Box<BTreeMap<PhpVersion, BTreeMap<String, String>>>,
     },
     /// Reply to [`crate::Request::AvailablePhp`].
     AvailablePhp {
@@ -636,6 +642,7 @@ mod variant_name_pinning {
             updates: vec![],
             settings: BTreeMap::new(),
             version_settings: Box::new(BTreeMap::new()),
+            directives: Box::new(BTreeMap::new()),
         });
         pin_response(Response::AvailablePhp {
             available: vec![PhpVersion::new(8, 4), PhpVersion::new(8, 5)],

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -127,6 +127,7 @@ fn encode_then_decode_response_roundtrip() {
         updates: vec![],
         settings: BTreeMap::new(),
         version_settings: Box::new(BTreeMap::new()),
+        directives: Box::new(BTreeMap::new()),
     });
     assert_response_roundtrips(Response::PhpVersions {
         installed: vec![PhpVersion::new(8, 5)],
@@ -140,6 +141,10 @@ fn encode_then_decode_response_roundtrip() {
         version_settings: Box::new(BTreeMap::from([(
             PhpVersion::new(8, 5),
             BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
+        )])),
+        directives: Box::new(BTreeMap::from([(
+            PhpVersion::new(8, 5),
+            BTreeMap::from([("xdebug.mode".to_string(), "debug".to_string())]),
         )])),
     });
     assert_response_roundtrips(Response::Parked { paths: vec![] });

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -656,6 +656,7 @@ fn response_php_versions_byte_shape() {
         updates: vec![],
         settings: BTreeMap::new(),
         version_settings: Box::new(BTreeMap::new()),
+        directives: Box::new(BTreeMap::new()),
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
@@ -698,6 +699,7 @@ fn response_php_versions_with_updates_byte_shape() {
         }],
         settings: BTreeMap::new(),
         version_settings: Box::new(BTreeMap::new()),
+        directives: Box::new(BTreeMap::new()),
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
@@ -718,6 +720,7 @@ fn response_php_versions_with_settings_byte_shape() {
             ("display_errors".to_string(), "On".to_string()),
         ]),
         version_settings: Box::new(BTreeMap::new()),
+        directives: Box::new(BTreeMap::new()),
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
@@ -728,7 +731,7 @@ fn response_php_versions_with_settings_byte_shape() {
 }
 
 #[test]
-fn response_php_versions_with_version_settings_byte_shape() {
+fn response_php_versions_with_version_settings_and_directives_byte_shape() {
     let r = Response::PhpVersions {
         installed: vec![PhpVersion::new(8, 3)],
         default: PhpVersion::new(8, 3),
@@ -738,11 +741,15 @@ fn response_php_versions_with_version_settings_byte_shape() {
             PhpVersion::new(8, 3),
             BTreeMap::from([("memory_limit".to_string(), "1G".to_string())]),
         )])),
+        directives: Box::new(BTreeMap::from([(
+            PhpVersion::new(8, 3),
+            BTreeMap::from([("xdebug.mode".to_string(), "debug".to_string())]),
+        )])),
     };
     let s = serde_json::to_string(&r).unwrap();
     assert_eq!(
         s,
-        r#"{"type":"php_versions","installed":["8.3"],"default":"8.3","version_settings":{"8.3":{"memory_limit":"1G"}}}"#
+        r#"{"type":"php_versions","installed":["8.3"],"default":"8.3","version_settings":{"8.3":{"memory_limit":"1G"}},"directives":{"8.3":{"xdebug.mode":"debug"}}}"#
     );
     assert_eq!(serde_json::from_str::<Response>(&s).unwrap(), r);
 
@@ -752,8 +759,9 @@ fn response_php_versions_with_version_settings_byte_shape() {
         decoded,
         Response::PhpVersions {
             ref version_settings,
+            ref directives,
             ..
-        } if version_settings.is_empty()
+        } if version_settings.is_empty() && directives.is_empty()
     ));
 }
 
@@ -790,6 +798,20 @@ fn request_set_php_version_settings_byte_shape() {
     assert_eq!(
         s,
         r#"{"type":"set_php_version_settings","version":"8.3","settings":{"memory_limit":"1G"}}"#
+    );
+    assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
+}
+
+#[test]
+fn request_set_php_directives_byte_shape() {
+    let r = Request::SetPhpDirectives {
+        version: PhpVersion::new(8, 3),
+        directives: BTreeMap::from([("xdebug.mode".to_string(), "debug".to_string())]),
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"set_php_directives","version":"8.3","directives":{"xdebug.mode":"debug"}}"#
     );
     assert_eq!(serde_json::from_str::<Request>(&s).unwrap(), r);
 }

--- a/crates/yerd-php/src/manager.rs
+++ b/crates/yerd-php/src/manager.rs
@@ -134,6 +134,7 @@ where
     binaries: BTreeMap<PhpVersion, PathBuf>,
     ini_settings: BTreeMap<String, String>,
     ini_overrides: BTreeMap<PhpVersion, BTreeMap<String, String>>,
+    directives: BTreeMap<PhpVersion, BTreeMap<String, String>>,
     dump_ext: Option<DumpExtSettings>,
     extensions: BTreeMap<PhpVersion, Vec<ExtLoad>>,
     ca_bundle: Option<PathBuf>,
@@ -174,6 +175,7 @@ where
             binaries,
             ini_settings: BTreeMap::new(),
             ini_overrides: BTreeMap::new(),
+            directives: BTreeMap::new(),
             dump_ext: None,
             extensions: BTreeMap::new(),
             ca_bundle: None,
@@ -209,6 +211,14 @@ where
     /// `set_extensions`.
     pub fn set_ini_overrides(&mut self, overrides: BTreeMap<PhpVersion, BTreeMap<String, String>>) {
         self.ini_overrides = overrides;
+    }
+
+    /// Replace the free-form per-version ini directives applied to each pool,
+    /// keyed by PHP version. Rendered as `php_value[...]` lines after the
+    /// typed settings. Takes effect on the next `ensure` / restart of a pool,
+    /// like `set_extensions`.
+    pub fn set_directives(&mut self, directives: BTreeMap<PhpVersion, BTreeMap<String, String>>) {
+        self.directives = directives;
     }
 
     /// Configure daemon-managed dump-extension loading. When set, each pool that
@@ -289,6 +299,11 @@ where
         cfg.ini = yerd_core::php_settings::merge_effective(&self.ini_settings, overrides)
             .into_iter()
             .collect();
+        cfg.directives = self
+            .directives
+            .get(&v)
+            .map(|m| m.iter().map(|(k, val)| (k.clone(), val.clone())).collect())
+            .unwrap_or_default();
         cfg.ca_bundle = self.ca_bundle.clone();
 
         if let Some(ext) = &self.dump_ext {

--- a/crates/yerd-php/src/pool.rs
+++ b/crates/yerd-php/src/pool.rs
@@ -35,6 +35,12 @@ pub struct PoolConfig {
     /// name. Rendered as `php_value[name] = value` / `php_flag[name] = value`
     /// (per [`yerd_core::php_settings::directive`]). Empty by default.
     pub ini: Vec<(String, String)>,
+    /// Free-form per-version ini directives (e.g. `xdebug.mode`), as
+    /// `(name, value)` pairs sorted by name. Rendered uniformly as
+    /// `php_value[name] = value` (FPM coerces boolean-valued directives);
+    /// entries are re-validated against [`yerd_core::php_directives`] at
+    /// render time and skipped when invalid or reserved. Empty by default.
+    pub directives: Vec<(String, String)>,
     /// Optional PHP extension to load via the FPM command line
     /// (`-d extension=<path>`). Loaded at PHP startup (MINIT); used for the
     /// daemon-managed dump-telemetry extension. `None` = none.
@@ -103,6 +109,7 @@ impl PoolConfig {
             pm: ProcessManagerMode::OnDemand,
             max_children: 16,
             ini: Vec::new(),
+            directives: Vec::new(),
             extension: None,
             ini_defines: Vec::new(),
             user_extensions: Vec::new(),

--- a/crates/yerd-php/src/pure/fpm_conf.rs
+++ b/crates/yerd-php/src/pure/fpm_conf.rs
@@ -55,6 +55,15 @@ pub fn render_fpm_conf(cfg: &PoolConfig) -> String {
         }
     }
 
+    for (key, value) in &cfg.directives {
+        if yerd_core::php_directives::validate_name(key).is_ok()
+            && yerd_core::php_directives::validate_value(value).is_ok()
+            && yerd_core::php_directives::reserved(key).is_none()
+        {
+            let _ = writeln!(out, "php_value[{key}] = {value}");
+        }
+    }
+
     out
 }
 
@@ -95,6 +104,7 @@ mod tests {
             pm,
             max_children: 16,
             ini: Vec::new(),
+            directives: Vec::new(),
             extension: None,
             ini_defines: Vec::new(),
             user_extensions: Vec::new(),
@@ -112,6 +122,7 @@ mod tests {
             pm: ProcessManagerMode::OnDemand,
             max_children: 16,
             ini: Vec::new(),
+            directives: Vec::new(),
             extension: None,
             ini_defines: Vec::new(),
             user_extensions: Vec::new(),
@@ -189,6 +200,43 @@ catch_workers_output = yes
         let s = render_fpm_conf(&cfg);
         assert!(!s.contains("not_a_setting"), "unsupported key leaked: {s}");
         assert!(!s.contains("evil"), "unsafe value leaked: {s}");
+    }
+
+    #[test]
+    fn free_form_directives_render_as_php_value_after_settings() {
+        let mut cfg = cfg_unix(ProcessManagerMode::OnDemand);
+        cfg.ini = vec![("memory_limit".to_string(), "512M".to_string())];
+        cfg.directives = vec![
+            ("opcache.enable".to_string(), "1".to_string()),
+            ("xdebug.mode".to_string(), "debug".to_string()),
+        ];
+        let s = render_fpm_conf(&cfg);
+        assert!(s.contains("php_value[opcache.enable] = 1\n"), "got: {s}");
+        assert!(s.contains("php_value[xdebug.mode] = debug\n"), "got: {s}");
+        assert!(
+            s.find("php_value[memory_limit]").unwrap()
+                < s.find("php_value[opcache.enable]").unwrap(),
+            "settings must precede free-form directives: {s}"
+        );
+    }
+
+    #[test]
+    fn free_form_directives_skip_invalid_and_reserved_entries() {
+        let mut cfg = cfg_unix(ProcessManagerMode::OnDemand);
+        cfg.directives = vec![
+            ("bad name".to_string(), "x".to_string()),
+            ("xdebug.mode".to_string(), "debug; evil".to_string()),
+            ("extension".to_string(), "/evil.so".to_string()),
+            ("memory_limit".to_string(), "1G".to_string()),
+            ("openssl.cafile".to_string(), "/evil.pem".to_string()),
+        ];
+        let s = render_fpm_conf(&cfg);
+        assert!(!s.contains("bad name"), "invalid name leaked: {s}");
+        assert!(!s.contains("evil"), "unsafe or reserved entry leaked: {s}");
+        assert!(
+            !s.contains("php_value[memory_limit]"),
+            "allowlisted name must not render via the free-form path: {s}"
+        );
     }
 
     #[test]

--- a/crates/yerd-php/tests/fpm_conf_golden.rs
+++ b/crates/yerd-php/tests/fpm_conf_golden.rs
@@ -45,7 +45,7 @@ catch_workers_output = yes
 }
 
 #[test]
-fn ini_settings_render_exact() {
+fn settings_and_directives_render_exact() {
     let dirs = PlatformDirs {
         config: PathBuf::from("/yerd/cfg"),
         data: PathBuf::from("/yerd/data"),
@@ -59,6 +59,12 @@ fn ini_settings_render_exact() {
     cfg.ini = vec![
         ("display_errors".to_string(), "On".to_string()),
         ("memory_limit".to_string(), "1G".to_string()),
+    ];
+    cfg.directives = vec![
+        ("opcache.enable".to_string(), "1".to_string()),
+        ("xdebug.mode".to_string(), "debug".to_string()),
+        ("extension".to_string(), "/evil.so".to_string()),
+        ("bad name".to_string(), "x".to_string()),
     ];
 
     let want = "\
@@ -75,6 +81,8 @@ clear_env = no
 catch_workers_output = yes
 php_flag[display_errors] = On
 php_value[memory_limit] = 1G
+php_value[opcache.enable] = 1
+php_value[xdebug.mode] = debug
 ";
     assert_eq!(render_fpm_conf(&cfg), want);
 }

--- a/docs/developer/config-schema-history.md
+++ b/docs/developer/config-schema-history.md
@@ -28,7 +28,22 @@ Each entry below states what changed, whether the daemon's own migration is a ba
 
 ## Version-by-version
 
-### v17 (current)
+### v18 (current)
+
+**Added:** the optional `[php.directives]` table - free-form (shape-validated) per-version ini directives such as `xdebug.mode`. `[php.directives."<version>"]` holds the directives for one installed version. It defaults to empty when absent, so an uncustomised file omits it entirely.
+
+```toml
+[php.directives."8.3"]
+"xdebug.mode" = "debug"
+```
+
+The table loads **leniently**: an invalid or reserved entry (e.g. from a hand-edit) is dropped during parsing rather than failing the load, so a bad entry can never stop the daemon. A malformed version key is still a hard error, and the strict validation lives at set time (CLI/GUI/IPC).
+
+**Migration from v17:** bare version bump - the table defaults to empty when absent, so a v17 file needs no other change.
+
+**To downgrade to v17:** change `version = 18` to `version = 17` and delete any `[php.directives.*]` tables (a v17 daemon rejects the unknown tables under `deny_unknown_fields`, it doesn't just ignore them). Every version falls back to the `[php.settings]` and `[php.version_settings]` values.
+
+### v17
 
 **Added:** the top-level `mcp_enabled` scalar (bool) - whether `yerd mcp` serves Yerd's tools to local AI agents. Defaults to `false`, so exposing Yerd to agents is an explicit opt-in, and is always emitted.
 

--- a/docs/developer/ipc-protocol.md
+++ b/docs/developer/ipc-protocol.md
@@ -169,6 +169,7 @@ The variant set is the daemon's whole RPC surface - liveness, site management, P
 | `UpdatePhp { version: Option }` | `{"type":"update_php","version":"8.5"}` or `…,"version":null` |
 | `SetPhpSettings { settings }` | `{"type":"set_php_settings","settings":{…}}` |
 | `SetPhpVersionSettings { version, settings }` | `{"type":"set_php_version_settings","version":"8.3","settings":{…}}` (per-version overrides; `""` removes → falls back to global) |
+| `SetPhpDirectives { version, directives }` | `{"type":"set_php_directives","version":"8.3","directives":{"xdebug.mode":"debug"}}` (free-form ini directives; `""` removes) |
 | `AddPhpExtension { version, path, name: Option, zend }` | `{"type":"add_php_extension","version":"8.5","path":"/a/scrypt.so","name":null,"zend":false}` |
 | `RemovePhpExtension { version, name }` | `{"type":"remove_php_extension","version":"8.5","name":"scrypt"}` |
 | `ListPhpExtensions` | `{"type":"list_php_extensions"}` (replies `PhpExtensions { by_version }`) |
@@ -396,7 +397,7 @@ The JSON shapes are the **published contract**, pinned three ways so a rename or
    }).unwrap(), r#"{"type":"set_php","name":"foo","version":"8.3"}"#);
    ```
 
-   It also pins additive back-compat: `Response::Info` decodes legacy daemons that omit `http_port`/`https_port` (they default to 0), and `Response::PhpVersions` skips an empty `updates`/`settings`/`version_settings` on the wire so the bytes match the pre-field shape.
+   It also pins additive back-compat: `Response::Info` decodes legacy daemons that omit `http_port`/`https_port` (they default to 0), and `Response::PhpVersions` skips an empty `updates`/`settings`/`version_settings`/`directives` on the wire so the bytes match the pre-field shape.
 
 2. **Inline `variant_name_pinning` modules** in `request.rs` and `response.rs` contain exhaustive `match` arms over the (in-crate, so matchable despite `#[non_exhaustive]`) enums. A renamed Rust variant fails to compile there - integration tests can't catch this across the crate boundary.
 

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -13,7 +13,7 @@ The fastest way to manage PHP is the **PHP** page (under the **Environment** gro
 - **Refresh** re-checks for updates and **Update all** updates every version with one pending - [updates are notify-only](#updates-are-notify-only).
 - Each row's `⋯` menu offers **Restart**, **Set default** (marks it with a star; disabled for legacy rows, which are tagged with a `legacy` badge), **Update** (when available), and **Uninstall**; **Restart all** restarts every running pool.
 - A **Default settings** card edits the [global ini defaults](#tuning-php-settings) applied to every version; leave a field blank to use PHP's built-in default, and saving restarts running pools to apply.
-- A **Per-version configuration** card holds one expandable panel per installed version: the same settings form scoped to that version (empty fields inherit the defaults; see [Per-version configuration](#per-version-configuration)). Saving restarts only that version's pool.
+- A **Per-version configuration** card holds one expandable panel per installed version: the same settings form scoped to that version (empty fields inherit the defaults; see [Per-version configuration](#per-version-configuration)) plus a free-form ini-directive editor (e.g. `xdebug.mode = debug`). Saving restarts only that version's pool.
 - A **Custom extensions** card registers extra `.so` extensions per version (see [Custom extensions](#custom-extensions)); each is load-probed before it's saved, and broken registrations are flagged.
 
 ## From the command line
@@ -409,11 +409,25 @@ yerd set php memory_limit 1G --only 8.3   # only PHP 8.3 gets 1G
 yerd unset php memory_limit --only 8.3    # 8.3 inherits the global value again
 ```
 
-A per-version change restarts only that version's pool, and per-version
-configuration survives uninstalling and reinstalling the version. In the
-desktop app the same lives in the **Per-version configuration** card on the
-PHP page: one expandable panel per installed version with the settings form
-(empty fields inherit the defaults).
+Beyond the allowlist, `yerd php ini` sets **free-form ini directives** per
+version - typically the settings of a custom extension. The classic xdebug
+setup is two commands:
+
+```sh
+yerd php ext add 8.3 /opt/php/xdebug.so --zend   # load the extension
+yerd php ini set 8.3 xdebug.mode debug           # configure it
+```
+
+Directive names and values are shape-checked so they can never corrupt the
+generated config, but Yerd doesn't second-guess their meaning - a directive PHP
+doesn't recognise is simply ignored by PHP. A per-version change restarts only
+that version's pool, and per-version configuration survives uninstalling and
+reinstalling the version. In the desktop app the same lives in the
+**Per-version configuration** card on the PHP page: one expandable panel per
+installed version with the settings form (empty fields inherit the defaults)
+and a directive editor. See the
+[PHP CLI reference](../reference/cli/php#custom-ini-directives) for the rules
+and the denylist of directives Yerd manages elsewhere.
 
 ### Command summary
 
@@ -429,6 +443,9 @@ PHP page: one expandable panel per installed version with the settings form
 | `yerd restart php [<version>]` | Restart one (or all) running FPM pools. |
 | `yerd set php <setting> <value> [--only <version>]` | Set a global PHP ini default, or a per-version override with `--only`. |
 | `yerd unset php <setting> [--only <version>]` | Reset a global setting to PHP's built-in value. With `--only`, remove one version's override so the global value applies again. |
+| `yerd php ini set <version> <name> <value>` | Set a free-form ini directive (e.g. `xdebug.mode`) for one version. |
+| `yerd php ini unset <version> <name>` | Remove a free-form ini directive. |
+| `yerd php ini list` | Show per-version overrides and directives. |
 | `yerd php ext add <version> <path> [--zend] [--name <name>]` | Register a custom extension (load-probed) for a version. |
 | `yerd php ext remove <version> <name>` | Remove a registered extension. |
 | `yerd php ext list` | List registered custom extensions, grouped by version. |

--- a/docs/reference/cli/php.md
+++ b/docs/reference/cli/php.md
@@ -149,3 +149,37 @@ than a broken pool. `add`/`remove` restart that version's running FPM pool.
 `yerd php ext list` tags any extension whose `.so` is missing on disk with
 `(missing!)`. See the [Configuration Reference](../configuration#php) for how the
 registry is stored.
+
+## Custom ini directives
+
+`yerd php ini` sets free-form ini directives for **one** installed version - the
+directives Yerd's typed allowlist doesn't cover, typically extension settings
+like `xdebug.mode` or `opcache.jit_buffer_size`. They apply to that version's
+FPM (web) pool and its CLI.
+
+| Command | Description | Example |
+| --- | --- | --- |
+| `yerd php ini set <VERSION> <NAME> <VALUE>` | Set a directive for one installed version. | `yerd php ini set 8.3 xdebug.mode debug` |
+| `yerd php ini unset <VERSION> <NAME>` | Remove a directive. | `yerd php ini unset 8.3 xdebug.mode` |
+| `yerd php ini list` | List per-version overrides and directives (same output as `yerd list php`). | `yerd php ini list` |
+
+```sh
+yerd php ext add 8.3 /opt/php/xdebug.so --zend   # 1. load the extension
+yerd php ini set 8.3 xdebug.mode debug           # 2. configure it
+yerd php ini list
+yerd php ini unset 8.3 xdebug.mode
+```
+
+Names and values are **shape-validated** (no control characters or the ini
+metacharacters `[ ] = ; #`), but not semantically: a well-formed directive PHP
+doesn't recognise is simply ignored by PHP. Directives Yerd manages through
+typed paths are refused with a pointer to the right command: the eight
+[allowlisted settings](#global-php-ini-settings) (use `yerd set php`,
+optionally with `--only`), `extension`/`zend_extension` (use `yerd php ext`),
+and `openssl.cafile`/`curl.cainfo` (Yerd manages the CA bundle).
+
+In the FPM pool config a directive renders as `php_value[name] = value`
+(FPM coerces boolean-valued directives); in the version's CLI ini it renders as
+a plain `name = value` line. Setting or removing a directive restarts only that
+version's pool, and directives survive uninstalling and reinstalling the
+version.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,7 @@ Every field below maps one-to-one to a field in `schema.rs`. The on-disk shape a
 
 | Key         | TOML type            | Meaning                                                            | Default        |
 | ----------- | -------------------- | ----------------------------------------------------------------- | -------------- |
-| `version`   | integer              | On-disk schema version. **Mandatory**; written as `17` by this release. | `n/a (required)` |
+| `version`   | integer              | On-disk schema version. **Mandatory**; written as `18` by this release. | `n/a (required)` |
 | `tld`       | string               | TLD served by Yerd's resolver.                                    | `"test"`       |
 | `dns_port`  | integer (u16)        | Loopback port for the embedded `.test` DNS responder.             | `1053`         |
 | `symlink_protection` | boolean     | Refuse to serve assets/scripts reached via a symlink resolving outside a site's document root. | `true` |
@@ -50,7 +50,7 @@ The parser uses `deny_unknown_fields` at every level. A typo'd or stray key (top
 
 ### `version`
 
-The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `17`, and Yerd always writes `version = 17`. Older `version = 1` through `version = 16` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
+The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `18`, and Yerd always writes `version = 18`. Older `version = 1` through `version = 17` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
 
 ### `tld`
 
@@ -116,6 +116,7 @@ PHP defaults applied across sites.
 | `default`          | string    | Default PHP version for new sites (e.g. `"8.3"`).            | `"8.3"` |
 | `settings`         | table     | Global PHP ini directives applied to every installed version's FPM pool. | empty   |
 | `version_settings` | table     | Sparse per-version overrides of `settings`, keyed by PHP version. | empty   |
+| `directives`       | table     | Free-form per-version ini directives, keyed by PHP version.  | empty   |
 | `extensions`       | table     | Custom `.so` extensions to load, keyed by PHP version.       | empty   |
 
 `default` is a `MAJOR.MINOR` version string validated by `yerd-core`'s `PhpVersion`; an out-of-range minor or a non-numeric value is rejected. See [PHP Versions](../guide/php-versions).
@@ -150,20 +151,31 @@ version's effective value is its override when present, else the global
 `[php.settings]` value, else PHP's built-in default. Omitted entirely when no
 overrides are set.
 
+`[php.directives."<version>"]` (schema v18) holds **free-form ini directives**
+per version - typically extension settings the allowlist doesn't cover
+(`xdebug.mode`, `opcache.*`, …). Names must start with a letter or `_` and use
+only letters, digits, `.`, `_`, `-`; values follow the same injection rules as
+`[php.settings]` (no control characters or `[ ] = ; #`, ≤ 256 bytes).
+Directives Yerd manages through typed paths are reserved: the eight allowlisted
+settings, `extension` / `zend_extension`, and `openssl.cafile` / `curl.cainfo`.
+
 ```toml
 [php.version_settings."8.3"]
 memory_limit = "1G"
+
+[php.directives."8.3"]
+"xdebug.mode" = "debug"
 ```
 
-::: tip This table loads leniently
-Unlike `[php.settings]`, a hand-edited invalid entry in `version_settings`
-never fails the load - it is silently dropped while valid siblings survive, so
-a bad edit can't stop the daemon. Setting values through the CLI/GUI still
-validates strictly. A malformed *version key* (e.g. `"eight"`) is still a hard
-error.
+::: tip These two tables load leniently
+Unlike `[php.settings]`, a hand-edited invalid or reserved entry in
+`version_settings` / `directives` never fails the load - it is silently
+dropped while valid siblings survive, so a bad edit can't stop the daemon.
+Setting values through the CLI/GUI still validates strictly. A malformed
+*version key* (e.g. `"eight"`) is still a hard error.
 :::
 
-Manage this with [`yerd set php --only <version>`](cli/php#global-php-ini-settings) or the desktop app's **Per-version configuration** card.
+Manage these with [`yerd set php --only <version>` and `yerd php ini`](cli/php#custom-ini-directives) or the desktop app's **Per-version configuration** card.
 
 `[php.extensions]` maps a **PHP version string** to an array of custom extensions to load into both that version's FPM pool and its CLI. It is written as an array-of-tables per version and omitted entirely when empty. Because a native `.so` is ABI-bound to a PHP minor, an entry only applies to the version it is keyed under.
 
@@ -463,14 +475,14 @@ the actively bound ports and sees parked sites on disk.
 
 ## Schema versioning and migration
 
-Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `17`.
+Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `18`.
 
 When the daemon loads a file, it routes on the version it finds:
 
 ```text
-found  > CURRENT (17)   →  error (UnsupportedVersion) - a newer Yerd wrote this file
-found == CURRENT (17)   →  parse directly
-found  < CURRENT (17)   →  walk forward migration steps, then parse
+found  > CURRENT (18)   →  error (UnsupportedVersion) - a newer Yerd wrote this file
+found == CURRENT (18)   →  parse directly
+found  < CURRENT (18)   →  walk forward migration steps, then parse
 ```
 
 A file written by a *newer* Yerd than you are running is refused rather than misread. Older files are migrated forward in place, one version at a time, before the normal wire-deserialisation and validation run:
@@ -491,6 +503,7 @@ A file written by a *newer* Yerd than you are running is refused rather than mis
 - **`v14 → v15`** is the multi-instance services rework: v15 **added** the optional per-instance `site` field and the `"{type}:{site}"` wire ids (both additive), and made the `enabled` flag actually gate boot autostart. The migration marks every existing single-instance engine `enabled = true` so previously-installed engines keep starting with Yerd across the upgrade.
 - **`v15 → v16`** is a bare version bump: v16 only **added** the optional `[php.version_settings]` table (per-version overrides of the global PHP settings), which defaults to empty when absent.
 - **`v16 → v17`** is a bare version bump: v17 only **added** the top-level `mcp_enabled` scalar (defaults to `false` when absent).
+- **`v17 → v18`** is a bare version bump: v18 only **added** the optional `[php.directives]` table (free-form per-version ini directives), which defaults to empty when absent.
 
 The on-disk schema version is deliberately decoupled from the IPC protocol version; the two evolve independently.
 
@@ -517,8 +530,8 @@ Yerd does not `fsync` the file or its parent directory after a save. For a devel
 This is a valid `yerd.toml` covering the core fields (see the sections above for the newer optional tables - `update_channel`, `[tunnel]`, `[groups]`, `[php.extensions]`, `[domains]`, `[[proxies]]`, `[proxy_rules]`, `wp_auto_login` - omitted here for brevity):
 
 ```toml
-# Schema version - mandatory, always written as 17 by this release.
-version = 17
+# Schema version - mandatory, always written as 18 by this release.
+version = 18
 
 # TLD served by the resolver; sites resolve as <name>.test
 tld = "test"


### PR DESCRIPTION
<!-- Thanks for contributing to Yerd! Please fill in the sections below. -->

## What does this PR do?

Adds free-form per-version ini directives — the missing half of custom extensions. Yerd can already load `xdebug.so` per version (`yerd php ext`), but there's no way to set `xdebug.mode`, so the extension can't actually be used. This makes the classic setup two commands:

```sh
yerd php ext add 8.3 /opt/php/xdebug.so --zend   # load the extension  (existing)
yerd php ini set 8.3 xdebug.mode debug           # configure it       (this PR)
```

<img width="1086" height="906" alt="CleanShot 2026-07-19 at 10 37 27" src="https://github.com/user-attachments/assets/3b04e745-08d9-455b-ba65-e8e074d7ce6c" />

## Related issues

Closes #164 

## Type of change

- [x] New feature

## Platforms tested

- [x] macOS
- [ ] Linux *(developed and gated on macOS; Linux verification via CI — happy to address anything it surfaces)*

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [ ] `cargo test` passes
- [x] Pure crates/modules still do no I/O (php_directives is pure string validation/rendering; lenient filtering is pure in yerd-config)
- [x] Docs updated (CLI reference incl. denylist + php_value rendering note, PHP-versions guide with the xdebug example, configuration reference, schema history, IPC protocol)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom PHP INI directive management per PHP version.
  * Desktop users can add, edit, validate, and remove directives such as `xdebug.mode`.
  * Added CLI commands to set, unset, and list directives.
  * Directives apply to both PHP-FPM and CLI configurations, with only the affected PHP version restarted.
* **Documentation**
  * Updated PHP configuration, CLI, and version-management guides.
* **Bug Fixes**
  * Added validation to prevent unsafe, invalid, or reserved directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->