### PR TITLE
[Feat] UI reorganisation

### DIFF
--- a/apps/yerd-gui/src/components/EnvironmentCard.vue
+++ b/apps/yerd-gui/src/components/EnvironmentCard.vue
@@ -14,6 +14,7 @@ import Modal from "@/components/ui/Modal.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
+import { privilegedFallback, portsElevated } from "@/lib/elevation";
 import {
   elevate,
   elevateAll,
@@ -24,7 +25,7 @@ import {
   unelevate,
   untrustCa,
 } from "@/ipc/client";
-import type { ElevateTarget, StatusReport } from "@/ipc/types";
+import type { ElevateTarget } from "@/ipc/types";
 
 // Self-contained OS-privileges panel (CA trust, .test resolver, privileged
 // ports). Lives on the Doctor page alongside the health checks - it's the same
@@ -59,17 +60,6 @@ function triLabel(v: Tri, yes: string, no: string): string {
   if (v === true) return yes;
   if (v === false) return no;
   return "unknown";
-}
-
-const PRIVILEGED_PORT_CEILING = 1024;
-function privilegedFallback(r: StatusReport): boolean {
-  return (
-    (r.http.requested < PRIVILEGED_PORT_CEILING && r.http.fell_back) ||
-    (r.https.requested < PRIVILEGED_PORT_CEILING && r.https.fell_back)
-  );
-}
-function portsElevated(r: StatusReport): boolean {
-  return !privilegedFallback(r) || r.port_redirect === true;
 }
 
 interface EnvItem {

--- a/apps/yerd-gui/src/components/NavLink.vue
+++ b/apps/yerd-gui/src/components/NavLink.vue
@@ -72,9 +72,9 @@ function handleBadge(e: MouseEvent): void {
         v-else-if="warn"
         class="ml-auto flex size-4 shrink-0 items-center justify-center rounded-full bg-warning/15 text-[10px] font-bold leading-none text-warning ring-1 ring-warning/40"
         :title="warnTitle"
-        aria-hidden="true"
       >
-        !
+        <span aria-hidden="true">!</span>
+        <span class="sr-only">{{ warnTitle ?? "Needs attention" }}</span>
       </span>
     </a>
   </RouterLink>

--- a/apps/yerd-gui/src/components/NavLink.vue
+++ b/apps/yerd-gui/src/components/NavLink.vue
@@ -12,6 +12,10 @@ import { RouterLink } from "vue-router";
  * the pill runs it instead of navigating the row (a mouse shortcut - keyboard
  * users still reach the same place via the row itself), and `badgeTitle` gives
  * the pill its tooltip.
+ *
+ * `warn` shows an amber `!` marker in the same right-hand slot - used to flag a
+ * row that needs attention (e.g. Doctor when an OS privilege is unelevated).
+ * Rows use either a count or the warn marker, never both.
  */
 const props = defineProps<{
   to: string;
@@ -20,6 +24,8 @@ const props = defineProps<{
   badge?: number;
   onBadgeClick?: () => void;
   badgeTitle?: string;
+  warn?: boolean;
+  warnTitle?: string;
 }>();
 
 function handleBadge(e: MouseEvent): void {
@@ -61,6 +67,14 @@ function handleBadge(e: MouseEvent): void {
         @click="handleBadge"
       >
         {{ badge > 99 ? "99+" : badge }}
+      </span>
+      <span
+        v-else-if="warn"
+        class="ml-auto flex size-4 shrink-0 items-center justify-center rounded-full bg-warning/15 text-[10px] font-bold leading-none text-warning ring-1 ring-warning/40"
+        :title="warnTitle"
+        aria-hidden="true"
+      >
+        !
       </span>
     </a>
   </RouterLink>

--- a/apps/yerd-gui/src/components/SideNav.vue
+++ b/apps/yerd-gui/src/components/SideNav.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Component } from "vue";
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 import {
   ClipboardList,
   Database,
@@ -20,14 +20,19 @@ import NavLink from "@/components/NavLink.vue";
 import OperationsIndicator from "@/components/OperationsIndicator.vue";
 import StatusPill from "@/components/StatusPill.vue";
 import { useDaemon } from "@/composables/useDaemon";
-import { showMailsWindow } from "@/ipc/client";
+import { loadPlatform, usePlatform } from "@/composables/usePlatform";
+import { useResource } from "@/composables/useResource";
+import { cachedUpdateStatus, listPhp, showMailsWindow } from "@/ipc/client";
+import { needsElevation } from "@/lib/elevation";
 import logoUrl from "@/assets/logo.svg";
 
-// Grouped left nav. Sections name the app's three real concerns: the runtime you
-// configure (Environment), what the daemon supervises (Services), and the system
-// itself (System). Overview sits above them as the home/dashboard. Icons are
-// monochrome - see NavLink; status colour is reserved for the pill below. The
-// Mail item carries an optional unread-count badge whose click opens the viewer.
+// Grouped left nav. Sections name the app's concerns: the runtime you configure
+// (Environment: sites, PHP, services), the developer tooling around it
+// (Developer), and the system itself (System). Overview sits above them as the
+// home/dashboard. Icons are monochrome - see NavLink; status colour is reserved
+// for the pill below. The Mail item carries an optional unread-count badge whose
+// click opens the viewer. PHP/About carry passive update-count badges; Doctor
+// carries an amber warn marker when an OS privilege is unelevated.
 type Item = {
   to: string;
   label: string;
@@ -35,11 +40,35 @@ type Item = {
   badge?: number;
   onBadgeClick?: () => void;
   badgeTitle?: string;
+  warn?: boolean;
+  warnTitle?: string;
 };
 
 const { connected, report } = useDaemon();
+const { isMac } = usePlatform();
 const unread = computed(() => report.value?.mail?.unread ?? 0);
 const sharedSites = computed(() => report.value?.shared_sites ?? 0);
+
+// Same shared "php" cache the PHP view uses, so the badge count matches what
+// that page shows. `updates` is populated on the list_php response.
+const { data: phpData } = useResource("php", listPhp);
+const phpUpdates = computed(() => phpData.value?.updates?.length ?? 0);
+
+// Yerd self-update: the daemon's last stored check (no network). Shows a 1 when
+// an update is available on the current track, nothing when up to date.
+const yerdUpdate = ref(0);
+
+// Unelevated OS privileges (CA trust, .test resolver, ports) → amber ! on Doctor.
+const unelevated = computed(() =>
+  report.value ? needsElevation(report.value, isMac.value) : false,
+);
+
+onMounted(() => {
+  void loadPlatform();
+  cachedUpdateStatus()
+    .then((s) => (yerdUpdate.value = s.available ? 1 : 0))
+    .catch(() => {});
+});
 
 // A computed (not a const) so the Mail item's unread badge stays reactive.
 const sections = computed<{ title: string; items: Item[] }[]>(() => [
@@ -47,21 +76,21 @@ const sections = computed<{ title: string; items: Item[] }[]>(() => [
     title: "General",
     items: [
       { to: "/overview", label: "Overview", icon: LayoutDashboard },
-      { to: "/about", label: "About", icon: Info },
+      { to: "/about", label: "About", icon: Info, badge: yerdUpdate.value },
     ],
   },
   {
     title: "Environment",
     items: [
-      { to: "/php", label: "PHP", icon: SquareCode },
       { to: "/sites", label: "Sites", icon: LayoutGrid },
+      { to: "/php", label: "PHP", icon: SquareCode, badge: phpUpdates.value },
+      { to: "/services", label: "Services", icon: Database },
     ],
   },
   {
     title: "Developer",
     items: [
       { to: "/tooling", label: "Tooling", icon: Wrench },
-      { to: "/services", label: "Services", icon: Database },
       { to: "/proxies", label: "Proxies", icon: Waypoints },
       {
         to: "/mail",
@@ -89,7 +118,13 @@ const sections = computed<{ title: string; items: Item[] }[]>(() => [
     title: "System",
     items: [
       { to: "/general", label: "Settings", icon: Settings },
-      { to: "/doctor", label: "Doctor", icon: Stethoscope },
+      {
+        to: "/doctor",
+        label: "Doctor",
+        icon: Stethoscope,
+        warn: unelevated.value,
+        warnTitle: "Something needs elevated permissions",
+      },
     ],
   },
 ]);

--- a/apps/yerd-gui/src/lib/elevation.test.ts
+++ b/apps/yerd-gui/src/lib/elevation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { StatusReport } from "@/ipc/types";
+import { needsElevation, portsElevated, privilegedFallback } from "./elevation";
+
+// Only the fields the predicates read matter; the rest of StatusReport is filled
+// with inert defaults so the tests stay focused on privilege state.
+function mk(over: {
+  httpReq?: number;
+  httpFell?: boolean;
+  httpsReq?: number;
+  httpsFell?: boolean;
+  portRedirect?: boolean | null;
+  trusted?: boolean | null;
+  resolver?: boolean | null;
+  webUnbound?: { http: number; https: number } | null;
+}): StatusReport {
+  // `in` checks, not `??`: an explicit `null` (tri-state "undeterminable") must
+  // survive rather than fall through to the `true` default.
+  return {
+    http: { requested: over.httpReq ?? 80, bound: 80, fell_back: over.httpFell ?? false },
+    https: { requested: over.httpsReq ?? 443, bound: 443, fell_back: over.httpsFell ?? false },
+    port_redirect: over.portRedirect,
+    ca: { path: "", fingerprint: "", trusted_system: "trusted" in over ? over.trusted : true },
+    resolver_installed: "resolver" in over ? over.resolver : true,
+    web_unbound: over.webUnbound,
+  } as StatusReport;
+}
+
+describe("privilegedFallback", () => {
+  it.each([
+    ["bound its requested privileged ports", mk({}), false],
+    ["fell back from privileged http", mk({ httpReq: 80, httpFell: true }), true],
+    ["fell back from privileged https", mk({ httpsReq: 443, httpsFell: true }), true],
+    ["fell back but from a high port", mk({ httpReq: 8080, httpFell: true }), false],
+  ])("%s → %s", (_label, r, expected) => {
+    expect(privilegedFallback(r)).toBe(expected);
+  });
+});
+
+describe("portsElevated", () => {
+  it.each([
+    ["no fallback", mk({}), true],
+    ["privileged fallback, no redirect", mk({ httpReq: 80, httpFell: true }), false],
+    ["privileged fallback but macOS redirect carries them", mk({ httpReq: 80, httpFell: true, portRedirect: true }), true],
+  ])("%s → %s", (_label, r, expected) => {
+    expect(portsElevated(r)).toBe(expected);
+  });
+});
+
+describe("needsElevation", () => {
+  it.each([
+    ["all privileges satisfied", mk({}), false, false],
+    ["all satisfied (macOS)", mk({}), true, false],
+    ["CA not trusted", mk({ trusted: false }), false, true],
+    ["CA trust undeterminable (null, not true)", mk({ trusted: null }), false, true],
+    ["resolver missing", mk({ resolver: false }), false, true],
+    ["ports fell back to high ports", mk({ httpReq: 80, httpFell: true }), false, true],
+    ["ports fell back but redirected on macOS", mk({ httpReq: 80, httpFell: true, portRedirect: true }), true, false],
+    ["web unbound on Linux is fixable via setcap", mk({ webUnbound: { http: 8080, https: 8443 } }), false, true],
+    ["web unbound on macOS is not fixable yet", mk({ webUnbound: { http: 8080, https: 8443 } }), true, false],
+  ])("%s → %s", (_label, r, isMac, expected) => {
+    expect(needsElevation(r, isMac)).toBe(expected);
+  });
+});

--- a/apps/yerd-gui/src/lib/elevation.test.ts
+++ b/apps/yerd-gui/src/lib/elevation.test.ts
@@ -4,7 +4,8 @@ import type { StatusReport } from "@/ipc/types";
 import { needsElevation, portsElevated, privilegedFallback } from "./elevation";
 
 // Only the fields the predicates read matter; the rest of StatusReport is filled
-// with inert defaults so the tests stay focused on privilege state.
+// with inert defaults so the tests stay focused on privilege state. `in` checks
+// (not `??`) preserve an explicit `null` tri-state rather than defaulting it.
 function mk(over: {
   httpReq?: number;
   httpFell?: boolean;
@@ -15,8 +16,6 @@ function mk(over: {
   resolver?: boolean | null;
   webUnbound?: { http: number; https: number } | null;
 }): StatusReport {
-  // `in` checks, not `??`: an explicit `null` (tri-state "undeterminable") must
-  // survive rather than fall through to the `true` default.
   return {
     http: { requested: over.httpReq ?? 80, bound: 80, fell_back: over.httpFell ?? false },
     https: { requested: over.httpsReq ?? 443, bound: 443, fell_back: over.httpsFell ?? false },

--- a/apps/yerd-gui/src/lib/elevation.ts
+++ b/apps/yerd-gui/src/lib/elevation.ts
@@ -1,0 +1,39 @@
+import type { StatusReport } from "@/ipc/types";
+
+/**
+ * Pure predicates for the daemon's OS-privilege state, shared between the Doctor
+ * page's EnvironmentCard (which renders the full fix/revert table) and the side
+ * nav (which shows an amber attention marker when anything still needs a
+ * privileged fix). Keeping them here is the single source of truth so the two
+ * surfaces can never disagree about whether elevation is needed.
+ */
+
+const PRIVILEGED_PORT_CEILING = 1024;
+
+/** The daemon wanted a privileged web port (< 1024) but fell back to a high one. */
+export function privilegedFallback(r: StatusReport): boolean {
+  return (
+    (r.http.requested < PRIVILEGED_PORT_CEILING && r.http.fell_back) ||
+    (r.https.requested < PRIVILEGED_PORT_CEILING && r.https.fell_back)
+  );
+}
+
+/** Privileged ports are served: either no privileged fallback, or macOS pf redirect. */
+export function portsElevated(r: StatusReport): boolean {
+  return !privilegedFallback(r) || r.port_redirect === true;
+}
+
+/**
+ * True when any OS privilege still needs a fix: CA trust, the .test resolver, or
+ * privileged ports. Mirrors EnvironmentCard's per-row `fixable` (its `anyFixable`
+ * aggregate). The ports branch depends on the host: when the daemon bound no web
+ * ports at all (`web_unbound`), elevation can only help on Linux (setcap binds
+ * 80/443 directly); macOS needs working ports set first, so it isn't fixable yet.
+ */
+export function needsElevation(r: StatusReport, isMac: boolean): boolean {
+  return (
+    r.ca.trusted_system !== true ||
+    r.resolver_installed !== true ||
+    (r.web_unbound ? !isMac : !portsElevated(r))
+  );
+}

--- a/apps/yerd-gui/src/views/DoctorView.vue
+++ b/apps/yerd-gui/src/views/DoctorView.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import { CheckCircle2, Copy, Info, Play, RefreshCw, RotateCw, Square, Wrench } from "lucide-vue-next";
-import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
+import { CheckCircle2, Copy, RefreshCw, Wrench } from "lucide-vue-next";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 
-import DaemonDiagnosticsPanel from "@/components/DaemonDiagnosticsPanel.vue";
 import EnvironmentCard from "@/components/EnvironmentCard.vue";
 import PageHeader from "@/components/PageHeader.vue";
-import StatusPill from "@/components/StatusPill.vue";
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
@@ -13,77 +11,15 @@ import CardContent from "@/components/ui/CardContent.vue";
 import CardDescription from "@/components/ui/CardDescription.vue";
 import CardHeader from "@/components/ui/CardHeader.vue";
 import CardTitle from "@/components/ui/CardTitle.vue";
-import Modal from "@/components/ui/Modal.vue";
 import Spinner from "@/components/ui/Spinner.vue";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
-import { useDaemonStart } from "@/composables/useDaemonStart";
 import { useToast } from "@/composables/useToast";
-import { diagnose, doctorFix, IpcError, restartDaemon, stopDaemon } from "@/ipc/client";
+import { diagnose, doctorFix, IpcError } from "@/ipc/client";
 import type { Diagnosis, Severity } from "@/ipc/types";
 
 const toast = useToast();
-const { connected, report, refresh: refreshStatus } = useDaemon();
-
-// ── daemon lifecycle (moved here from Settings) ──
-const {
-  starting: daemonStarting,
-  activeLabel: daemonStartLabel,
-  diagnostics: startDiagnostics,
-  start: startDaemonFlow,
-} = useDaemonStart();
-const busy = ref<string | null>(null);
-const running = computed(() => connected.value === true);
-const daemonPid = computed(() => report.value?.daemon_pid ?? null);
-
-async function onStart(): Promise<void> {
-  // Spinner + on-failure diagnostics are owned by the composable; it keeps
-  // spinning until the daemon connects (watch) or surfaces the panel.
-  await startDaemonFlow({ nudge: true });
-  await refreshStatus();
-}
-
-async function onStop(): Promise<void> {
-  busy.value = "daemon";
-  try {
-    await stopDaemon();
-    toast.success("Stopping daemon…");
-  } catch (e) {
-    toast.error("Couldn't stop the daemon", (e as IpcError).message);
-  } finally {
-    busy.value = null;
-    await refreshStatus();
-  }
-}
-
-const restartDaemonOpen = ref(false);
-function openRestartDaemon(): void {
-  void nextTick(() => {
-    restartDaemonOpen.value = true;
-  });
-}
-async function confirmRestartDaemon(close: () => void): Promise<void> {
-  busy.value = "restart:daemon";
-  close();
-  try {
-    await restartDaemon();
-    // The daemon replies before it re-execs, so a resolved call means the
-    // restart was accepted; the connection drop is handled by the status poll.
-    toast.info("Restarting daemon…", "It returns in a few seconds.");
-  } catch (e) {
-    // Reaching here is a genuine failure (the reply arrives ahead of the drop),
-    // so don't imply the restart started.
-    toast.error("Couldn't restart the daemon", (e as IpcError).message);
-  } finally {
-    busy.value = null;
-  }
-}
+const { refresh: refreshStatus } = useDaemon();
 
 const diagnoses = ref<Diagnosis[]>([]);
 const diagLoading = ref(true);
@@ -170,56 +106,6 @@ onUnmounted(registerViewActions({ refresh: () => void loadDiagnoses() }));
     />
 
     <div class="min-h-0 flex-1 space-y-6 overflow-y-auto p-6">
-      <!-- Daemon control -->
-      <Card>
-        <CardHeader class="flex-row items-center justify-between space-y-0">
-          <div class="flex items-center gap-1.5">
-            <CardTitle>Daemon</CardTitle>
-            <TooltipProvider v-if="running && daemonPid" :delay-duration="0">
-              <Tooltip>
-                <TooltipTrigger as-child>
-                  <span class="inline-flex cursor-help text-muted-foreground">
-                    <Info class="size-3.5" />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">running as pid {{ daemonPid }}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-          <StatusPill
-            :tone="running ? 'ok' : 'bad'"
-            :label="running ? 'Running' : 'Stopped'"
-          />
-        </CardHeader>
-        <CardContent class="space-y-4">
-          <p class="text-sm text-muted-foreground">
-            <code>yerdd</code> is the background service that supervises PHP-FPM,
-            serves your <code>.test</code> sites over HTTP/HTTPS, answers DNS, and
-            runs databases. It runs unprivileged - this app is just a client.
-          </p>
-          <!-- Why a start attempt failed (only when the daemon is down). -->
-          <DaemonDiagnosticsPanel v-if="startDiagnostics && !running" :diagnostics="startDiagnostics" />
-          <div class="flex justify-end gap-2">
-            <Button v-if="!running" :disabled="daemonStarting" @click="onStart">
-              <Spinner v-if="daemonStarting" class="size-4" />
-              <Play v-else class="size-4" /> {{ daemonStartLabel ?? "Start" }}
-            </Button>
-            <Button v-else variant="outline" :disabled="busy !== null" @click="onStop">
-              <Spinner v-if="busy === 'daemon'" class="size-4" />
-              <Square v-else class="size-4" /> Stop
-            </Button>
-            <Button
-              variant="outline"
-              :disabled="!running || busy !== null"
-              @click="openRestartDaemon"
-            >
-              <Spinner v-if="busy === 'restart:daemon'" class="size-4" />
-              <RotateCw v-else class="size-4" /> Restart
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-
       <Card>
         <CardHeader class="flex-row items-center justify-between space-y-0">
           <div class="space-y-1.5">
@@ -296,17 +182,5 @@ onUnmounted(registerViewActions({ refresh: () => void loadDiagnoses() }));
            reflects the new state without a manual re-check. -->
       <EnvironmentCard @elevated="loadDiagnoses()" />
     </div>
-
-    <Modal v-model:open="restartDaemonOpen" title="Restart daemon">
-      <p class="text-sm text-muted-foreground">
-        This briefly stops all <strong class="text-foreground">.test</strong> sites,
-        DNS, and this connection while the daemon restarts. It returns in a few
-        seconds.
-      </p>
-      <template #footer="{ close }">
-        <Button variant="ghost" @click="close">Cancel</Button>
-        <Button @click="confirmRestartDaemon(close)">Restart</Button>
-      </template>
-    </Modal>
   </div>
 </template>

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -64,8 +64,10 @@ const daemonPid = computed(() => report.value?.daemon_pid ?? null);
 // ── daemon lifecycle (Stop / Restart; Start lives in the daemon-down hero) ──
 const busy = ref<string | null>(null);
 
-async function onStop(): Promise<void> {
+const stopDaemonOpen = ref(false);
+async function confirmStopDaemon(close: () => void): Promise<void> {
   busy.value = "daemon";
+  close();
   try {
     await stopDaemon();
     toast.success("Stopping daemon…");
@@ -78,17 +80,18 @@ async function onStop(): Promise<void> {
 }
 
 const restartDaemonOpen = ref(false);
+/**
+ * Restart is fire-and-forget: the daemon acknowledges before it re-execs, so a
+ * resolved call means the restart was accepted (the status poll handles the
+ * connection drop), while a rejection is a genuine failure worth surfacing.
+ */
 async function confirmRestartDaemon(close: () => void): Promise<void> {
   busy.value = "restart:daemon";
   close();
   try {
     await restartDaemon();
-    // The daemon replies before it re-execs, so a resolved call means the
-    // restart was accepted; the connection drop is handled by the status poll.
     toast.info("Restarting daemon…", "It returns in a few seconds.");
   } catch (e) {
-    // Reaching here is a genuine failure (the reply arrives ahead of the drop),
-    // so don't imply the restart started.
     toast.error("Couldn't restart the daemon", (e as IpcError).message);
   } finally {
     busy.value = null;
@@ -479,7 +482,7 @@ const emptyEnvironment = computed(
             <code>.test</code> sites, answers DNS, and runs databases.
           </p>
           <div class="mt-4 flex justify-end gap-2">
-            <Button variant="outline" :disabled="busy !== null" @click="onStop">
+            <Button variant="outline" :disabled="busy !== null" @click="stopDaemonOpen = true">
               <Spinner v-if="busy === 'daemon'" class="size-4" />
               <Square v-else class="size-4" /> Stop
             </Button>
@@ -525,6 +528,17 @@ const emptyEnvironment = computed(
         </Card>
       </template>
     </div>
+
+    <Modal v-model:open="stopDaemonOpen" title="Stop daemon">
+      <p class="text-sm text-muted-foreground">
+        This stops all <strong class="text-foreground">.test</strong> sites, DNS,
+        and databases until you start Yerd again.
+      </p>
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close">Cancel</Button>
+        <Button @click="confirmStopDaemon(close)">Stop</Button>
+      </template>
+    </Modal>
 
     <Modal v-model:open="restartDaemonOpen" title="Restart daemon">
       <p class="text-sm text-muted-foreground">

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -3,13 +3,16 @@ import {
   ArrowRight,
   ArrowUpRight,
   Database,
+  Info,
   LayoutGrid,
   Lock,
   LockOpen,
   Mail,
   Rocket,
+  RotateCw,
   ShieldAlert,
   ShieldCheck,
+  Square,
   SquareCode,
 } from "lucide-vue-next";
 import type { Component } from "vue";
@@ -21,13 +24,28 @@ import PageHeader from "@/components/PageHeader.vue";
 import StatusPill, { type Tone } from "@/components/StatusPill.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
+import Modal from "@/components/ui/Modal.vue";
 import Spinner from "@/components/ui/Spinner.vue";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { useDaemon } from "@/composables/useDaemon";
 import { useOnboarding } from "@/composables/useOnboarding";
 import { usePoll } from "@/composables/usePoll";
 import { useResource } from "@/composables/useResource";
-import { daemonVersionConflict, openInBrowser, sitesAndParked } from "@/ipc/client";
+import {
+  daemonVersionConflict,
+  IpcError,
+  openInBrowser,
+  restartDaemon,
+  sitesAndParked,
+  stopDaemon,
+} from "@/ipc/client";
+import { useToast } from "@/composables/useToast";
 import type { StatusReport } from "@/ipc/types";
 import { openTitle, siteUrl } from "@/lib/siteUrl";
 import { humaniseUptime } from "@/lib/utils";
@@ -35,11 +53,47 @@ import { humaniseUptime } from "@/lib/utils";
 // The home/dashboard. It reads the shared daemon report (no poller of its own)
 // and shows the shared daemon-down hero, so it stays useful when the socket is
 // gone - the same surface that celebrates "serving N sites" becomes the start button.
-const { report, connected } = useDaemon();
+const { report, connected, refresh } = useDaemon();
 const { relaunch } = useOnboarding();
+const toast = useToast();
 
 const r = computed(() => report.value);
 const running = computed(() => connected.value === true);
+const daemonPid = computed(() => report.value?.daemon_pid ?? null);
+
+// ── daemon lifecycle (Stop / Restart; Start lives in the daemon-down hero) ──
+const busy = ref<string | null>(null);
+
+async function onStop(): Promise<void> {
+  busy.value = "daemon";
+  try {
+    await stopDaemon();
+    toast.success("Stopping daemon…");
+  } catch (e) {
+    toast.error("Couldn't stop the daemon", (e as IpcError).message);
+  } finally {
+    busy.value = null;
+    await refresh();
+  }
+}
+
+const restartDaemonOpen = ref(false);
+async function confirmRestartDaemon(close: () => void): Promise<void> {
+  busy.value = "restart:daemon";
+  close();
+  try {
+    await restartDaemon();
+    // The daemon replies before it re-execs, so a resolved call means the
+    // restart was accepted; the connection drop is handled by the status poll.
+    toast.info("Restarting daemon…", "It returns in a few seconds.");
+  } catch (e) {
+    // Reaching here is a genuine failure (the reply arrives ahead of the drop),
+    // so don't imply the restart started.
+    toast.error("Couldn't restart the daemon", (e as IpcError).message);
+  } finally {
+    busy.value = null;
+  }
+}
 // First paint, before the poll has resolved either way.
 const connecting = computed(() => connected.value === null && !report.value);
 const tld = computed(() => r.value?.tld ?? "test");
@@ -401,6 +455,45 @@ const emptyEnvironment = computed(
           </RouterLink>
         </div>
 
+        <!-- Daemon control - Stop/Restart. Start is owned by the daemon-down
+             hero above (this branch only renders while the daemon is up). -->
+        <Card>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-1.5">
+              <h3 class="text-sm font-semibold">Daemon</h3>
+              <TooltipProvider v-if="daemonPid" :delay-duration="0">
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <span class="inline-flex cursor-help text-muted-foreground">
+                      <Info class="size-3.5" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">running as pid {{ daemonPid }}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+            <StatusPill tone="ok" label="Running" />
+          </div>
+          <p class="mt-3 text-sm text-muted-foreground">
+            <code>yerdd</code> supervises PHP-FPM, serves your
+            <code>.test</code> sites, answers DNS, and runs databases.
+          </p>
+          <div class="mt-4 flex justify-end gap-2">
+            <Button variant="outline" :disabled="busy !== null" @click="onStop">
+              <Spinner v-if="busy === 'daemon'" class="size-4" />
+              <Square v-else class="size-4" /> Stop
+            </Button>
+            <Button
+              variant="outline"
+              :disabled="busy !== null"
+              @click="restartDaemonOpen = true"
+            >
+              <Spinner v-if="busy === 'restart:daemon'" class="size-4" />
+              <RotateCw v-else class="size-4" /> Restart
+            </Button>
+          </div>
+        </Card>
+
         <!-- System health summary → Settings. -->
         <Card>
           <div class="flex items-center justify-between">
@@ -432,5 +525,17 @@ const emptyEnvironment = computed(
         </Card>
       </template>
     </div>
+
+    <Modal v-model:open="restartDaemonOpen" title="Restart daemon">
+      <p class="text-sm text-muted-foreground">
+        This briefly stops all <strong class="text-foreground">.test</strong> sites,
+        DNS, and this connection while the daemon restarts. It returns in a few
+        seconds.
+      </p>
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close">Cancel</Button>
+        <Button @click="confirmRestartDaemon(close)">Restart</Button>
+      </template>
+    </Modal>
   </div>
 </template>


### PR DESCRIPTION
## What does this PR do?

Moves Services into the Environment section
Frames Sites first in the environment section
Includes badges for PHP and yerd updates, as well as elevation requirements.

## Related issues

n/a

## Type of change

- [x] New feature
- [x] Refactor / internal change

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stop and Restart controls for the daemon on the Overview page, including restart confirmation.
  * Added navigation warnings using an amber indicator (with tooltip) when action is required.
  * Added update badges and a conditional “Doctor” warning indicator to the side navigation.
* **Improvements**
  * Centralized privileged-port/elevation logic so elevation-related decisions stay consistent across views (including the Environment card).
  * Simplified the Doctor page by removing daemon lifecycle controls.
* **Tests**
  * Added coverage for elevation decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->