### PR TITLE
[Feat] Add shared Meilisearch support for Laravel Scout

### DIFF
--- a/apps/yerd-gui/src/views/ServicesView.vue
+++ b/apps/yerd-gui/src/views/ServicesView.vue
@@ -631,7 +631,7 @@ async function openConfig(s: ServiceStatus): Promise<void> {
       configLaravelSites.value = sites.filter((site) => site.is_laravel);
       configScoutSite.value = configLaravelSites.value[0]?.name ?? "your_app";
     } catch {
-      configScoutSite.value = "your_app";
+      if (reqSeq === configReqSeq.value) configScoutSite.value = "your_app";
     }
     return;
   }

--- a/apps/yerd-gui/src/views/ServicesView.vue
+++ b/apps/yerd-gui/src/views/ServicesView.vue
@@ -601,6 +601,8 @@ const configTarget = ref<ServiceStatus | null>(null);
 const configDbs = ref<DatabaseSummary[]>([]);
 const configDbName = ref<string>("");
 const configDbLoading = ref(false);
+const configLaravelSites = ref<SiteEntry[]>([]);
+const configScoutSite = ref("");
 // The linked site for a per-site instance (Reverb), resolved for host + TLS.
 const configSite = ref<SiteEntry | null>(null);
 // Bumped on each open so a slow listDatabases can't overwrite a newer modal.
@@ -609,6 +611,9 @@ const configReqSeq = ref(0);
 const configDbOptions = computed(() =>
   configDbs.value.map((d) => ({ value: d.name, label: d.name })),
 );
+const configSiteOptions = computed(() =>
+  configLaravelSites.value.map((s) => ({ value: s.name, label: s.name })),
+);
 
 async function openConfig(s: ServiceStatus): Promise<void> {
   const reqSeq = ++configReqSeq.value;
@@ -616,7 +621,20 @@ async function openConfig(s: ServiceStatus): Promise<void> {
   configDbName.value = "";
   configDbs.value = [];
   configSite.value = null;
+  configLaravelSites.value = [];
+  configScoutSite.value = "";
   configOpen.value = true;
+  if (s.service === "meilisearch") {
+    try {
+      const sites = await listSites();
+      if (reqSeq !== configReqSeq.value) return;
+      configLaravelSites.value = sites.filter((site) => site.is_laravel);
+      configScoutSite.value = configLaravelSites.value[0]?.name ?? "your_app";
+    } catch {
+      configScoutSite.value = "your_app";
+    }
+    return;
+  }
   // Per-site app server (Reverb): resolve its linked site for the host + whether
   // it's served over HTTPS, so the client (Echo) values are the right scheme/port.
   if (s.site) {
@@ -719,6 +737,13 @@ const configSnippet = computed(() => {
       return dbEnv("mariadb", s.port, db, "root");
     case "postgres":
       return dbEnv("pgsql", s.port, db, "postgres");
+    case "meilisearch":
+      return [
+        "SCOUT_DRIVER=meilisearch",
+        `SCOUT_PREFIX=${configScoutSite.value.trim() || "your_app"}_`,
+        `MEILISEARCH_HOST=http://127.0.0.1:${s.port}`,
+        "MEILISEARCH_KEY=",
+      ].join("\n");
     default:
       return "";
   }
@@ -741,7 +766,7 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
   <div class="flex h-full flex-col">
     <PageHeader
       title="Services"
-      subtitle="Databases, caches, and per-site app servers Yerd supervises"
+      subtitle="Databases, caches, search, and per-site app servers Yerd supervises"
       docs="/guide/services"
     >
       <template #actions>
@@ -756,8 +781,8 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
         <CardHeader>
           <CardTitle>Managed services</CardTitle>
           <CardDescription>
-            Services Yerd runs for you - database and cache engines, plus per-site
-            app servers like Reverb. Each binds to localhost; start or stop them
+            Services Yerd runs for you - database, cache, and search engines, plus
+            per-site app servers like Reverb. Each binds to localhost; start or stop them
             here, or add another with <span class="font-medium">Add Service</span>.
           </CardDescription>
         </CardHeader>
@@ -1012,8 +1037,14 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
         </div>
         <p class="mt-2 text-xs text-muted-foreground">
           <template v-if="installMode === 'change'">
-            Installs the selected version, restarts the service onto it, and removes
-            the current version. Your stored data is kept.
+            <template v-if="installTarget?.service === 'meilisearch'">
+              Meilisearch indexes do not transfer between versions automatically.
+              The previous version's data is retained; rebuild indexes with Laravel Scout.
+            </template>
+            <template v-else>
+              Installs the selected version, restarts the service onto it, and removes
+              the current version. Your stored data is kept.
+            </template>
           </template>
           <template v-else>
             Downloads a prebuilt build; this can take a few minutes with no progress
@@ -1218,6 +1249,25 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
                 ? "No databases yet - create one under \"Manage databases\". Using a placeholder below."
                 : "Start the service to list databases. Using a placeholder below."
             }}
+          </p>
+        </div>
+
+        <div v-if="configTarget?.service === 'meilisearch'">
+          <span class="text-sm font-medium">Laravel site / index prefix</span>
+          <Select
+            v-if="configSiteOptions.length"
+            class="mt-2 w-full"
+            :model-value="configScoutSite"
+            :options="configSiteOptions"
+            aria-label="Laravel site"
+            @update:model-value="(v: string) => (configScoutSite = v)"
+          />
+          <Input v-else v-model="configScoutSite" class="mt-2" aria-label="Scout prefix" />
+          <p class="mt-2 text-xs text-muted-foreground">
+            Install <code>laravel/scout</code> and <code>meilisearch/meilisearch-php</code>,
+            then run <code>php artisan scout:sync-index-settings</code> and
+            <code>php artisan scout:import "App\\Models\\YourModel"</code>. Yerd does not
+            change project files or run Composer or Artisan for you.
           </p>
         </div>
 

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -133,11 +133,11 @@ pub enum Command {
         #[arg(long, requires = "yes")]
         force: bool,
     },
-    /// List local database / cache services and their status.
+    /// List local managed services and their status.
     Services,
     /// List installable dev tools (Composer, Node, Bun) and their install status.
     Tools,
-    /// Manage a local database or cache service (redis, mysql, mariadb, postgres).
+    /// Manage a local service (redis, mysql, mariadb, postgres, meilisearch).
     Service {
         /// What to do.
         #[command(subcommand)]
@@ -380,7 +380,7 @@ pub enum ServiceAction {
     Available,
     /// Install a service version (downloads a prebuilt build).
     Install {
-        /// Service id: `redis`, `mysql`, `mariadb`, or `postgres`.
+        /// Service id: `redis`, `mysql`, `mariadb`, `postgres`, or `meilisearch`.
         service: String,
         /// Version to install, e.g. `8` (see `yerd service available`).
         version: String,
@@ -436,7 +436,7 @@ pub enum ServiceAction {
     /// Add a new service instance (a DB/cache engine, or a per-site app server
     /// like `reverb`).
     Add {
-        /// Service type id: `redis`, `mysql`, `mariadb`, `postgres`, or `reverb`.
+        /// Service type id: `redis`, `mysql`, `mariadb`, `postgres`, `meilisearch`, or `reverb`.
         #[arg(long = "type")]
         type_id: String,
         /// Linked site name (required for a per-site type like `reverb`).

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -433,8 +433,8 @@ pub enum ServiceAction {
         #[arg(long, default_value_t = 100)]
         lines: u32,
     },
-    /// Add a new service instance (a DB/cache engine, or a per-site app server
-    /// like `reverb`).
+    /// Add a new service instance (a DB/cache/search engine, or a per-site app
+    /// server like `reverb`).
     Add {
         /// Service type id: `redis`, `mysql`, `mariadb`, `postgres`, `meilisearch`, or `reverb`.
         #[arg(long = "type")]

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -118,6 +118,21 @@ pub async fn run(cli: Cli) -> ExitCode {
             if !r.stderr.is_empty() {
                 eprintln!("{}", r.stderr);
             }
+            if !cli.json
+                && r.code == 0
+                && matches!(
+                    &cli.command,
+                    Command::Service {
+                        action: crate::cli::ServiceAction::ChangeVersion { service, .. }
+                    } if service == "meilisearch"
+                )
+            {
+                eprintln!(
+                    "warning: Meilisearch indexes do not transfer between versions; \
+                     rebuild them with Laravel Scout (scout:sync-index-settings and scout:import). \
+                     The previous version's data is retained until uninstall --purge."
+                );
+            }
             if !cli.json && r.code == 0 && matches!(cli.command, Command::Use { version: None, .. })
             {
                 print_php_path_hint();

--- a/bin/yerdd/src/service_install.rs
+++ b/bin/yerdd/src/service_install.rs
@@ -16,7 +16,7 @@ use yerd_supervise::Downloader;
 use yerd_platform::PlatformDirs;
 use yerd_services::version::{self, VERSION_MARKER};
 use yerd_services::{
-    current_os_arch, listing_url, resolve_from_listing, ServiceError, ServiceVersion,
+    current_os_arch, listing_url, resolve_from_listing, DatadirScope, ServiceError, ServiceVersion,
 };
 
 /// Install `service_id` at `version` into `data/services/<id>/<version>/`.
@@ -68,11 +68,10 @@ pub async fn install(
 /// Remove an installed version's files. With `purge`, also delete the engine's
 /// datadir (destructive). Returns the retained datadir path when it was kept.
 ///
-/// `pinned_to_major` selects the datadir layout (per-major for engines whose
-/// on-disk format is major-incompatible, otherwise one shared datadir).
+/// `datadir_scope` selects the engine's compatibility layout.
 pub fn uninstall(
     service_id: &str,
-    pinned_to_major: bool,
+    datadir_scope: DatadirScope,
     version: &ServiceVersion,
     dirs: &PlatformDirs,
     purge: bool,
@@ -81,7 +80,7 @@ pub fn uninstall(
     if dir.exists() {
         fs_ctx(std::fs::remove_dir_all(&dir), &dir)?;
     }
-    let datadir = version::datadir(dirs, service_id, pinned_to_major, version);
+    let datadir = version::datadir(dirs, service_id, datadir_scope, version);
     if purge {
         if datadir.exists() {
             fs_ctx(std::fs::remove_dir_all(&datadir), &datadir)?;

--- a/bin/yerdd/src/service_install.rs
+++ b/bin/yerdd/src/service_install.rs
@@ -66,11 +66,15 @@ pub async fn install(
 }
 
 /// Remove an installed version's files. With `purge`, also delete the engine's
-/// datadir (destructive). Returns the retained datadir path when it was kept.
+/// stored data (destructive). For exact-version-scoped services this removes
+/// the target store plus orphaned `data-*` stores, while preserving stores
+/// owned by other versions whose expected server binary is still installed.
+/// Returns the selected version's retained datadir path when data was kept.
 ///
 /// `datadir_scope` selects the engine's compatibility layout.
 pub fn uninstall(
     service_id: &str,
+    server_binary: Option<&str>,
     datadir_scope: DatadirScope,
     version: &ServiceVersion,
     dirs: &PlatformDirs,
@@ -82,13 +86,58 @@ pub fn uninstall(
     }
     let datadir = version::datadir(dirs, service_id, datadir_scope, version);
     if purge {
-        if datadir.exists() {
+        if matches!(datadir_scope, DatadirScope::Version) {
+            purge_version_datadirs(dirs, service_id, server_binary, version)?;
+        } else if datadir.exists() {
             fs_ctx(std::fs::remove_dir_all(&datadir), &datadir)?;
         }
         Ok(None)
     } else {
         Ok(datadir.exists().then_some(datadir))
     }
+}
+
+/// Delete only exact-version datadirs under this service root. Install dirs,
+/// staging dirs, notices, and unrelated entries are deliberately untouched.
+fn purge_version_datadirs(
+    dirs: &PlatformDirs,
+    service_id: &str,
+    server_binary: Option<&str>,
+    target_version: &ServiceVersion,
+) -> Result<(), ServiceError> {
+    let root = version::service_root(dirs, service_id);
+    let entries = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(fs_err(&root, &e)),
+    };
+    for entry in entries {
+        let entry = entry.map_err(|e| fs_err(&root, &e))?;
+        let name = entry.file_name();
+        let Some(suffix) = name.to_str().and_then(|name| name.strip_prefix("data-")) else {
+            continue;
+        };
+        if !entry
+            .file_type()
+            .map_err(|e| fs_err(&entry.path(), &e))?
+            .is_dir()
+        {
+            continue;
+        }
+        let owned_by_other_install = suffix != target_version.as_str()
+            && server_binary.is_some_and(|binary| {
+                suffix
+                    .parse::<ServiceVersion>()
+                    .is_ok_and(|installed_version| {
+                        version::server_path(dirs, service_id, binary, &installed_version).is_file()
+                    })
+            });
+        if !owned_by_other_install {
+            let path = entry.path();
+            fs_ctx(std::fs::remove_dir_all(&path), &path)?;
+        }
+    }
+    Ok(())
 }
 
 async fn stage(
@@ -156,5 +205,107 @@ fn extract_msg(url: &str, detail: String) -> ServiceError {
     ServiceError::Extract {
         what: url.to_owned(),
         detail,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn dirs_in(root: &Path) -> PlatformDirs {
+        PlatformDirs {
+            config: root.join("config"),
+            data: root.join("data"),
+            state: root.join("state"),
+            cache: root.join("cache"),
+            runtime: root.join("runtime"),
+        }
+    }
+
+    #[test]
+    fn version_scoped_purge_removes_all_retained_datadirs_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let root = version::service_root(&dirs, "meilisearch");
+        for name in ["data-1.10", "data-1.11", "data-1.12", "1.12", ".staging-x"] {
+            std::fs::create_dir_all(root.join(name)).unwrap();
+        }
+        std::fs::write(root.join("data-not-a-directory"), b"keep").unwrap();
+
+        uninstall(
+            "meilisearch",
+            Some("meilisearch"),
+            DatadirScope::Version,
+            &"1.12".parse().unwrap(),
+            &dirs,
+            true,
+        )
+        .unwrap();
+
+        for name in ["data-1.10", "data-1.11", "data-1.12", "1.12"] {
+            assert!(!root.join(name).exists(), "{name} should be removed");
+        }
+        assert!(root.join(".staging-x").is_dir());
+        assert!(root.join("data-not-a-directory").is_file());
+    }
+
+    #[test]
+    fn version_scoped_uninstall_without_purge_retains_every_datadir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let root = version::service_root(&dirs, "meilisearch");
+        for name in ["data-1.11", "data-1.12", "1.12"] {
+            std::fs::create_dir_all(root.join(name)).unwrap();
+        }
+
+        let retained = uninstall(
+            "meilisearch",
+            Some("meilisearch"),
+            DatadirScope::Version,
+            &"1.12".parse().unwrap(),
+            &dirs,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(retained, Some(root.join("data-1.12")));
+        assert!(root.join("data-1.11").is_dir());
+        assert!(root.join("data-1.12").is_dir());
+    }
+
+    #[test]
+    fn version_scoped_purge_preserves_datadir_owned_by_another_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_in(tmp.path());
+        let root = version::service_root(&dirs, "meilisearch");
+        for version in ["1.11", "1.12"] {
+            std::fs::create_dir_all(root.join(version).join("bin")).unwrap();
+            std::fs::write(root.join(version).join("bin/meilisearch"), b"binary").unwrap();
+            std::fs::create_dir_all(root.join(format!("data-{version}"))).unwrap();
+        }
+        std::fs::create_dir_all(root.join("data-1.10")).unwrap();
+
+        uninstall(
+            "meilisearch",
+            Some("meilisearch"),
+            DatadirScope::Version,
+            &"1.11".parse().unwrap(),
+            &dirs,
+            true,
+        )
+        .unwrap();
+
+        assert!(!root.join("1.11").exists());
+        assert!(!root.join("data-1.11").exists());
+        assert!(
+            !root.join("data-1.10").exists(),
+            "orphan should be reclaimed"
+        );
+        assert!(root.join("1.12/bin/meilisearch").is_file());
+        assert!(
+            root.join("data-1.12").is_dir(),
+            "live version data must survive"
+        );
     }
 }

--- a/bin/yerdd/src/services.rs
+++ b/bin/yerdd/src/services.rs
@@ -327,13 +327,9 @@ pub async fn change_service_version(
         return resp;
     }
     for old in superseded {
-        if let Err(e) = service_install::uninstall(
-            def.id(),
-            def.datadir_pinned_to_major(),
-            &old,
-            &state.dirs,
-            false,
-        ) {
+        if let Err(e) =
+            service_install::uninstall(def.id(), def.datadir_scope(), &old, &state.dirs, false)
+        {
             tracing::warn!(service = def.id(), version = %old, error = %e,
                 "couldn't remove superseded service version");
         }
@@ -357,13 +353,7 @@ pub async fn uninstall_service(
         Err(e) => return service_error_response(&e),
     };
     let _ = state.service_manager.lock().await.stop(def.id()).await;
-    match service_install::uninstall(
-        def.id(),
-        def.datadir_pinned_to_major(),
-        &version,
-        &state.dirs,
-        purge,
-    ) {
+    match service_install::uninstall(def.id(), def.datadir_scope(), &version, &state.dirs, purge) {
         Ok(retained) => {
             if let Some(path) = retained {
                 tracing::info!(service = def.id(), datadir = %path.display(),

--- a/bin/yerdd/src/services.rs
+++ b/bin/yerdd/src/services.rs
@@ -327,9 +327,14 @@ pub async fn change_service_version(
         return resp;
     }
     for old in superseded {
-        if let Err(e) =
-            service_install::uninstall(def.id(), def.datadir_scope(), &old, &state.dirs, false)
-        {
+        if let Err(e) = service_install::uninstall(
+            def.id(),
+            def.server_binary(),
+            def.datadir_scope(),
+            &old,
+            &state.dirs,
+            false,
+        ) {
             tracing::warn!(service = def.id(), version = %old, error = %e,
                 "couldn't remove superseded service version");
         }
@@ -353,7 +358,14 @@ pub async fn uninstall_service(
         Err(e) => return service_error_response(&e),
     };
     let _ = state.service_manager.lock().await.stop(def.id()).await;
-    match service_install::uninstall(def.id(), def.datadir_scope(), &version, &state.dirs, purge) {
+    match service_install::uninstall(
+        def.id(),
+        def.server_binary(),
+        def.datadir_scope(),
+        &version,
+        &state.dirs,
+        purge,
+    ) {
         Ok(retained) => {
             if let Some(path) = retained {
                 tracing::info!(service = def.id(), datadir = %path.display(),

--- a/crates/yerd-config/src/parse.rs
+++ b/crates/yerd-config/src/parse.rs
@@ -22,7 +22,8 @@ use crate::ConfigError;
 ///
 /// Duplicated here rather than read from the `yerd-services` registry: this crate
 /// sits *below* `yerd-services` in the dependency order and must not depend on it.
-pub(crate) const KNOWN_SINGLE_SERVICES: &[&str] = &["mysql", "mariadb", "postgres", "redis"];
+pub(crate) const KNOWN_SINGLE_SERVICES: &[&str] =
+    &["mysql", "mariadb", "meilisearch", "postgres", "redis"];
 
 /// Per-site service type ids (keyed by `"{type}:{site}"`). See
 /// [`KNOWN_SINGLE_SERVICES`] for why the list is duplicated here.

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -305,7 +305,7 @@ pub enum Request {
     },
     /// Download + install a prebuilt service version into yerd's data dir.
     InstallService {
-        /// Service id (`"redis"`, `"mysql"`, `"mariadb"`, `"postgres"`).
+        /// Service id (`"redis"`, `"mysql"`, `"mariadb"`, `"postgres"`, `"meilisearch"`).
         service: String,
         /// The version to install.
         version: String,

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -375,7 +375,7 @@ pub enum ServiceRunState {
 /// the enclosing `Response` keeps its `Eq` derive (no floats on the wire).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceStatus {
-    /// Stable service id (`"redis"`, `"mysql"`, `"mariadb"`, `"postgres"`).
+    /// Stable service id (`"redis"`, `"mysql"`, `"mariadb"`, `"postgres"`, `"meilisearch"`).
     pub service: String,
     /// Human-facing label (`"Redis (Valkey)"`, `"PostgreSQL"`, …).
     pub display_name: String,

--- a/crates/yerd-mcp/src/tools.rs
+++ b/crates/yerd-mcp/src/tools.rs
@@ -115,7 +115,7 @@ const TOOLS: &[ToolDef] = &[
     },
     ToolDef {
         name: "list_services",
-        description: "List Yerd's managed services (databases, caches) with run state and ports.",
+        description: "List Yerd's managed services (databases, caches, search, app servers) with run state and ports.",
     },
     ToolDef {
         name: "list_databases",

--- a/crates/yerd-services/Cargo.toml
+++ b/crates/yerd-services/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace      = true
 rust-version.workspace = true
 license.workspace      = true
 publish.workspace      = true
-description            = "Local database / cache service supervision and version management for Yerd (Redis/Valkey, MySQL, MariaDB, Postgres)."
+description            = "Local service supervision and version management for Yerd (Redis/Valkey, MySQL, MariaDB, Postgres, Meilisearch)."
 
 [dependencies]
 yerd-platform  = { path = "../yerd-platform" }

--- a/crates/yerd-services/src/health.rs
+++ b/crates/yerd-services/src/health.rs
@@ -63,6 +63,8 @@ impl ReadinessProbe for ServiceProbes {
 /// documented available status, rather than treating an open HTTP port as ready.
 pub struct MeilisearchProbe;
 
+const MEILISEARCH_HEALTH_RESPONSE_LIMIT: u64 = 8 * 1024;
+
 #[async_trait]
 impl HealthProbe for MeilisearchProbe {
     async fn probe(&self, listen: &Listen) -> Result<(), io::Error> {
@@ -72,12 +74,15 @@ impl HealthProbe for MeilisearchProbe {
             .write_all(b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
             .await?;
         let mut response = Vec::new();
-        stream.read_to_end(&mut response).await?;
+        stream
+            .take(MEILISEARCH_HEALTH_RESPONSE_LIMIT)
+            .read_to_end(&mut response)
+            .await?;
         let split = response
             .windows(4)
             .position(|w| w == b"\r\n\r\n")
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "malformed HTTP response"))?;
-        let headers = std::str::from_utf8(&response[..split])
+        let headers = std::str::from_utf8(response.get(..split).unwrap_or_default())
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-UTF-8 HTTP headers"))?;
         let status = headers.lines().next().unwrap_or_default();
         if !status.starts_with("HTTP/1.1 200 ") && !status.starts_with("HTTP/1.0 200 ") {

--- a/crates/yerd-services/src/health.rs
+++ b/crates/yerd-services/src/health.rs
@@ -53,7 +53,45 @@ impl ReadinessProbe for ServiceProbes {
             ReadinessKind::RedisPing => RedisProbe.probe(listen).await,
             ReadinessKind::MySqlHandshake => MySqlProbe.probe(listen).await,
             ReadinessKind::PostgresStartup => PostgresProbe.probe(listen).await,
+            ReadinessKind::MeilisearchHealth => MeilisearchProbe.probe(listen).await,
             ReadinessKind::TcpConnect => TcpConnectProbe.probe(listen).await,
+        }
+    }
+}
+
+/// Meilisearch readiness probe: require a successful health endpoint and the
+/// documented available status, rather than treating an open HTTP port as ready.
+pub struct MeilisearchProbe;
+
+#[async_trait]
+impl HealthProbe for MeilisearchProbe {
+    async fn probe(&self, listen: &Listen) -> Result<(), io::Error> {
+        let addr = tcp_addr(listen)?;
+        let mut stream = TcpStream::connect(addr).await?;
+        stream
+            .write_all(b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+            .await?;
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await?;
+        let split = response
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "malformed HTTP response"))?;
+        let headers = std::str::from_utf8(&response[..split])
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-UTF-8 HTTP headers"))?;
+        let status = headers.lines().next().unwrap_or_default();
+        if !status.starts_with("HTTP/1.1 200 ") && !status.starts_with("HTTP/1.0 200 ") {
+            return Err(io::Error::other(
+                "Meilisearch health returned non-200 status",
+            ));
+        }
+        let body = response.get(split + 4..).unwrap_or_default();
+        let value: serde_json::Value = serde_json::from_slice(body)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        if value.get("status").and_then(serde_json::Value::as_str) == Some("available") {
+            Ok(())
+        } else {
+            Err(io::Error::other("Meilisearch is not available"))
         }
     }
 }
@@ -308,6 +346,43 @@ mod tests {
             .probe(ReadinessKind::PostgresStartup, &Listen::TcpLoopback(pg))
             .await
             .is_ok());
+    }
+
+    async fn fake_http(status: &'static str, body: &'static str) -> SocketAddr {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut request = [0u8; 256];
+                let _ = sock.read(&mut request).await;
+                let reply = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(reply.as_bytes()).await;
+            }
+        });
+        addr
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn meilisearch_probe_requires_healthy_200_response() {
+        let healthy = fake_http("200 OK", r#"{"status":"available"}"#).await;
+        assert!(MeilisearchProbe
+            .probe(&Listen::TcpLoopback(healthy))
+            .await
+            .is_ok());
+        for (status, body) in [
+            ("503 Service Unavailable", r#"{"status":"available"}"#),
+            ("200 OK", r#"{"status":"unavailable"}"#),
+            ("200 OK", "not json"),
+        ] {
+            let addr = fake_http(status, body).await;
+            assert!(MeilisearchProbe
+                .probe(&Listen::TcpLoopback(addr))
+                .await
+                .is_err());
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/yerd-services/src/lib.rs
+++ b/crates/yerd-services/src/lib.rs
@@ -5,7 +5,8 @@
 //! machine (under the database [`yerd_supervise::supervisor::SupervisorPolicy`]),
 //! and reports their live state. Mirrors `yerd-php` in structure.
 //!
-//! All four engines - **Redis (Valkey)**, `MySQL`, `MariaDB`, and Postgres - are
+//! The engines - **Redis (Valkey)**, `MySQL`, `MariaDB`, Postgres, and
+//! Meilisearch - are
 //! implemented end-to-end (supervision, datadir init, config rendering, health
 //! probing, and SQL database administration for the three SQL engines). Whether a
 //! given engine/version installs depends only on whether a prebuilt build is
@@ -25,7 +26,7 @@ pub mod version;
 
 pub use database::DbNameError;
 pub use error::ServiceError;
-pub use health::{ReadinessProbe, RedisProbe, ServiceProbes, TcpConnectProbe};
+pub use health::{MeilisearchProbe, ReadinessProbe, RedisProbe, ServiceProbes, TcpConnectProbe};
 pub use manager::{ServiceManager, ServiceRunState, ServiceSnapshot};
 pub use port::candidate_ports;
 pub use release::{
@@ -33,8 +34,8 @@ pub use release::{
     resolve_from_listing, Arch, Artifact, Os, LISTING_SCHEMA, SERVICES_BASE_URL,
 };
 pub use service::{
-    LaunchContext, LaunchPlan, MariaDb, Multiplicity, MySql, Postgres, ReadinessKind, Redis,
-    Reverb, ServiceDefinition, ServiceKind, ServiceRegistry, SqlEngine,
+    DatadirScope, LaunchContext, LaunchPlan, MariaDb, Meilisearch, Multiplicity, MySql, Postgres,
+    ReadinessKind, Redis, Reverb, ServiceDefinition, ServiceKind, ServiceRegistry, SqlEngine,
 };
 pub use version::{discover_installed, ServiceVersion};
 

--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -174,7 +174,7 @@ where
                     version: v.clone(),
                 });
             }
-            let datadir = version::datadir(&self.dirs, id, def.datadir_pinned_to_major(), v);
+            let datadir = version::datadir(&self.dirs, id, def.datadir_scope(), v);
             (program, Some((v.clone(), datadir)))
         };
 
@@ -341,7 +341,7 @@ where
             return Ok(());
         }
         if def.is_initialized(datadir) {
-            if def.datadir_pinned_to_major() {
+            if matches!(def.datadir_scope(), crate::service::DatadirScope::Major) {
                 check_pg_major(datadir, version)?;
             }
             return Ok(());

--- a/crates/yerd-services/src/service.rs
+++ b/crates/yerd-services/src/service.rs
@@ -30,9 +30,22 @@ pub enum ServiceKind {
     Cache,
     /// SQL database server (supports `CREATE DATABASE`).
     Database,
+    /// Search/index server (no SQL databases).
+    Search,
     /// A supervised application server (e.g. Laravel Reverb) - no databases, no
     /// downloadable version; runs against a linked site's PHP.
     AppServer,
+}
+
+/// How a service's mutable data is isolated from installed binary versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatadirScope {
+    /// One datadir shared by every installed version.
+    Shared,
+    /// One datadir per major version.
+    Major,
+    /// One datadir per exact version.
+    Version,
 }
 
 /// How many instances of a service type may exist at once.
@@ -55,6 +68,8 @@ pub enum ReadinessKind {
     MySqlHandshake,
     /// `PostgreSQL` startup-message reply.
     PostgresStartup,
+    /// Meilisearch `GET /health` returning 200 and `{ "status": "available" }`.
+    MeilisearchHealth,
     /// A bare TCP connect succeeds (the listener is open). Used by app servers
     /// (Reverb) whose readiness is "the socket accepts connections".
     TcpConnect,
@@ -172,10 +187,9 @@ pub trait ServiceDefinition: Send + Sync + 'static {
     /// `None` for a type with no installed server binary (app servers).
     fn server_binary(&self) -> Option<&'static str>;
 
-    /// Whether on-disk datadirs are incompatible across *major* versions (so the
-    /// datadir path is pinned per major). True only for Postgres.
-    fn datadir_pinned_to_major(&self) -> bool {
-        false
+    /// Compatibility scope used to select the service's mutable datadir.
+    fn datadir_scope(&self) -> DatadirScope {
+        DatadirScope::Shared
     }
 
     /// The `bin/` tool performing one-time datadir init, or `None` for a type
@@ -304,6 +318,7 @@ impl ServiceRegistry {
                 Arc::new(MySql),
                 Arc::new(MariaDb),
                 Arc::new(Postgres),
+                Arc::new(Meilisearch),
                 Arc::new(Reverb),
             ],
         }
@@ -344,6 +359,8 @@ pub struct MySql;
 pub struct MariaDb;
 /// `PostgreSQL`.
 pub struct Postgres;
+/// Meilisearch Community Edition: shared local search infrastructure.
+pub struct Meilisearch;
 
 impl ServiceDefinition for Redis {
     fn id(&self) -> &'static str {
@@ -572,8 +589,8 @@ impl ServiceDefinition for Postgres {
     fn server_binary(&self) -> Option<&'static str> {
         Some("postgres")
     }
-    fn datadir_pinned_to_major(&self) -> bool {
-        true
+    fn datadir_scope(&self) -> DatadirScope {
+        DatadirScope::Major
     }
     fn init_binary(&self) -> Option<&'static str> {
         Some("initdb")
@@ -632,6 +649,57 @@ impl ServiceDefinition for Postgres {
             .arg(ctx.datadir)
             .arg("-c")
             .arg(format!("config_file={}", ctx.config_path.display()));
+        Ok(LaunchPlan {
+            command,
+            capture_output_to_log: true,
+        })
+    }
+}
+
+impl ServiceDefinition for Meilisearch {
+    fn id(&self) -> &'static str {
+        "meilisearch"
+    }
+    fn display_name(&self) -> &'static str {
+        "Meilisearch"
+    }
+    fn kind(&self) -> ServiceKind {
+        ServiceKind::Search
+    }
+    fn multiplicity(&self) -> Multiplicity {
+        Multiplicity::Single
+    }
+    fn default_autostart(&self) -> bool {
+        true
+    }
+    fn default_port(&self) -> u16 {
+        7700
+    }
+    fn requires_version(&self) -> bool {
+        true
+    }
+    fn server_binary(&self) -> Option<&'static str> {
+        Some("meilisearch")
+    }
+    fn datadir_scope(&self) -> DatadirScope {
+        DatadirScope::Version
+    }
+    fn supervisor_policy(&self) -> SupervisorPolicy {
+        SupervisorPolicy::database()
+    }
+    fn readiness(&self) -> ReadinessKind {
+        ReadinessKind::MeilisearchHealth
+    }
+    fn plan_launch(&self, ctx: &LaunchContext<'_>) -> Result<LaunchPlan, ServiceError> {
+        let mut command = base_command(ctx);
+        command
+            .arg("--http-addr")
+            .arg(format!("127.0.0.1:{}", ctx.port))
+            .arg("--db-path")
+            .arg(ctx.datadir)
+            .arg("--env")
+            .arg("development")
+            .arg("--no-analytics");
         Ok(LaunchPlan {
             command,
             capture_output_to_log: true,
@@ -733,18 +801,18 @@ mod tests {
     #[test]
     fn registry_lookup_round_trips_every_type() {
         let r = reg();
-        for id in ["redis", "mysql", "mariadb", "postgres"] {
+        for id in ["redis", "mysql", "mariadb", "postgres", "meilisearch"] {
             assert_eq!(r.get(id).map(|d| d.id()), Some(id));
         }
         assert!(r.get("nope").is_none());
     }
 
     #[test]
-    fn registry_has_four_single_and_one_per_site() {
+    fn registry_has_five_single_and_one_per_site() {
         let r = reg();
-        assert_eq!(r.iter().count(), 5);
-        assert_eq!(r.single_instance().count(), 4);
-        for id in ["redis", "mysql", "mariadb", "postgres"] {
+        assert_eq!(r.iter().count(), 6);
+        assert_eq!(r.single_instance().count(), 5);
+        for id in ["redis", "mysql", "mariadb", "postgres", "meilisearch"] {
             assert!(matches!(
                 r.get(id).unwrap().multiplicity(),
                 Multiplicity::Single
@@ -812,6 +880,43 @@ mod tests {
     }
 
     #[test]
+    fn meilisearch_metadata_and_launch_are_safe_for_local_development() {
+        let d = reg().get("meilisearch").unwrap();
+        assert_eq!(d.kind(), ServiceKind::Search);
+        assert_eq!(d.default_port(), 7700);
+        assert!(d.default_autostart());
+        assert_eq!(d.readiness(), ReadinessKind::MeilisearchHealth);
+        let ctx = LaunchContext {
+            port: 7701,
+            program: std::path::Path::new("/bin/meilisearch"),
+            config_path: std::path::Path::new(""),
+            datadir: std::path::Path::new("/data/meili"),
+            log_path: std::path::Path::new("/logs/meili.log"),
+            geo_env: &[],
+            cwd: None,
+        };
+        let plan = d.plan_launch(&ctx).unwrap();
+        let args: Vec<_> = plan
+            .command
+            .get_args()
+            .map(|a| a.to_string_lossy())
+            .collect();
+        assert_eq!(
+            args,
+            [
+                "--http-addr",
+                "127.0.0.1:7701",
+                "--db-path",
+                "/data/meili",
+                "--env",
+                "development",
+                "--no-analytics"
+            ]
+        );
+        assert!(plan.capture_output_to_log);
+    }
+
+    #[test]
     fn sql_engines_are_databases_and_need_init() {
         for id in ["mysql", "mariadb", "postgres"] {
             let d = reg().get(id).unwrap();
@@ -837,9 +942,16 @@ mod tests {
 
     #[test]
     fn only_postgres_pins_datadir_to_major() {
-        assert!(reg().get("postgres").unwrap().datadir_pinned_to_major());
+        assert_eq!(
+            reg().get("postgres").unwrap().datadir_scope(),
+            DatadirScope::Major
+        );
+        assert_eq!(
+            reg().get("meilisearch").unwrap().datadir_scope(),
+            DatadirScope::Version
+        );
         for id in ["redis", "mysql", "mariadb"] {
-            assert!(!reg().get(id).unwrap().datadir_pinned_to_major());
+            assert_eq!(reg().get(id).unwrap().datadir_scope(), DatadirScope::Shared);
         }
     }
 

--- a/crates/yerd-services/src/version.rs
+++ b/crates/yerd-services/src/version.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use yerd_platform::PlatformDirs;
 
 use crate::error::ServiceError;
-use crate::service::ServiceRegistry;
+use crate::service::{DatadirScope, ServiceRegistry};
 
 /// Filename of the installed-version marker inside a per-version install dir.
 pub const VERSION_MARKER: &str = ".yerd-version";
@@ -198,21 +198,19 @@ pub fn server_path(
         .join(server_binary)
 }
 
-/// The datadir for a service+version. Pinned per *major* when `pinned_to_major`
-/// (engines whose on-disk format is major-incompatible, i.e. Postgres);
-/// otherwise a single shared datadir per engine.
+/// The datadir for a service+version, according to its compatibility scope.
 #[must_use]
 pub fn datadir(
     dirs: &PlatformDirs,
     service_id: &str,
-    pinned_to_major: bool,
+    scope: DatadirScope,
     version: &ServiceVersion,
 ) -> PathBuf {
     let root = service_root(dirs, service_id);
-    if pinned_to_major {
-        root.join(format!("data-{}", version.major()))
-    } else {
-        root.join("data")
+    match scope {
+        DatadirScope::Shared => root.join("data"),
+        DatadirScope::Major => root.join(format!("data-{}", version.major())),
+        DatadirScope::Version => root.join(format!("data-{}", version.as_str())),
     }
 }
 
@@ -448,13 +446,17 @@ mod tests {
         let dirs = dirs_in(std::path::Path::new("/tmp/x"));
         let v = ServiceVersion::from_str("16.2").unwrap();
         assert_eq!(
-            datadir(&dirs, "postgres", true, &v),
+            datadir(&dirs, "postgres", DatadirScope::Major, &v),
             PathBuf::from("/tmp/x/d/services/postgres/data-16")
         );
         let v8 = ServiceVersion::from_str("8.4").unwrap();
         assert_eq!(
-            datadir(&dirs, "mysql", false, &v8),
+            datadir(&dirs, "mysql", DatadirScope::Shared, &v8),
             PathBuf::from("/tmp/x/d/services/mysql/data")
+        );
+        assert_eq!(
+            datadir(&dirs, "meilisearch", DatadirScope::Version, &v),
+            PathBuf::from("/tmp/x/d/services/meilisearch/data-16.2")
         );
     }
 
@@ -467,7 +469,7 @@ mod tests {
         for label in ["17", "17.10", "17.10-full", "17-full"] {
             let v = ServiceVersion::from_str(label).unwrap();
             assert_eq!(
-                datadir(&dirs, "postgres", true, &v),
+                datadir(&dirs, "postgres", DatadirScope::Major, &v),
                 shared,
                 "label {label}"
             );

--- a/docs/developer/crates/yerd-config.md
+++ b/docs/developer/crates/yerd-config.md
@@ -172,7 +172,7 @@ Notable design decisions, all grounded in the source:
   downstream in [`yerd-services`](./yerd-services), and a string key allows
   forward-compatibility with experimental services without a `yerd-config`
   release. Keys are validated against the private `KNOWN_SERVICES` const in
-  `parse.rs`: `["mysql", "mariadb", "postgres", "redis"]`.
+  `parse.rs`: `["mysql", "mariadb", "meilisearch", "postgres", "redis"]`.
 - **`MailSection`** (the `[mail]` table, added in schema v4) configures the
   built-in mail-capture SMTP sink. It carries `enabled: bool` (**default
   `true`**) and `port: u16` (the loopback port, default `DEFAULT_MAIL_PORT` =

--- a/docs/guide/services.md
+++ b/docs/guide/services.md
@@ -1,6 +1,6 @@
 # Services & Databases
 
-Yerd installs and supervises local **database and cache** engines as native,
+Yerd installs and supervises local **database, cache, and search** engines as native,
 per-user processes - the way [DBngin](https://dbngin.com) does, but folded into
 the same [`yerdd` daemon](./daemon) that already runs your sites, PHP, HTTPS, and
 DNS. No Docker, no containers, no VM. A single `yerd status` shows the whole

--- a/docs/guide/services.md
+++ b/docs/guide/services.md
@@ -6,7 +6,7 @@ the same [`yerdd` daemon](./daemon) that already runs your sites, PHP, HTTPS, an
 DNS. No Docker, no containers, no VM. A single `yerd status` shows the whole
 stack.
 
-The four engines:
+The five engines:
 
 | Service | `id` | Kind | Default port |
 |---|---|---|---|
@@ -14,6 +14,7 @@ The four engines:
 | MySQL | `mysql` | SQL database | 3306 |
 | MariaDB | `mariadb` | SQL database | 3306 |
 | PostgreSQL | `postgres` | SQL database | 5432 |
+| Meilisearch | `meilisearch` | Search index | 7700 |
 
 ::: info Redis is served by Valkey
 The `redis` slot is filled by **Valkey**, the BSD-licensed fork, because recent
@@ -22,7 +23,7 @@ your Redis clients work unchanged. Yerd shows it as `Redis (Valkey)`.
 :::
 
 ::: tip Engine availability
-All four engines are implemented end-to-end. Whether a specific engine/version
+All five engines are implemented end-to-end. Whether a specific engine/version
 installs depends on whether a prebuilt build is published for your platform in
 Yerd's hosted distribution - run `yerd service available` to see what you can
 install right now. MySQL/MariaDB share port 3306, so only one can be enabled on it

--- a/docs/reference/cli/services.md
+++ b/docs/reference/cli/services.md
@@ -1,8 +1,8 @@
 # Services
 
-Yerd installs and supervises local database and cache engines as native,
+Yerd installs and supervises local database, cache, and search engines as native,
 per-user processes - no Docker. Each engine is identified by a short `id`:
-`redis`, `mysql`, `mariadb`, or `postgres`. The [Services & Databases
+`redis`, `mysql`, `mariadb`, `postgres`, or `meilisearch`. The [Services & Databases
 guide](../../guide/services) covers the model in depth; this page is the command
 reference. For creating and managing the databases *inside* a SQL engine, see
 [Databases](./db).
@@ -84,7 +84,7 @@ yerd service logs mysql --lines 50
 ```
 
 Default ports: Redis `6379`, MySQL / MariaDB `3306` (they share the port, so only
-one can be enabled on it at a time), PostgreSQL `5432`.
+one can be enabled on it at a time), PostgreSQL `5432`, Meilisearch `7700`.
 
 ## See also
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -276,8 +276,8 @@ The `path` key is the parked site's document-root string, stored **byte-exact an
 
 ### `[services.<id>]`
 
-Installed database / cache services, one table per engine, keyed by its `id`
-(`mysql`, `mariadb`, `postgres`, or `redis`). An unknown service id fails
+Installed services, one table per engine, keyed by its `id`
+(`mysql`, `mariadb`, `postgres`, `redis`, or `meilisearch`). An unknown service id fails
 validation (`UnknownService`). See [Services & Databases](../guide/services).
 
 | Key       | TOML type      | Meaning                                            | Default |
@@ -580,8 +580,8 @@ php = "8.4"
 secure = true
 web_root = "public"
 
-# Installed database / cache services, one table per engine.
-# Known ids: mysql, mariadb, postgres, redis. Usually managed via `yerd service`.
+# Installed services, one table per engine.
+# Known ids: mysql, mariadb, postgres, redis, meilisearch. Usually managed via `yerd service`.
 [services.redis]
 version = "8"
 port = 6379


### PR DESCRIPTION
## What does this PR do?

Adds a globally managed, version-isolated Meilisearch service with health checks, Laravel Scout configuration, lifecycle controls, safe data purging, and CLI/GUI guidance

## Related issues

closes #115

## Type of change

- [x] New feature
- [x] Documentation

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native Meilisearch support as a managed local search service.
  - Added Meilisearch health monitoring with readiness checks.
  - Generated Laravel `.env` snippets for Laravel Scout + Meilisearch (including Scout index prefix and connection settings).
- **Bug Fixes**
  - Improved version-aware cleanup for Meilisearch/service data to avoid deleting data belonging to other installed versions.
- **Documentation**
  - Updated service/CLI/config docs and default ports to include Meilisearch.
  - Updated install/change guidance for rebuilding search indexes after version changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->