### PR TITLE
[Fix] Meilisearch Startup Failure And Silent Install Progress

### DIFF
--- a/apps/yerd-gui/src/views/ServicesView.spec.ts
+++ b/apps/yerd-gui/src/views/ServicesView.spec.ts
@@ -1,0 +1,162 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+
+import ServicesView from "./ServicesView.vue";
+import { useDaemon } from "@/composables/useDaemon";
+import { resetResourceCache } from "@/composables/useResource";
+import type { AddableServiceType } from "@/ipc/types";
+
+function meilisearchType(): AddableServiceType {
+  return {
+    type_id: "meilisearch",
+    display_name: "Meilisearch",
+    multiplicity: "single",
+    requires_site: false,
+    requires_version: true,
+    already_installed: false,
+    available_versions: ["1.49.0"],
+    default_port: 7700,
+    suggested_port: 7700,
+  };
+}
+
+/** No services installed yet and Meilisearch offered in the Add dialog - the
+ *  state a first-time install starts from. `add_service` is left pending so the
+ *  in-flight window can be asserted. */
+function stubIpc(): { resolveAdd: () => void } {
+  let resolveAdd = (): void => {};
+  const pending = new Promise<{ type: string; id: string }>((resolve) => {
+    resolveAdd = () => resolve({ type: "service_instance_id", id: "meilisearch" });
+  });
+  invokeMock.mockImplementation((cmd: string) => {
+    switch (cmd) {
+      case "list_services":
+        return Promise.resolve({ type: "services", services: [] });
+      case "addable_service_types":
+        return Promise.resolve({ type: "addable_services", types: [meilisearchType()] });
+      case "list_sites":
+        return Promise.resolve({ type: "sites", sites: [] });
+      case "list_databases":
+        return Promise.resolve({ type: "databases", databases: [] });
+      case "add_service":
+        return pending;
+      default:
+        return Promise.reject(new Error(`unexpected invoke ${cmd}`));
+    }
+  });
+  return { resolveAdd };
+}
+
+const mounted: { unmount: () => void }[] = [];
+
+async function mountView() {
+  const wrapper = mount(ServicesView, {
+    global: { stubs: { teleport: true, RouterLink: true } },
+  });
+  mounted.push(wrapper);
+  await flushPromises();
+  return wrapper;
+}
+
+/** Exact-match, so the dialog's "Add" is not shadowed by the header's
+ *  "Add Service". */
+function findButton(wrapper: Awaited<ReturnType<typeof mountView>>, text: string) {
+  const btn = wrapper.findAll("button").find((b) => b.text().trim() === text);
+  if (!btn) throw new Error(`no button with text "${text}"`);
+  return btn;
+}
+
+/** Walk the Add dialog to step 2, leaving it ready to submit. Nothing is
+ *  pre-selected, so the type has to be picked before Continue enables. */
+async function openAddToConfigureStep(wrapper: Awaited<ReturnType<typeof mountView>>) {
+  await findButton(wrapper, "Add Service").trigger("click");
+  await flushPromises();
+  await wrapper.find('select[aria-label="Service type"]').setValue("meilisearch");
+  await flushPromises();
+  await findButton(wrapper, "Continue").trigger("click");
+  await flushPromises();
+}
+
+describe("ServicesView add-in-flight state", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    resetResourceCache();
+    useDaemon().report.value = null;
+  });
+
+  afterEach(() => {
+    mounted.forEach((w) => w.unmount());
+    mounted.length = 0;
+  });
+
+  it("swaps the Add button for a disabled spinner while the install runs", async () => {
+    const { resolveAdd } = stubIpc();
+    const wrapper = await mountView();
+    await openAddToConfigureStep(wrapper);
+
+    expect(findButton(wrapper, "Add").attributes("disabled")).toBeUndefined();
+
+    await findButton(wrapper, "Add").trigger("click");
+    await flushPromises();
+
+    const submit = findButton(wrapper, "Installing…");
+    expect(submit.attributes("disabled")).toBeDefined();
+    expect(submit.find(".animate-spin").exists()).toBe(true);
+
+    resolveAdd();
+    await flushPromises();
+  });
+
+  it("keeps the dialog open and locks every control until the install finishes", async () => {
+    const { resolveAdd } = stubIpc();
+    const wrapper = await mountView();
+    await openAddToConfigureStep(wrapper);
+    await findButton(wrapper, "Add").trigger("click");
+    await flushPromises();
+
+    const dialog = wrapper.find('[role="dialog"]');
+    expect(dialog.exists()).toBe(true);
+    expect(dialog.text()).toContain("this can take a few minutes");
+    for (const control of dialog.findAll("input, select, button")) {
+      expect(control.attributes("disabled")).toBeDefined();
+    }
+    expect(dialog.find('[aria-label="Close"]').exists()).toBe(false);
+
+    resolveAdd();
+    await flushPromises();
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false);
+  });
+
+  it("closes the dialog and clears the busy state when the install fails", async () => {
+    stubIpc();
+    invokeMock.mockImplementation((cmd: string) => {
+      switch (cmd) {
+        case "list_services":
+          return Promise.resolve({ type: "services", services: [] });
+        case "addable_service_types":
+          return Promise.resolve({ type: "addable_services", types: [meilisearchType()] });
+        case "list_sites":
+          return Promise.resolve({ type: "sites", sites: [] });
+        case "list_databases":
+          return Promise.resolve({ type: "databases", databases: [] });
+        case "add_service":
+          return Promise.reject(new Error("download failed"));
+        default:
+          return Promise.reject(new Error(`unexpected invoke ${cmd}`));
+      }
+    });
+    const wrapper = await mountView();
+    await openAddToConfigureStep(wrapper);
+    await findButton(wrapper, "Add").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false);
+  });
+});

--- a/apps/yerd-gui/src/views/ServicesView.vue
+++ b/apps/yerd-gui/src/views/ServicesView.vue
@@ -79,6 +79,11 @@ const services = computed(() => data.value ?? []);
 const busy = ref<string | null>(null); // a key naming the in-flight op (e.g. "start:redis")
 const search = ref("");
 
+/** An add is in flight. The service has no row to show a spinner on until it is
+ *  installed, so the Add dialog itself has to carry the progress: it stays open,
+ *  locked, and non-dismissible until the download finishes. */
+const adding = computed(() => busy.value?.startsWith("add:") ?? false);
+
 /** The "Managed services" list: only configured instances (installed engines or
  *  per-site instances) - uninstalled engines live in the Add Service dialog, not
  *  here - optionally narrowed by the search box (name / port / linked site). */
@@ -281,9 +286,9 @@ async function confirmAdd(close: () => void): Promise<void> {
     // dialog either way - the add is done - and refresh so the row appears.
     toast.error(`${t.display_name} added, but couldn't start`, (e as IpcError).message);
   } finally {
+    close();
     busy.value = null;
   }
-  close();
   await Promise.all([load({ force: true }), refresh()]);
 }
 
@@ -910,7 +915,7 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
     </div>
 
     <!-- Add Service (two stages: choose, then configure) -->
-    <Modal v-model:open="addOpen" title="Add service">
+    <Modal v-model:open="addOpen" title="Add service" :dismissible="!adding">
       <div v-if="addLoading" class="flex justify-center py-8"><Spinner class="size-6" /></div>
 
       <div v-else-if="!addableTypes.length" class="py-6 text-center text-sm text-muted-foreground">
@@ -933,6 +938,7 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
             <Select
               v-model="addForm.typeId"
               :options="typeOptions"
+              :disabled="adding"
               class="mt-2 w-full"
               aria-label="Service type"
             />
@@ -942,6 +948,7 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
             <Select
               v-model="addForm.version"
               :options="versionOptions"
+              :disabled="adding"
               class="mt-2 w-full"
               aria-label="Version"
             />
@@ -968,6 +975,7 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
               v-if="siteOptions.length"
               v-model="addForm.site"
               :options="siteOptions"
+              :disabled="adding"
               class="mt-2 w-full"
               aria-label="Linked site"
             />
@@ -981,7 +989,14 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
 
           <div>
             <label class="text-sm font-medium">Port</label>
-            <Input v-model="addForm.port" type="number" min="1" max="65535" class="mt-2" />
+            <Input
+              v-model="addForm.port"
+              type="number"
+              min="1"
+              max="65535"
+              :disabled="adding"
+              class="mt-2"
+            />
             <p class="mt-1.5 text-xs text-muted-foreground">Suggested from the next free port.</p>
           </div>
 
@@ -990,24 +1005,28 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
               <p class="text-sm font-medium">Start with Yerd</p>
               <p class="text-xs text-muted-foreground">Launch this service when Yerd starts.</p>
             </div>
-            <Switch v-model="addForm.autostart" aria-label="Start with Yerd" />
+            <Switch v-model="addForm.autostart" :disabled="adding" aria-label="Start with Yerd" />
           </div>
+
+          <p v-if="adding" class="text-xs text-muted-foreground">
+            Downloading a prebuilt build and starting it - this can take a few minutes.
+            The daemon reports only on completion, so there's no percentage to show.
+          </p>
         </div>
       </div>
 
       <template #footer="{ close }">
         <template v-if="!addLoading && addableTypes.length">
-          <Button v-if="addStep === 2" variant="ghost" @click="addStep = 1">Back</Button>
-          <Button variant="ghost" @click="close">Cancel</Button>
+          <Button v-if="addStep === 2" variant="ghost" :disabled="adding" @click="addStep = 1">
+            Back
+          </Button>
+          <Button variant="ghost" :disabled="adding" @click="close">Cancel</Button>
           <Button v-if="addStep === 1" :disabled="!canContinue" @click="addStep = 2">
             Continue
           </Button>
-          <Button
-            v-else
-            :disabled="!canSubmitAdd || busy?.startsWith('add:')"
-            @click="confirmAdd(close)"
-          >
-            Add
+          <Button v-else :disabled="!canSubmitAdd || adding" @click="confirmAdd(close)">
+            <Spinner v-if="adding" class="size-4" />
+            {{ adding ? "Installing…" : "Add" }}
           </Button>
         </template>
         <Button v-else variant="ghost" @click="close">Close</Button>

--- a/crates/yerd-services/src/service.rs
+++ b/crates/yerd-services/src/service.rs
@@ -360,6 +360,20 @@ pub struct MariaDb;
 /// `PostgreSQL`.
 pub struct Postgres;
 /// Meilisearch Community Edition: shared local search infrastructure.
+///
+/// Its dump and snapshot dirs default to `dumps/` and `snapshots/` *relative to
+/// the working directory*, and it creates the dump dir eagerly at startup, so
+/// both are pinned under the datadir. Neither unit sets a working directory, and
+/// the inherited default differs by OS: launchd gives `/`, the read-only system
+/// volume on macOS, so startup died with EROFS before ever binding a port; the
+/// systemd *user* manager gives `$HOME`, which is writable, so Linux instead
+/// quietly littered `~/dumps`. Pinning fixes both.
+///
+/// Anchoring under the datadir (rather than beside it) keeps these version-scoped
+/// with the store they belong to, so `uninstall --purge` reclaims them with the
+/// data. The trade-off is that dumps taken before a version change stay behind
+/// with the old version's data, which matches how Yerd already retains the rest
+/// of that version's state.
 pub struct Meilisearch;
 
 impl ServiceDefinition for Redis {
@@ -697,6 +711,10 @@ impl ServiceDefinition for Meilisearch {
             .arg(format!("127.0.0.1:{}", ctx.port))
             .arg("--db-path")
             .arg(ctx.datadir)
+            .arg("--dump-dir")
+            .arg(ctx.datadir.join("dumps"))
+            .arg("--snapshot-dir")
+            .arg(ctx.datadir.join("snapshots"))
             .arg("--env")
             .arg("development")
             .arg("--no-analytics");
@@ -908,12 +926,47 @@ mod tests {
                 "127.0.0.1:7701",
                 "--db-path",
                 "/data/meili",
+                "--dump-dir",
+                "/data/meili/dumps",
+                "--snapshot-dir",
+                "/data/meili/snapshots",
                 "--env",
                 "development",
                 "--no-analytics"
             ]
         );
         assert!(plan.capture_output_to_log);
+    }
+
+    /// Regression: both dirs default to cwd-relative, and the daemon's cwd is the
+    /// read-only `/` on macOS, so neither may be left to Meilisearch's default.
+    #[test]
+    fn meilisearch_pins_dump_and_snapshot_dirs_under_the_datadir() {
+        let ctx = LaunchContext {
+            port: 7700,
+            program: std::path::Path::new("/bin/meilisearch"),
+            config_path: std::path::Path::new(""),
+            datadir: std::path::Path::new("/data/meili"),
+            log_path: std::path::Path::new("/logs/meili.log"),
+            geo_env: &[],
+            cwd: None,
+        };
+        let plan = reg().get("meilisearch").unwrap().plan_launch(&ctx).unwrap();
+        let args: Vec<_> = plan
+            .command
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        for (flag, expected) in [
+            ("--dump-dir", "/data/meili/dumps"),
+            ("--snapshot-dir", "/data/meili/snapshots"),
+        ] {
+            let Some(at) = args.iter().position(|a| a == flag) else {
+                panic!("{flag} must be passed explicitly")
+            };
+            assert_eq!(args.get(at + 1).map(String::as_str), Some(expected));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Pins Meilisearch's --dump-dir and --snapshot-dir under its datadir so it no longer dies with EROFS on macOS (or litters ~/dumps on Linux) when the daemon inherits a working directory it can't write to, and replaces the Add Service dialog's inert button with a disabled spinner and locked, non-dismissible form while the download runs.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear installation progress feedback when adding a service, including an “Installing…” indicator.

* **Bug Fixes**
  * Prevented accidental changes or closing the dialog while a service is being installed.
  * Ensured the add-service dialog and controls recover correctly after installation failures.
  * Improved Meilisearch data handling by keeping dumps and snapshots within the service data directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->