### PR TITLE
[Fix] PHP install dialog, Overview layout, and framework PHP selection

### DIFF
--- a/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
+++ b/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
@@ -184,6 +184,9 @@ const managedComposer = computed(() =>
 const needsComposer = computed(() => !toolAvailable("composer"));
 const needsInstaller = computed(() => !toolAvailable("laravel"));
 const noPhp = computed(() => supportedPhpVersions.value.length === 0);
+// Distinguishes "no PHP at all" from "PHP installed, none of it supported" so
+// the prerequisites row can say which, rather than implying PHP is missing.
+const phpUnsupported = computed(() => noPhp.value && props.phpVersions.length > 0);
 // Node/Bun are only conditionally needed and the daemon installs them inline
 // during the job (shown as a phase), so they don't block the wizard.
 const needsNode = computed(() => form.js === "npm" && !toolAvailable("node"));
@@ -458,12 +461,16 @@ watch(
   },
 );
 
-// When PHP appears (e.g. installed from the prerequisites screen), pick the
-// default so the Basics step has a valid selection once the wizard unlocks.
+// Keep the selection honest as the installed set changes underneath the wizard
+// (PHP installed from the prerequisites screen, or the selected version
+// uninstalled elsewhere): anything no longer supported falls back to the
+// preferred version rather than being submitted for a version that isn't there.
 watch(
   () => props.phpVersions,
   () => {
-    if (!form.php) form.php = preferredPhp();
+    if (!form.php || !supportedPhpVersions.value.includes(form.php)) {
+      form.php = preferredPhp();
+    }
   },
 );
 
@@ -503,7 +510,7 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
       <div class="divide-y rounded-lg border">
         <div
           v-for="row in [
-            { id: 'php', label: 'PHP', sub: `Runtime ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}`, ok: !noPhp, busyKey: 'php' },
+            { id: 'php', label: 'PHP', sub: phpUnsupported ? `Installed, but not ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}` : `Runtime ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}`, ok: !noPhp, busyKey: 'php' },
             { id: 'composer', label: 'Composer', sub: 'Dependency manager', ok: !needsComposer, busyKey: 'composer' },
             { id: 'laravel', label: 'Laravel installer', sub: 'laravel new', ok: !needsInstaller, busyKey: 'laravel' },
           ]"

--- a/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
+++ b/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
@@ -183,10 +183,10 @@ const managedComposer = computed(() =>
 // PHP, Composer and the Laravel installer are *required* and gated up front.
 const needsComposer = computed(() => !toolAvailable("composer"));
 const needsInstaller = computed(() => !toolAvailable("laravel"));
-const noPhp = computed(() => supportedPhpVersions.value.length === 0);
+const noSupportedPhp = computed(() => supportedPhpVersions.value.length === 0);
 // Distinguishes "no PHP at all" from "PHP installed, none of it supported" so
 // the prerequisites row can say which, rather than implying PHP is missing.
-const phpUnsupported = computed(() => noPhp.value && props.phpVersions.length > 0);
+const phpUnsupported = computed(() => noSupportedPhp.value && props.phpVersions.length > 0);
 // Node/Bun are only conditionally needed and the daemon installs them inline
 // during the job (shown as a phase), so they don't block the wizard.
 const needsNode = computed(() => form.js === "npm" && !toolAvailable("node"));
@@ -194,7 +194,7 @@ const needsBun = computed(() => form.js === "bun" && !toolAvailable("bun"));
 
 /** Whether the required toolchain is present (the wizard is unlocked). */
 const ready = computed(
-  () => !noPhp.value && !needsComposer.value && !needsInstaller.value,
+  () => !noSupportedPhp.value && !needsComposer.value && !needsInstaller.value,
 );
 /** Any prerequisite install in flight (per-item or install-all). */
 const installBusy = computed(() => installingAll.value || installingTool.value !== null);
@@ -236,12 +236,13 @@ async function installPrereq(id: "composer" | "laravel" | "node" | "bun"): Promi
   }
 }
 
+/**
+ * Install the newest available minor within the supported window (the
+ * distribution returns them ascending), rather than pinning a version that rots
+ * each release. The daemon resolves the patch and makes it the global default;
+ * the live status poll then surfaces it, which unlocks the wizard automatically.
+ */
 async function installFirstPhp(): Promise<boolean> {
-  // The user has no PHP Laravel can run on: install the newest available minor
-  // within the supported window (the distribution returns them ascending), rather
-  // than pinning a version that rots each release. The daemon resolves the patch
-  // and makes it the global default; the live status poll then surfaces it, which
-  // unlocks the wizard automatically.
   installingTool.value = "php";
   installLog.value = [];
   try {
@@ -274,7 +275,7 @@ async function installFirstPhp(): Promise<boolean> {
 async function installAllMissing(): Promise<void> {
   installingAll.value = true;
   try {
-    if (noPhp.value && !(await installFirstPhp())) return;
+    if (noSupportedPhp.value && !(await installFirstPhp())) return;
     if (needsComposer.value && !(await installPrereq("composer"))) return;
     // The managed Laravel installer is BUILT via Yerd's own Composer, so it can
     // only be auto-installed when managed Composer is present. If Composer is only
@@ -510,7 +511,7 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
       <div class="divide-y rounded-lg border">
         <div
           v-for="row in [
-            { id: 'php', label: 'PHP', sub: phpUnsupported ? `Installed, but not ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}` : `Runtime ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}`, ok: !noPhp, busyKey: 'php' },
+            { id: 'php', label: 'PHP', sub: phpUnsupported ? `Installed, but not ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}` : `Runtime ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}`, ok: !noSupportedPhp, busyKey: 'php' },
             { id: 'composer', label: 'Composer', sub: 'Dependency manager', ok: !needsComposer, busyKey: 'composer' },
             { id: 'laravel', label: 'Laravel installer', sub: 'laravel new', ok: !needsInstaller, busyKey: 'laravel' },
           ]"

--- a/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
+++ b/apps/yerd-gui/src/components/site-create/CreateLaravelWizard.vue
@@ -17,6 +17,7 @@ import Modal from "@/components/ui/Modal.vue";
 import Select from "@/components/ui/Select.vue";
 import Switch from "@/components/ui/Switch.vue";
 import Spinner from "@/components/ui/Spinner.vue";
+import { phpVersionInRange } from "@/lib/phpVersion";
 import { siteUrl } from "@/lib/siteUrl";
 import { useDaemon } from "@/composables/useDaemon";
 import { useToast } from "@/composables/useToast";
@@ -107,9 +108,24 @@ const isJsKit = computed(() =>
 const isLivewire = computed(() => kitChoice.value === "livewire");
 const hasAuthKit = computed(() => kitChoice.value !== "none");
 
-const phpOptions = computed(() =>
-  props.phpVersions.map((v) => ({ value: v, label: `PHP ${v}` })),
+// The Laravel installer only supports this window; anything outside it is hidden
+// from the picker rather than offered and then failing mid-create.
+const LARAVEL_MIN_PHP = "8.3";
+const LARAVEL_MAX_PHP = "8.5";
+const supportedPhpVersions = computed(() =>
+  props.phpVersions.filter((v) => phpVersionInRange(v, LARAVEL_MIN_PHP, LARAVEL_MAX_PHP)),
 );
+const phpOptions = computed(() =>
+  supportedPhpVersions.value.map((v) => ({ value: v, label: `PHP ${v}` })),
+);
+
+// The default only applies when it falls in the supported window; otherwise the
+// newest supported version wins so the Basics step always opens on a valid pick.
+function preferredPhp(): string {
+  const supported = supportedPhpVersions.value;
+  if (props.defaultPhp && supported.includes(props.defaultPhp)) return props.defaultPhp;
+  return supported[supported.length - 1] ?? "";
+}
 const locationOptions = computed(() => {
   const opts = props.parkedFolders.map((f) => ({ value: f, label: `${f}  (parked)` }));
   // Include a custom-picked location that isn't a parked root.
@@ -167,7 +183,7 @@ const managedComposer = computed(() =>
 // PHP, Composer and the Laravel installer are *required* and gated up front.
 const needsComposer = computed(() => !toolAvailable("composer"));
 const needsInstaller = computed(() => !toolAvailable("laravel"));
-const noPhp = computed(() => props.phpVersions.length === 0);
+const noPhp = computed(() => supportedPhpVersions.value.length === 0);
 // Node/Bun are only conditionally needed and the daemon installs them inline
 // during the job (shown as a phase), so they don't block the wizard.
 const needsNode = computed(() => form.js === "npm" && !toolAvailable("node"));
@@ -218,18 +234,24 @@ async function installPrereq(id: "composer" | "laravel" | "node" | "bun"): Promi
 }
 
 async function installFirstPhp(): Promise<boolean> {
-  // The user has no PHP: install the latest available minor (the distribution
-  // returns them ascending, so the last entry is newest), matching the onboarding
-  // flow rather than pinning a version that rots each release. The daemon resolves
-  // the patch and makes it the global default; the live status poll then surfaces
-  // it, which unlocks the wizard automatically.
+  // The user has no PHP Laravel can run on: install the newest available minor
+  // within the supported window (the distribution returns them ascending), rather
+  // than pinning a version that rots each release. The daemon resolves the patch
+  // and makes it the global default; the live status poll then surfaces it, which
+  // unlocks the wizard automatically.
   installingTool.value = "php";
   installLog.value = [];
   try {
     const { available } = await availablePhp();
-    const version = available[available.length - 1];
+    const supported = available.filter((v) =>
+      phpVersionInRange(v, LARAVEL_MIN_PHP, LARAVEL_MAX_PHP),
+    );
+    const version = supported[supported.length - 1];
     if (!version) {
-      toast.error("Couldn't install PHP", "No installable PHP versions were found.");
+      toast.error(
+        "Couldn't install PHP",
+        `No installable PHP between ${LARAVEL_MIN_PHP} and ${LARAVEL_MAX_PHP} was found.`,
+      );
       return false;
     }
     void appendInstallLog([`Installing PHP ${version}…`]);
@@ -399,7 +421,7 @@ function resetForm(): void {
   step.value = 0;
   form.name = "";
   form.location = props.parkedFolders[0] ?? "";
-  form.php = props.defaultPhp || props.phpVersions[0] || "";
+  form.php = preferredPhp();
   form.secure = false;
   kitChoice.value = "none";
   form.communityPackage = "";
@@ -440,10 +462,8 @@ watch(
 // default so the Basics step has a valid selection once the wizard unlocks.
 watch(
   () => props.phpVersions,
-  (versions) => {
-    if (!form.php && versions.length) {
-      form.php = props.defaultPhp || versions[0];
-    }
+  () => {
+    if (!form.php) form.php = preferredPhp();
   },
 );
 
@@ -483,7 +503,7 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
       <div class="divide-y rounded-lg border">
         <div
           v-for="row in [
-            { id: 'php', label: 'PHP', sub: 'Runtime', ok: !noPhp, busyKey: 'php' },
+            { id: 'php', label: 'PHP', sub: `Runtime ${LARAVEL_MIN_PHP}-${LARAVEL_MAX_PHP}`, ok: !noPhp, busyKey: 'php' },
             { id: 'composer', label: 'Composer', sub: 'Dependency manager', ok: !needsComposer, busyKey: 'composer' },
             { id: 'laravel', label: 'Laravel installer', sub: 'laravel new', ok: !needsInstaller, busyKey: 'laravel' },
           ]"
@@ -585,7 +605,10 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
       <div class="flex items-center justify-between gap-4 rounded-lg border p-3">
         <div>
           <p class="text-sm font-medium">PHP version</p>
-          <p class="text-xs text-muted-foreground">The version this site runs on.</p>
+          <p class="text-xs text-muted-foreground">
+            The version this site runs on. Laravel needs PHP {{ LARAVEL_MIN_PHP }} to
+            {{ LARAVEL_MAX_PHP }}.
+          </p>
         </div>
         <Select
           v-if="phpOptions.length"
@@ -596,7 +619,9 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
           aria-label="PHP version"
           @update:model-value="(v: string) => (form.php = v)"
         />
-        <span v-else class="shrink-0 text-xs text-destructive">No PHP installed.</span>
+        <span v-else class="shrink-0 text-xs text-destructive">
+          No supported PHP installed.
+        </span>
       </div>
 
       <div class="flex items-center justify-between gap-4 rounded-lg border p-3">

--- a/apps/yerd-gui/src/components/site-create/CreateWordPressWizard.vue
+++ b/apps/yerd-gui/src/components/site-create/CreateWordPressWizard.vue
@@ -19,7 +19,7 @@ import Modal from "@/components/ui/Modal.vue";
 import Select from "@/components/ui/Select.vue";
 import Switch from "@/components/ui/Switch.vue";
 import Spinner from "@/components/ui/Spinner.vue";
-import { phpVersionInRange } from "@/lib/phpVersion";
+import { isLegacyVersion, phpVersionInRange } from "@/lib/phpVersion";
 import { isUnbound, siteUrl, wpAdminLoginUrl, wpAdminUrl } from "@/lib/siteUrl";
 import { WORDPRESS_LOCALES } from "@/lib/wordpressLocales";
 import { useDaemon } from "@/composables/useDaemon";
@@ -95,9 +95,15 @@ const form = reactive({
 });
 let dbNameTouched = false;
 
+// A native <select> can't host a Badge, so legacy is called out in the option
+// label itself and expanded on by the hint below the picker.
 const phpOptions = computed(() =>
-  props.phpVersions.map((v) => ({ value: v, label: `PHP ${v}` })),
+  props.phpVersions.map((v) => ({
+    value: v,
+    label: isLegacyVersion(v) ? `PHP ${v} (legacy)` : `PHP ${v}`,
+  })),
 );
+const phpIsLegacy = computed(() => !!form.php && isLegacyVersion(form.php));
 const locationOptions = computed(() => {
   const opts = props.parkedFolders.map((f) => ({ value: f, label: `${f}  (parked)` }));
   if (form.location && !props.parkedFolders.includes(form.location)) {
@@ -713,7 +719,12 @@ const busy = computed(() => jobStateRef.value === "running" && step.value === 4)
       <div class="flex items-center justify-between gap-4 rounded-lg border p-3">
         <div>
           <p class="text-sm font-medium">PHP version</p>
-          <p class="text-xs text-muted-foreground">The version this site runs on.</p>
+          <p class="text-xs text-muted-foreground">
+            <template v-if="phpIsLegacy">
+              Out of support: no dumps or coverage, and it can't be your default.
+            </template>
+            <template v-else>The version this site runs on.</template>
+          </p>
         </div>
         <Select
           v-if="phpOptions.length"

--- a/apps/yerd-gui/src/views/LaravelDumpsView.vue
+++ b/apps/yerd-gui/src/views/LaravelDumpsView.vue
@@ -180,7 +180,7 @@ async function openViewer(): Promise<void> {
       <div
         v-if="hasLegacy"
         data-testid="dumps-legacy-banner"
-        class="rounded-md border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-warning-foreground"
+        class="rounded-md border border-warning/40 bg-warning/10 px-4 py-3 text-sm"
       >
         One or more installed PHP versions are legacy (&lt; 8.2). Dumps are never captured for
         legacy versions - the <code>yerd-dump</code> extension isn't built for out-of-support PHP.

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -345,6 +345,41 @@ const emptyEnvironment = computed(
           </Button>
         </div>
 
+        <!-- Stat tiles → each links to its page. -->
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <RouterLink
+            v-for="tile in tiles"
+            :key="tile.to"
+            :to="tile.to"
+            class="group relative overflow-hidden rounded-lg border bg-card pl-5 pr-4 py-3.5 shadow-sm transition-colors hover:border-brand/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span
+              class="pointer-events-none absolute inset-y-0 left-0 w-[3px] bg-brand/50 transition-colors group-hover:bg-brand"
+            />
+            <div class="flex items-center gap-1.5">
+              <component :is="tile.icon" class="size-3.5 text-muted-foreground" />
+              <span class="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                {{ tile.label }}
+              </span>
+              <ArrowUpRight
+                class="ml-auto size-3.5 text-muted-foreground/40 transition-colors group-hover:text-brand"
+              />
+            </div>
+            <p class="mt-2.5 flex items-baseline gap-1.5 leading-none">
+              <span class="text-[2rem] font-semibold tabular-nums tracking-tight">
+                {{ tile.value }}
+              </span>
+              <span class="text-xs text-muted-foreground">{{ tile.unit }}</span>
+            </p>
+            <p
+              class="mt-3 truncate border-t pt-2 font-mono text-[11px] text-muted-foreground"
+              :title="tile.sub"
+            >
+              {{ tile.sub }}
+            </p>
+          </RouterLink>
+        </div>
+
         <Card class="relative overflow-hidden">
           <!-- A soft brand wash - the only place indigo gets a hero surface.
                A gradient fade rather than a blurred circle: `filter: blur()`
@@ -407,7 +442,7 @@ const emptyEnvironment = computed(
               </button>
               <RouterLink
                 to="/sites"
-                class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-brand hover:underline"
+                class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-brand transition-colors hover:text-brand/70"
               >
                 {{ moreCount ? `+${moreCount} more` : "Manage" }}
                 <ArrowRight class="size-3" />
@@ -428,76 +463,48 @@ const emptyEnvironment = computed(
           </div>
         </Card>
 
-        <!-- Stat tiles → each links to its page. -->
-        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <RouterLink
-            v-for="tile in tiles"
-            :key="tile.to"
-            :to="tile.to"
-            class="group rounded-lg border bg-card p-4 shadow-sm transition-colors hover:border-brand/40"
-          >
-            <div class="flex items-center justify-between">
-              <component
-                :is="tile.icon"
-                class="size-4 text-muted-foreground transition-colors group-hover:text-brand"
-              />
-              <ArrowUpRight
-                class="size-3.5 text-transparent transition-colors group-hover:text-muted-foreground"
-              />
-            </div>
-            <p class="mt-3 text-2xl font-semibold tracking-tight">
-              {{ tile.value }}
-              <span class="ml-0.5 text-sm font-normal text-muted-foreground">
-                {{ tile.unit }}
-              </span>
-            </p>
-            <p class="mt-0.5 text-xs font-medium">{{ tile.label }}</p>
-            <p class="mt-1 truncate text-xs text-muted-foreground" :title="tile.sub">
-              {{ tile.sub }}
-            </p>
-          </RouterLink>
-        </div>
-
         <!-- Daemon control - Stop/Restart. Start is owned by the daemon-down
              hero above (this branch only renders while the daemon is up). -->
-        <Card>
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-1.5">
-              <h3 class="text-sm font-semibold">Daemon</h3>
-              <TooltipProvider v-if="daemonPid" :delay-duration="0">
-                <Tooltip>
-                  <TooltipTrigger as-child>
-                    <span class="inline-flex cursor-help text-muted-foreground">
-                      <Info class="size-3.5" />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">running as pid {{ daemonPid }}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+        <Card class="p-4">
+          <div class="flex flex-wrap items-center justify-between gap-x-8 gap-y-3">
+            <div class="min-w-0 flex-1 basis-64">
+              <div class="flex items-center gap-1.5">
+                <h3 class="text-sm font-semibold">Daemon</h3>
+                <TooltipProvider v-if="daemonPid" :delay-duration="0">
+                  <Tooltip>
+                    <TooltipTrigger as-child>
+                      <span class="inline-flex cursor-help text-muted-foreground">
+                        <Info class="size-3.5" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">running as pid {{ daemonPid }}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <StatusPill tone="ok" label="Running" />
+              </div>
+              <p class="mt-1 text-xs text-muted-foreground">
+                <code>yerdd</code> supervises PHP-FPM, serves your
+                <code>.test</code> sites, answers DNS, and runs databases.
+              </p>
             </div>
-            <StatusPill tone="ok" label="Running" />
-          </div>
-          <p class="mt-3 text-sm text-muted-foreground">
-            <code>yerdd</code> supervises PHP-FPM, serves your
-            <code>.test</code> sites, answers DNS, and runs databases.
-          </p>
-          <div class="mt-4 flex justify-end gap-2">
-            <Button variant="outline" :disabled="busy !== null" @click="stopDaemonOpen = true">
-              <Spinner v-if="busy === 'daemon'" class="size-4" />
-              <Square v-else class="size-4" /> Stop
-            </Button>
-            <Button
-              variant="outline"
-              :disabled="busy !== null"
-              @click="restartDaemonOpen = true"
-            >
-              <Spinner v-if="busy === 'restart:daemon'" class="size-4" />
-              <RotateCw v-else class="size-4" /> Restart
-            </Button>
+            <div class="flex shrink-0 gap-2">
+              <Button variant="outline" :disabled="busy !== null" @click="stopDaemonOpen = true">
+                <Spinner v-if="busy === 'daemon'" class="size-4" />
+                <Square v-else class="size-4" /> Stop
+              </Button>
+              <Button
+                variant="outline"
+                :disabled="busy !== null"
+                @click="restartDaemonOpen = true"
+              >
+                <Spinner v-if="busy === 'restart:daemon'" class="size-4" />
+                <RotateCw v-else class="size-4" /> Restart
+              </Button>
+            </div>
           </div>
         </Card>
 
-        <!-- System health summary → Settings. -->
+        <!-- System health summary → Doctor, which owns the fixes for these checks. -->
         <Card>
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-2">
@@ -506,10 +513,10 @@ const emptyEnvironment = computed(
               <h3 class="text-sm font-semibold">System health</h3>
             </div>
             <RouterLink
-              to="/general"
-              class="text-xs font-medium text-brand hover:underline"
+              to="/doctor"
+              class="text-xs font-medium text-brand transition-colors hover:text-brand/70"
             >
-              Open Settings
+              Open Doctor
             </RouterLink>
           </div>
           <div class="mt-3 grid gap-2 sm:grid-cols-3">

--- a/apps/yerd-gui/src/views/OverviewView.vue
+++ b/apps/yerd-gui/src/views/OverviewView.vue
@@ -484,7 +484,7 @@ const emptyEnvironment = computed(
               </div>
               <p class="mt-1 text-xs text-muted-foreground">
                 <code>yerdd</code> supervises PHP-FPM, serves your
-                <code>.test</code> sites, answers DNS, and runs databases.
+                <code>.{{ tld }}</code> sites, answers DNS, and runs databases.
               </p>
             </div>
             <div class="flex shrink-0 gap-2">

--- a/apps/yerd-gui/src/views/PhpView.spec.ts
+++ b/apps/yerd-gui/src/views/PhpView.spec.ts
@@ -81,35 +81,27 @@ describe("PhpView legacy handling", () => {
     await openBtn!.trigger("click");
     await flushPromises();
 
-    // The legacy disclosure is present; reveal it.
+    expect(wrapper.find('[data-testid="legacy-warning"]').exists()).toBe(false);
     const toggle = wrapper.find('[data-testid="toggle-legacy"]');
     expect(toggle.exists()).toBe(true);
     await toggle.trigger("click");
     await flushPromises();
     expect(wrapper.find('[data-testid="legacy-warning"]').exists()).toBe(true);
 
-    // The footer "Install legacy version" button is disabled until confirmed.
-    const installBtn = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("Install legacy version"));
-    expect(installBtn).toBeTruthy();
-    expect(installBtn!.attributes("disabled")).toBeDefined();
+    const installBtn = wrapper.find('[data-testid="install-submit"]');
+    expect(installBtn.attributes("disabled")).toBeDefined();
 
-    // Tick the confirmation switch → enabled, and installing streams the flag.
     await wrapper.find('button[aria-label="Confirm legacy install"]').trigger("click");
     await flushPromises();
-    const enabled = wrapper
-      .findAll("button")
-      .find((b) => b.text().includes("Install legacy version"));
-    expect(enabled!.attributes("disabled")).toBeUndefined();
+    expect(wrapper.find('[data-testid="install-submit"]').attributes("disabled")).toBeUndefined();
 
-    await enabled!.trigger("click");
+    await wrapper.find('[data-testid="install-submit"]').trigger("click");
     await flushPromises();
     const streamed = invokeMock.mock.calls.find((c) => c[0] === "install_php_streamed");
-    expect(streamed?.[1]).toMatchObject({ confirmLegacy: true });
+    expect(streamed?.[1]).toMatchObject({ version: "8.0", confirmLegacy: true });
   });
 
-  it("keeps the stable install available while the legacy disclosure is open", async () => {
+  it("installs the stable version while the legacy toggle is off", async () => {
     stubIpc({});
     const wrapper = await mountView();
 
@@ -119,10 +111,7 @@ describe("PhpView legacy handling", () => {
     await openBtn!.trigger("click");
     await flushPromises();
 
-    await wrapper.find('[data-testid="toggle-legacy"]').trigger("click");
-    await flushPromises();
-
-    const stableBtn = wrapper.find('[data-testid="install-stable"]');
+    const stableBtn = wrapper.find('[data-testid="install-submit"]');
     expect(stableBtn.exists()).toBe(true);
     expect(stableBtn.attributes("disabled")).toBeUndefined();
 
@@ -130,5 +119,54 @@ describe("PhpView legacy handling", () => {
     await flushPromises();
     const streamed = invokeMock.mock.calls.find((c) => c[0] === "install_php_streamed");
     expect(streamed?.[1]).toMatchObject({ confirmLegacy: false });
+  });
+
+  it("re-arms the opt-in when the legacy toggle is switched back off", async () => {
+    stubIpc({});
+    const wrapper = await mountView();
+
+    const openBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Install") && b.attributes("disabled") === undefined);
+    await openBtn!.trigger("click");
+    await flushPromises();
+
+    await wrapper.find('[data-testid="toggle-legacy-label"]').trigger("click");
+    await flushPromises();
+    expect(wrapper.find('[data-testid="legacy-warning"]').exists()).toBe(true);
+
+    await wrapper.find('button[aria-label="Confirm legacy install"]').trigger("click");
+    await flushPromises();
+
+    await wrapper.find('[data-testid="toggle-legacy"]').trigger("click");
+    await wrapper.find('[data-testid="toggle-legacy"]').trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="install-submit"]').attributes("disabled")).toBeDefined();
+  });
+
+  it("starts in legacy mode, locked, when no stable version is left to install", async () => {
+    stubIpc({ available: [] });
+    const wrapper = await mountView();
+
+    const openBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Install") && b.attributes("disabled") === undefined);
+    await openBtn!.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="legacy-warning"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="toggle-legacy"]').attributes("disabled")).toBeDefined();
+
+    await wrapper.find('[data-testid="toggle-legacy-label"]').trigger("click");
+    await flushPromises();
+    expect(wrapper.find('[data-testid="legacy-warning"]').exists()).toBe(true);
+
+    await wrapper.find('button[aria-label="Confirm legacy install"]').trigger("click");
+    await flushPromises();
+    await wrapper.find('[data-testid="install-submit"]').trigger("click");
+    await flushPromises();
+    const streamed = invokeMock.mock.calls.find((c) => c[0] === "install_php_streamed");
+    expect(streamed?.[1]).toMatchObject({ version: "8.0", confirmLegacy: true });
   });
 });

--- a/apps/yerd-gui/src/views/PhpView.vue
+++ b/apps/yerd-gui/src/views/PhpView.vue
@@ -387,15 +387,30 @@ const installOpen = ref(false);
 const installLoading = ref(false);
 const installOptions = ref<{ value: PhpVersion; label: string }[]>([]);
 const selectedVersion = ref<PhpVersion>("");
-// Legacy (< 8.2) versions are offered behind an explicit, warned opt-in.
+// Legacy (< 8.2) versions are offered behind an explicit, warned opt-in: the
+// toggle swaps the version picker over rather than adding a second install path.
 const legacyOptions = ref<{ value: PhpVersion; label: string }[]>([]);
 const selectedLegacy = ref<PhpVersion>("");
 const showLegacy = ref(false);
 const confirmLegacy = ref(false);
-const canInstallStable = computed(() => !!selectedVersion.value);
-const canInstallLegacy = computed(
-  () => !!selectedLegacy.value && confirmLegacy.value,
+const canInstall = computed(() =>
+  showLegacy.value
+    ? !!selectedLegacy.value && confirmLegacy.value
+    : !!selectedVersion.value,
 );
+
+// Re-arming the opt-in every time the toggle flips keeps the confirmation an
+// active choice rather than something left ticked from an earlier glance.
+watch(showLegacy, () => {
+  confirmLegacy.value = false;
+});
+
+// Flip between the stable and legacy pickers. Refused when there is no stable
+// version left to install, which would swap in an empty, unsubmittable Select.
+function toggleLegacyMode(): void {
+  if (!installOptions.value.length) return;
+  showLegacy.value = !showLegacy.value;
+}
 
 // ── install-progress dialog ──
 // A blocking, non-dismissible dialog owns the install's status (spinner + the
@@ -407,8 +422,11 @@ const installError = ref("");
 const installTarget = ref<PhpVersion>("");
 
 // Open the modal and fetch the distribution's installable versions, hiding any
-// already installed. Pre-selects the LATEST (the daemon returns them ascending,
-// so the last entry is newest) so the Select (no placeholder) is always valid.
+// already installed. Both pickers pre-select the LATEST of their own list (the
+// daemon returns them ascending, so the last entry is newest) so whichever one
+// the legacy toggle shows is valid without a placeholder. The toggle starts off,
+// unless every stable version is already installed, in which case it starts on
+// and stays there because legacy is all that is left to offer.
 async function openInstall(): Promise<void> {
   installOpen.value = true;
   installLoading.value = true;
@@ -431,6 +449,7 @@ async function openInstall(): Promise<void> {
     selectedVersion.value = opts[opts.length - 1]?.value ?? "";
     const legacyOpts = legacyOptions.value;
     selectedLegacy.value = legacyOpts[legacyOpts.length - 1]?.value ?? "";
+    if (!opts.length && legacyOpts.length) showLegacy.value = true;
   } catch (e) {
     toast.error("Couldn't load installable versions", (e as IpcError).message);
   } finally {
@@ -446,7 +465,8 @@ async function openInstall(): Promise<void> {
  * version list AND the status poll so the new row shows its patch + "idle" state
  * immediately rather than on the next 4s tick.
  */
-async function confirmInstall(legacy: boolean): Promise<void> {
+async function confirmInstall(): Promise<void> {
+  const legacy = showLegacy.value;
   const v = legacy ? selectedLegacy.value : selectedVersion.value;
   if (!v || installing.value) return;
   if (legacy && !confirmLegacy.value) return;
@@ -842,10 +862,44 @@ onUnmounted(
         <Spinner class="size-5" />
       </div>
       <template v-else-if="installOptions.length || legacyOptions.length">
-        <template v-if="installOptions.length">
+        <div v-if="legacyOptions.length">
+          <span class="text-sm font-medium">Stable vs Legacy</span>
+          <div class="mt-2 flex items-center gap-2 text-sm">
+            <Switch
+              :model-value="showLegacy"
+              :disabled="!installOptions.length"
+              aria-labelledby="legacy-mode-label"
+              data-testid="toggle-legacy"
+              @update:model-value="toggleLegacyMode"
+            />
+            <span
+              id="legacy-mode-label"
+              :class="installOptions.length ? 'cursor-pointer' : 'opacity-50'"
+              data-testid="toggle-legacy-label"
+              @click="toggleLegacyMode"
+            >
+              Install a legacy version (7.4 / 8.0 / 8.1)
+            </span>
+          </div>
+          <p v-if="!installOptions.length" class="mt-2 text-xs text-muted-foreground">
+            Legacy is all that's left to offer - every other version is already
+            installed, or the rest of the list couldn't be reached.
+          </p>
+        </div>
+
+        <div :class="legacyOptions.length ? 'mt-4 border-t pt-4' : ''">
           <span class="text-sm font-medium">Version</span>
           <div class="mt-2">
             <Select
+              v-if="showLegacy"
+              class="w-full"
+              :model-value="selectedLegacy"
+              :options="legacyOptions"
+              aria-label="Legacy PHP version to install"
+              @update:model-value="(v: PhpVersion) => (selectedLegacy = v)"
+            />
+            <Select
+              v-else
               class="w-full"
               :model-value="selectedVersion"
               :options="installOptions"
@@ -857,49 +911,24 @@ onUnmounted(
             Downloads a prebuilt static build; this can take a few minutes. A
             dialog shows live progress and can be closed once it finishes.
           </p>
-        </template>
 
-        <div v-if="legacyOptions.length" class="mt-4 border-t pt-3">
-          <button
-            type="button"
-            class="text-sm text-muted-foreground underline-offset-2 hover:underline"
-            data-testid="toggle-legacy"
-            @click="showLegacy = !showLegacy"
-          >
-            {{ showLegacy ? "Hide" : "Show" }} legacy versions (7.4 / 8.0 / 8.1)
-          </button>
-
-          <div v-if="showLegacy" class="mt-3 space-y-3">
+          <template v-if="showLegacy">
             <div
-              class="flex gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-xs text-warning-foreground"
+              class="mt-3 flex gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-xs"
               data-testid="legacy-warning"
             >
-              <TriangleAlert class="mt-0.5 size-4 shrink-0" />
+              <TriangleAlert class="mt-0.5 size-4 shrink-0 text-warning" />
               <span>
                 Legacy PHP versions are out of support and may contain unpatched security
                 vulnerabilities. They have no code coverage (phpcover), no yerd-dumps capture, and
                 cannot be set as the default PHP version. Use only for maintaining old projects.
               </span>
             </div>
-            <Select
-              class="w-full"
-              :model-value="selectedLegacy"
-              :options="legacyOptions"
-              aria-label="Legacy PHP version to install"
-              @update:model-value="(v: PhpVersion) => (selectedLegacy = v)"
-            />
-            <label class="flex items-center gap-2 text-sm">
+            <label class="mt-3 flex items-center gap-2 text-sm">
               <Switch v-model="confirmLegacy" aria-label="Confirm legacy install" />
               I understand and want to install this legacy version anyway.
             </label>
-            <Button
-              class="w-full"
-              :disabled="!canInstallLegacy || installing"
-              @click="confirmInstall(true)"
-            >
-              Install legacy version
-            </Button>
-          </div>
+          </template>
         </div>
       </template>
       <p v-else class="py-2 text-sm text-muted-foreground">
@@ -909,10 +938,10 @@ onUnmounted(
       <template #footer="{ close }">
         <Button variant="ghost" @click="close">Cancel</Button>
         <Button
-          v-if="installOptions.length"
-          :disabled="!canInstallStable || installing"
-          data-testid="install-stable"
-          @click="confirmInstall(false)"
+          v-if="installOptions.length || legacyOptions.length"
+          :disabled="!canInstall || installing"
+          data-testid="install-submit"
+          @click="confirmInstall()"
         >
           Install
         </Button>

--- a/bin/yerdd/src/tools/wp_cli.rs
+++ b/bin/yerdd/src/tools/wp_cli.rs
@@ -11,6 +11,7 @@
 //! directly - bypassing upstream's `bin/wp` shell wrapper (which only exists to
 //! locate a `php` on `PATH`; we already know which PHP to use).
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -22,6 +23,20 @@ use crate::ext_install::installed_versions;
 /// The Composer package providing the `wp` command (a root project depending
 /// on `wp-cli/wp-cli`, not a package named `wp-cli/wp-cli` itself).
 const PACKAGE: &str = "wp-cli/wp-cli-bundle";
+
+/// The oldest PHP a site can run: the floor of the legacy download channel
+/// (7.4 / 8.0 / 8.1).
+///
+/// WP-CLI is built once under whichever PHP is newest, but the `wp` shim execs
+/// the built tree under the *site's* PHP, which may be any installed version.
+/// Left to itself Composer resolves against the building PHP, so a tree built on
+/// 8.4 can pull dependencies requiring 8.0+ and then fatal when a 7.4 site runs
+/// `wp core download`. Pinning `platform.php` decouples resolution from the
+/// building PHP and yields one tree that runs everywhere Yerd can install.
+///
+/// The older dependency versions this selects emit `E_DEPRECATED` under newer
+/// PHP, which [`QUIET_DEPRECATIONS`] and the scan-dir drop-in already suppress.
+const PLATFORM_PHP_FLOOR: &str = "7.4";
 
 /// Upper bound on a single short, non-streaming `wp` helper invocation (e.g.
 /// `wp option update`, `wp user list`) - each boots WordPress and does one DB
@@ -123,15 +138,82 @@ pub async fn install(dirs: &PlatformDirs, progress: Option<&ProgressTx>) -> Resu
     let build = tools_root.join(format!(".wp-cli-build-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&build);
 
-    let mut child = tokio::process::Command::new(&php)
-        .arg(&phar)
-        .arg("create-project")
-        .arg("--prefer-dist")
-        .arg("--no-interaction")
-        .arg("--no-dev")
-        .arg(PACKAGE)
-        .arg(&build)
-        .env("COMPOSER_HOME", &home)
+    for (label, args) in build_steps(&build) {
+        if let Err(e) = composer_step(&php, &phar, &home, &args, progress, label).await {
+            let _ = std::fs::remove_dir_all(&build);
+            return Err(e);
+        }
+    }
+
+    let version = read_wp_cli_version(&build).unwrap_or_else(|| "installed".to_owned());
+    let swapped = stage_and_swap(dirs, Tool::WpCli, &version, |staging| {
+        move_dir_contents(&build, staging)
+    });
+    let _ = std::fs::remove_dir_all(&build);
+    swapped?;
+    tracing::info!(version = %version, "installed WP-CLI");
+    Ok(())
+}
+
+/// The Composer invocations that build WP-CLI into `build`, in order.
+///
+/// `create-project --no-install` fetches only the root package, leaving a
+/// `composer.json` to configure; `config platform.php` then pins resolution to
+/// [`PLATFORM_PHP_FLOOR`]; `install` resolves and downloads against that pin
+/// rather than against the PHP running Composer.
+fn build_steps(build: &Path) -> Vec<(&'static str, Vec<OsString>)> {
+    let dir = build.as_os_str().to_owned();
+    vec![
+        (
+            "create-project",
+            vec![
+                OsString::from("create-project"),
+                OsString::from("--prefer-dist"),
+                OsString::from("--no-interaction"),
+                OsString::from("--no-dev"),
+                OsString::from("--no-install"),
+                OsString::from(PACKAGE),
+                dir.clone(),
+            ],
+        ),
+        (
+            "config platform.php",
+            vec![
+                OsString::from("config"),
+                OsString::from("platform.php"),
+                OsString::from(PLATFORM_PHP_FLOOR),
+                OsString::from("--working-dir"),
+                dir.clone(),
+            ],
+        ),
+        (
+            "install",
+            vec![
+                OsString::from("install"),
+                OsString::from("--prefer-dist"),
+                OsString::from("--no-interaction"),
+                OsString::from("--no-dev"),
+                OsString::from("--working-dir"),
+                dir,
+            ],
+        ),
+    ]
+}
+
+/// Run one managed-Composer invocation, streaming its output to `progress`.
+/// `label` names the step in timeout/failure errors.
+async fn composer_step(
+    php: &Path,
+    phar: &Path,
+    home: &Path,
+    args: &[OsString],
+    progress: Option<&ProgressTx>,
+    label: &str,
+) -> Result<(), ToolError> {
+    let mut child = tokio::process::Command::new(php)
+        .arg(phar)
+        .args(args)
+        .env("COMPOSER_HOME", home)
         .env("COMPOSER_NO_INTERACTION", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -151,26 +233,16 @@ pub async fn install(dirs: &PlatformDirs, progress: Option<&ProgressTx>) -> Resu
     })
     .await;
     let Ok(((), (), status)) = joined else {
-        let _ = std::fs::remove_dir_all(&build);
         return Err(ToolError::Download(format!(
-            "composer create-project {PACKAGE} timed out"
+            "composer {label} {PACKAGE} timed out"
         )));
     };
     let status = status.map_err(|e| ToolError::Io(format!("await composer: {e}")))?;
     if !status.success() {
-        let _ = std::fs::remove_dir_all(&build);
         return Err(ToolError::Download(format!(
-            "composer create-project {PACKAGE} failed (exit {status})"
+            "composer {label} {PACKAGE} failed (exit {status})"
         )));
     }
-
-    let version = read_wp_cli_version(&build).unwrap_or_else(|| "installed".to_owned());
-    let swapped = stage_and_swap(dirs, Tool::WpCli, &version, |staging| {
-        move_dir_contents(&build, staging)
-    });
-    let _ = std::fs::remove_dir_all(&build);
-    swapped?;
-    tracing::info!(version = %version, "installed WP-CLI");
     Ok(())
 }
 
@@ -244,5 +316,58 @@ mod tests {
     fn read_wp_cli_version_absent_is_none() {
         let tmp = tempfile::tempdir().unwrap();
         assert_eq!(read_wp_cli_version(tmp.path()), None);
+    }
+
+    fn step_args(build: &Path, label: &str) -> Vec<String> {
+        build_steps(build)
+            .into_iter()
+            .find(|(l, _)| *l == label)
+            .map(|(_, args)| {
+                args.iter()
+                    .map(|a| a.to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn create_project_defers_dependency_resolution() {
+        let args = step_args(Path::new("/data/tools/.build"), "create-project");
+        assert!(args.contains(&"--no-install".to_owned()));
+        assert!(args.contains(&PACKAGE.to_owned()));
+        assert_eq!(args.last().map(String::as_str), Some("/data/tools/.build"));
+    }
+
+    #[test]
+    fn platform_is_pinned_to_the_legacy_floor_before_install() {
+        let build = Path::new("/data/tools/.build");
+        let steps = build_steps(build);
+        let labels: Vec<&str> = steps.iter().map(|(l, _)| *l).collect();
+        assert_eq!(labels, ["create-project", "config platform.php", "install"]);
+
+        let args = step_args(build, "config platform.php");
+        assert_eq!(args.first().map(String::as_str), Some("config"));
+        assert!(args.contains(&"platform.php".to_owned()));
+        assert!(args.contains(&PLATFORM_PHP_FLOOR.to_owned()));
+    }
+
+    #[test]
+    fn install_resolves_in_the_configured_build_dir() {
+        let args = step_args(Path::new("/data/tools/.build"), "install");
+        assert_eq!(args.first().map(String::as_str), Some("install"));
+        assert!(args.contains(&"--no-dev".to_owned()));
+        let dir_at = args.iter().position(|a| a == "--working-dir").unwrap();
+        assert_eq!(
+            args.get(dir_at + 1).map(String::as_str),
+            Some("/data/tools/.build")
+        );
+    }
+
+    #[test]
+    fn platform_floor_covers_every_installable_php() {
+        let floor: yerd_core::PhpVersion = PLATFORM_PHP_FLOOR.parse().unwrap();
+        for (major, minor) in [(7, 4), (8, 0), (8, 1), (8, 2), (8, 5)] {
+            assert!(floor <= yerd_core::PhpVersion::new(major, minor));
+        }
     }
 }

--- a/bin/yerdd/src/tools/wp_cli.rs
+++ b/bin/yerdd/src/tools/wp_cli.rs
@@ -11,7 +11,6 @@
 //! directly - bypassing upstream's `bin/wp` shell wrapper (which only exists to
 //! locate a `php` on `PATH`; we already know which PHP to use).
 
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -23,20 +22,6 @@ use crate::ext_install::installed_versions;
 /// The Composer package providing the `wp` command (a root project depending
 /// on `wp-cli/wp-cli`, not a package named `wp-cli/wp-cli` itself).
 const PACKAGE: &str = "wp-cli/wp-cli-bundle";
-
-/// The oldest PHP a site can run: the floor of the legacy download channel
-/// (7.4 / 8.0 / 8.1).
-///
-/// WP-CLI is built once under whichever PHP is newest, but the `wp` shim execs
-/// the built tree under the *site's* PHP, which may be any installed version.
-/// Left to itself Composer resolves against the building PHP, so a tree built on
-/// 8.4 can pull dependencies requiring 8.0+ and then fatal when a 7.4 site runs
-/// `wp core download`. Pinning `platform.php` decouples resolution from the
-/// building PHP and yields one tree that runs everywhere Yerd can install.
-///
-/// The older dependency versions this selects emit `E_DEPRECATED` under newer
-/// PHP, which [`QUIET_DEPRECATIONS`] and the scan-dir drop-in already suppress.
-const PLATFORM_PHP_FLOOR: &str = "7.4";
 
 /// Upper bound on a single short, non-streaming `wp` helper invocation (e.g.
 /// `wp option update`, `wp user list`) - each boots WordPress and does one DB
@@ -138,82 +123,15 @@ pub async fn install(dirs: &PlatformDirs, progress: Option<&ProgressTx>) -> Resu
     let build = tools_root.join(format!(".wp-cli-build-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&build);
 
-    for (label, args) in build_steps(&build) {
-        if let Err(e) = composer_step(&php, &phar, &home, &args, progress, label).await {
-            let _ = std::fs::remove_dir_all(&build);
-            return Err(e);
-        }
-    }
-
-    let version = read_wp_cli_version(&build).unwrap_or_else(|| "installed".to_owned());
-    let swapped = stage_and_swap(dirs, Tool::WpCli, &version, |staging| {
-        move_dir_contents(&build, staging)
-    });
-    let _ = std::fs::remove_dir_all(&build);
-    swapped?;
-    tracing::info!(version = %version, "installed WP-CLI");
-    Ok(())
-}
-
-/// The Composer invocations that build WP-CLI into `build`, in order.
-///
-/// `create-project --no-install` fetches only the root package, leaving a
-/// `composer.json` to configure; `config platform.php` then pins resolution to
-/// [`PLATFORM_PHP_FLOOR`]; `install` resolves and downloads against that pin
-/// rather than against the PHP running Composer.
-fn build_steps(build: &Path) -> Vec<(&'static str, Vec<OsString>)> {
-    let dir = build.as_os_str().to_owned();
-    vec![
-        (
-            "create-project",
-            vec![
-                OsString::from("create-project"),
-                OsString::from("--prefer-dist"),
-                OsString::from("--no-interaction"),
-                OsString::from("--no-dev"),
-                OsString::from("--no-install"),
-                OsString::from(PACKAGE),
-                dir.clone(),
-            ],
-        ),
-        (
-            "config platform.php",
-            vec![
-                OsString::from("config"),
-                OsString::from("platform.php"),
-                OsString::from(PLATFORM_PHP_FLOOR),
-                OsString::from("--working-dir"),
-                dir.clone(),
-            ],
-        ),
-        (
-            "install",
-            vec![
-                OsString::from("install"),
-                OsString::from("--prefer-dist"),
-                OsString::from("--no-interaction"),
-                OsString::from("--no-dev"),
-                OsString::from("--working-dir"),
-                dir,
-            ],
-        ),
-    ]
-}
-
-/// Run one managed-Composer invocation, streaming its output to `progress`.
-/// `label` names the step in timeout/failure errors.
-async fn composer_step(
-    php: &Path,
-    phar: &Path,
-    home: &Path,
-    args: &[OsString],
-    progress: Option<&ProgressTx>,
-    label: &str,
-) -> Result<(), ToolError> {
-    let mut child = tokio::process::Command::new(php)
-        .arg(phar)
-        .args(args)
-        .env("COMPOSER_HOME", home)
+    let mut child = tokio::process::Command::new(&php)
+        .arg(&phar)
+        .arg("create-project")
+        .arg("--prefer-dist")
+        .arg("--no-interaction")
+        .arg("--no-dev")
+        .arg(PACKAGE)
+        .arg(&build)
+        .env("COMPOSER_HOME", &home)
         .env("COMPOSER_NO_INTERACTION", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -233,16 +151,26 @@ async fn composer_step(
     })
     .await;
     let Ok(((), (), status)) = joined else {
+        let _ = std::fs::remove_dir_all(&build);
         return Err(ToolError::Download(format!(
-            "composer {label} {PACKAGE} timed out"
+            "composer create-project {PACKAGE} timed out"
         )));
     };
     let status = status.map_err(|e| ToolError::Io(format!("await composer: {e}")))?;
     if !status.success() {
+        let _ = std::fs::remove_dir_all(&build);
         return Err(ToolError::Download(format!(
-            "composer {label} {PACKAGE} failed (exit {status})"
+            "composer create-project {PACKAGE} failed (exit {status})"
         )));
     }
+
+    let version = read_wp_cli_version(&build).unwrap_or_else(|| "installed".to_owned());
+    let swapped = stage_and_swap(dirs, Tool::WpCli, &version, |staging| {
+        move_dir_contents(&build, staging)
+    });
+    let _ = std::fs::remove_dir_all(&build);
+    swapped?;
+    tracing::info!(version = %version, "installed WP-CLI");
     Ok(())
 }
 
@@ -316,58 +244,5 @@ mod tests {
     fn read_wp_cli_version_absent_is_none() {
         let tmp = tempfile::tempdir().unwrap();
         assert_eq!(read_wp_cli_version(tmp.path()), None);
-    }
-
-    fn step_args(build: &Path, label: &str) -> Vec<String> {
-        build_steps(build)
-            .into_iter()
-            .find(|(l, _)| *l == label)
-            .map(|(_, args)| {
-                args.iter()
-                    .map(|a| a.to_string_lossy().into_owned())
-                    .collect()
-            })
-            .unwrap()
-    }
-
-    #[test]
-    fn create_project_defers_dependency_resolution() {
-        let args = step_args(Path::new("/data/tools/.build"), "create-project");
-        assert!(args.contains(&"--no-install".to_owned()));
-        assert!(args.contains(&PACKAGE.to_owned()));
-        assert_eq!(args.last().map(String::as_str), Some("/data/tools/.build"));
-    }
-
-    #[test]
-    fn platform_is_pinned_to_the_legacy_floor_before_install() {
-        let build = Path::new("/data/tools/.build");
-        let steps = build_steps(build);
-        let labels: Vec<&str> = steps.iter().map(|(l, _)| *l).collect();
-        assert_eq!(labels, ["create-project", "config platform.php", "install"]);
-
-        let args = step_args(build, "config platform.php");
-        assert_eq!(args.first().map(String::as_str), Some("config"));
-        assert!(args.contains(&"platform.php".to_owned()));
-        assert!(args.contains(&PLATFORM_PHP_FLOOR.to_owned()));
-    }
-
-    #[test]
-    fn install_resolves_in_the_configured_build_dir() {
-        let args = step_args(Path::new("/data/tools/.build"), "install");
-        assert_eq!(args.first().map(String::as_str), Some("install"));
-        assert!(args.contains(&"--no-dev".to_owned()));
-        let dir_at = args.iter().position(|a| a == "--working-dir").unwrap();
-        assert_eq!(
-            args.get(dir_at + 1).map(String::as_str),
-            Some("/data/tools/.build")
-        );
-    }
-
-    #[test]
-    fn platform_floor_covers_every_installable_php() {
-        let floor: yerd_core::PhpVersion = PLATFORM_PHP_FLOOR.parse().unwrap();
-        for (major, minor) in [(7, 4), (8, 0), (8, 1), (8, 2), (8, 5)] {
-            assert!(floor <= yerd_core::PhpVersion::new(major, minor));
-        }
     }
 }

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -9,7 +9,7 @@ The fastest way to manage PHP is the **PHP** page (under the **Environment** gro
 <ThemedImage light="/images/php-light.png" dark="/images/php-dark.png" alt="The PHP page in the Yerd desktop app" />
 
 - A table of installed versions shows live FPM pool state, patch level, pool memory (RSS), and whether an update is available.
-- **Install** opens a picker of installable versions (already-installed ones are hidden); progress streams live next to the Install button as the prebuilt static build downloads. A **Show legacy versions** disclosure reveals [legacy minors](#legacy-php-versions) (7.4 / 8.0 / 8.1) behind a warning block and a mandatory confirmation checkbox.
+- **Install** opens a picker of installable versions (already-installed ones are hidden); progress streams live next to the Install button as the prebuilt static build downloads. An **Install a legacy version** toggle (off by default) swaps the picker over to the [legacy minors](#legacy-php-versions) (7.4 / 8.0 / 8.1) behind a warning block and a mandatory confirmation checkbox; when every current version is already installed the toggle starts on and locks there, since legacy is all that's left to add.
 - **Refresh** re-checks for updates and **Update all** updates every version with one pending - [updates are notify-only](#updates-are-notify-only).
 - Each row's `⋯` menu offers **Restart**, **Set default** (marks it with a star; disabled for legacy rows, which are tagged with a `legacy` badge), **Update** (when available), and **Uninstall**; **Restart all** restarts every running pool.
 - A **Default settings** card edits the [global ini defaults](#tuning-php-settings) applied to every version; leave a field blank to use PHP's built-in default, and saving restarts running pools to apply.
@@ -52,9 +52,10 @@ yerd install php 7.4 --legacy
 
 Running `yerd install php 7.4` without `--legacy` refuses and prints an
 out-of-support warning instead of installing. In the desktop app, the Install
-picker's **Show legacy versions** disclosure opens a warning block and a
-mandatory confirmation checkbox ("I understand and want to install this legacy
-version anyway.") before the Install button is enabled.
+picker's **Install a legacy version** toggle replaces the version list with the
+legacy minors and opens a warning block and a mandatory confirmation checkbox
+("I understand and want to install this legacy version anyway.") before the
+Install button is enabled.
 
 A legacy version carries hard restrictions once installed:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Yerd! Please fill in the sections below. -->

## What does this PR do?

Reworks the PHP install dialog into a single stable/legacy mode toggle with a readable dark-mode warning, consolidates the Overview daemon card and restyles the stat tiles, and constrains the Laravel wizard to PHP 8.3-8.5 while labelling legacy versions in the WordPress wizard.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets` is clean
- [ ] `cargo test` passes
- [ ] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [ ] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a unified “Stable vs Legacy” PHP installation flow with a legacy toggle and required confirmation.
  - Updated Laravel and WordPress wizards to improve PHP version presentation and selection (including legacy labeling).
  - Refreshed the dashboard layout and added “Open Doctor” quick access.
- **Bug Fixes**
  - Improved messaging and gating when no supported PHP versions are available or selected.
  - Kept PHP selections valid when available versions change.
- **Documentation**
  - Updated the PHP Versions guide to match the new legacy-installation toggle workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->