### PR TITLE
[Fix] Mails: restore document-like rendering in the HTML viewer

### DIFF
--- a/apps/yerd-gui/src/lib/mailLinks.test.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.test.ts
@@ -258,6 +258,42 @@ describe("buildMailFrameDocument", () => {
     expect(head).not.toContain("prefetch");
     expect(head).not.toContain("ok.css");
   });
+
+  it("carries body background and spacing resets into bodyStyle", () => {
+    const { bodyStyle } = buildMailFrameDocument(
+      `<!doctype html><html><body style="background-color: #f4f4f7; margin: 0; padding: 0; color: #52525b;"><p>Hi</p></body></html>`,
+    );
+    expect(bodyStyle).toContain("background-color: rgb(244, 244, 247)");
+    expect(bodyStyle).toContain("margin: 0");
+    expect(bodyStyle).toContain("padding: 0");
+    expect(bodyStyle).toContain("color: rgb(82, 82, 91)");
+  });
+
+  it("falls back to the bgcolor attribute when body has no inline background", () => {
+    const { bodyStyle } = buildMailFrameDocument(
+      `<!doctype html><html><body bgcolor="#eeeeee"><p>Hi</p></body></html>`,
+    );
+    expect(bodyStyle).toContain("background-color: rgb(238, 238, 238)");
+  });
+
+  it("drops body declarations that could escape the viewer pane", () => {
+    const { bodyStyle } = buildMailFrameDocument(
+      `<!doctype html><html><body style="position: fixed; top: 0; z-index: 9999; width: 100%; height: 100%; background: #fff;"><p>Hi</p></body></html>`,
+    );
+    expect(bodyStyle).not.toContain("position");
+    expect(bodyStyle).not.toContain("z-index");
+    expect(bodyStyle).not.toContain("top");
+    expect(bodyStyle).not.toContain("width");
+    expect(bodyStyle).not.toContain("height");
+    expect(bodyStyle).toContain("background");
+  });
+
+  it("returns an empty bodyStyle when the message styles nothing", () => {
+    const { bodyStyle } = buildMailFrameDocument(
+      `<!doctype html><html><body><p>Hi</p></body></html>`,
+    );
+    expect(bodyStyle).toBe("");
+  });
 });
 
 describe("listRemoteContentUrls", () => {

--- a/apps/yerd-gui/src/lib/mailLinks.ts
+++ b/apps/yerd-gui/src/lib/mailLinks.ts
@@ -356,6 +356,54 @@ function stripRemoteResources(doc: Document): void {
 }
 
 /**
+ * Presentation-only declarations carried over from `<body>`. Deliberately
+ * excludes positioning and sizing so a captured message cannot lay itself over
+ * the surrounding app chrome.
+ */
+const BODY_STYLE_ALLOWLIST = [
+  "background",
+  "color",
+  "font",
+  "margin",
+  "padding",
+  "line-height",
+  "text-align",
+  "letter-spacing",
+  "word-spacing",
+  "direction",
+];
+
+/**
+ * Read the sanitized `<body>` presentation so a Shadow DOM host can stand in
+ * for the document canvas. Mail templates put their page background and reset
+ * (`margin: 0`) on `<body>`; without this the wrapper ignores both and the
+ * message ends up framed in the host's own background.
+ */
+function bodyPresentationStyle(doc: Document): string {
+  const body = doc.body;
+  if (!body) return "";
+  const decl = body.style;
+  const bgcolor = body.getAttribute("bgcolor")?.trim();
+  if (bgcolor && !decl.getPropertyValue("background-color")) {
+    decl.setProperty("background-color", bgcolor);
+  }
+  const parts: string[] = [];
+  for (let index = 0; index < decl.length; index += 1) {
+    const name = decl.item(index);
+    if (!name) continue;
+    const allowed = BODY_STYLE_ALLOWLIST.some(
+      (prop) => name === prop || name.startsWith(`${prop}-`),
+    );
+    if (!allowed) continue;
+    const value = decl.getPropertyValue(name);
+    if (!value) continue;
+    const priority = decl.getPropertyPriority(name);
+    parts.push(`${name}: ${value}${priority ? ` !${priority}` : ""}`);
+  }
+  return parts.join("; ");
+}
+
+/**
  * Sanitize a captured HTML email with DOMPurify and stamp openable anchors.
  * Preserves inline `<style>` blocks. Remote stylesheets, images, and CSS URLs
  * are stripped unless `loadRemoteContent` is true.
@@ -363,7 +411,7 @@ function stripRemoteResources(doc: Document): void {
 export function buildMailFrameDocument(
   html: string,
   options: BuildMailFrameOptions = {},
-): { head: string; body: string } {
+): { head: string; body: string; bodyStyle: string } {
   const cleaned = DOMPurify.sanitize(html, MAIL_PURIFY_CONFIG);
   const doc = new DOMParser().parseFromString(cleaned, "text/html");
   filterHeadHazards(doc);
@@ -372,6 +420,7 @@ export function buildMailFrameDocument(
   return {
     head: doc.head?.innerHTML ?? "",
     body: doc.body?.innerHTML ?? "",
+    bodyStyle: bodyPresentationStyle(doc),
   };
 }
 

--- a/apps/yerd-gui/src/views/MailsViewerView.vue
+++ b/apps/yerd-gui/src/views/MailsViewerView.vue
@@ -226,10 +226,20 @@ function onHtmlLinkClick(ev: Event): void {
   openMailLink(action.url);
 }
 
+/**
+ * Render sanitized mail HTML into the host's shadow root.
+ *
+ * A shadow root scopes style *rules* but not inheritance, so the message would
+ * otherwise pick up the app shell's typography through the host. The wrapper
+ * resets what the old sandboxed iframe used to get for free as a separate
+ * document: grayscale font smoothing and `optimizeLegibility` (see
+ * `body` in style.css) render mail text noticeably lighter than the sender
+ * intended, and the global `user-select: none` would make it uncopyable.
+ */
 function renderHtmlBody(html: string): void {
   const host = htmlHost.value;
   if (!host) return;
-  const { head, body } = buildMailFrameDocument(html, {
+  const { head, body, bodyStyle } = buildMailFrameDocument(html, {
     loadRemoteContent: loadRemoteContent.value,
   });
   let root = host.shadowRoot;
@@ -240,17 +250,45 @@ function renderHtmlBody(html: string): void {
   root.innerHTML = `<style>
 :host { display: block; }
 .yerd-mail-body {
-  padding: 1.25rem;
+  min-height: 100%;
+  padding: 8px;
   box-sizing: border-box;
   color: #111;
   font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: auto;
+  text-rendering: auto;
+  font-feature-settings: normal;
+  font-variant-ligatures: normal;
+  -webkit-user-select: text;
+  user-select: text;
 }
 .yerd-mail-body img, .yerd-mail-body table { max-width: 100%; }
 .yerd-mail-body a { cursor: pointer; }
 </style>${head}<div class="yerd-mail-body">${body}</div>`;
+  const wrapper = root.querySelector<HTMLElement>(".yerd-mail-body");
+  if (wrapper && bodyStyle) wrapper.setAttribute("style", bodyStyle);
+  propagateMailBackground(host, wrapper);
+}
+
+/**
+ * Mirror CSS background propagation: a document's `<body>` background paints
+ * the whole canvas, so the mail's background must reach the scroll container
+ * rather than stopping at the end of its content.
+ */
+function propagateMailBackground(
+  host: HTMLElement,
+  wrapper: HTMLElement | null,
+): void {
+  host.style.removeProperty("background-color");
+  if (!wrapper) return;
+  const background = getComputedStyle(wrapper).backgroundColor;
+  if (!background || background === "transparent") return;
+  if (/^rgba\(.*,\s*0\)$/.test(background)) return;
+  host.style.backgroundColor = background;
 }
 
 function clearHtmlBody(): void {
+  htmlHost.value?.style.removeProperty("background-color");
   const root = htmlHost.value?.shadowRoot;
   if (root) root.innerHTML = "";
 }


### PR DESCRIPTION
## What does this PR do?

Restore the pre-Shadow-DOM look of HTML mail by carrying the message's own body presentation onto the viewer wrapper and resetting the app typography it inherits.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML email rendering by preserving supported body styling, including background color, spacing, and text color.
  * Added fallback support for email background colors defined through legacy attributes.
  * Removed unsafe body styling that could affect layout or escape the email frame.
  * Improved mail content layout, typography, selection behavior, and background cleanup when switching messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->