### PR TITLE
[Fix] Trust the local CA in browsers (Chromium & Firefox) via per-user NSS

### DIFF
--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -757,16 +757,16 @@ pub async fn unelevate(target: String) -> Result<(), GuiError> {
 
 /// Trust the local CA for the current user, in-process (macOS only). Unlike
 /// `elevate("trust")` this needs no root and prompts as "Yerd"; see `mac_trust`.
+///
+/// The keychain trust covers Safari and the Chromium-family browsers; Firefox
+/// on macOS keeps its own NSS store, so this also asks the daemon to populate
+/// it (best-effort - a missing `certutil` or Firefox profile is surfaced by
+/// `doctor`, not treated as a trust failure).
 #[tauri::command]
 pub async fn trust_ca() -> Result<(), GuiError> {
     #[cfg(target_os = "macos")]
     {
         crate::mac_trust::trust_ca().await?;
-        // The keychain trust above covers Safari and the Chromium-family
-        // browsers (Brave/Chrome/Edge). Firefox on macOS keeps its own NSS
-        // store, so also populate it via the daemon (which runs as the user).
-        // Best-effort: a missing certutil / no Firefox profile is surfaced by
-        // `doctor` (CaNotTrustedByBrowsers), not treated as a trust failure.
         let _ = exchange(&Request::TrustBrowsers { uninstall: false }).await;
         Ok(())
     }
@@ -780,12 +780,12 @@ pub async fn trust_ca() -> Result<(), GuiError> {
 
 /// Remove the current user's trust of the local CA (macOS only). Returns `true`
 /// if a system-wide trust set via the terminal still remains (the GUI can't
-/// remove that without root).
+/// remove that without root). Also removes the CA from the browser NSS store
+/// (the mirror of [`trust_ca`]).
 #[tauri::command]
 pub async fn untrust_ca() -> Result<bool, GuiError> {
     #[cfg(target_os = "macos")]
     {
-        // Mirror trust_ca: also remove the CA from the browser NSS store.
         let _ = exchange(&Request::TrustBrowsers { uninstall: true }).await;
         crate::mac_trust::untrust_ca().await
     }

--- a/apps/yerd-gui/src-tauri/src/commands.rs
+++ b/apps/yerd-gui/src-tauri/src/commands.rs
@@ -761,7 +761,14 @@ pub async fn unelevate(target: String) -> Result<(), GuiError> {
 pub async fn trust_ca() -> Result<(), GuiError> {
     #[cfg(target_os = "macos")]
     {
-        crate::mac_trust::trust_ca().await
+        crate::mac_trust::trust_ca().await?;
+        // The keychain trust above covers Safari and the Chromium-family
+        // browsers (Brave/Chrome/Edge). Firefox on macOS keeps its own NSS
+        // store, so also populate it via the daemon (which runs as the user).
+        // Best-effort: a missing certutil / no Firefox profile is surfaced by
+        // `doctor` (CaNotTrustedByBrowsers), not treated as a trust failure.
+        let _ = exchange(&Request::TrustBrowsers { uninstall: false }).await;
+        Ok(())
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -778,6 +785,8 @@ pub async fn trust_ca() -> Result<(), GuiError> {
 pub async fn untrust_ca() -> Result<bool, GuiError> {
     #[cfg(target_os = "macos")]
     {
+        // Mirror trust_ca: also remove the CA from the browser NSS store.
+        let _ = exchange(&Request::TrustBrowsers { uninstall: true }).await;
         crate::mac_trust::untrust_ca().await
     }
     #[cfg(not(target_os = "macos"))]

--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -308,6 +308,7 @@ export type DiagnosisCode =
   | "web_ports_unbound"
   | "foreign_web_listener"
   | "ca_not_trusted"
+  | "ca_not_trusted_by_browsers"
   | "resolver_not_installed"
   | "no_php_installed"
   | "default_php_not_installed"

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -119,9 +119,6 @@ mod unix_impl {
                 }
             }
         }
-        // The system-store install above does not reach browsers on Linux
-        // (Brave/Chrome/Firefox use their own per-user NSS store); ask the
-        // daemon - which runs as the user - to update it. Non-fatal.
         if trust_applied {
             report_browser_trust(undo).await;
         }

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -105,17 +105,72 @@ mod unix_impl {
         };
 
         let mut any_failed = false;
+        let mut trust_applied = false;
         for t in concrete_targets {
-            if let Err(e) = run_one(t, &facts, &helper, &yerdd, undo) {
-                eprintln!("    failed: {e}");
-                any_failed = true;
+            match run_one(t, &facts, &helper, &yerdd, undo) {
+                Ok(()) => {
+                    if t == ElevateTarget::Trust {
+                        trust_applied = true;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("    failed: {e}");
+                    any_failed = true;
+                }
             }
+        }
+        // The system-store install above does not reach browsers on Linux
+        // (Brave/Chrome/Firefox use their own per-user NSS store); ask the
+        // daemon - which runs as the user - to update it. Non-fatal.
+        if trust_applied {
+            report_browser_trust(undo).await;
         }
         if any_failed {
             ExitCode::from(1)
         } else {
             ExitCode::SUCCESS
         }
+    }
+
+    /// Ask the user's daemon to add (or remove) the CA in the per-user browser
+    /// NSS stores and print the outcome. The daemon runs unprivileged as the
+    /// user, so the NSS databases stay user-owned even though this CLI is root.
+    async fn report_browser_trust(undo: bool) {
+        println!("==> Browser trust (Brave / Chrome / Firefox)");
+        let req = Request::TrustBrowsers { uninstall: undo };
+        for sock in socket_candidates() {
+            match transport::exchange_at(&sock, &req).await {
+                Ok(Response::BrowserTrust {
+                    attempted,
+                    succeeded,
+                    certutil_missing,
+                }) => {
+                    if certutil_missing {
+                        println!("    certutil not found - browsers were not updated.");
+                        println!("    install it, then re-run `sudo yerd elevate trust`:");
+                        println!("      Debian/Ubuntu/Zorin:  sudo apt install libnss3-tools");
+                        println!("      Fedora:               sudo dnf install nss-tools");
+                        println!("      Arch:                 sudo pacman -S nss");
+                    } else if undo {
+                        println!("    removed from {succeeded}/{attempted} browser store(s).");
+                    } else if attempted == 0 {
+                        println!(
+                            "    no browser certificate store found yet - launch your browser \
+                             once, then re-run `sudo yerd elevate trust`."
+                        );
+                    } else {
+                        println!("    trusted in {succeeded}/{attempted} browser store(s).");
+                    }
+                    return;
+                }
+                Ok(other) => {
+                    eprintln!("    unexpected response updating browser trust: {other:?}");
+                    return;
+                }
+                Err(_) => {}
+            }
+        }
+        eprintln!("    could not reach the daemon to update browser trust (is it running?).");
     }
 
     /// Run a single target: build the invocation, spawn the helper (or print

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -2698,6 +2698,7 @@ mod tests {
                 fingerprint: "ab".repeat(32),
                 trusted_system: Some(false),
                 php_trusts_ca: None,
+                browser_trust: None,
             },
             resolver_installed: None,
             port_redirect: None,

--- a/bin/yerd/src/mcp_cmd.rs
+++ b/bin/yerd/src/mcp_cmd.rs
@@ -379,6 +379,7 @@ mod tests {
                 fingerprint: "ab".repeat(32),
                 trusted_system: Some(true),
                 php_trusts_ca: None,
+                browser_trust: None,
             },
             resolver_installed: Some(true),
             port_redirect: None,

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -385,6 +385,7 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         Request::SetMcpEnabled { enabled } => set_mcp_enabled(enabled, state).await,
         Request::SetLanEnabled { enabled } => set_lan_enabled(enabled, state).await,
         Request::MintRemoteSetupCode => mint_remote_setup_code(state).await,
+        Request::TrustBrowsers { uninstall } => trust_browsers(uninstall, state).await,
         Request::ListTools => Response::Tools {
             tools: list_tools_with_external(state).await,
         },
@@ -754,6 +755,18 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
     .ok()
     .flatten();
 
+    let browser_fp = state.ca_fingerprint;
+    let browser_trust = tokio::task::spawn_blocking(move || {
+        use yerd_platform::TrustStore;
+        yerd_platform::ActiveTrustStore::new()
+            .browser_ca_trust(&browser_fp)
+            .ok()
+            .map(map_browser_trust)
+    })
+    .await
+    .ok()
+    .flatten();
+
     let tld_probe = tld.clone();
     let dns_addr = state.dns_addr;
     let resolver_installed = tokio::task::spawn_blocking(move || {
@@ -800,6 +813,7 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
             fingerprint: state.ca_fingerprint.to_hex(),
             trusted_system,
             php_trusts_ca: php_trusts_ca(state).await,
+            browser_trust,
         },
         resolver_installed,
         port_redirect,
@@ -1359,6 +1373,48 @@ async fn rebuild_php_ca_bundle(state: &DaemonState) -> bool {
     })
     .await
     .unwrap_or(false)
+}
+
+/// Map the platform browser-trust probe to the wire enum.
+fn map_browser_trust(t: yerd_platform::BrowserCaTrust) -> yerd_ipc::BrowserTrust {
+    match t {
+        yerd_platform::BrowserCaTrust::Trusted => yerd_ipc::BrowserTrust::Trusted,
+        yerd_platform::BrowserCaTrust::Untrusted => yerd_ipc::BrowserTrust::Untrusted,
+        yerd_platform::BrowserCaTrust::ToolMissing => yerd_ipc::BrowserTrust::ToolMissing,
+    }
+}
+
+/// Install (or remove) the Yerd CA into the per-user **browser** NSS stores.
+/// Runs unprivileged as the daemon's user; the CA PEM is read from the daemon's
+/// on-disk `ca_path`, so no cert material crosses the IPC boundary.
+async fn trust_browsers(uninstall: bool, state: &DaemonState) -> Response {
+    let ca_path = state.ca_path.clone();
+    let joined = tokio::task::spawn_blocking(move || {
+        use yerd_platform::TrustStore;
+        let ts = yerd_platform::ActiveTrustStore::new();
+        if uninstall {
+            ts.uninstall_firefox_nss()
+        } else {
+            ts.install_firefox_nss(&ca_path)
+        }
+    })
+    .await;
+
+    match joined {
+        Ok(Ok(o)) => Response::BrowserTrust {
+            attempted: o.profiles_attempted,
+            succeeded: o.profiles_succeeded,
+            certutil_missing: o.certutil_missing,
+        },
+        Ok(Err(e)) => Response::Error {
+            code: yerd_ipc::ErrorCode::Internal,
+            message: format!("browser NSS trust failed: {e}"),
+        },
+        Err(e) => Response::Error {
+            code: yerd_ipc::ErrorCode::Internal,
+            message: format!("browser NSS trust task panicked: {e}"),
+        },
+    }
 }
 
 /// Probe whether the bundled PHP trusts the Yerd CA: `None` when the feature is

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -101,20 +101,20 @@ fn trust_findings(report: &StatusReport) -> Vec<Diagnosis> {
         Some(BrowserTrust::Untrusted) => out.push(warn(
             DiagnosisCode::CaNotTrustedByBrowsers,
             "Browsers don't trust the local CA",
-            "Brave, Chrome and Firefox keep their own certificate store on Linux \
-             (separate from the system store), so they show HTTPS warnings on \
-             .test sites until the CA is added there."
+            "Brave, Chrome and Firefox keep their own certificate store, separate \
+             from the system store, so they show HTTPS warnings on .test sites \
+             until the CA is added there."
                 .to_owned(),
             "yerd elevate trust",
         )),
         Some(BrowserTrust::ToolMissing) => out.push(warn(
             DiagnosisCode::CaNotTrustedByBrowsers,
             "Can't establish browser trust (certutil missing)",
-            "Browsers won't trust the local CA until certutil is available. Install \
-             libnss3-tools (Debian/Ubuntu/Zorin), nss-tools (Fedora) or nss (Arch), \
-             then run trust again."
+            "Browsers won't trust the local CA until certutil is installed: \
+             libnss3-tools (Debian/Ubuntu/Zorin), nss-tools (Fedora), nss (Arch), \
+             or `brew install nss` (macOS). Install it, then run trust again."
                 .to_owned(),
-            "sudo apt install libnss3-tools",
+            "yerd elevate trust",
         )),
         _ => {}
     }
@@ -755,11 +755,10 @@ mod tests {
             .into_iter()
             .find(|d| d.code == DiagnosisCode::CaNotTrustedByBrowsers)
             .expect("tool-missing warns");
-        assert!(d
-            .remedy
-            .as_deref()
-            .unwrap_or_default()
-            .contains("libnss3-tools"));
+        // The doctor is pure and cannot detect the host OS, so the hint is
+        // distro/OS-neutral: it names the tool and covers Linux and macOS.
+        assert!(d.detail.contains("certutil"));
+        assert!(d.detail.contains("brew install nss"));
     }
 
     #[test]

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -16,7 +16,9 @@
 #![forbid(unsafe_code)]
 
 use yerd_core::PhpVersion;
-use yerd_ipc::{Diagnosis, DiagnosisCode, PoolRunState, ServiceRunState, Severity, StatusReport};
+use yerd_ipc::{
+    BrowserTrust, Diagnosis, DiagnosisCode, PoolRunState, ServiceRunState, Severity, StatusReport,
+};
 
 /// Ports below this are privileged (need elevation to bind).
 const PRIVILEGED_PORT_CEILING: u16 = 1024;
@@ -94,6 +96,27 @@ fn trust_findings(report: &StatusReport) -> Vec<Diagnosis> {
             "HTTPS sites will show certificate warnings until the CA is trusted.".to_owned(),
             "sudo yerd elevate trust",
         ));
+    }
+    match report.ca.browser_trust {
+        Some(BrowserTrust::Untrusted) => out.push(warn(
+            DiagnosisCode::CaNotTrustedByBrowsers,
+            "Browsers don't trust the local CA",
+            "Brave, Chrome and Firefox keep their own certificate store on Linux \
+             (separate from the system store), so they show HTTPS warnings on \
+             .test sites until the CA is added there."
+                .to_owned(),
+            "yerd elevate trust",
+        )),
+        Some(BrowserTrust::ToolMissing) => out.push(warn(
+            DiagnosisCode::CaNotTrustedByBrowsers,
+            "Can't establish browser trust (certutil missing)",
+            "Browsers won't trust the local CA until certutil is available. Install \
+             libnss3-tools (Debian/Ubuntu/Zorin), nss-tools (Fedora) or nss (Arch), \
+             then run trust again."
+                .to_owned(),
+            "sudo apt install libnss3-tools",
+        )),
+        _ => {}
     }
     if report.ca.php_trusts_ca == Some(false) {
         out.push(warn(
@@ -434,6 +457,7 @@ mod tests {
                 fingerprint: "ab".repeat(32),
                 trusted_system: Some(true),
                 php_trusts_ca: Some(true),
+                browser_trust: Some(BrowserTrust::Trusted),
             },
             resolver_installed: Some(true),
             port_redirect: None,
@@ -710,6 +734,41 @@ mod tests {
         let cs = codes(&diagnose(&r, None));
         assert!(cs.contains(&DiagnosisCode::CaNotTrusted));
         assert!(cs.contains(&DiagnosisCode::ResolverNotInstalled));
+    }
+
+    #[test]
+    fn browser_untrusted_warns() {
+        let mut r = healthy();
+        r.ca.browser_trust = Some(BrowserTrust::Untrusted);
+        let ds = diagnose(&r, None);
+        assert!(ds.iter().any(
+            |d| d.code == DiagnosisCode::CaNotTrustedByBrowsers && d.severity == Severity::Warn
+        ));
+        assert!(!is_auto_fixable(DiagnosisCode::CaNotTrustedByBrowsers));
+    }
+
+    #[test]
+    fn browser_tool_missing_warns_with_install_hint() {
+        let mut r = healthy();
+        r.ca.browser_trust = Some(BrowserTrust::ToolMissing);
+        let d = diagnose(&r, None)
+            .into_iter()
+            .find(|d| d.code == DiagnosisCode::CaNotTrustedByBrowsers)
+            .expect("tool-missing warns");
+        assert!(d
+            .remedy
+            .as_deref()
+            .unwrap_or_default()
+            .contains("libnss3-tools"));
+    }
+
+    #[test]
+    fn browser_trusted_or_unknown_is_silent() {
+        let mut r = healthy();
+        r.ca.browser_trust = Some(BrowserTrust::Trusted);
+        assert!(!codes(&diagnose(&r, None)).contains(&DiagnosisCode::CaNotTrustedByBrowsers));
+        r.ca.browser_trust = None;
+        assert!(!codes(&diagnose(&r, None)).contains(&DiagnosisCode::CaNotTrustedByBrowsers));
     }
 
     #[test]

--- a/crates/yerd-ipc/src/lib.rs
+++ b/crates/yerd-ipc/src/lib.rs
@@ -51,11 +51,11 @@ pub use response::{
     WordPressAdminUser,
 };
 pub use status::{
-    AddableServiceType, CaStatus, CloudflaredSource, CloudflaredStatus, DatabaseSummary, Diagnosis,
-    DiagnosisCode, DomainShadow, FixReport, FixResult, MailAttachment, MailDetail, MailHeader,
-    MailStatus, MailSummary, NamedTunnelMeta, PhpPoolStatus, PoolRunState, PortStatus,
-    ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts, SiteHostname,
-    StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UnboundWeb,
+    AddableServiceType, BrowserTrust, CaStatus, CloudflaredSource, CloudflaredStatus,
+    DatabaseSummary, Diagnosis, DiagnosisCode, DomainShadow, FixReport, FixResult, MailAttachment,
+    MailDetail, MailHeader, MailStatus, MailSummary, NamedTunnelMeta, PhpPoolStatus, PoolRunState,
+    PortStatus, ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts,
+    SiteHostname, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UnboundWeb,
     WordPressVersionInfo,
 };
 pub use update::{Channel, StagedArtifact, UpdateSource};

--- a/crates/yerd-ipc/src/request.rs
+++ b/crates/yerd-ipc/src/request.rs
@@ -762,6 +762,14 @@ pub enum Request {
     /// the setup URL + the CA fingerprint (for out-of-band verification). Only
     /// valid while LAN mode is up; otherwise the daemon returns an error.
     MintRemoteSetupCode,
+    /// Install (or remove) the Yerd CA into the per-user **browser** NSS stores
+    /// (`~/.pki/nssdb`, Firefox profiles, Snap/Flatpak). Runs unprivileged as
+    /// the daemon's user; the CA PEM is read from disk daemon-side, so it is
+    /// **not** carried on the wire. Reported back via [`crate::Response::BrowserTrust`].
+    TrustBrowsers {
+        /// `true` removes the CA from the NSS stores; `false` installs it.
+        uninstall: bool,
+    },
 }
 
 #[cfg(test)]
@@ -896,6 +904,7 @@ mod variant_name_pinning {
             Request::SetMcpEnabled { .. } => {}
             Request::SetLanEnabled { .. } => {}
             Request::MintRemoteSetupCode => {}
+            Request::TrustBrowsers { .. } => {}
         }
     }
 

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -384,6 +384,18 @@ pub enum Response {
         /// map is ungrouped ("Unallocated").
         members: BTreeMap<String, String>,
     },
+    /// Reply to [`crate::Request::TrustBrowsers`] - the per-user browser NSS
+    /// trust outcome.
+    BrowserTrust {
+        /// Number of NSS databases attempted (0 when nothing was found or
+        /// `certutil` is missing).
+        attempted: usize,
+        /// Of those attempted, how many succeeded.
+        succeeded: usize,
+        /// `certutil` (`libnss3-tools`) was not installed, so nothing was
+        /// changed - the client should tell the user to install it.
+        certutil_missing: bool,
+    },
 }
 
 /// One registered custom PHP extension (see [`Response::PhpExtensions`]).
@@ -617,6 +629,7 @@ mod variant_name_pinning {
             Response::Tunnels { .. } => {}
             Response::NamedTunnels { .. } => {}
             Response::Groups { .. } => {}
+            Response::BrowserTrust { .. } => {}
             Response::Proxies { .. } => {}
         }
     }
@@ -717,6 +730,7 @@ mod variant_name_pinning {
                     fingerprint: "ab".repeat(32),
                     trusted_system: Some(false),
                     php_trusts_ca: None,
+                    browser_trust: None,
                 },
                 resolver_installed: None,
                 port_redirect: None,

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -337,6 +337,30 @@ pub struct CaStatus {
     /// older clients/daemons.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub php_trusts_ca: Option<bool>,
+    /// Whether the per-user **browser** NSS stores (Brave/Chrome/Chromium/Edge
+    /// and Firefox) trust the Yerd CA. On Linux these are independent of the
+    /// system store, so a CA can be `trusted_system` yet not trusted here.
+    /// `None` = probe not applicable/not run. `#[serde(default, skip_serializing_if)]`
+    /// keeps the wire additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub browser_trust: Option<BrowserTrust>,
+}
+
+/// Whether the per-user browser NSS stores trust the Yerd CA
+/// ([`CaStatus::browser_trust`]). Mirrors `yerd_platform::BrowserCaTrust`
+/// (this crate does not depend on `yerd-platform`); the daemon maps between
+/// them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BrowserTrust {
+    /// The CA is trusted (or there are no browser NSS stores to worry about).
+    Trusted,
+    /// Browser NSS stores exist but do not trust the CA - run the trust flow.
+    Untrusted,
+    /// `certutil` (`libnss3-tools`) is not installed, so browser trust can
+    /// neither be verified nor established.
+    ToolMissing,
 }
 
 /// Site counts by kind, for [`StatusReport`].
@@ -588,6 +612,11 @@ pub enum DiagnosisCode {
     DnsPortUnbound,
     /// The local CA is not trusted in the system store.
     CaNotTrusted,
+    /// The local CA is not trusted by the per-user **browser** NSS stores
+    /// (Brave/Chrome/Chromium/Edge/Firefox on Linux use these instead of the
+    /// system store), or `certutil` (`libnss3-tools`) is missing so browser
+    /// trust cannot be established. See [`CaStatus::browser_trust`].
+    CaNotTrustedByBrowsers,
     /// The OS resolver does not route `*.<tld>` to Yerd.
     ResolverNotInstalled,
     /// No PHP versions are installed.

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -209,6 +209,7 @@ fn encode_then_decode_response_roundtrip() {
                 fingerprint: "ab".repeat(32),
                 trusted_system: None,
                 php_trusts_ca: Some(true),
+                browser_trust: Some(yerd_ipc::BrowserTrust::Untrusted),
             },
             resolver_installed: Some(false),
             port_redirect: Some(true),

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -61,6 +61,44 @@ fn request_mint_remote_setup_code_byte_shape() {
 }
 
 #[test]
+fn request_trust_browsers_byte_shape() {
+    let s = serde_json::to_string(&Request::TrustBrowsers { uninstall: false }).unwrap();
+    assert_eq!(s, r#"{"type":"trust_browsers","uninstall":false}"#);
+    let back: Request = serde_json::from_str(&s).unwrap();
+    assert_eq!(back, Request::TrustBrowsers { uninstall: false });
+}
+
+#[test]
+fn response_browser_trust_byte_shape() {
+    let r = Response::BrowserTrust {
+        attempted: 3,
+        succeeded: 2,
+        certutil_missing: false,
+    };
+    let s = serde_json::to_string(&r).unwrap();
+    assert_eq!(
+        s,
+        r#"{"type":"browser_trust","attempted":3,"succeeded":2,"certutil_missing":false}"#
+    );
+    let back: Response = serde_json::from_str(&s).unwrap();
+    assert_eq!(back, r);
+}
+
+#[test]
+fn browser_trust_enum_byte_shape() {
+    for (v, tag) in [
+        (yerd_ipc::BrowserTrust::Trusted, "trusted"),
+        (yerd_ipc::BrowserTrust::Untrusted, "untrusted"),
+        (yerd_ipc::BrowserTrust::ToolMissing, "tool_missing"),
+    ] {
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, format!("\"{tag}\""));
+        let back: yerd_ipc::BrowserTrust = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
 fn response_remote_setup_byte_shape() {
     let r = Response::RemoteSetup {
         code: "deadbeef".into(),
@@ -950,6 +988,7 @@ fn response_status_byte_shape() {
                 fingerprint: "ab".repeat(32),
                 trusted_system: Some(false),
                 php_trusts_ca: None,
+                browser_trust: None,
             },
             resolver_installed: Some(true),
             port_redirect: None,
@@ -1067,6 +1106,7 @@ fn sample_status_report() -> StatusReport {
             fingerprint: "ab".repeat(32),
             trusted_system: Some(true),
             php_trusts_ca: None,
+            browser_trust: None,
         },
         resolver_installed: Some(true),
         port_redirect: None,

--- a/crates/yerd-mcp/tests/render.rs
+++ b/crates/yerd-mcp/tests/render.rs
@@ -80,6 +80,7 @@ fn sample_report() -> yerd_ipc::StatusReport {
             fingerprint: "ab".repeat(32),
             trusted_system: Some(true),
             php_trusts_ca: None,
+            browser_trust: None,
         },
         resolver_installed: Some(true),
         port_redirect: None,

--- a/crates/yerd-platform/src/error.rs
+++ b/crates/yerd-platform/src/error.rs
@@ -186,8 +186,12 @@ pub mod ops {
     pub const INSTALL_CA: &str = "install-ca";
     /// System trust-store uninstall.
     pub const UNINSTALL_CA: &str = "uninstall-ca";
-    /// Per-user Firefox/NSS trust-store install.
+    /// Per-user browser (Chromium/Firefox) NSS trust-store install.
     pub const INSTALL_FIREFOX_NSS: &str = "install-firefox-nss";
+    /// Per-user browser (Chromium/Firefox) NSS trust-store uninstall.
+    pub const UNINSTALL_FIREFOX_NSS: &str = "uninstall-firefox-nss";
+    /// Per-user browser NSS effective-trust probe.
+    pub const BROWSER_CA_TRUST: &str = "browser-ca-trust";
     /// System trust-store presence probe.
     pub const IS_PRESENT_SYSTEM: &str = "is-present-system";
     /// Effective-trust probe (trusted, not merely present).

--- a/crates/yerd-platform/src/lib.rs
+++ b/crates/yerd-platform/src/lib.rs
@@ -28,6 +28,7 @@ pub mod error;
 pub mod helper;
 pub mod lan_ip;
 pub mod metrics;
+pub mod nss_exec;
 pub mod paths;
 pub mod port_binder;
 pub mod port_redirect;
@@ -46,7 +47,9 @@ pub use paths::{Paths, PlatformDirs};
 pub use port_binder::{BoundPort, PortBinder, PortPair};
 pub use port_redirect::PortRedirector;
 pub use resolver::ResolverInstaller;
-pub use trust_store::{CaFingerprint, FingerprintParseError, NssFailure, NssOutcome, TrustStore};
+pub use trust_store::{
+    BrowserCaTrust, CaFingerprint, FingerprintParseError, NssFailure, NssOutcome, TrustStore,
+};
 
 pub use os::active::{
     ActivePaths, ActivePortBinder, ActivePortRedirector, ActiveResolverInstaller,

--- a/crates/yerd-platform/src/nss_exec.rs
+++ b/crates/yerd-platform/src/nss_exec.rs
@@ -1,0 +1,542 @@
+//! Per-user NSS trust orchestration, shared by the Linux and macOS impls.
+//!
+//! The side effects - running `certutil` and probing the filesystem - are
+//! injected behind [`CertutilRunner`] and [`NssFs`], so the discover -> argv ->
+//! run -> aggregate logic is unit-tested in-memory with fakes (the definition
+//! of done requires every side-effecting path be behind a trait and tested with
+//! a fake). The real impls ([`RealCertutil`], [`RealNssFs`]) live under
+//! `#[cfg(unix)]` and are the thin edge.
+//!
+//! Path derivation and the `certutil` argv are pure ([`crate::pure::nss`]).
+
+use std::path::{Path, PathBuf};
+
+use crate::pure::nss::{self, NssDb};
+use crate::trust_store::{BrowserCaTrust, CaFingerprint, NssFailure, NssOutcome};
+
+/// Result of one `certutil` invocation.
+pub struct RunResult {
+    /// Process exit code (`-1` if terminated by signal).
+    pub code: i32,
+    /// Captured stdout (used for the `-L -a` PEM readback).
+    pub stdout: Vec<u8>,
+}
+
+impl RunResult {
+    fn ok(&self) -> bool {
+        self.code == 0
+    }
+}
+
+/// Runs `certutil`. Injected so orchestration is testable without the binary.
+pub trait CertutilRunner {
+    /// Whether `certutil` is installed and runnable.
+    fn available(&self) -> bool;
+    /// Run `certutil` with `args`.
+    fn run(&self, args: &[String]) -> RunResult;
+}
+
+/// Filesystem probes the orchestration needs. Injected for testing.
+pub trait NssFs {
+    /// The invoking user's home directory (from `$HOME`; never `SUDO_*`).
+    fn home(&self) -> Option<PathBuf>;
+    /// Whether `path` is an existing directory.
+    fn dir_exists(&self, path: &Path) -> bool;
+    /// Whether `path` is an existing file.
+    fn file_exists(&self, path: &Path) -> bool;
+    /// Immediate sub-directory names of `dir` (empty if `dir` is absent).
+    fn list_subdirs(&self, dir: &Path) -> Vec<String>;
+    /// Read a file to a `String`, or `None` if absent/unreadable.
+    fn read_to_string(&self, path: &Path) -> Option<String>;
+    /// Create `dir` and parents (mode 0700 on the real impl).
+    fn create_dir_all(&self, dir: &Path) -> std::io::Result<()>;
+}
+
+fn empty_outcome() -> NssOutcome {
+    NssOutcome {
+        profiles_attempted: 0,
+        profiles_succeeded: 0,
+        failures: vec![],
+        certutil_missing: false,
+    }
+}
+
+/// Discover every existing sql NSS database: the shared `~/.pki/nssdb`
+/// (native + Snap + Flatpak) plus every Firefox profile containing a
+/// `cert9.db`. Read-only; does not create anything.
+fn discover(fs: &impl NssFs, home: &Path) -> Vec<NssDb> {
+    let snap_apps = fs.list_subdirs(&home.join("snap"));
+    let flatpak_apps = fs.list_subdirs(&home.join(".var/app"));
+
+    let mut dbs: Vec<NssDb> = Vec::new();
+    let push = |db: NssDb, dbs: &mut Vec<NssDb>| {
+        if !dbs.contains(&db) {
+            dbs.push(db);
+        }
+    };
+
+    for dir in nss::pki_nssdb_candidates(home, &snap_apps, &flatpak_apps) {
+        if fs.dir_exists(&dir) {
+            push(NssDb::Sql(dir), &mut dbs);
+        }
+    }
+    for root in nss::firefox_root_candidates(home, &snap_apps, &flatpak_apps) {
+        let Some(ini) = fs.read_to_string(&root.join("profiles.ini")) else {
+            continue;
+        };
+        for profile in nss::firefox_profile_dirs(&root, &ini) {
+            if fs.file_exists(&profile.join("cert9.db")) {
+                push(NssDb::Sql(profile), &mut dbs);
+            }
+        }
+    }
+    dbs
+}
+
+/// Install the CA (PEM at `ca_path`) into every browser NSS database,
+/// creating and initialising `~/.pki/nssdb` first if it is absent (so a
+/// browser installed-but-never-launched still trusts the CA on first run).
+pub fn install(fs: &impl NssFs, runner: &impl CertutilRunner, ca_path: &Path) -> NssOutcome {
+    if !runner.available() {
+        return NssOutcome {
+            certutil_missing: true,
+            ..empty_outcome()
+        };
+    }
+    let Some(home) = fs.home() else {
+        return empty_outcome();
+    };
+
+    let pki = nss::pki_nssdb_dir(&home);
+    if !fs.dir_exists(&pki) && fs.create_dir_all(&pki).is_ok() {
+        let _ = runner.run(&nss::init_args(&pki));
+    }
+
+    let mut out = empty_outcome();
+    for db in discover(fs, &home) {
+        let _ = runner.run(&nss::delete_args(&db));
+        let res = runner.run(&nss::add_args(&db, ca_path));
+        out.profiles_attempted += 1;
+        if res.ok() {
+            out.profiles_succeeded += 1;
+        } else {
+            out.failures
+                .push((db.dir().to_path_buf(), NssFailure::CertutilExit(res.code)));
+        }
+    }
+    out
+}
+
+/// Remove the Yerd CA from every discovered browser NSS database.
+pub fn uninstall(fs: &impl NssFs, runner: &impl CertutilRunner) -> NssOutcome {
+    if !runner.available() {
+        return NssOutcome {
+            certutil_missing: true,
+            ..empty_outcome()
+        };
+    }
+    let Some(home) = fs.home() else {
+        return empty_outcome();
+    };
+
+    let mut out = empty_outcome();
+    for db in discover(fs, &home) {
+        let res = runner.run(&nss::delete_args(&db));
+        out.profiles_attempted += 1;
+        // A missing entry (nothing to delete) exits non-zero but is success
+        // for our purposes; treat any non-crash exit as removed.
+        out.profiles_succeeded += 1;
+        let _ = res;
+    }
+    out
+}
+
+/// Whether the browser NSS stores trust the CA with fingerprint `fp`.
+pub fn browser_trust(
+    fs: &impl NssFs,
+    runner: &impl CertutilRunner,
+    fp: &CaFingerprint,
+) -> BrowserCaTrust {
+    let Some(home) = fs.home() else {
+        return BrowserCaTrust::Trusted;
+    };
+    let dbs = discover(fs, &home);
+    if dbs.is_empty() {
+        // No browser NSS store exists - nothing to trust, so don't nag.
+        return BrowserCaTrust::Trusted;
+    }
+    if !runner.available() {
+        return BrowserCaTrust::ToolMissing;
+    }
+    for db in &dbs {
+        let res = runner.run(&nss::list_pem_args(db));
+        if !res.ok() {
+            continue;
+        }
+        let Ok(pem) = String::from_utf8(res.stdout) else {
+            continue;
+        };
+        if CaFingerprint::from_pem(&pem).as_ref() == Some(fp) {
+            return BrowserCaTrust::Trusted;
+        }
+    }
+    BrowserCaTrust::Untrusted
+}
+
+// ---- real (edge) impls ----------------------------------------------------
+
+#[cfg(unix)]
+pub use real::{real_browser_trust, real_install, real_uninstall};
+
+#[cfg(unix)]
+mod real {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    use super::{CertutilRunner, NssFs, RunResult};
+    use crate::trust_store::{BrowserCaTrust, CaFingerprint, NssOutcome};
+
+    /// `certutil` located at an absolute path (resolved once). Absolute-path
+    /// resolution mirrors the `/usr/bin/id` / `/bin/ps` precedent - a stripped
+    /// `PATH` under a service manager must not hide the tool.
+    struct RealCertutil {
+        path: Option<PathBuf>,
+    }
+
+    impl RealCertutil {
+        fn resolve() -> Self {
+            let common = Path::new("/usr/bin/certutil");
+            if common.is_file() {
+                return Self {
+                    path: Some(common.to_path_buf()),
+                };
+            }
+            let path = std::env::var_os("PATH").and_then(|paths| {
+                std::env::split_paths(&paths)
+                    .map(|dir| dir.join("certutil"))
+                    .find(|candidate| candidate.is_file())
+            });
+            Self { path }
+        }
+    }
+
+    impl CertutilRunner for RealCertutil {
+        fn available(&self) -> bool {
+            self.path.is_some()
+        }
+
+        fn run(&self, args: &[String]) -> RunResult {
+            let Some(bin) = self.path.as_ref() else {
+                return RunResult {
+                    code: -1,
+                    stdout: Vec::new(),
+                };
+            };
+            match Command::new(bin).args(args).output() {
+                Ok(out) => RunResult {
+                    code: out.status.code().unwrap_or(-1),
+                    stdout: out.stdout,
+                },
+                Err(_) => RunResult {
+                    code: -1,
+                    stdout: Vec::new(),
+                },
+            }
+        }
+    }
+
+    struct RealNssFs;
+
+    impl NssFs for RealNssFs {
+        fn home(&self) -> Option<PathBuf> {
+            std::env::var_os("HOME").map(PathBuf::from)
+        }
+
+        fn dir_exists(&self, path: &Path) -> bool {
+            path.is_dir()
+        }
+
+        fn file_exists(&self, path: &Path) -> bool {
+            path.is_file()
+        }
+
+        fn list_subdirs(&self, dir: &Path) -> Vec<String> {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return Vec::new();
+            };
+            entries
+                .flatten()
+                .filter(|e| e.path().is_dir())
+                .filter_map(|e| e.file_name().into_string().ok())
+                .collect()
+        }
+
+        fn read_to_string(&self, path: &Path) -> Option<String> {
+            std::fs::read_to_string(path).ok()
+        }
+
+        fn create_dir_all(&self, dir: &Path) -> std::io::Result<()> {
+            std::fs::create_dir_all(dir)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+            }
+            Ok(())
+        }
+    }
+
+    /// Install the CA at `ca_path` into every per-user browser NSS store.
+    #[must_use]
+    pub fn real_install(ca_path: &Path) -> NssOutcome {
+        super::install(&RealNssFs, &RealCertutil::resolve(), ca_path)
+    }
+
+    /// Remove the Yerd CA from every per-user browser NSS store.
+    #[must_use]
+    pub fn real_uninstall() -> NssOutcome {
+        super::uninstall(&RealNssFs, &RealCertutil::resolve())
+    }
+
+    /// Probe whether browsers trust the CA with fingerprint `fp`.
+    #[must_use]
+    pub fn real_browser_trust(fp: &CaFingerprint) -> BrowserCaTrust {
+        super::browser_trust(&RealNssFs, &RealCertutil::resolve(), fp)
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::{HashMap, HashSet};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeFs {
+        home: Option<PathBuf>,
+        dirs: HashSet<PathBuf>,
+        files: HashMap<PathBuf, String>,
+        created: RefCell<Vec<PathBuf>>,
+    }
+
+    impl NssFs for FakeFs {
+        fn home(&self) -> Option<PathBuf> {
+            self.home.clone()
+        }
+        fn dir_exists(&self, path: &Path) -> bool {
+            self.dirs.contains(path)
+        }
+        fn file_exists(&self, path: &Path) -> bool {
+            self.files.contains_key(path)
+        }
+        fn list_subdirs(&self, dir: &Path) -> Vec<String> {
+            self.dirs
+                .iter()
+                .filter_map(|d| d.parent().filter(|p| *p == dir).and(d.file_name()))
+                .filter_map(|n| n.to_str().map(str::to_owned))
+                .collect()
+        }
+        fn read_to_string(&self, path: &Path) -> Option<String> {
+            self.files.get(path).cloned()
+        }
+        fn create_dir_all(&self, dir: &Path) -> std::io::Result<()> {
+            self.created.borrow_mut().push(dir.to_path_buf());
+            Ok(())
+        }
+    }
+
+    struct FakeRunner {
+        available: bool,
+        calls: RefCell<Vec<Vec<String>>>,
+        list_pem: Option<String>,
+        add_fails: bool,
+    }
+
+    impl FakeRunner {
+        fn new(available: bool) -> Self {
+            Self {
+                available,
+                calls: RefCell::new(vec![]),
+                list_pem: None,
+                add_fails: false,
+            }
+        }
+    }
+
+    impl CertutilRunner for FakeRunner {
+        fn available(&self) -> bool {
+            self.available
+        }
+        fn run(&self, args: &[String]) -> RunResult {
+            self.calls.borrow_mut().push(args.to_vec());
+            if args.iter().any(|a| a == "-L") {
+                return match &self.list_pem {
+                    Some(pem) => RunResult {
+                        code: 0,
+                        stdout: pem.clone().into_bytes(),
+                    },
+                    None => RunResult {
+                        code: 255,
+                        stdout: vec![],
+                    },
+                };
+            }
+            if args.iter().any(|a| a == "-A") && self.add_fails {
+                return RunResult {
+                    code: 255,
+                    stdout: vec![],
+                };
+            }
+            RunResult {
+                code: 0,
+                stdout: vec![],
+            }
+        }
+    }
+
+    fn home() -> PathBuf {
+        PathBuf::from("/home/alice")
+    }
+
+    fn fs_with_pki() -> FakeFs {
+        let mut fs = FakeFs {
+            home: Some(home()),
+            ..FakeFs::default()
+        };
+        fs.dirs.insert(home().join(".pki/nssdb"));
+        fs
+    }
+
+    #[test]
+    fn install_missing_certutil_flags_it() {
+        let out = install(
+            &fs_with_pki(),
+            &FakeRunner::new(false),
+            Path::new("/ca.pem"),
+        );
+        assert!(out.certutil_missing);
+        assert_eq!(out.profiles_attempted, 0);
+    }
+
+    #[test]
+    fn install_adds_to_existing_pki_with_delete_then_add() {
+        let fs = fs_with_pki();
+        let runner = FakeRunner::new(true);
+        let out = install(&fs, &runner, Path::new("/ca.pem"));
+        assert_eq!(out.profiles_attempted, 1);
+        assert_eq!(out.profiles_succeeded, 1);
+        let calls = runner.calls.borrow();
+        // delete precedes add for idempotency.
+        let del = calls.iter().position(|c| c.contains(&"-D".to_owned()));
+        let add = calls.iter().position(|c| c.contains(&"-A".to_owned()));
+        assert!(del < add);
+    }
+
+    #[test]
+    fn install_creates_and_inits_absent_pki() {
+        let fs = FakeFs {
+            home: Some(home()),
+            ..FakeFs::default()
+        };
+        let runner = FakeRunner::new(true);
+        let _ = install(&fs, &runner, Path::new("/ca.pem"));
+        assert_eq!(fs.created.borrow().as_slice(), &[home().join(".pki/nssdb")]);
+        assert!(runner
+            .calls
+            .borrow()
+            .iter()
+            .any(|c| c.contains(&"-N".to_owned())));
+    }
+
+    #[test]
+    fn install_records_failure_exit() {
+        let fs = fs_with_pki();
+        let mut runner = FakeRunner::new(true);
+        runner.add_fails = true;
+        let out = install(&fs, &runner, Path::new("/ca.pem"));
+        assert_eq!(out.profiles_succeeded, 0);
+        assert_eq!(out.failures.len(), 1);
+    }
+
+    #[test]
+    fn discover_finds_firefox_profile_with_cert9() {
+        let mut fs = FakeFs {
+            home: Some(home()),
+            ..FakeFs::default()
+        };
+        let ff_root = home().join(".mozilla/firefox");
+        fs.files.insert(
+            ff_root.join("profiles.ini"),
+            "[Profile0]\nIsRelative=1\nPath=abc.default\n".to_owned(),
+        );
+        fs.files
+            .insert(ff_root.join("abc.default/cert9.db"), String::new());
+        let runner = FakeRunner::new(true);
+        let out = install(&fs, &runner, Path::new("/ca.pem"));
+        assert_eq!(out.profiles_attempted, 1);
+    }
+
+    #[test]
+    fn browser_trust_none_when_no_dbs() {
+        let fs = FakeFs {
+            home: Some(home()),
+            ..FakeFs::default()
+        };
+        let fp = CaFingerprint::new([7u8; 32]);
+        assert_eq!(
+            browser_trust(&fs, &FakeRunner::new(true), &fp),
+            BrowserCaTrust::Trusted
+        );
+    }
+
+    #[test]
+    fn browser_trust_tool_missing_when_db_exists_but_no_certutil() {
+        let fp = CaFingerprint::new([7u8; 32]);
+        assert_eq!(
+            browser_trust(&fs_with_pki(), &FakeRunner::new(false), &fp),
+            BrowserCaTrust::ToolMissing
+        );
+    }
+
+    #[test]
+    fn browser_trust_untrusted_when_absent() {
+        let fp = CaFingerprint::new([7u8; 32]);
+        assert_eq!(
+            browser_trust(&fs_with_pki(), &FakeRunner::new(true), &fp),
+            BrowserCaTrust::Untrusted
+        );
+    }
+
+    #[test]
+    fn browser_trust_trusted_on_fingerprint_match() {
+        // Build a real self-signed CA so its PEM fingerprint round-trips.
+        let pem = sample_ca_pem();
+        let fp = CaFingerprint::from_pem(&pem).unwrap();
+        let mut runner = FakeRunner::new(true);
+        runner.list_pem = Some(pem);
+        assert_eq!(
+            browser_trust(&fs_with_pki(), &runner, &fp),
+            BrowserCaTrust::Trusted
+        );
+    }
+
+    fn sample_ca_pem() -> String {
+        // A throwaway PEM; fingerprint identity is over its DER, so any real
+        // cert works. Reuse yerd-tls to mint one.
+        let now = time::OffsetDateTime::now_utc();
+        let v =
+            yerd_tls::Validity::new(now - time::Duration::days(1), now + time::Duration::days(1))
+                .unwrap();
+        yerd_tls::CertAuthority::generate("Sample CA", v)
+            .unwrap()
+            .cert_pem()
+            .to_owned()
+    }
+}

--- a/crates/yerd-platform/src/nss_exec.rs
+++ b/crates/yerd-platform/src/nss_exec.rs
@@ -149,7 +149,9 @@ pub fn install(
     out
 }
 
-/// Remove the Yerd CA from every discovered browser NSS database.
+/// Remove the Yerd CA from every discovered browser NSS database. Deleting a
+/// missing entry exits non-zero (nothing to remove) and still counts as a
+/// success; only a spawn failure (code `-1`) counts as a failure.
 pub fn uninstall(fs: &impl NssFs, runner: &impl CertutilRunner, os: Os) -> NssOutcome {
     if !runner.available() {
         return NssOutcome {
@@ -165,8 +167,6 @@ pub fn uninstall(fs: &impl NssFs, runner: &impl CertutilRunner, os: Os) -> NssOu
     for db in discover(fs, &home, os) {
         let res = runner.run(&nss::delete_args(&db));
         out.profiles_attempted += 1;
-        // Deleting a missing entry exits non-zero (nothing to remove) - still a
-        // success for us. Only a spawn failure (code -1) counts as a failure.
         if res.code == -1 {
             out.failures
                 .push((db.dir().to_path_buf(), NssFailure::CertutilExit(res.code)));
@@ -195,7 +195,8 @@ fn db_trusts(runner: &impl CertutilRunner, db: &NssDb, fp: &CaFingerprint) -> bo
 /// Requires **every** discovered store to trust it: a single untrusted store
 /// (e.g. a Firefox profile created after the last trust run) yields `Untrusted`
 /// so the doctor warning fires rather than being masked by another store that
-/// happens to trust the CA.
+/// happens to trust the CA. When no browser NSS store exists there is nothing
+/// to trust, so it reports `Trusted` (no false-alarm nag).
 pub fn browser_trust(
     fs: &impl NssFs,
     runner: &impl CertutilRunner,
@@ -207,7 +208,6 @@ pub fn browser_trust(
     };
     let dbs = discover(fs, &home, os);
     if dbs.is_empty() {
-        // No browser NSS store exists - nothing to trust, so don't nag.
         return BrowserCaTrust::Trusted;
     }
     if !runner.available() {

--- a/crates/yerd-platform/src/nss_exec.rs
+++ b/crates/yerd-platform/src/nss_exec.rs
@@ -61,13 +61,19 @@ fn empty_outcome() -> NssOutcome {
     }
 }
 
-/// Discover every existing sql NSS database: the shared `~/.pki/nssdb`
-/// (native + Snap + Flatpak) plus every Firefox profile containing a
-/// `cert9.db`. Read-only; does not create anything.
-fn discover(fs: &impl NssFs, home: &Path) -> Vec<NssDb> {
-    let snap_apps = fs.list_subdirs(&home.join("snap"));
-    let flatpak_apps = fs.list_subdirs(&home.join(".var/app"));
+/// The platforms whose per-user NSS layout differs. On Linux, Chromium-family
+/// browsers use `~/.pki/nssdb`; on macOS they use the system keychain, so only
+/// Firefox has an NSS store there - under a different profile root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Os {
+    /// Linux/other Unix: `~/.pki/nssdb` + `~/.mozilla/firefox` + Snap/Flatpak.
+    Linux,
+    /// macOS: Firefox only, under `~/Library/Application Support/Firefox`.
+    Macos,
+}
 
+/// Discover every existing sql NSS database for `os`. Read-only; creates nothing.
+fn discover(fs: &impl NssFs, home: &Path, os: Os) -> Vec<NssDb> {
     let mut dbs: Vec<NssDb> = Vec::new();
     let push = |db: NssDb, dbs: &mut Vec<NssDb>| {
         if !dbs.contains(&db) {
@@ -75,12 +81,20 @@ fn discover(fs: &impl NssFs, home: &Path) -> Vec<NssDb> {
         }
     };
 
-    for dir in nss::pki_nssdb_candidates(home, &snap_apps, &flatpak_apps) {
-        if fs.dir_exists(&dir) {
-            push(NssDb::Sql(dir), &mut dbs);
+    let firefox_roots = match os {
+        Os::Linux => {
+            let snap_apps = fs.list_subdirs(&home.join("snap"));
+            let flatpak_apps = fs.list_subdirs(&home.join(".var/app"));
+            for dir in nss::pki_nssdb_candidates(home, &snap_apps, &flatpak_apps) {
+                if fs.dir_exists(&dir) {
+                    push(NssDb::Sql(dir), &mut dbs);
+                }
+            }
+            nss::firefox_root_candidates(home, &snap_apps, &flatpak_apps)
         }
-    }
-    for root in nss::firefox_root_candidates(home, &snap_apps, &flatpak_apps) {
+        Os::Macos => vec![nss::macos_firefox_root(home)],
+    };
+    for root in firefox_roots {
         let Some(ini) = fs.read_to_string(&root.join("profiles.ini")) else {
             continue;
         };
@@ -93,10 +107,16 @@ fn discover(fs: &impl NssFs, home: &Path) -> Vec<NssDb> {
     dbs
 }
 
-/// Install the CA (PEM at `ca_path`) into every browser NSS database,
-/// creating and initialising `~/.pki/nssdb` first if it is absent (so a
-/// browser installed-but-never-launched still trusts the CA on first run).
-pub fn install(fs: &impl NssFs, runner: &impl CertutilRunner, ca_path: &Path) -> NssOutcome {
+/// Install the CA (PEM at `ca_path`) into every browser NSS database. On Linux,
+/// the shared Chromium store `~/.pki/nssdb` is created and initialised first if
+/// absent (so a browser installed-but-never-launched still trusts the CA on
+/// first run); macOS has no such shared store.
+pub fn install(
+    fs: &impl NssFs,
+    runner: &impl CertutilRunner,
+    ca_path: &Path,
+    os: Os,
+) -> NssOutcome {
     if !runner.available() {
         return NssOutcome {
             certutil_missing: true,
@@ -107,13 +127,15 @@ pub fn install(fs: &impl NssFs, runner: &impl CertutilRunner, ca_path: &Path) ->
         return empty_outcome();
     };
 
-    let pki = nss::pki_nssdb_dir(&home);
-    if !fs.dir_exists(&pki) && fs.create_dir_all(&pki).is_ok() {
-        let _ = runner.run(&nss::init_args(&pki));
+    if os == Os::Linux {
+        let pki = nss::pki_nssdb_dir(&home);
+        if !fs.dir_exists(&pki) && fs.create_dir_all(&pki).is_ok() {
+            let _ = runner.run(&nss::init_args(&pki));
+        }
     }
 
     let mut out = empty_outcome();
-    for db in discover(fs, &home) {
+    for db in discover(fs, &home, os) {
         let _ = runner.run(&nss::delete_args(&db));
         let res = runner.run(&nss::add_args(&db, ca_path));
         out.profiles_attempted += 1;
@@ -128,7 +150,7 @@ pub fn install(fs: &impl NssFs, runner: &impl CertutilRunner, ca_path: &Path) ->
 }
 
 /// Remove the Yerd CA from every discovered browser NSS database.
-pub fn uninstall(fs: &impl NssFs, runner: &impl CertutilRunner) -> NssOutcome {
+pub fn uninstall(fs: &impl NssFs, runner: &impl CertutilRunner, os: Os) -> NssOutcome {
     if !runner.available() {
         return NssOutcome {
             certutil_missing: true,
@@ -140,27 +162,50 @@ pub fn uninstall(fs: &impl NssFs, runner: &impl CertutilRunner) -> NssOutcome {
     };
 
     let mut out = empty_outcome();
-    for db in discover(fs, &home) {
+    for db in discover(fs, &home, os) {
         let res = runner.run(&nss::delete_args(&db));
         out.profiles_attempted += 1;
-        // A missing entry (nothing to delete) exits non-zero but is success
-        // for our purposes; treat any non-crash exit as removed.
-        out.profiles_succeeded += 1;
-        let _ = res;
+        // Deleting a missing entry exits non-zero (nothing to remove) - still a
+        // success for us. Only a spawn failure (code -1) counts as a failure.
+        if res.code == -1 {
+            out.failures
+                .push((db.dir().to_path_buf(), NssFailure::CertutilExit(res.code)));
+        } else {
+            out.profiles_succeeded += 1;
+        }
     }
     out
 }
 
+/// Whether a single NSS database `db` trusts the CA with fingerprint `fp`:
+/// reads back the cert stored under our nickname and compares fingerprints.
+fn db_trusts(runner: &impl CertutilRunner, db: &NssDb, fp: &CaFingerprint) -> bool {
+    let res = runner.run(&nss::list_pem_args(db));
+    if !res.ok() {
+        return false;
+    }
+    let Ok(pem) = String::from_utf8(res.stdout) else {
+        return false;
+    };
+    CaFingerprint::from_pem(&pem).as_ref() == Some(fp)
+}
+
 /// Whether the browser NSS stores trust the CA with fingerprint `fp`.
+///
+/// Requires **every** discovered store to trust it: a single untrusted store
+/// (e.g. a Firefox profile created after the last trust run) yields `Untrusted`
+/// so the doctor warning fires rather than being masked by another store that
+/// happens to trust the CA.
 pub fn browser_trust(
     fs: &impl NssFs,
     runner: &impl CertutilRunner,
     fp: &CaFingerprint,
+    os: Os,
 ) -> BrowserCaTrust {
     let Some(home) = fs.home() else {
         return BrowserCaTrust::Trusted;
     };
-    let dbs = discover(fs, &home);
+    let dbs = discover(fs, &home, os);
     if dbs.is_empty() {
         // No browser NSS store exists - nothing to trust, so don't nag.
         return BrowserCaTrust::Trusted;
@@ -168,19 +213,11 @@ pub fn browser_trust(
     if !runner.available() {
         return BrowserCaTrust::ToolMissing;
     }
-    for db in &dbs {
-        let res = runner.run(&nss::list_pem_args(db));
-        if !res.ok() {
-            continue;
-        }
-        let Ok(pem) = String::from_utf8(res.stdout) else {
-            continue;
-        };
-        if CaFingerprint::from_pem(&pem).as_ref() == Some(fp) {
-            return BrowserCaTrust::Trusted;
-        }
+    if dbs.iter().all(|db| db_trusts(runner, db, fp)) {
+        BrowserCaTrust::Trusted
+    } else {
+        BrowserCaTrust::Untrusted
     }
-    BrowserCaTrust::Untrusted
 }
 
 // ---- real (edge) impls ----------------------------------------------------
@@ -193,8 +230,20 @@ mod real {
     use std::path::{Path, PathBuf};
     use std::process::Command;
 
-    use super::{CertutilRunner, NssFs, RunResult};
+    use super::{CertutilRunner, NssFs, Os, RunResult};
     use crate::trust_store::{BrowserCaTrust, CaFingerprint, NssOutcome};
+
+    /// The layout of the host we are running on.
+    const fn current_os() -> Os {
+        #[cfg(target_os = "macos")]
+        {
+            Os::Macos
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Os::Linux
+        }
+    }
 
     /// `certutil` located at an absolute path (resolved once). Absolute-path
     /// resolution mirrors the `/usr/bin/id` / `/bin/ps` precedent - a stripped
@@ -289,19 +338,19 @@ mod real {
     /// Install the CA at `ca_path` into every per-user browser NSS store.
     #[must_use]
     pub fn real_install(ca_path: &Path) -> NssOutcome {
-        super::install(&RealNssFs, &RealCertutil::resolve(), ca_path)
+        super::install(&RealNssFs, &RealCertutil::resolve(), ca_path, current_os())
     }
 
     /// Remove the Yerd CA from every per-user browser NSS store.
     #[must_use]
     pub fn real_uninstall() -> NssOutcome {
-        super::uninstall(&RealNssFs, &RealCertutil::resolve())
+        super::uninstall(&RealNssFs, &RealCertutil::resolve(), current_os())
     }
 
     /// Probe whether browsers trust the CA with fingerprint `fp`.
     #[must_use]
     pub fn real_browser_trust(fp: &CaFingerprint) -> BrowserCaTrust {
-        super::browser_trust(&RealNssFs, &RealCertutil::resolve(), fp)
+        super::browser_trust(&RealNssFs, &RealCertutil::resolve(), fp, current_os())
     }
 }
 
@@ -420,6 +469,7 @@ mod tests {
             &fs_with_pki(),
             &FakeRunner::new(false),
             Path::new("/ca.pem"),
+            Os::Linux,
         );
         assert!(out.certutil_missing);
         assert_eq!(out.profiles_attempted, 0);
@@ -429,7 +479,7 @@ mod tests {
     fn install_adds_to_existing_pki_with_delete_then_add() {
         let fs = fs_with_pki();
         let runner = FakeRunner::new(true);
-        let out = install(&fs, &runner, Path::new("/ca.pem"));
+        let out = install(&fs, &runner, Path::new("/ca.pem"), Os::Linux);
         assert_eq!(out.profiles_attempted, 1);
         assert_eq!(out.profiles_succeeded, 1);
         let calls = runner.calls.borrow();
@@ -446,7 +496,7 @@ mod tests {
             ..FakeFs::default()
         };
         let runner = FakeRunner::new(true);
-        let _ = install(&fs, &runner, Path::new("/ca.pem"));
+        let _ = install(&fs, &runner, Path::new("/ca.pem"), Os::Linux);
         assert_eq!(fs.created.borrow().as_slice(), &[home().join(".pki/nssdb")]);
         assert!(runner
             .calls
@@ -460,7 +510,7 @@ mod tests {
         let fs = fs_with_pki();
         let mut runner = FakeRunner::new(true);
         runner.add_fails = true;
-        let out = install(&fs, &runner, Path::new("/ca.pem"));
+        let out = install(&fs, &runner, Path::new("/ca.pem"), Os::Linux);
         assert_eq!(out.profiles_succeeded, 0);
         assert_eq!(out.failures.len(), 1);
     }
@@ -479,7 +529,7 @@ mod tests {
         fs.files
             .insert(ff_root.join("abc.default/cert9.db"), String::new());
         let runner = FakeRunner::new(true);
-        let out = install(&fs, &runner, Path::new("/ca.pem"));
+        let out = install(&fs, &runner, Path::new("/ca.pem"), Os::Linux);
         assert_eq!(out.profiles_attempted, 1);
     }
 
@@ -491,7 +541,7 @@ mod tests {
         };
         let fp = CaFingerprint::new([7u8; 32]);
         assert_eq!(
-            browser_trust(&fs, &FakeRunner::new(true), &fp),
+            browser_trust(&fs, &FakeRunner::new(true), &fp, Os::Linux),
             BrowserCaTrust::Trusted
         );
     }
@@ -500,7 +550,7 @@ mod tests {
     fn browser_trust_tool_missing_when_db_exists_but_no_certutil() {
         let fp = CaFingerprint::new([7u8; 32]);
         assert_eq!(
-            browser_trust(&fs_with_pki(), &FakeRunner::new(false), &fp),
+            browser_trust(&fs_with_pki(), &FakeRunner::new(false), &fp, Os::Linux),
             BrowserCaTrust::ToolMissing
         );
     }
@@ -509,7 +559,7 @@ mod tests {
     fn browser_trust_untrusted_when_absent() {
         let fp = CaFingerprint::new([7u8; 32]);
         assert_eq!(
-            browser_trust(&fs_with_pki(), &FakeRunner::new(true), &fp),
+            browser_trust(&fs_with_pki(), &FakeRunner::new(true), &fp, Os::Linux),
             BrowserCaTrust::Untrusted
         );
     }
@@ -522,9 +572,97 @@ mod tests {
         let mut runner = FakeRunner::new(true);
         runner.list_pem = Some(pem);
         assert_eq!(
-            browser_trust(&fs_with_pki(), &runner, &fp),
+            browser_trust(&fs_with_pki(), &runner, &fp, Os::Linux),
             BrowserCaTrust::Trusted
         );
+    }
+
+    #[test]
+    fn macos_uses_library_firefox_and_no_pki() {
+        // macOS discovery must find the Library Firefox profile and must NOT
+        // create or touch ~/.pki/nssdb (no macOS browser reads it).
+        let mut fs = FakeFs {
+            home: Some(home()),
+            ..FakeFs::default()
+        };
+        let ff_root = home().join("Library/Application Support/Firefox");
+        fs.files.insert(
+            ff_root.join("profiles.ini"),
+            "[Profile0]\nIsRelative=1\nPath=abc.default\n".to_owned(),
+        );
+        fs.files
+            .insert(ff_root.join("abc.default/cert9.db"), String::new());
+        let runner = FakeRunner::new(true);
+        let out = install(&fs, &runner, Path::new("/ca.pem"), Os::Macos);
+        assert_eq!(out.profiles_attempted, 1);
+        assert!(
+            fs.created.borrow().is_empty(),
+            "must not create ~/.pki/nssdb on macOS"
+        );
+        assert!(!runner
+            .calls
+            .borrow()
+            .iter()
+            .any(|c| c.iter().any(|a| a.contains(".pki/nssdb"))));
+    }
+
+    #[test]
+    fn browser_trust_untrusted_when_any_store_untrusted() {
+        // Two stores exist; only ~/.pki/nssdb trusts the CA (list_pem set), the
+        // Firefox profile does not (its -L is answered the same way by the fake,
+        // so instead use a runner that only trusts when the db is the pki one).
+        let pem = sample_ca_pem();
+        let fp = CaFingerprint::from_pem(&pem).unwrap();
+        let mut fs = fs_with_pki();
+        let ff_root = home().join(".mozilla/firefox");
+        fs.files.insert(
+            ff_root.join("profiles.ini"),
+            "[Profile0]\nIsRelative=1\nPath=abc.default\n".to_owned(),
+        );
+        fs.files
+            .insert(ff_root.join("abc.default/cert9.db"), String::new());
+        // Fake trusts only the pki store: -L returns the PEM only for that dir.
+        let runner = SelectiveRunner {
+            trusted_dir: home().join(".pki/nssdb").display().to_string(),
+            pem,
+        };
+        assert_eq!(
+            browser_trust(&fs, &runner, &fp, Os::Linux),
+            BrowserCaTrust::Untrusted
+        );
+    }
+
+    /// A runner whose `-L` returns the CA PEM only for the one db dir it trusts.
+    struct SelectiveRunner {
+        trusted_dir: String,
+        pem: String,
+    }
+
+    impl CertutilRunner for SelectiveRunner {
+        fn available(&self) -> bool {
+            true
+        }
+        fn run(&self, args: &[String]) -> RunResult {
+            if args.iter().any(|a| a == "-L") {
+                let for_trusted = args
+                    .iter()
+                    .any(|a| a == &format!("sql:{}", self.trusted_dir));
+                if for_trusted {
+                    return RunResult {
+                        code: 0,
+                        stdout: self.pem.clone().into_bytes(),
+                    };
+                }
+                return RunResult {
+                    code: 255,
+                    stdout: vec![],
+                };
+            }
+            RunResult {
+                code: 0,
+                stdout: vec![],
+            }
+        }
     }
 
     fn sample_ca_pem() -> String {

--- a/crates/yerd-platform/src/os/linux.rs
+++ b/crates/yerd-platform/src/os/linux.rs
@@ -22,7 +22,7 @@ use crate::pure::{
     networkmanager_dnsmasq, pem_match, port_plan, proc_metrics, resolved_drop_in, system_roots,
 };
 use crate::resolver::ResolverInstaller;
-use crate::trust_store::{CaFingerprint, NssOutcome, TrustStore};
+use crate::trust_store::{BrowserCaTrust, CaFingerprint, NssOutcome, TrustStore};
 use crate::{BindPairErrorReason, PlatformError, ResolverErrorReason, TrustStoreErrorReason};
 
 /// Linux `Paths` implementation.
@@ -171,13 +171,16 @@ impl TrustStore for LinuxTrustStore {
         self.is_present_system(fp)
     }
 
-    fn install_firefox_nss(&self, _: &str) -> Result<NssOutcome, PlatformError> {
-        Ok(NssOutcome {
-            profiles_attempted: 0,
-            profiles_succeeded: 0,
-            failures: vec![],
-            certutil_missing: false,
-        })
+    fn install_firefox_nss(&self, ca_path: &Path) -> Result<NssOutcome, PlatformError> {
+        Ok(crate::nss_exec::real_install(ca_path))
+    }
+
+    fn uninstall_firefox_nss(&self) -> Result<NssOutcome, PlatformError> {
+        Ok(crate::nss_exec::real_uninstall())
+    }
+
+    fn browser_ca_trust(&self, fp: &CaFingerprint) -> Result<BrowserCaTrust, PlatformError> {
+        Ok(crate::nss_exec::real_browser_trust(fp))
     }
 
     fn system_root_bundle(&self) -> Result<Option<String>, PlatformError> {

--- a/crates/yerd-platform/src/os/macos.rs
+++ b/crates/yerd-platform/src/os/macos.rs
@@ -30,7 +30,7 @@ use crate::port_redirect::{
 };
 use crate::pure::{pem_match, port_plan, ps_metrics, resolver_file};
 use crate::resolver::ResolverInstaller;
-use crate::trust_store::{CaFingerprint, NssOutcome, TrustStore};
+use crate::trust_store::{BrowserCaTrust, CaFingerprint, NssOutcome, TrustStore};
 use crate::{BindPairErrorReason, PlatformError, ResolverErrorReason, TrustStoreErrorReason};
 
 /// macOS `Paths` implementation.
@@ -210,13 +210,16 @@ impl TrustStore for MacosTrustStore {
         Ok(trusted_in(Domain::User)? || trusted_in(Domain::Admin)?)
     }
 
-    fn install_firefox_nss(&self, _: &str) -> Result<NssOutcome, PlatformError> {
-        Ok(NssOutcome {
-            profiles_attempted: 0,
-            profiles_succeeded: 0,
-            failures: vec![],
-            certutil_missing: true,
-        })
+    fn install_firefox_nss(&self, ca_path: &Path) -> Result<NssOutcome, PlatformError> {
+        Ok(crate::nss_exec::real_install(ca_path))
+    }
+
+    fn uninstall_firefox_nss(&self) -> Result<NssOutcome, PlatformError> {
+        Ok(crate::nss_exec::real_uninstall())
+    }
+
+    fn browser_ca_trust(&self, fp: &CaFingerprint) -> Result<BrowserCaTrust, PlatformError> {
+        Ok(crate::nss_exec::real_browser_trust(fp))
     }
 
     /// Enumerates the system root keychains **in-process** via
@@ -652,15 +655,10 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn install_firefox_nss_reports_certutil_missing() {
-        let ts = MacosTrustStore::new();
-        let outcome = ts.install_firefox_nss("pem").unwrap();
-        assert!(outcome.certutil_missing);
-        assert_eq!(outcome.profiles_attempted, 0);
-        assert_eq!(outcome.profiles_succeeded, 0);
-        assert!(outcome.failures.is_empty());
-    }
+    // Browser NSS install/uninstall/probe orchestration is tested in-memory
+    // with fakes in `crate::nss_exec`; exercising the real delegation here
+    // would spawn `certutil` and mutate the host's `~/.pki/nssdb` during
+    // `cargo test`, so it is deliberately not tested at this edge.
 
     // ---- bind_loopback / bind_pair_impl integration -------------------
 

--- a/crates/yerd-platform/src/os/unsupported.rs
+++ b/crates/yerd-platform/src/os/unsupported.rs
@@ -5,6 +5,7 @@
 //! macOS + Linux impls are the only ones with behaviour.
 
 use std::net::SocketAddr;
+use std::path::Path;
 
 use crate::error::ops;
 use crate::metrics::SystemMetrics;
@@ -58,9 +59,15 @@ impl TrustStore for UnsupportedTrustStore {
         })
     }
 
-    fn install_firefox_nss(&self, _: &str) -> Result<NssOutcome, PlatformError> {
+    fn install_firefox_nss(&self, _: &Path) -> Result<NssOutcome, PlatformError> {
         Err(PlatformError::Unsupported {
             operation: ops::INSTALL_FIREFOX_NSS,
+        })
+    }
+
+    fn uninstall_firefox_nss(&self) -> Result<NssOutcome, PlatformError> {
+        Err(PlatformError::Unsupported {
+            operation: ops::UNINSTALL_FIREFOX_NSS,
         })
     }
 

--- a/crates/yerd-platform/src/pure/mod.rs
+++ b/crates/yerd-platform/src/pure/mod.rs
@@ -8,6 +8,7 @@ pub mod cert_identity;
 pub mod dns_probe;
 pub mod firefox;
 pub mod networkmanager_dnsmasq;
+pub mod nss;
 pub mod pem_match;
 pub mod pf_anchor;
 pub mod port_plan;

--- a/crates/yerd-platform/src/pure/nss.rs
+++ b/crates/yerd-platform/src/pure/nss.rs
@@ -1,0 +1,294 @@
+//! Pure decision helpers for per-user NSS trust (`certutil`).
+//!
+//! On Linux, Chromium-family browsers (Brave, Chrome, Chromium, Edge) and
+//! Firefox do not consult the system CA store; each reads a per-user **NSS
+//! database**. Chromium-family share `~/.pki/nssdb`; Firefox keeps one
+//! `cert9.db` per profile. Making the Yerd CA trusted there requires
+//! `certutil` from `libnss3-tools`.
+//!
+//! This module derives *which* database directories to touch and builds the
+//! `certutil` argv - both pure, so they are table-tested on every host. The
+//! actual `read_dir`, existence checks, and process spawning stay in the OS
+//! impl (`os::linux` / `os::macos`), mirroring the pure/edge split used by
+//! [`crate::pure::system_roots`].
+//!
+//! v1 is **sql-only**: modern Firefox and Chromium use the `sql:` (`cert9.db`)
+//! store. Legacy `cert8.db` (dbm) databases are not written.
+
+use std::path::{Path, PathBuf};
+
+use crate::pure::firefox;
+
+/// Nickname the Yerd CA is stored under in every NSS database. Stable so that
+/// re-trusting (or a CA rotation) overwrites the same entry rather than
+/// accumulating duplicates: the edge deletes this nickname before adding.
+pub const NICKNAME: &str = "Yerd Local CA";
+
+/// NSS trust flags for a locally-trusted TLS server-auth root. `C` in the SSL
+/// trust field marks the certificate a trusted CA (the same flag `mkcert`
+/// uses). Peer flags (`p`/`P`) must not be used - they would not let a served
+/// leaf chain to this root.
+pub const TRUST_FLAGS: &str = "C,,";
+
+/// An NSS database directory. Only the `sql:` form is produced in v1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NssDb {
+    /// A modern `sql:`-prefixed database (`cert9.db`).
+    Sql(PathBuf),
+}
+
+impl NssDb {
+    /// The directory this database lives in.
+    #[must_use]
+    pub fn dir(&self) -> &Path {
+        match self {
+            Self::Sql(p) => p,
+        }
+    }
+
+    /// The `-d` argument value `certutil` expects (`sql:<dir>`).
+    #[must_use]
+    pub fn db_arg(&self) -> String {
+        match self {
+            Self::Sql(p) => format!("sql:{}", p.display()),
+        }
+    }
+}
+
+/// `certutil` argv to add the CA (from a PEM file at `ca_path`) as a trusted
+/// root. Delete first (see [`delete_args`]) for idempotency.
+#[must_use]
+pub fn add_args(db: &NssDb, ca_path: &Path) -> Vec<String> {
+    vec![
+        "-d".to_owned(),
+        db.db_arg(),
+        "-A".to_owned(),
+        "-n".to_owned(),
+        NICKNAME.to_owned(),
+        "-t".to_owned(),
+        TRUST_FLAGS.to_owned(),
+        "-i".to_owned(),
+        ca_path.display().to_string(),
+    ]
+}
+
+/// `certutil` argv to delete any certificate stored under [`NICKNAME`].
+#[must_use]
+pub fn delete_args(db: &NssDb) -> Vec<String> {
+    vec![
+        "-d".to_owned(),
+        db.db_arg(),
+        "-D".to_owned(),
+        "-n".to_owned(),
+        NICKNAME.to_owned(),
+    ]
+}
+
+/// `certutil` argv to print (ASCII/PEM) the certificate stored under
+/// [`NICKNAME`], for fingerprint identity comparison. Exits non-zero when no
+/// such entry exists.
+#[must_use]
+pub fn list_pem_args(db: &NssDb) -> Vec<String> {
+    vec![
+        "-d".to_owned(),
+        db.db_arg(),
+        "-L".to_owned(),
+        "-n".to_owned(),
+        NICKNAME.to_owned(),
+        "-a".to_owned(),
+    ]
+}
+
+/// `certutil` argv to initialise a fresh, password-less database in `dir`.
+/// Used only when `~/.pki/nssdb` does not yet exist.
+#[must_use]
+pub fn init_args(dir: &Path) -> Vec<String> {
+    vec![
+        "-d".to_owned(),
+        format!("sql:{}", dir.display()),
+        "-N".to_owned(),
+        "--empty-password".to_owned(),
+    ]
+}
+
+/// The shared Chromium-family NSS database directory (`<home>/.pki/nssdb`).
+#[must_use]
+pub fn pki_nssdb_dir(home: &Path) -> PathBuf {
+    home.join(".pki/nssdb")
+}
+
+/// Every `.pki/nssdb` directory to consider, given the home dir and the app
+/// directory names discovered under `~/snap` and `~/.var/app`.
+///
+/// Native Chromium-family use `<home>/.pki/nssdb`. Snap apps persist data in
+/// either `common/` (survives refresh) or `current/` (migrated on refresh, and
+/// where Chromium-snap actually reads), so both are probed. Flatpak apps use
+/// `<home>/.var/app/<id>/.pki/nssdb`.
+#[must_use]
+pub fn pki_nssdb_candidates(
+    home: &Path,
+    snap_apps: &[String],
+    flatpak_apps: &[String],
+) -> Vec<PathBuf> {
+    let mut out = vec![pki_nssdb_dir(home)];
+    let snap_root = home.join("snap");
+    for app in snap_apps {
+        out.push(snap_root.join(app).join("common/.pki/nssdb"));
+        out.push(snap_root.join(app).join("current/.pki/nssdb"));
+    }
+    let flatpak_root = home.join(".var/app");
+    for app in flatpak_apps {
+        out.push(flatpak_root.join(app).join(".pki/nssdb"));
+    }
+    out
+}
+
+/// Every Firefox profiles-root directory (the parent of the per-profile dirs,
+/// i.e. where `profiles.ini` lives) to consider. The edge reads each
+/// `profiles.ini` and calls [`firefox_profile_dirs`].
+#[must_use]
+pub fn firefox_root_candidates(
+    home: &Path,
+    snap_apps: &[String],
+    flatpak_apps: &[String],
+) -> Vec<PathBuf> {
+    let mut out = vec![home.join(".mozilla/firefox")];
+    let snap_root = home.join("snap");
+    for app in snap_apps {
+        out.push(snap_root.join(app).join("common/.mozilla/firefox"));
+        out.push(snap_root.join(app).join("current/.mozilla/firefox"));
+    }
+    let flatpak_root = home.join(".var/app");
+    for app in flatpak_apps {
+        out.push(flatpak_root.join(app).join(".mozilla/firefox"));
+    }
+    out
+}
+
+/// Resolve the per-profile directories under a Firefox `profiles_root` from the
+/// text of its `profiles.ini`. Relative `Path=` entries are joined against
+/// `profiles_root`; absolute entries are used as-is. The edge then keeps only
+/// those that actually contain a `cert9.db`.
+#[must_use]
+pub fn firefox_profile_dirs(profiles_root: &Path, profiles_ini_text: &str) -> Vec<PathBuf> {
+    firefox::parse_profiles_ini(profiles_ini_text)
+        .into_iter()
+        .map(|p| {
+            if p.is_relative {
+                profiles_root.join(p.path)
+            } else {
+                PathBuf::from(p.path)
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    fn home() -> PathBuf {
+        PathBuf::from("/home/alice")
+    }
+
+    #[test]
+    fn add_args_uses_c_flag_and_sql_prefix() {
+        let db = NssDb::Sql(PathBuf::from("/home/alice/.pki/nssdb"));
+        let args = add_args(&db, Path::new("/data/ca.cert.pem"));
+        assert_eq!(
+            args,
+            vec![
+                "-d",
+                "sql:/home/alice/.pki/nssdb",
+                "-A",
+                "-n",
+                "Yerd Local CA",
+                "-t",
+                "C,,",
+                "-i",
+                "/data/ca.cert.pem",
+            ]
+        );
+    }
+
+    #[test]
+    fn delete_and_list_and_init_args() {
+        let db = NssDb::Sql(PathBuf::from("/db"));
+        assert_eq!(
+            delete_args(&db),
+            vec!["-d", "sql:/db", "-D", "-n", "Yerd Local CA"]
+        );
+        assert_eq!(
+            list_pem_args(&db),
+            vec!["-d", "sql:/db", "-L", "-n", "Yerd Local CA", "-a"]
+        );
+        assert_eq!(
+            init_args(Path::new("/db")),
+            vec!["-d", "sql:/db", "-N", "--empty-password"]
+        );
+    }
+
+    #[test]
+    fn pki_candidates_cover_native_snap_both_roots_and_flatpak() {
+        let got = pki_nssdb_candidates(
+            &home(),
+            &["firefox".to_owned(), "chromium".to_owned()],
+            &["com.brave.Browser".to_owned()],
+        );
+        assert_eq!(got[0], PathBuf::from("/home/alice/.pki/nssdb"));
+        assert!(got.contains(&PathBuf::from(
+            "/home/alice/snap/chromium/common/.pki/nssdb"
+        )));
+        assert!(got.contains(&PathBuf::from(
+            "/home/alice/snap/chromium/current/.pki/nssdb"
+        )));
+        assert!(got.contains(&PathBuf::from(
+            "/home/alice/.var/app/com.brave.Browser/.pki/nssdb"
+        )));
+    }
+
+    #[test]
+    fn firefox_roots_cover_native_snap_common_and_flatpak() {
+        let got = firefox_root_candidates(
+            &home(),
+            &["firefox".to_owned()],
+            &["org.mozilla.firefox".to_owned()],
+        );
+        assert_eq!(got[0], PathBuf::from("/home/alice/.mozilla/firefox"));
+        assert!(got.contains(&PathBuf::from(
+            "/home/alice/snap/firefox/common/.mozilla/firefox"
+        )));
+        assert!(got.contains(&PathBuf::from(
+            "/home/alice/.var/app/org.mozilla.firefox/.mozilla/firefox"
+        )));
+    }
+
+    #[test]
+    fn firefox_profile_dirs_joins_relative_against_root() {
+        let ini = "[Profile0]\nIsRelative=1\nPath=abc.default\n";
+        let dirs = firefox_profile_dirs(Path::new("/home/alice/.mozilla/firefox"), ini);
+        assert_eq!(
+            dirs,
+            vec![PathBuf::from("/home/alice/.mozilla/firefox/abc.default")]
+        );
+    }
+
+    #[test]
+    fn firefox_profile_dirs_keeps_absolute_paths() {
+        let ini = "[Profile0]\nIsRelative=0\nPath=/custom/profile\n";
+        let dirs = firefox_profile_dirs(Path::new("/home/alice/.mozilla/firefox"), ini);
+        assert_eq!(dirs, vec![PathBuf::from("/custom/profile")]);
+    }
+
+    #[test]
+    fn no_snap_or_flatpak_apps_yields_native_only() {
+        assert_eq!(pki_nssdb_candidates(&home(), &[], &[]).len(), 1);
+        assert_eq!(firefox_root_candidates(&home(), &[], &[]).len(), 1);
+    }
+}

--- a/crates/yerd-platform/src/pure/nss.rs
+++ b/crates/yerd-platform/src/pure/nss.rs
@@ -165,6 +165,15 @@ pub fn firefox_root_candidates(
     out
 }
 
+/// The macOS Firefox profiles-root directory
+/// (`<home>/Library/Application Support/Firefox`). macOS Firefox does not use
+/// `~/.mozilla/firefox`, and macOS Chromium-family browsers use the system
+/// keychain (not NSS), so this is the only NSS store to manage on macOS.
+#[must_use]
+pub fn macos_firefox_root(home: &Path) -> PathBuf {
+    home.join("Library/Application Support/Firefox")
+}
+
 /// Resolve the per-profile directories under a Firefox `profiles_root` from the
 /// text of its `profiles.ini`. Relative `Path=` entries are joined against
 /// `profiles_root`; absolute entries are used as-is. The edge then keeps only

--- a/crates/yerd-platform/src/trust_store.rs
+++ b/crates/yerd-platform/src/trust_store.rs
@@ -103,6 +103,23 @@ pub enum NssFailure {
     DbMissing,
 }
 
+/// Whether the per-user browser (Chromium/Firefox) NSS stores trust the Yerd CA.
+///
+/// Three states rather than a `bool` so the daemon and doctor can distinguish
+/// "not trusted, run trust" from "can't manage NSS at all - install the tool".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserCaTrust {
+    /// The CA is present and fingerprint-matches in a browser NSS store (or
+    /// there are no browser NSS stores to worry about).
+    Trusted,
+    /// Browser NSS stores exist but none trust the Yerd CA - the user should
+    /// run the trust flow.
+    Untrusted,
+    /// `certutil` (`libnss3-tools`) is not installed, so browser trust can
+    /// neither be verified nor established.
+    ToolMissing,
+}
+
 /// Trust-store abstraction.
 ///
 /// `install_system` / `uninstall_system` always return `NeedsHelper` in
@@ -152,13 +169,39 @@ pub trait TrustStore {
         })
     }
 
-    /// Install `ca_pem` into every discovered NSS database (Firefox
-    /// profiles + `~/.pki/nssdb`).
+    /// Install the CA (PEM file at `ca_path`) into every discovered per-user
+    /// NSS database: the shared Chromium-family store `~/.pki/nssdb` (created
+    /// and initialised if absent) plus every Firefox profile, including
+    /// Snap/Flatpak-sandboxed copies. Fixes browsers that ignore the system
+    /// trust store (Brave/Chrome/Chromium/Edge/Firefox on Linux).
     ///
-    /// Best-effort: returns `Ok(NssOutcome)` even when `certutil` is
-    /// missing or some profiles fail. The caller decides whether to
-    /// surface the degraded outcome to the user.
-    fn install_firefox_nss(&self, ca_pem: &str) -> Result<NssOutcome, PlatformError>;
+    /// Best-effort: returns `Ok(NssOutcome)` even when `certutil` is missing
+    /// (`certutil_missing`) or some databases fail. The caller decides whether
+    /// to surface the degraded outcome to the user.
+    fn install_firefox_nss(&self, ca_path: &Path) -> Result<NssOutcome, PlatformError>;
+
+    /// Remove the Yerd CA from every discovered per-user NSS database (the
+    /// inverse of [`Self::install_firefox_nss`]). Best-effort; delete-by-
+    /// nickname, so it also clears a stale CA left by a prior rotation.
+    fn uninstall_firefox_nss(&self) -> Result<NssOutcome, PlatformError>;
+
+    /// Report whether the CA matching `fp` is trusted by the per-user
+    /// **browser** NSS stores. Read-only, unprivileged.
+    ///
+    /// Distinct from [`Self::is_trusted`], which covers the *system* store
+    /// (curl/PHP/OS): on Linux those are unrelated to what browsers trust.
+    /// [`BrowserCaTrust::ToolMissing`] is a first-class outcome so the daemon
+    /// can tell the user to install `libnss3-tools` rather than silently
+    /// reporting healthy.
+    ///
+    /// Default `Unsupported` body so non-macOS/Linux impls and fakes need not
+    /// override it.
+    fn browser_ca_trust(&self, fp: &CaFingerprint) -> Result<BrowserCaTrust, PlatformError> {
+        let _ = fp;
+        Err(PlatformError::Unsupported {
+            operation: crate::error::ops::BROWSER_CA_TRUST,
+        })
+    }
 
     /// Return the host's public CA roots as a PEM string, for composing the
     /// bundle the bundled PHP verifies against (see `yerd_tls::compose_ca_bundle`).

--- a/crates/yerd-platform/src/trust_store.rs
+++ b/crates/yerd-platform/src/trust_store.rs
@@ -160,8 +160,8 @@ pub trait TrustStore {
     /// [`Self::is_present_system`].
     ///
     /// This method has a default `Unsupported` body so non-macOS/Linux
-    /// impls (and test fakes) need not override it - the only deliberate
-    /// defaulted method on this trait.
+    /// impls (and test fakes) need not override it. [`Self::browser_ca_trust`]
+    /// is defaulted for the same reason.
     fn is_trusted(&self, ca_path: &Path, fp: &CaFingerprint) -> Result<bool, PlatformError> {
         let _ = (ca_path, fp);
         Err(PlatformError::Unsupported {

--- a/crates/yerd-platform/tests/common/mod.rs
+++ b/crates/yerd-platform/tests/common/mod.rs
@@ -13,8 +13,8 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use yerd_platform::{
-    BoundPort, CaFingerprint, NssOutcome, Paths, PlatformDirs, PlatformError, PortBinder, PortPair,
-    ResolverInstaller, TrustStore,
+    BoundPort, BrowserCaTrust, CaFingerprint, NssOutcome, Paths, PlatformDirs, PlatformError,
+    PortBinder, PortPair, ResolverInstaller, TrustStore,
 };
 
 /// In-memory `Paths` fixture. Returns the directories it was constructed
@@ -48,6 +48,9 @@ impl Paths for MockPaths {
 pub struct MockTrustStore {
     pub installed: RefCell<Vec<CaFingerprint>>,
     pub nss_calls: RefCell<usize>,
+    pub nss_uninstall_calls: RefCell<usize>,
+    /// Tunable browser-trust result the fake returns (default `Untrusted`).
+    pub browser_trust: Option<BrowserCaTrust>,
 }
 
 impl TrustStore for MockTrustStore {
@@ -65,7 +68,7 @@ impl TrustStore for MockTrustStore {
         Ok(self.installed.borrow().contains(fp))
     }
 
-    fn install_firefox_nss(&self, _: &str) -> Result<NssOutcome, PlatformError> {
+    fn install_firefox_nss(&self, _: &std::path::Path) -> Result<NssOutcome, PlatformError> {
         *self.nss_calls.borrow_mut() += 1;
         Ok(NssOutcome {
             profiles_attempted: 0,
@@ -73,6 +76,20 @@ impl TrustStore for MockTrustStore {
             failures: vec![],
             certutil_missing: true,
         })
+    }
+
+    fn uninstall_firefox_nss(&self) -> Result<NssOutcome, PlatformError> {
+        *self.nss_uninstall_calls.borrow_mut() += 1;
+        Ok(NssOutcome {
+            profiles_attempted: 0,
+            profiles_succeeded: 0,
+            failures: vec![],
+            certutil_missing: true,
+        })
+    }
+
+    fn browser_ca_trust(&self, _: &CaFingerprint) -> Result<BrowserCaTrust, PlatformError> {
+        Ok(self.browser_trust.unwrap_or(BrowserCaTrust::Untrusted))
     }
 
     fn system_root_bundle(&self) -> Result<Option<String>, PlatformError> {

--- a/crates/yerd-platform/tests/unsupported.rs
+++ b/crates/yerd-platform/tests/unsupported.rs
@@ -47,7 +47,16 @@ fn trust_store_unsupported() {
         PlatformError::Unsupported { .. }
     ));
     assert!(matches!(
-        ts.install_firefox_nss("p").unwrap_err(),
+        ts.install_firefox_nss(std::path::Path::new("/ca.pem"))
+            .unwrap_err(),
+        PlatformError::Unsupported { .. }
+    ));
+    assert!(matches!(
+        ts.uninstall_firefox_nss().unwrap_err(),
+        PlatformError::Unsupported { .. }
+    ));
+    assert!(matches!(
+        ts.browser_ca_trust(&fp).unwrap_err(),
         PlatformError::Unsupported { .. }
     ));
 }

--- a/docs/developer/crates/yerd-platform.md
+++ b/docs/developer/crates/yerd-platform.md
@@ -89,7 +89,11 @@ pub trait TrustStore {
     // `Unsupported` (the only defaulted method); macOS uses `security
     // verify-cert`, Linux delegates to `is_present_system`.
     fn is_trusted(&self, ca_path: &Path, fp: &CaFingerprint) -> Result<bool, PlatformError>;
-    fn install_firefox_nss(&self, ca_pem: &str) -> Result<NssOutcome, PlatformError>;
+    fn install_firefox_nss(&self, ca_path: &Path) -> Result<NssOutcome, PlatformError>;
+    fn uninstall_firefox_nss(&self) -> Result<NssOutcome, PlatformError>;
+    // Whether the per-user *browser* NSS stores trust the CA. Defaulted to
+    // `Unsupported`; macOS + Linux override.
+    fn browser_ca_trust(&self, fp: &CaFingerprint) -> Result<BrowserCaTrust, PlatformError>;
 }
 ```
 
@@ -97,7 +101,7 @@ The CA is identified by a `CaFingerprint` - a newtype around `[u8; 32]` (SHA-256
 
 - `install_system` / `uninstall_system` always return `Err(PlatformError::NeedsHelper { .. })` in Phase 1. They are write operations against a root-owned store, so the daemon materialises the matching `HelperInvocation` and runs `yerd-helper`.
 - `is_present_system` is a **read-only, unprivileged presence probe**. It reports whether a CA matching the fingerprint is *in* the store - not whether it is trusted for SSL by every consumer. On macOS it enumerates `/Library/Keychains/System.keychain` via `security-framework` and hashes each cert's DER; on Linux it iterates the distro's anchor directory and hashes each PEM block (the candidate directories are `/usr/local/share/ca-certificates`, `/etc/pki/ca-trust/source/anchors`, and `/etc/ca-certificates/trust-source/anchors`).
-- `install_firefox_nss` is the one trust operation that runs **per-user and unprivileged** - Firefox keeps its own NSS database. It is best-effort and returns `Ok(NssOutcome)` even on partial failure:
+- `install_firefox_nss` / `uninstall_firefox_nss` / `browser_ca_trust` are the trust operations that run **per-user and unprivileged**. On Linux, Chromium-family browsers (Brave/Chrome/Chromium/Edge) and Firefox ignore the system store and read their own per-user NSS database - `~/.pki/nssdb` (shared by Chromium-family) and one `cert9.db` per Firefox profile, including Snap (`~/snap/<app>/{common,current}/...`) and Flatpak (`~/.var/app/<id>/...`) copies. Path derivation and the `certutil` argv are pure (`pure::nss`); the discover→run→aggregate orchestration is behind injected seams (`nss_exec`) so it is unit-tested in-memory. `certutil` (from `libnss3-tools`) missing is a first-class outcome (`certutil_missing` / `BrowserCaTrust::ToolMissing`), not an error. `install_firefox_nss` takes the CA **path** (read `-i` by `certutil`), creating and initialising `~/.pki/nssdb` if absent. It is best-effort and returns `Ok(NssOutcome)` even on partial failure:
 
 ```rust
 pub struct NssOutcome {

--- a/docs/guide/elevation.md
+++ b/docs/guide/elevation.md
@@ -91,6 +91,27 @@ The CA cert is added to the system store, then the store is refreshed:
   - `/etc/pki/ca-trust/source/anchors` then `update-ca-trust extract` (RHEL/Fedora)
   - `/etc/ca-certificates/trust-source/anchors` then `trust extract-compat` (Arch)
 
+`elevate trust` then also updates your **browsers**. On Linux (and for Firefox
+on macOS), Chromium-family browsers - Brave, Chrome, Chromium, Edge - and
+Firefox keep their **own** per-user certificate store (NSS) and ignore the
+system store above, so the system-store step alone is not enough for them. Yerd
+adds the CA to `~/.pki/nssdb` (shared by Chromium-family) and to each Firefox
+profile, including Snap and Flatpak copies. This runs unprivileged as your user,
+so the browser stores stay user-owned.
+
+::: warning Browsers need `certutil`
+Updating the browser stores requires `certutil`, which is **not installed by
+default** on many distros. If Yerd reports it missing (and `yerd doctor` warns
+`CaNotTrustedByBrowsers`), install it and re-run `sudo yerd elevate trust`:
+
+- Debian/Ubuntu/Zorin: `sudo apt install libnss3-tools`
+- Fedora: `sudo dnf install nss-tools`
+- Arch: `sudo pacman -S nss`
+
+A newly-installed browser that has never been launched has no store yet; launch
+it once, then re-run `sudo yerd elevate trust`.
+:::
+
 See [HTTPS & Certificates](./https) for how the CA and leaf certs are generated.
 
 ### Resolver

--- a/docs/guide/elevation.md
+++ b/docs/guide/elevation.md
@@ -107,8 +107,9 @@ default** on many distros. If Yerd reports it missing (and `yerd doctor` warns
 - Debian/Ubuntu/Zorin: `sudo apt install libnss3-tools`
 - Fedora: `sudo dnf install nss-tools`
 - Arch: `sudo pacman -S nss`
+- macOS (only needed for Firefox; Safari/Chrome/Brave use the keychain): `brew install nss`
 
-A newly-installed browser that has never been launched has no store yet; launch
+A newly installed browser that has never been launched has no store yet; launch
 it once, then re-run `sudo yerd elevate trust`.
 :::
 


### PR DESCRIPTION
## What does this PR do?

Fix HTTPS certificate errors in Brave/Chrome/Firefox by installing the Yerd CA into their per-user NSS stores, since browsers ignore the system trust store on Linux.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser certificate trust is now supported for Chromium-based browsers and Firefox on Linux and macOS.
  * Trust install/remove operations now report per-browser outcomes and treat missing browser tooling as non-fatal.
  * `yerd doctor` now flags when the local CA is not trusted by browser stores (or when browser trust checks can’t run).

* **Documentation**
  * Updated elevation and setup guidance to include browser trust, required tooling, and the “launch browser once” step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->