### PR TITLE
[Fix] Manage non-Yerd created databases with valid names

### DIFF
--- a/apps/yerd-gui/src/lib/databaseFilename.test.ts
+++ b/apps/yerd-gui/src/lib/databaseFilename.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { databaseExportFilename } from "./databaseFilename";
+
+describe("databaseExportFilename", () => {
+  it("preserves safe database names", () => {
+    expect(databaseExportFilename("sales-data.日本語")).toBe("sales-data.日本語.sql");
+  });
+
+  it("replaces path separators and portable filename-invalid characters", () => {
+    expect(databaseExportFilename('a/b\\c:"d*?\n')).toBe("a_b_c__d___.sql");
+  });
+
+  it("never suggests an empty filename stem", () => {
+    expect(databaseExportFilename("...")).toBe("_.sql");
+    expect(databaseExportFilename("\n")).toBe("_.sql");
+  });
+});

--- a/apps/yerd-gui/src/lib/databaseFilename.test.ts
+++ b/apps/yerd-gui/src/lib/databaseFilename.test.ts
@@ -14,4 +14,27 @@ describe("databaseExportFilename", () => {
     expect(databaseExportFilename("...")).toBe("_.sql");
     expect(databaseExportFilename("\n")).toBe("_.sql");
   });
+
+  it("prefixes Windows reserved device-name stems, case-insensitively", () => {
+    expect(databaseExportFilename("con")).toBe("_con.sql");
+    expect(databaseExportFilename("PRN")).toBe("_PRN.sql");
+    expect(databaseExportFilename("Aux")).toBe("_Aux.sql");
+    expect(databaseExportFilename("nul")).toBe("_nul.sql");
+    expect(databaseExportFilename("com1")).toBe("_com1.sql");
+    expect(databaseExportFilename("COM9")).toBe("_COM9.sql");
+    expect(databaseExportFilename("lpt1")).toBe("_lpt1.sql");
+    expect(databaseExportFilename("LPT9")).toBe("_LPT9.sql");
+  });
+
+  it("guards a reserved stem even when it already carries an extension", () => {
+    expect(databaseExportFilename("nul.backup")).toBe("_nul.backup.sql");
+  });
+
+  it("leaves names that merely resemble reserved devices unchanged", () => {
+    expect(databaseExportFilename("console")).toBe("console.sql");
+    expect(databaseExportFilename("com")).toBe("com.sql");
+    expect(databaseExportFilename("com0")).toBe("com0.sql");
+    expect(databaseExportFilename("comment")).toBe("comment.sql");
+    expect(databaseExportFilename("lpt")).toBe("lpt.sql");
+  });
 });

--- a/apps/yerd-gui/src/lib/databaseFilename.ts
+++ b/apps/yerd-gui/src/lib/databaseFilename.ts
@@ -1,9 +1,16 @@
-/** Build a portable suggested SQL export filename without changing the DB name. */
+/**
+ * Build a portable suggested SQL export filename without changing the DB name.
+ *
+ * Sanitised for the strictest useful portable target (Windows): its forbidden
+ * filename characters plus controls (which also cover embedded tabs/newlines)
+ * become `_`, trailing dots/spaces are dropped, a reserved device-name stem
+ * (`CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`, `LPT1`-`LPT9`, case-insensitively,
+ * even with an extension) is prefixed so it can't name a device, and an empty
+ * stem falls back to `database`.
+ */
 export function databaseExportFilename(databaseName: string): string {
-  // Windows' forbidden filename characters are the strictest useful portable set;
-  // controls also cover embedded tabs/newlines. Avoid trailing dots/spaces too.
-  const safe = databaseName
-    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_")
-    .replace(/[. ]+$/g, "_");
-  return `${safe || "database"}.sql`;
+  const stem =
+    databaseName.replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_").replace(/[. ]+$/g, "_") || "database";
+  const guarded = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i.test(stem) ? `_${stem}` : stem;
+  return `${guarded}.sql`;
 }

--- a/apps/yerd-gui/src/lib/databaseFilename.ts
+++ b/apps/yerd-gui/src/lib/databaseFilename.ts
@@ -1,0 +1,9 @@
+/** Build a portable suggested SQL export filename without changing the DB name. */
+export function databaseExportFilename(databaseName: string): string {
+  // Windows' forbidden filename characters are the strictest useful portable set;
+  // controls also cover embedded tabs/newlines. Avoid trailing dots/spaces too.
+  const safe = databaseName
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_")
+    .replace(/[. ]+$/g, "_");
+  return `${safe || "database"}.sql`;
+}

--- a/apps/yerd-gui/src/views/ServicesView.vue
+++ b/apps/yerd-gui/src/views/ServicesView.vue
@@ -67,6 +67,7 @@ import {
   uninstallService,
 } from "@/ipc/client";
 import type { AddableServiceType, DatabaseSummary, ServiceStatus, SiteEntry } from "@/ipc/types";
+import { databaseExportFilename } from "@/lib/databaseFilename";
 import { poolStateLabel, poolStateTone } from "@/lib/utils";
 
 const toast = useToast();
@@ -487,8 +488,9 @@ const confirmDrop = ref<string | null>(null);
 // A restore awaiting confirmation: the chosen file is picked first, then confirmed.
 const confirmRestore = ref<{ name: string; path: string } | null>(null);
 
-/** Mirror of the daemon's `validate_db_name` for instant feedback (the daemon
- *  re-validates authoritatively). */
+/** Mirror of the daemon's `validate_db_name` for instant feedback when *creating*
+ *  a database (the daemon re-validates authoritatively). Drop, backup, and restore
+ *  act on names that already exist and are not gated by this. */
 function dbNameValid(name: string): boolean {
   return /^[A-Za-z_]\w{0,62}$/.test(name);
 }
@@ -554,7 +556,7 @@ async function doDropDb(name: string): Promise<void> {
 async function doBackupDb(name: string): Promise<void> {
   const s = dbTarget.value;
   if (!s) return;
-  const path = await pickSaveFile(`${name}.sql`);
+  const path = await pickSaveFile(databaseExportFilename(name));
   if (!path) return; // user cancelled
   dbActionBusy.value = true;
   try {

--- a/bin/yerdd/src/db_admin.rs
+++ b/bin/yerdd/src/db_admin.rs
@@ -5,9 +5,10 @@
 //! engine (`mysql`/`mariadb` over the Unix socket; `psql` over TCP loopback) and
 //! captures its output. All the decision logic - name validation, SQL and `argv`
 //! construction, output parsing - is pure and unit-tested in
-//! `yerd_services::database`. The SQL is passed as a single `argv` element (never
-//! a shell), so combined with the validating allowlist there is no injection
-//! surface.
+//! `yerd_services::database`. SQL is passed as a single `argv` element and existing
+//! identifiers are quoted for their engine (never a shell), so there is no injection
+//! surface. Existing names use the engine-compatible validator; the strict creation
+//! allowlist is only applied when Yerd creates a database.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -28,11 +29,14 @@ pub async fn list(service_id: &str, state: &DaemonState) -> Response {
         Err(r) => return r,
     };
     match run_client(&ctx, database::list_sql(ctx.engine)).await {
-        Ok(stdout) => Response::Databases {
-            databases: database::parse_db_list(ctx.engine, &stdout)
-                .into_iter()
-                .map(|name| DatabaseSummary { name })
-                .collect(),
+        Ok(stdout) => match database::parse_db_list(ctx.engine, &stdout) {
+            Ok(names) => Response::Databases {
+                databases: names
+                    .into_iter()
+                    .map(|name| DatabaseSummary { name })
+                    .collect(),
+            },
+            Err(e) => internal(e),
         },
         Err(r) => r,
     }
@@ -59,7 +63,7 @@ pub async fn drop(service_id: &str, name: &str, state: &DaemonState) -> Response
         Ok(c) => c,
         Err(r) => return r,
     };
-    if let Err(e) = database::validate_db_name(name) {
+    if let Err(e) = database::validate_existing_db_name(name) {
         return invalid_name(&e.to_string());
     }
     if database::is_system_database(ctx.engine, name) {
@@ -85,7 +89,7 @@ pub async fn backup(service_id: &str, name: &str, path: &Path, state: &DaemonSta
         Ok(c) => c,
         Err(r) => return r,
     };
-    if let Err(e) = database::validate_db_name(name) {
+    if let Err(e) = database::validate_existing_db_name(name) {
         return invalid_name(&e.to_string());
     }
     let dump_bin = ctx.engine.dump_binary();
@@ -161,7 +165,7 @@ pub async fn restore(service_id: &str, name: &str, path: &Path, state: &DaemonSt
         Ok(c) => c,
         Err(r) => return r,
     };
-    if let Err(e) = database::validate_db_name(name) {
+    if let Err(e) = database::validate_existing_db_name(name) {
         return invalid_name(&e.to_string());
     }
     if database::is_system_database(ctx.engine, name) {
@@ -376,7 +380,7 @@ fn classify(detail: &str) -> ErrorCode {
     }
 }
 
-/// A name that failed [`database::validate_db_name`].
+/// A name that failed the validator appropriate to its operation.
 fn invalid_name(detail: &str) -> Response {
     Response::Error {
         code: ErrorCode::InvalidPath,

--- a/crates/yerd-services/src/database.rs
+++ b/crates/yerd-services/src/database.rs
@@ -4,9 +4,10 @@
 //! validation result, a SQL string, an argv vector, a parsed list). The daemon's
 //! `db_admin` glue spawns the bundled client with these and captures the output.
 //!
-//! This module is the **security boundary** for "Manage DBs": [`validate_db_name`]
-//! is a strict allowlist so a database name can never carry SQL/shell payload,
-//! and [`quote_ident`] quotes the (already-validated) identifier belt-and-braces.
+//! This module is the **security boundary** for database administration.
+//! [`validate_db_name`] is the strict policy for names Yerd creates, while
+//! [`validate_existing_db_name`] accepts engine-created names used by Manage DBs.
+//! SQL identifiers are always quoted and process arguments never pass through a shell.
 //! Because the daemon passes each SQL string as a single `argv` element to the
 //! client (never a shell), there is no shell-injection surface either.
 
@@ -28,6 +29,26 @@ pub enum DbNameError {
     /// The name contained a character outside `[A-Za-z0-9_]`.
     BadChar(char),
 }
+
+/// Why the name of an existing, engine-created database was rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExistingDbNameError {
+    /// The name was empty.
+    Empty,
+    /// The name contained a NUL, which cannot be represented in process arguments.
+    Nul,
+}
+
+impl fmt::Display for ExistingDbNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("database name must not be empty"),
+            Self::Nul => f.write_str("database name must not contain a NUL character"),
+        }
+    }
+}
+
+impl std::error::Error for ExistingDbNameError {}
 
 impl fmt::Display for DbNameError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -77,6 +98,21 @@ pub fn validate_db_name(name: &str) -> Result<(), DbNameError> {
     Ok(())
 }
 
+/// Validate a name selected from an engine's existing databases.
+///
+/// Engines permit substantially more names than Yerd's portable creation policy.
+/// Preserve those names exactly; only values that cannot identify a database or be
+/// represented in an OS process argument are rejected.
+pub fn validate_existing_db_name(name: &str) -> Result<(), ExistingDbNameError> {
+    if name.is_empty() {
+        return Err(ExistingDbNameError::Empty);
+    }
+    if name.contains('\0') {
+        return Err(ExistingDbNameError::Nul);
+    }
+    Ok(())
+}
+
 /// Whether `name` is a built-in/system database that must not be listed,
 /// dropped, or renamed. Compared case-insensitively.
 #[must_use]
@@ -91,9 +127,8 @@ pub fn is_system_database(service: SqlEngine, name: &str) -> bool {
     systems.contains(&lower.as_str())
 }
 
-/// Quote a (validated) identifier for `service`: backticks for `MySQL`/`MariaDB`,
-/// double quotes for `PostgreSQL`, each doubling the quote char. Validated names
-/// contain no quote chars, so this is defence in depth.
+/// Quote an identifier for `service`: backticks for `MySQL`/`MariaDB`, double
+/// quotes for `PostgreSQL`, each doubling an embedded delimiter.
 #[must_use]
 pub fn quote_ident(service: SqlEngine, name: &str) -> String {
     match service {
@@ -120,12 +155,18 @@ pub fn drop_sql(service: SqlEngine, name: &str) -> String {
     }
 }
 
-/// The statement that lists databases for `service` (one name per output row).
+/// The statement that lists databases as one hexadecimal UTF-8 name per row.
+/// Encoding makes the line-oriented client output reversible even when names
+/// contain whitespace or line breaks.
 #[must_use]
 pub fn list_sql(service: SqlEngine) -> &'static str {
     match service {
-        SqlEngine::MySql | SqlEngine::MariaDb => "SHOW DATABASES;",
-        SqlEngine::Postgres => "SELECT datname FROM pg_database WHERE datistemplate = false;",
+        SqlEngine::MySql | SqlEngine::MariaDb => {
+            "SELECT HEX(SCHEMA_NAME) FROM INFORMATION_SCHEMA.SCHEMATA;"
+        }
+        SqlEngine::Postgres => {
+            "SELECT encode(convert_to(datname, 'UTF8'), 'hex') FROM pg_database WHERE datistemplate = false;"
+        }
     }
 }
 
@@ -160,6 +201,18 @@ pub fn client_args(service: SqlEngine, socket: &Path, port: u16, sql: &str) -> V
     }
 }
 
+/// Wrap `db` as a libpq conninfo `dbname` value for `psql`/`pg_dump`.
+///
+/// `psql`/`pg_dump` treat a `--dbname` value containing `=` or a `postgresql://`
+/// prefix as a full conninfo string, so a bare name like `a=b` would be misread
+/// as connection keywords. Emitting the name as an explicit, single-quoted
+/// `dbname='...'` conninfo (backslash-escaping `\` and `'`) forces it to be taken
+/// as a literal database name for every engine-valid name.
+fn pg_dbname_conninfo(db: &str) -> String {
+    let escaped = db.replace('\\', "\\\\").replace('\'', "\\'");
+    format!("dbname='{escaped}'")
+}
+
 /// Build the dump-tool argv to write a complete plain-SQL dump of `db` to **stdout**.
 ///
 /// Same connection model as [`client_args`] (`MySQL`/`MariaDB` over the Unix
@@ -188,6 +241,7 @@ pub fn dump_args(service: SqlEngine, socket: &Path, port: u16, db: &str) -> Vec<
             "--events".to_owned(),
             "--triggers".to_owned(),
             "--set-gtid-purged=OFF".to_owned(),
+            "--".to_owned(),
             db.to_owned(),
         ],
         SqlEngine::MariaDb => vec![
@@ -196,6 +250,7 @@ pub fn dump_args(service: SqlEngine, socket: &Path, port: u16, db: &str) -> Vec<
             "--routines".to_owned(),
             "--events".to_owned(),
             "--triggers".to_owned(),
+            "--".to_owned(),
             db.to_owned(),
         ],
         SqlEngine::Postgres => vec![
@@ -207,7 +262,7 @@ pub fn dump_args(service: SqlEngine, socket: &Path, port: u16, db: &str) -> Vec<
             "--if-exists".to_owned(),
             "--no-owner".to_owned(),
             "--no-privileges".to_owned(),
-            db.to_owned(),
+            format!("--dbname={}", pg_dbname_conninfo(db)),
         ],
     }
 }
@@ -215,16 +270,19 @@ pub fn dump_args(service: SqlEngine, socket: &Path, port: u16, db: &str) -> Vec<
 /// Build the restore-client argv to replay a plain-SQL stream from **stdin** into `db`.
 ///
 /// Same connection model as [`client_args`], but targets the **requested** `db`:
-/// `MySQL`/`MariaDB` take `db` positionally; `PostgreSQL` connects with
-/// `--dbname=db` (not the `postgres` maintenance db) and `--set=ON_ERROR_STOP=1` so a
-/// failed statement aborts with a non-zero exit instead of silently partially
-/// restoring. The input file is never named here - the daemon feeds it on stdin.
+/// `MySQL`/`MariaDB` take `db` positionally after a `--` end-of-options guard;
+/// `PostgreSQL` connects with the db as a quoted `--dbname` conninfo (see
+/// [`pg_dbname_conninfo`], not the `postgres` maintenance db) and
+/// `--set=ON_ERROR_STOP=1` so a failed statement aborts with a non-zero exit instead
+/// of silently partially restoring. The input file is never named here - the daemon
+/// feeds it on stdin.
 #[must_use]
 pub fn restore_args(service: SqlEngine, socket: &Path, port: u16, db: &str) -> Vec<String> {
     match service {
         SqlEngine::MySql | SqlEngine::MariaDb => vec![
             format!("--socket={}", socket.display()),
             "--user=root".to_owned(),
+            "--".to_owned(),
             db.to_owned(),
         ],
         SqlEngine::Postgres => vec![
@@ -233,25 +291,55 @@ pub fn restore_args(service: SqlEngine, socket: &Path, port: u16, db: &str) -> V
             "--username=postgres".to_owned(),
             "--no-password".to_owned(),
             "--set=ON_ERROR_STOP=1".to_owned(),
-            format!("--dbname={db}"),
+            format!("--dbname={}", pg_dbname_conninfo(db)),
         ],
     }
 }
 
-/// Parse a client's database-list stdout into user-visible names: one per line,
-/// trimmed, empties dropped, system databases filtered out, sorted + deduped.
-#[must_use]
-pub fn parse_db_list(service: SqlEngine, stdout: &str) -> Vec<String> {
+/// Parse hexadecimal database-list stdout into exact user-visible names.
+/// Invalid hexadecimal or UTF-8 indicates a broken client/query contract.
+pub fn parse_db_list(service: SqlEngine, stdout: &str) -> Result<Vec<String>, String> {
     let mut names: Vec<String> = stdout
         .lines()
         .map(str::trim)
         .filter(|l| !l.is_empty())
-        .filter(|l| !is_system_database(service, l))
-        .map(str::to_owned)
-        .collect();
+        .map(decode_hex_name)
+        .collect::<Result<_, _>>()?;
+    names.retain(|name| !is_system_database(service, name));
     names.sort();
     names.dedup();
-    names
+    Ok(names)
+}
+
+fn decode_hex_name(encoded: &str) -> Result<String, String> {
+    if encoded.len() % 2 != 0 {
+        return Err(format!(
+            "database list contained odd-length hexadecimal: {encoded:?}"
+        ));
+    }
+    let bytes = encoded
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| match pair {
+            [high, low] => match (hex_nibble(*high), hex_nibble(*low)) {
+                (Some(high), Some(low)) => Ok((high << 4) | low),
+                _ => Err(format!(
+                    "database list contained invalid hexadecimal: {encoded:?}"
+                )),
+            },
+            _ => Err("database list decoder received an incomplete pair".to_owned()),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    String::from_utf8(bytes).map_err(|_| "database list contained invalid UTF-8".to_owned())
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -299,6 +387,32 @@ mod tests {
     }
 
     #[test]
+    fn existing_name_validation_only_rejects_empty_and_nul() {
+        for ok in [
+            "-leading",
+            "has spaces",
+            "naïve 日本語",
+            "quote\"",
+            "back`tick",
+            "a.b",
+            " line\n break ",
+        ] {
+            assert!(
+                validate_existing_db_name(ok).is_ok(),
+                "{ok:?} should be valid"
+            );
+        }
+        assert_eq!(
+            validate_existing_db_name(""),
+            Err(ExistingDbNameError::Empty)
+        );
+        assert_eq!(
+            validate_existing_db_name("bad\0name"),
+            Err(ExistingDbNameError::Nul)
+        );
+    }
+
+    #[test]
     fn system_databases_per_engine() {
         assert!(is_system_database(SqlEngine::MySql, "mysql"));
         assert!(is_system_database(SqlEngine::MySql, "INFORMATION_SCHEMA"));
@@ -323,6 +437,11 @@ mod tests {
         assert_eq!(
             drop_sql(SqlEngine::Postgres, "app"),
             "DROP DATABASE \"app\" WITH (FORCE);"
+        );
+        assert_eq!(drop_sql(SqlEngine::MySql, "a`b"), "DROP DATABASE `a``b`;");
+        assert_eq!(
+            drop_sql(SqlEngine::Postgres, "a\"b"),
+            "DROP DATABASE \"a\"\"b\" WITH (FORCE);"
         );
     }
 
@@ -374,7 +493,7 @@ mod tests {
             assert!(pg.contains(&flag.to_owned()), "pg dump missing {flag}");
         }
         assert!(pg.iter().all(|a| !a.starts_with("--socket")));
-        assert_eq!(pg.last().unwrap(), "app");
+        assert_eq!(pg.last().unwrap(), "--dbname=dbname='app'");
     }
 
     #[test]
@@ -384,26 +503,71 @@ mod tests {
         let my = restore_args(SqlEngine::MySql, &sock, 3306, "app");
         assert!(my.contains(&"--socket=/run/yerd/mysql.sock".to_owned()));
         assert!(my.contains(&"--user=root".to_owned()));
+        assert_eq!(my[my.len() - 2], "--");
         assert_eq!(my.last().unwrap(), "app");
 
         let pg = restore_args(SqlEngine::Postgres, &sock, 5432, "app");
         assert!(pg.contains(&"--host=127.0.0.1".to_owned()));
         assert!(pg.contains(&"--set=ON_ERROR_STOP=1".to_owned()));
-        assert!(pg.contains(&"--dbname=app".to_owned()));
+        assert!(pg.contains(&"--dbname=dbname='app'".to_owned()));
         assert!(pg.iter().all(|a| a != "--dbname=postgres"));
     }
 
     #[test]
-    fn parse_filters_system_and_sorts() {
-        let mysql_out = "mysql\ninformation_schema\nzeta\napp\nsys\nperformance_schema\n";
+    fn parse_decodes_losslessly_filters_system_and_sorts() {
+        let mysql_out = "6d7973716c\n7a657461\n206c696e650a627265616b20\n617070\n";
         assert_eq!(
-            parse_db_list(SqlEngine::MySql, mysql_out),
-            vec!["app".to_owned(), "zeta".to_owned()]
+            parse_db_list(SqlEngine::MySql, mysql_out).unwrap(),
+            vec![
+                " line\nbreak ".to_owned(),
+                "app".to_owned(),
+                "zeta".to_owned()
+            ]
         );
-        let pg_out = "  postgres \n app \n template1\nbravo\n\n";
+        let pg_out = "  706f737467726573  \n617070\ne697a5e69cace8aa9e\n6122626063\n";
         assert_eq!(
-            parse_db_list(SqlEngine::Postgres, pg_out),
-            vec!["app".to_owned(), "bravo".to_owned()]
+            parse_db_list(SqlEngine::Postgres, pg_out).unwrap(),
+            vec!["a\"b`c".to_owned(), "app".to_owned(), "日本語".to_owned()]
         );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_encoded_output() {
+        assert!(parse_db_list(SqlEngine::Postgres, "abc\n").is_err());
+        assert!(parse_db_list(SqlEngine::MySql, "zz\n").is_err());
+        assert!(parse_db_list(SqlEngine::MySql, "ff\n").is_err());
+    }
+
+    #[test]
+    fn argv_preserves_unusual_names_as_one_argument() {
+        let sock = PathBuf::from("/run/yerd/mysql.sock");
+        let name = "- odd ` \" 日本語";
+        for engine in [SqlEngine::MySql, SqlEngine::MariaDb] {
+            let dump = dump_args(engine, &sock, 3306, name);
+            assert_eq!(&dump[dump.len() - 2..], &["--", name]);
+            let restore = restore_args(engine, &sock, 3306, name);
+            assert_eq!(&restore[restore.len() - 2..], &["--", name]);
+        }
+        assert_eq!(
+            dump_args(SqlEngine::Postgres, &sock, 5432, name).last(),
+            Some(&format!("--dbname=dbname='{name}'"))
+        );
+        assert_eq!(
+            restore_args(SqlEngine::Postgres, &sock, 5432, name).last(),
+            Some(&format!("--dbname=dbname='{name}'"))
+        );
+    }
+
+    #[test]
+    fn pg_dbname_conninfo_forces_literal_names() {
+        assert_eq!(pg_dbname_conninfo("app"), "dbname='app'");
+        assert_eq!(pg_dbname_conninfo("a=b"), "dbname='a=b'");
+        assert_eq!(
+            pg_dbname_conninfo("postgresql://evil"),
+            "dbname='postgresql://evil'"
+        );
+        assert_eq!(pg_dbname_conninfo("a'b"), "dbname='a\\'b'");
+        assert_eq!(pg_dbname_conninfo("a\\b"), "dbname='a\\\\b'");
+        assert_eq!(pg_dbname_conninfo("a\\'b"), "dbname='a\\\\\\'b'");
     }
 }

--- a/crates/yerd-services/src/lib.rs
+++ b/crates/yerd-services/src/lib.rs
@@ -24,7 +24,7 @@ pub mod release;
 pub mod service;
 pub mod version;
 
-pub use database::DbNameError;
+pub use database::{DbNameError, ExistingDbNameError};
 pub use error::ServiceError;
 pub use health::{MeilisearchProbe, ReadinessProbe, RedisProbe, ServiceProbes, TcpConnectProbe};
 pub use manager::{ServiceManager, ServiceRunState, ServiceSnapshot};

--- a/docs/developer/crates/yerd-services.md
+++ b/docs/developer/crates/yerd-services.md
@@ -86,7 +86,10 @@ never through a shell.
 - **`validate_db_name(name)`** - strict allowlist: non-empty, ≤ 63 chars (the
   lowest engine cap), first char an ASCII letter or `_`, the rest
   `[A-Za-z0-9_]`. Returns `DbNameError` (`Empty`, `TooLong`, `BadStart`,
-  `BadChar(char)`). This makes injection impossible by construction.
+  `BadChar(char)`). This policy applies only to databases Yerd creates.
+- **`validate_existing_db_name(name)`** - accepts engine-created names selected
+  for drop, backup, or restore, including whitespace, punctuation, Unicode, and
+  quoting characters. It rejects only empty strings and embedded NUL characters.
 - **`is_system_database(service, name)`** - case-insensitive guard. MySQL/MariaDB:
   `information_schema`, `performance_schema`, `mysql`, `sys`; Postgres: `postgres`,
   `template0`, `template1`. System databases cannot be dropped or restored over.
@@ -94,14 +97,15 @@ never through a shell.
   for Postgres (each doubling the quote char).
 - **`create_sql` / `drop_sql` / `list_sql`** - per-engine statements. Postgres
   drop uses `DROP DATABASE <ident> WITH (FORCE);` (PG13+); Postgres list queries
-  `pg_database WHERE datistemplate = false`; MySQL/MariaDB use `SHOW DATABASES;`.
+  `pg_database WHERE datistemplate = false`. List queries return hexadecimal
+  UTF-8 so line breaks and surrounding whitespace in names survive client output.
 - **`client_args` / `dump_args` / `restore_args`** - build the argv for the
   interactive client / dump tool. MySQL & MariaDB connect over the local **Unix
   socket** as a passwordless `root`; Postgres connects over **TCP loopback** as
   `postgres`. Restore reuses the *client* binary (replaying SQL on stdin), not the
   dump binary.
-- **`parse_db_list(service, stdout)`** - trims, drops empties, filters system DBs,
-  sorts, and dedups the client's output.
+- **`parse_db_list(service, stdout)`** - decodes hexadecimal names, filters system
+  DBs, sorts, and deduplicates without altering database names.
 
 ## `config_render.rs` - pure config rendering
 
@@ -216,7 +220,9 @@ crate over IPC:
   requires a *running* SQL engine with a client binary present, passes the pure
   SQL as a single argv element (no shell), streams `BackupDatabase` to a temp
   sibling and atomically renames it (never truncating the target), and streams
-  `RestoreDatabase` into the client's stdin. Engine errors are classified into
+  `RestoreDatabase` into the client's stdin. Create uses the portable name
+  allowlist; drop/backup/restore use exact existing names after empty/NUL checks.
+  Engine errors are classified into
   typed `ErrorCode`s (`AlreadyExists` / `NotFound` / `Internal`).
 
 See [IPC Protocol](../ipc-protocol) for the full service/database message set.

--- a/docs/developer/ipc-protocol.md
+++ b/docs/developer/ipc-protocol.md
@@ -212,6 +212,13 @@ The variant set is the daemon's whole RPC surface - liveness, site management, P
 | `SetWordpressAutoLogin { name, enabled, user: Option }` | `{"type":"set_wordpress_auto_login","name":"blog","enabled":true,"user":"admin"}` |
 | `WordpressAdminUsers { site }` | `{"type":"wordpress_admin_users","site":"blog"}` |
 
+Database `name` has operation-specific validation. `CreateDatabase` uses Yerd's
+portable creation allowlist. `DropDatabase`, `BackupDatabase`, and
+`RestoreDatabase` address an existing engine database and preserve the supplied
+name exactly; only an empty name or embedded NUL is rejected. Drop and restore
+continue to protect engine system databases. `ListDatabases` returns exact decoded
+names in `DatabaseSummary`, including surrounding whitespace and line breaks.
+
 Note `Unpark { path: String }` deliberately uses a `String`, not `PathBuf`: clients echo a value straight back from `Response::Parked`, and an exact-identity match avoids lossy path normalisation (the daemon does not canonicalise it).
 
 ::: info Legacy PHP support: an additive `confirm_legacy` field

--- a/docs/reference/cli/db.md
+++ b/docs/reference/cli/db.md
@@ -32,17 +32,19 @@ yerd db drop mysql my_app
 
 ## Database names
 
-`create` and the other commands validate the database name client-side before
-connecting, and the daemon validates it again before building any SQL. A name
-must:
+`create` uses Yerd's portable naming policy. The daemon validates the name before
+building SQL. A newly created name must:
 
 - be non-empty and at most **63 characters** (the lowest limit across the engines);
 - start with an ASCII letter or underscore (`_`);
 - contain only letters, digits, and underscores.
 
-This strict allowlist is a deliberate security boundary: because the name can
-never contain quoting or statement separators, the generated SQL is injection-proof
-by construction.
+For `drop`, `backup`, and `restore`, the name identifies a database that already
+exists. Those operations accept engine-valid names exactly as listed, including
+whitespace, punctuation, Unicode, quotes, backticks, periods, and leading hyphens.
+Only empty names and names containing NUL are rejected. SQL identifiers are quoted
+and escaped per engine, and backup/restore names are passed directly as one process
+argument without a shell.
 
 ::: warning System databases are protected
 Engine-internal databases (`mysql`, `information_schema`, `performance_schema`,


### PR DESCRIPTION
## What does this PR do?

Lets Yerd back up, restore, and delete existing databases whose names fall outside Yerd's strict creation policy (hyphens, whitespace, Unicode, quotes, =, etc.) by validating existing names only for empty/NUL, quoting identifiers and passing them as single argv elements per engine (including a libpq dbname='…' conninfo for Postgres), and listing names as lossless hex so exotic names survive round-trip.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Database backups now save with portable, Windows-safe `.sql` filenames, including safe handling of empty/unsupported names and reserved device-name patterns.
  - Database listings now preserve exact database names (including whitespace and special characters) while filtering system databases.

- **Bug Fixes**
  - Improved database name validation for drop/backup/restore (now rejects only empty names and NUL-containing names).
  - More robust listing/decoding and safer SQL engine argument handling during dump/restore flows.

- **Documentation**
  - Updated CLI and developer docs to reflect operation-specific database-name validation and exact listing preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->