### PR TITLE
[Meta] Upload release files and manifests to a CDN

### DIFF
--- a/.github/scripts/bunny-delete.sh
+++ b/.github/scripts/bunny-delete.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Delete one object from a Bunny Storage zone.
+#
+# Usage: bunny-delete.sh <remote-path>
+#   <remote-path> is relative to the storage-zone root, e.g.
+#   releases/v1.0.0/OLD.deb
+#
+# Requires: BUNNY_STORAGE_ACCESS_KEY, BUNNY_STORAGE_ZONE, BUNNY_STORAGE_ENDPOINT
+set -euo pipefail
+
+remote=${1:?usage: bunny-delete.sh <remote-path>}
+
+: "${BUNNY_STORAGE_ACCESS_KEY:?BUNNY_STORAGE_ACCESS_KEY is not set}"
+: "${BUNNY_STORAGE_ZONE:?BUNNY_STORAGE_ZONE is not set}"
+: "${BUNNY_STORAGE_ENDPOINT:?BUNNY_STORAGE_ENDPOINT is not set (region host)}"
+
+# Refuse anything outside releases/ - deletion must never touch builds/ or the
+# root manifests, whatever the caller passes. A `..` segment or a leading slash
+# is rejected up front: without that, `releases/../latest.json` passes the glob
+# but curl's default path normalisation would collapse the `..` and issue the
+# DELETE against /latest.json, escaping releases/.
+case "$remote" in
+  /*) echo "::error::bunny-delete: refusing absolute path: $remote" >&2; exit 1 ;;
+  *..*) echo "::error::bunny-delete: refusing path with '..': $remote" >&2; exit 1 ;;
+  releases/*) ;;
+  *) echo "::error::bunny-delete: refusing to delete outside releases/: $remote" >&2; exit 1 ;;
+esac
+
+url="https://${BUNNY_STORAGE_ENDPOINT}/${BUNNY_STORAGE_ZONE}/${remote}"
+
+# --path-as-is: send the literal (guard-checked) path; do not let curl normalise
+# away any dot segment, belt-and-suspenders alongside the `..` rejection above.
+curl -fsS --retry 3 --retry-connrefused --retry-delay 2 --path-as-is \
+  -X DELETE -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" "$url"
+
+echo "DELETE $remote"

--- a/.github/scripts/bunny-delete.sh
+++ b/.github/scripts/bunny-delete.sh
@@ -20,10 +20,13 @@ remote=${1:?usage: bunny-delete.sh <remote-path>}
 # is rejected up front: without that, `releases/../latest.json` passes the glob
 # but curl's default path normalisation would collapse the `..` and issue the
 # DELETE against /latest.json, escaping releases/.
+# `releases/[!/]*` requires at least one non-slash char after `releases/`, so a
+# bare `releases/` (which would target the whole tree) falls through to the
+# reject arm rather than matching.
 case "$remote" in
   /*) echo "::error::bunny-delete: refusing absolute path: $remote" >&2; exit 1 ;;
   *..*) echo "::error::bunny-delete: refusing path with '..': $remote" >&2; exit 1 ;;
-  releases/*) ;;
+  releases/[!/]*) ;;
   *) echo "::error::bunny-delete: refusing to delete outside releases/: $remote" >&2; exit 1 ;;
 esac
 
@@ -32,6 +35,7 @@ url="https://${BUNNY_STORAGE_ENDPOINT}/${BUNNY_STORAGE_ZONE}/${remote}"
 # --path-as-is: send the literal (guard-checked) path; do not let curl normalise
 # away any dot segment, belt-and-suspenders alongside the `..` rejection above.
 curl -fsS --retry 3 --retry-connrefused --retry-delay 2 --path-as-is \
+  --connect-timeout 30 --max-time 120 \
   -X DELETE -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" "$url"
 
 echo "DELETE $remote"

--- a/.github/scripts/bunny-list.sh
+++ b/.github/scripts/bunny-list.sh
@@ -31,7 +31,7 @@ base="https://${BUNNY_STORAGE_ENDPOINT}/${BUNNY_STORAGE_ZONE}"
 # (prefix does not exist yet) is treated as empty.
 list_dir() {
   local dir=$1 resp code body
-  resp=$(curl -sS -w $'\n%{http_code}' \
+  resp=$(curl -sS -w $'\n%{http_code}' --connect-timeout 30 --max-time 120 \
     -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" "${base}/${dir}")
   code=${resp##*$'\n'}
   body=${resp%$'\n'*}

--- a/.github/scripts/bunny-list.sh
+++ b/.github/scripts/bunny-list.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Recursively list a Bunny Storage prefix as a JSON array of files.
+#
+# Usage: bunny-list.sh <remote-dir>            (e.g. releases/)
+# Output (stdout):
+#   [ {"path":"releases/<tag>/<name>","size":N,"checksum":"HEX"|null}, ... ]
+#
+# Bunny's Storage list endpoint is NOT recursive, so this walks each
+# subdirectory itself. `Checksum` is an uppercase SHA-256 that Bunny populates
+# only for objects it hashed (null otherwise); it is emitted verbatim and the
+# consumer case-folds / falls back to size. Directories are omitted (files only).
+#
+# Requires: BUNNY_STORAGE_ACCESS_KEY, BUNNY_STORAGE_ZONE, BUNNY_STORAGE_ENDPOINT
+set -euo pipefail
+
+start=${1:?usage: bunny-list.sh <remote-dir>}
+
+: "${BUNNY_STORAGE_ACCESS_KEY:?BUNNY_STORAGE_ACCESS_KEY is not set}"
+: "${BUNNY_STORAGE_ZONE:?BUNNY_STORAGE_ZONE is not set}"
+: "${BUNNY_STORAGE_ENDPOINT:?BUNNY_STORAGE_ENDPOINT is not set (region host)}"
+
+# Normalise to "<prefix>/" with no leading slash.
+start=${start#/}
+[ -z "$start" ] || [ "${start: -1}" = "/" ] || start="${start}/"
+
+base="https://${BUNNY_STORAGE_ENDPOINT}/${BUNNY_STORAGE_ZONE}"
+
+# List one directory (trailing-slash, leading-slash-free path). Emits one
+# compact JSON object per FILE to stdout and recurses into subdirectories. A 404
+# (prefix does not exist yet) is treated as empty.
+list_dir() {
+  local dir=$1 resp code body
+  resp=$(curl -sS -w $'\n%{http_code}' \
+    -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" "${base}/${dir}")
+  code=${resp##*$'\n'}
+  body=${resp%$'\n'*}
+  case "$code" in
+    200) ;;
+    404) return 0 ;;
+    *) echo "::error::bunny-list: HTTP $code listing ${dir}" >&2; exit 1 ;;
+  esac
+
+  # Iterate entries; recurse into dirs, emit files with a zone-root-relative path.
+  local obj isdir name
+  while IFS= read -r obj; do
+    [ -n "$obj" ] || continue
+    isdir=$(printf '%s' "$obj" | jq -r '.IsDirectory')
+    name=$(printf '%s' "$obj" | jq -r '.ObjectName')
+    if [ "$isdir" = "true" ]; then
+      list_dir "${dir}${name}/"
+    else
+      printf '%s' "$obj" | jq -c --arg path "${dir}${name}" \
+        '{path: $path, size: .Length, checksum: (.Checksum // null)}'
+    fi
+  done < <(printf '%s' "$body" | jq -c '.[]')
+}
+
+list_dir "$start" | jq -s '.'

--- a/.github/scripts/bunny-purge.sh
+++ b/.github/scripts/bunny-purge.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 for u in "$@"; do
   encoded=$(jq -rn --arg u "$u" '$u | @uri')
   curl -fsS --retry 3 --retry-connrefused --retry-delay 2 \
+    --connect-timeout 30 --max-time 120 \
     -X POST -H "AccessKey: ${BUNNY_PURGE_API_KEY}" \
     "https://api.bunny.net/purge?url=${encoded}&async=false"
   echo "PURGE $u"

--- a/.github/scripts/bunny-purge.sh
+++ b/.github/scripts/bunny-purge.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Purge one or more pull-zone URLs from Bunny's edge cache, so a freshly
+# overwritten root manifest is visible immediately instead of serving a cached
+# copy.
+#
+# Usage: bunny-purge.sh <url> [<url> ...]
+#
+# Requires: BUNNY_PURGE_API_KEY (an account-scoped Bunny API key - broader than
+# the storage-zone key; provision it as its own secret and scope/rotate it as
+# narrowly as Bunny allows).
+set -euo pipefail
+
+: "${BUNNY_PURGE_API_KEY:?BUNNY_PURGE_API_KEY is not set}"
+[ "$#" -ge 1 ] || { echo "usage: bunny-purge.sh <url> [<url> ...]" >&2; exit 1; }
+
+for u in "$@"; do
+  encoded=$(jq -rn --arg u "$u" '$u | @uri')
+  curl -fsS --retry 3 --retry-connrefused --retry-delay 2 \
+    -X POST -H "AccessKey: ${BUNNY_PURGE_API_KEY}" \
+    "https://api.bunny.net/purge?url=${encoded}&async=false"
+  echo "PURGE $u"
+done

--- a/.github/scripts/bunny-put.sh
+++ b/.github/scripts/bunny-put.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Upload one file to a Bunny Storage zone and verify it landed.
+#
+# Usage: bunny-put.sh <local-file> <remote-path>
+#   <remote-path> is relative to the storage-zone root, e.g.
+#   releases/v2.0.4/Yerd_Linux_x86_64_v2-0-4.deb
+#
+# Requires: BUNNY_STORAGE_ACCESS_KEY, BUNNY_STORAGE_ZONE, BUNNY_STORAGE_ENDPOINT
+# (the region host, e.g. ny.storage.bunnycdn.com - a wrong/absent region host
+# hard-401s indistinguishably from a bad key, so it is mandatory).
+set -euo pipefail
+
+local_file=${1:?usage: bunny-put.sh <local-file> <remote-path>}
+remote=${2:?usage: bunny-put.sh <local-file> <remote-path>}
+
+: "${BUNNY_STORAGE_ACCESS_KEY:?BUNNY_STORAGE_ACCESS_KEY is not set}"
+: "${BUNNY_STORAGE_ZONE:?BUNNY_STORAGE_ZONE is not set}"
+: "${BUNNY_STORAGE_ENDPOINT:?BUNNY_STORAGE_ENDPOINT is not set (region host, e.g. ny.storage.bunnycdn.com)}"
+
+[ -f "$local_file" ] || { echo "::error::bunny-put: no such file: $local_file" >&2; exit 1; }
+
+url="https://${BUNNY_STORAGE_ENDPOINT}/${BUNNY_STORAGE_ZONE}/${remote}"
+
+# -T streams the file (implies PUT, sets Content-Length; no chunked, which Bunny
+# rejects). -f makes any non-2xx a hard failure.
+curl -fsS --retry 3 --retry-connrefused --retry-delay 2 \
+  -T "$local_file" \
+  -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" \
+  -H "Content-Type: application/octet-stream" \
+  "$url"
+
+# Bunny Storage has no HEAD method; a ranged GET with the AccessKey is the
+# documented existence check.
+curl -fsS -o /dev/null -r 0-0 -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" "$url" \
+  || { echo "::error::bunny-put: post-upload verify failed for $remote" >&2; exit 1; }
+
+echo "PUT $remote"

--- a/.github/scripts/bunny-put.sh
+++ b/.github/scripts/bunny-put.sh
@@ -24,7 +24,11 @@ url="https://${BUNNY_STORAGE_ENDPOINT}/${BUNNY_STORAGE_ZONE}/${remote}"
 
 # -T streams the file (implies PUT, sets Content-Length; no chunked, which Bunny
 # rejects). -f makes any non-2xx a hard failure.
+# --max-time is generous here: release artifacts (.dmg/.app.tar.gz) run to
+# hundreds of MB, so the upload budget is far larger than the small requests in
+# the sibling scripts. --connect-timeout bounds a hung connect either way.
 curl -fsS --retry 3 --retry-connrefused --retry-delay 2 \
+  --connect-timeout 30 --max-time 1800 \
   -T "$local_file" \
   -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" \
   -H "Content-Type: application/octet-stream" \
@@ -32,7 +36,8 @@ curl -fsS --retry 3 --retry-connrefused --retry-delay 2 \
 
 # Bunny Storage has no HEAD method; a ranged GET with the AccessKey is the
 # documented existence check.
-curl -fsS -o /dev/null -r 0-0 -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" "$url" \
+curl -fsS -o /dev/null -r 0-0 --connect-timeout 30 --max-time 120 \
+  -H "AccessKey: ${BUNNY_STORAGE_ACCESS_KEY}" "$url" \
   || { echo "::error::bunny-put: post-upload verify failed for $remote" >&2; exit 1; }
 
 echo "PUT $remote"

--- a/.github/workflows/build-cdn.yml
+++ b/.github/workflows/build-cdn.yml
@@ -140,6 +140,12 @@ jobs:
     needs: [setup, build]
     runs-on: ubuntu-22.04
     steps:
+      # Needed so the Bunny helper scripts (.github/scripts/bunny-*.sh) are
+      # present; no authenticated git op follows, so don't persist the token.
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -191,45 +197,21 @@ jobs:
         id: bunny
         working-directory: dist
         env:
-          BUNNY_KEY: ${{ secrets.BUNNY_STORAGE_ACCESS_KEY }}
-          BUNNY_ZONE: ${{ vars.BUNNY_STORAGE_ZONE }}
-          BUNNY_ENDPOINT: ${{ vars.BUNNY_STORAGE_ENDPOINT }}
+          BUNNY_STORAGE_ACCESS_KEY: ${{ secrets.BUNNY_STORAGE_ACCESS_KEY }}
+          BUNNY_STORAGE_ZONE: ${{ vars.BUNNY_STORAGE_ZONE }}
+          BUNNY_STORAGE_ENDPOINT: ${{ vars.BUNNY_STORAGE_ENDPOINT }}
           DEST: ${{ needs.setup.outputs.dest }}
         run: |
           set -euo pipefail
-          [ -n "${BUNNY_KEY:-}" ] \
-            || { echo "::error::secret BUNNY_STORAGE_ACCESS_KEY is not set"; exit 1; }
-          [ -n "${BUNNY_ZONE:-}" ] \
-            || { echo "::error::variable BUNNY_STORAGE_ZONE is not set"; exit 1; }
-          # Mandatory: a wrong/absent region host hard-401s (indistinguishable from
-          # a bad key), so never silently default to the DE region.
-          [ -n "${BUNNY_ENDPOINT:-}" ] \
-            || { echo "::error::variable BUNNY_STORAGE_ENDPOINT is not set (region host, e.g. ny.storage.bunnycdn.com — must match the zone's region)"; exit 1; }
-
-          url() { printf 'https://%s/%s/builds/%s/%s' "$BUNNY_ENDPOINT" "$BUNNY_ZONE" "$DEST" "$1"; }
-          put() {
-            # -T streams the file (implies PUT, sets Content-Length; no chunked,
-            # which Bunny rejects). -f makes any non-2xx a hard failure.
-            curl -fsS --retry 3 --retry-connrefused --retry-delay 2 \
-              -T "$1" -H "AccessKey: ${BUNNY_KEY}" \
-              -H "Content-Type: application/octet-stream" \
-              "$(url "$(basename "$1")")"
-          }
-
+          put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
           shopt -s nullglob
           arts=(Yerd_*)
           [ ${#arts[@]} -gt 0 ] || { echo "::error::no artifacts to upload"; exit 1; }
-          for f in "${arts[@]}"; do echo "PUT $f"; put "$f"; done
+          # bunny-put.sh PUTs then verifies each object with a ranged GET.
+          for f in "${arts[@]}"; do bash "$put" "$f" "builds/${DEST}/$f"; done
           # Manifest strictly last, so its presence signals a complete upload
           # (Yerd_* sorts AFTER SHA256SUMS, so it must not ride the loop).
-          echo "PUT SHA256SUMS"; put SHA256SUMS
-
-          # Verify each object landed with a cheap ranged GET (Bunny Storage has no
-          # HEAD method; a GET with AccessKey is the documented existence check).
-          for f in "${arts[@]}" SHA256SUMS; do
-            curl -fsS -o /dev/null -r 0-0 -H "AccessKey: ${BUNNY_KEY}" "$(url "$f")" \
-              || { echo "::error::post-upload verify failed for $f"; exit 1; }
-          done
+          bash "$put" SHA256SUMS "builds/${DEST}/SHA256SUMS"
           echo "Uploaded + verified ${#arts[@]} artifact(s) + SHA256SUMS."
 
       # Runs even on failure, but only claims success (and prints download URLs)

--- a/.github/workflows/cdn-sync.yml
+++ b/.github/workflows/cdn-sync.yml
@@ -1,0 +1,190 @@
+name: CDN sync
+
+# Manually drive the BunnyCDN release area into exact sync with GitHub Releases:
+# upload missing/old release files, re-upload changed ones, and (optionally)
+# delete CDN objects that no longer correspond to any GitHub release. Running
+# once with apply=true also performs the historical BACKFILL (uploads every past
+# release). DELETE is destructive, so this defaults to a DRY RUN: it prints the
+# full plan and mutates nothing until you re-run with apply=true.
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Actually upload/update/delete (unchecked = dry run: print the plan only)."
+        type: boolean
+        default: false
+      include_deletes:
+        description: "Include deletions of orphaned CDN objects (uncheck for an additive-only sync)."
+        type: boolean
+        default: true
+      max_deletes:
+        description: "Refuse to apply if the plan would delete more than this many objects (guards a partial GitHub read)."
+        type: string
+        default: "20"
+
+permissions:
+  contents: read
+
+# Share the writers' lock with release.yml's cdn-mirror job so a manual sync and
+# an automatic release mirror can never interleave root-manifest writes.
+concurrency:
+  group: yerd-cdn-writes
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      BUNNY_STORAGE_ACCESS_KEY: ${{ secrets.BUNNY_STORAGE_ACCESS_KEY }}
+      BUNNY_STORAGE_ZONE: ${{ vars.BUNNY_STORAGE_ZONE }}
+      BUNNY_STORAGE_ENDPOINT: ${{ vars.BUNNY_STORAGE_ENDPOINT }}
+      BUNNY_PURGE_API_KEY: ${{ secrets.BUNNY_PURGE_API_KEY }}
+      PULLZONE: ${{ vars.BUNNY_PULLZONE_HOST }}
+      APPLY: ${{ inputs.apply }}
+      INCLUDE_DELETES: ${{ inputs.include_deletes }}
+      MAX_DELETES: ${{ inputs.max_deletes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Fetch the source of truth. A partial/rate-limited paginated read yields
+      # invalid concatenated JSON that fails the jq parse below (set -e) - never a
+      # silent truncation. Require >=1 release before anything can be deleted.
+      - name: Fetch GitHub releases
+        run: |
+          set -euo pipefail
+          : "${PULLZONE:?BUNNY_PULLZONE_HOST is not set}"
+          gh api --paginate "repos/${GH_REPO}/releases" > api.json
+          count=$(jq 'length' api.json)
+          [ "$count" -ge 1 ] \
+            || { echo "::error::GitHub returned 0 releases - refusing to reconcile"; exit 1; }
+          echo "GitHub releases: $count"
+
+      - name: List CDN releases/ (recursive)
+        run: |
+          set -euo pipefail
+          bash .github/scripts/bunny-list.sh releases/ > listing.json
+          echo "CDN objects under releases/: $(jq 'length' listing.json)"
+
+      # Pull just each non-draft tag's SHA256SUMS so the reconcile can compare
+      # hashes (not only sizes). Full assets are fetched later, only for the files
+      # the plan will actually upload.
+      - name: Fetch per-tag SHA256SUMS
+        run: |
+          set -euo pipefail
+          mkdir -p sums
+          for tag in $(jq -r '.[] | select(.draft | not) | .tag_name' api.json); do
+            mkdir -p "sums/${tag}"
+            gh release download "$tag" --dir "sums/${tag}" \
+              --pattern SHA256SUMS --clobber || true
+          done
+
+      - name: Compute reconcile plan
+        run: |
+          set -euo pipefail
+          cargo run -q -p xtask -- cdn-reconcile-plan \
+            --releases-json api.json \
+            --cdn-listing listing.json \
+            --sha256sums-dir sums \
+            --out-dir plan
+
+      # Blank the delete set when additive-only was requested, then enforce the
+      # cap. Always print the (possibly-adjusted) plan to the summary - this is
+      # the human review gate for a dry run.
+      - name: Review plan + guard deletes
+        id: guard
+        run: |
+          set -euo pipefail
+          if [ "$INCLUDE_DELETES" != "true" ]; then
+            jq '.to_delete = []' plan/plan.json > plan/plan.adj.json
+            mv plan/plan.adj.json plan/plan.json
+          fi
+          n_up=$(jq '.to_upload | length' plan/plan.json)
+          n_ch=$(jq '.to_update | length' plan/plan.json)
+          n_del=$(jq '.to_delete | length' plan/plan.json)
+          {
+            echo "### CDN sync plan ($([ "$APPLY" = "true" ] && echo APPLY || echo 'dry run'))"
+            echo ""
+            echo "- upload: **$n_up**"
+            echo "- update: **$n_ch**"
+            echo "- delete: **$n_del**"
+            if [ "$n_del" -gt 0 ]; then
+              echo ""
+              echo "<details><summary>Deletions</summary>"
+              echo ""
+              jq -r '.to_delete[] | "- `" + . + "`"' plan/plan.json
+              echo ""
+              echo "</details>"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$n_del" -gt "$MAX_DELETES" ]; then
+            echo "::error::plan would delete $n_del objects (> max_deletes=$MAX_DELETES); raise max_deletes to proceed"
+            exit 1
+          fi
+          echo "n_del=$n_del" >> "$GITHUB_OUTPUT"
+
+      - name: Dry run notice
+        if: ${{ inputs.apply != true }}
+        run: echo "Dry run only. Re-run with apply=true to execute this plan."
+
+      # Upload every file the plan flagged (missing or changed). Fetch each file
+      # individually by name from its release, then PUT.
+      - name: Apply uploads + updates
+        if: ${{ inputs.apply == true }}
+        run: |
+          set -euo pipefail
+          put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
+          jq -r '(.to_upload + .to_update)[] | [.tag, .name, .path] | @tsv' plan/plan.json \
+          | while IFS=$'\t' read -r tag name path; do
+              [ -n "$tag" ] || continue
+              gh release download "$tag" --dir "dl/${tag}" --pattern "$name" --clobber
+              bash "$put" "dl/${tag}/${name}" "$path"
+            done
+
+      # Delete orphans. The plan was computed this same run from a fresh
+      # gh api, so it already protects known (incl. draft) folders. This step
+      # additionally guards the small TOCTOU window since then: re-fetch the
+      # current DRAFT tags and skip any delete whose tag is now a draft, so a
+      # release reverted to draft mid-run can't be pruned. Orphan-tag and
+      # stale-asset-in-a-public-tag deletes still proceed. bunny-delete.sh
+      # independently refuses anything outside releases/.
+      - name: Apply deletes
+        if: ${{ inputs.apply == true && inputs.include_deletes == true && steps.guard.outputs.n_del != '0' }}
+        run: |
+          set -euo pipefail
+          gh api --paginate "repos/${GH_REPO}/releases" \
+            --jq '.[] | select(.draft) | .tag_name' | sort -u > draft_tags.txt
+          del="${GITHUB_WORKSPACE}/.github/scripts/bunny-delete.sh"
+          jq -r '.to_delete[]' plan/plan.json | while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            # tag = second component of releases/<tag>/<name>
+            tag=$(printf '%s' "$path" | cut -d/ -f2)
+            if grep -Fxq "$tag" draft_tags.txt; then
+              echo "skip (tag $tag is now a draft on GitHub): $path"
+              continue
+            fi
+            bash "$del" "$path"
+          done
+
+      # Regenerate the manifests from a POST-upload listing (reusing the same
+      # api.json), so a first full backfill yields CDN URLs in a single run
+      # instead of self-healing only on a second pass.
+      - name: Regenerate + upload root manifests
+        if: ${{ inputs.apply == true }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/bunny-list.sh releases/ > listing.post.json
+          cargo run -q -p xtask -- cdn-manifests \
+            --releases-json api.json \
+            --cdn-listing listing.post.json \
+            --cdn-base "https://${PULLZONE}" \
+            --out-dir cdn
+          put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
+          bash "$put" cdn/releases.json releases.json
+          bash "$put" cdn/latest.json latest.json
+          bash .github/scripts/bunny-purge.sh \
+            "https://${PULLZONE}/releases.json" \
+            "https://${PULLZONE}/latest.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,6 +420,7 @@ jobs:
       # runner, and re-signing here would drag MINISIGN_SECRET_KEY into this job).
       # `gh release download` yields byte-identical mirrors with no signing secret.
       - name: Mirror release assets to releases/<tag>/
+        id: mirror
         run: |
           set -euo pipefail
           : "${PULLZONE:?BUNNY_PULLZONE_HOST is not set}"
@@ -438,6 +439,7 @@ jobs:
       # mirrored (CDN URLs) while any un-mirrored historical file keeps its working
       # GitHub URL (per-asset gating - never a dead CDN link).
       - name: Regenerate root manifests
+        id: regen
         run: |
           set -euo pipefail
           gh api --paginate "repos/${GH_REPO}/releases" > api.json
@@ -451,6 +453,7 @@ jobs:
       # 3. Upload releases.json BEFORE latest.json (latest.json must never
       # reference a release absent from releases.json).
       - name: Upload root manifests
+        id: upload
         run: |
           set -euo pipefail
           put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
@@ -459,18 +462,35 @@ jobs:
 
       # 4. Purge the edge cache so the overwritten manifests are visible at once.
       - name: Purge manifest cache
+        id: purge
         run: |
           set -euo pipefail
           bash .github/scripts/bunny-purge.sh \
             "https://${PULLZONE}/releases.json" \
             "https://${PULLZONE}/latest.json"
 
+      # Report the ACTUAL outcome of the steps above (any of which can fail while
+      # the job stays green via continue-on-error). Mirrors build-cdn.yml's
+      # branch-on-step-outcome summary rather than always claiming success.
       - name: Summarize
         if: always()
+        env:
+          MIRROR: ${{ steps.mirror.outcome }}
+          REGEN: ${{ steps.regen.outcome }}
+          UPLOAD: ${{ steps.upload.outcome }}
+          PURGE: ${{ steps.purge.outcome }}
         run: |
           {
-            echo "### CDN mirror"
-            echo ""
-            echo "- Release folder: \`releases/${TAG}/\`"
-            echo "- Root manifests regenerated: \`releases.json\`, \`latest.json\`"
+            if [ "$UPLOAD" = "success" ]; then
+              echo "### CDN mirror uploaded"
+              echo ""
+              echo "- Release folder: \`releases/${TAG}/\` (mirror: ${MIRROR})"
+              echo "- Root manifests regenerated + uploaded: \`releases.json\`, \`latest.json\`"
+              echo "- Edge cache purge: ${PURGE}"
+            else
+              echo "### CDN mirror did not complete"
+              echo ""
+              echo "- mirror: ${MIRROR} / regenerate: ${REGEN} / upload: ${UPLOAD} / purge: ${PURGE}"
+              echo "- GitHub Releases remains the source of truth; rerun \`cdn-sync.yml\` to reconcile."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,3 +385,92 @@ jobs:
             -X POST -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"; then
             echo "Discord notification failed; release succeeded regardless"
           fi
+
+  # Mirror the just-published release to BunnyCDN and regenerate the root
+  # manifests (latest.json / releases.json). ADDITIVE: never deletes (pruning is
+  # the manual cdn-sync.yml's job). NON-FATAL: GitHub Releases stays the source of
+  # truth during the transition, so a CDN hiccup must not fail the release.
+  cdn-mirror:
+    name: cdn-mirror
+    needs: publish
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    # Serialize ALL root-manifest writers (rapid rc tags + a manual cdn-sync) so
+    # latest.json/releases.json can't be clobbered out of order. release.yml's
+    # top-level group is per-tag and does NOT serialize distinct tags.
+    concurrency:
+      group: yerd-cdn-writes
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      BUNNY_STORAGE_ACCESS_KEY: ${{ secrets.BUNNY_STORAGE_ACCESS_KEY }}
+      BUNNY_STORAGE_ZONE: ${{ vars.BUNNY_STORAGE_ZONE }}
+      BUNNY_STORAGE_ENDPOINT: ${{ vars.BUNNY_STORAGE_ENDPOINT }}
+      BUNNY_PURGE_API_KEY: ${{ secrets.BUNNY_PURGE_API_KEY }}
+      PULLZONE: ${{ vars.BUNNY_PULLZONE_HOST }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # 1. Fetch THIS tag's PUBLISHED assets from the source of truth (not a
+      # rebuild - the signed .minisig/.sig and SHA256SUMS live only in the publish
+      # runner, and re-signing here would drag MINISIGN_SECRET_KEY into this job).
+      # `gh release download` yields byte-identical mirrors with no signing secret.
+      - name: Mirror release assets to releases/<tag>/
+        run: |
+          set -euo pipefail
+          : "${PULLZONE:?BUNNY_PULLZONE_HOST is not set}"
+          mkdir -p rel
+          gh release download "$TAG" --dir rel --clobber
+          put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
+          shopt -s nullglob
+          assets=(rel/*)
+          [ ${#assets[@]} -gt 0 ] || { echo "::error::release $TAG has no downloadable assets"; exit 1; }
+          for f in "${assets[@]}"; do
+            bash "$put" "$f" "releases/${TAG}/$(basename "$f")"
+          done
+
+      # 2. Regenerate the root manifests from the FULL GitHub release list against
+      # a POST-upload CDN listing, so this tag's freshly-uploaded assets count as
+      # mirrored (CDN URLs) while any un-mirrored historical file keeps its working
+      # GitHub URL (per-asset gating - never a dead CDN link).
+      - name: Regenerate root manifests
+        run: |
+          set -euo pipefail
+          gh api --paginate "repos/${GH_REPO}/releases" > api.json
+          bash .github/scripts/bunny-list.sh releases/ > listing.json
+          cargo run -q -p xtask -- cdn-manifests \
+            --releases-json api.json \
+            --cdn-listing listing.json \
+            --cdn-base "https://${PULLZONE}" \
+            --out-dir cdn
+
+      # 3. Upload releases.json BEFORE latest.json (latest.json must never
+      # reference a release absent from releases.json).
+      - name: Upload root manifests
+        run: |
+          set -euo pipefail
+          put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
+          bash "$put" cdn/releases.json releases.json
+          bash "$put" cdn/latest.json latest.json
+
+      # 4. Purge the edge cache so the overwritten manifests are visible at once.
+      - name: Purge manifest cache
+        run: |
+          set -euo pipefail
+          bash .github/scripts/bunny-purge.sh \
+            "https://${PULLZONE}/releases.json" \
+            "https://${PULLZONE}/latest.json"
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "### CDN mirror"
+            echo ""
+            echo "- Release folder: \`releases/${TAG}/\`"
+            echo "- Root manifests regenerated: \`releases.json\`, \`latest.json\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6267,6 +6267,10 @@ version = "2.0.4-rc.1"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "serde_json",
+ "yerd-release-manifest",
+ "yerd-update",
 ]
 
 [[package]]
@@ -6502,6 +6506,16 @@ dependencies = [
  "yerd-core",
  "yerd-depcheck",
  "yerd-tls",
+]
+
+[[package]]
+name = "yerd-release-manifest"
+version = "2.0.4-rc.1"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "yerd-update",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members  = ["crates/yerd-core", "crates/yerd-ipc", "crates/yerd-config", "crates/yerd-tls", "crates/yerd-platform", "crates/yerd-dns", "crates/yerd-supervise", "crates/yerd-php", "crates/yerd-services", "crates/yerd-tunnel", "crates/yerd-proxy", "crates/yerd-doctor", "crates/yerd-mail", "crates/yerd-mcp", "crates/yerd-update", "crates/yerd-service-ctl", "crates/yerd-depcheck", "bin/yerd-helper", "bin/yerdd", "bin/yerd", "apps/yerd-gui/src-tauri", "xtask"]
+members  = ["crates/yerd-core", "crates/yerd-ipc", "crates/yerd-config", "crates/yerd-tls", "crates/yerd-platform", "crates/yerd-dns", "crates/yerd-supervise", "crates/yerd-php", "crates/yerd-services", "crates/yerd-tunnel", "crates/yerd-proxy", "crates/yerd-doctor", "crates/yerd-mail", "crates/yerd-mcp", "crates/yerd-update", "crates/yerd-release-manifest", "crates/yerd-service-ctl", "crates/yerd-depcheck", "bin/yerd-helper", "bin/yerdd", "bin/yerd", "apps/yerd-gui/src-tauri", "xtask"]
 
 [workspace.package]
 version      = "2.0.4-rc.1"

--- a/crates/yerd-release-manifest/Cargo.toml
+++ b/crates/yerd-release-manifest/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name                   = "yerd-release-manifest"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+publish.workspace      = true
+description            = "Pure schema + transforms for the CDN release manifests (latest.json / releases.json) and CDN<->GitHub reconciliation."
+
+[dependencies]
+serde       = { workspace = true }
+semver      = { workspace = true }
+yerd-update = { path = "../yerd-update" }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/yerd-release-manifest/src/lib.rs
+++ b/crates/yerd-release-manifest/src/lib.rs
@@ -1,0 +1,680 @@
+//! Pure schema and transforms for the Yerd CDN release manifests.
+//!
+//! This crate does **no I/O**. It defines the JSON shapes published to the CDN
+//! and the pure functions that build them from the GitHub Releases API and
+//! reconcile the CDN against GitHub. The workflow layer (xtask + CI scripts)
+//! does the fetching, uploading, listing, and deleting; this crate is the
+//! testable core it calls.
+//!
+//! Two files are published at the CDN root:
+//! - `releases.json` - a **bare array** of [`ReleaseEntry`], field-compatible
+//!   with the daemon's GitHub-release wire struct so a future self-update
+//!   migration is a one-URL change rather than a new parser.
+//! - `latest.json` - a [`LatestManifest`] envelope carrying the latest stable
+//!   and RC releases (GitHub has no two-channel "latest" equivalent).
+//!
+//! Version precedence and pre-release classification are borrowed from
+//! [`yerd_update`] (`parse_tag` + semver ordering + the flag-or-semver
+//! pre-release rule) so this crate cannot drift from the self-update decision
+//! logic. `latest.stable` corresponds exactly to `select_target`'s
+//! `latest_stable`; a test asserts that. `latest.rc` is a **pre-release-only**
+//! channel (the highest pre-release newer than stable), which is deliberately
+//! *not* `select_target`'s pre-release-inclusive `latest_edge` - a future edge
+//! consumer reconstructs edge as `rc ?? stable`.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// The `latest.json` schema version. Bumped only on a breaking envelope change.
+pub const LATEST_SCHEMA: u32 = 1;
+
+/// One release, shaped exactly like the subset of the GitHub Releases API that
+/// the daemon's self-update path consumes. Serializing this is what makes
+/// `releases.json` byte-compatible with that parser; deserializing it is also
+/// how the CI layer reads the `gh api .../releases` response (unknown fields are
+/// ignored). All fields default so a sparse source still decodes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseEntry {
+    /// The release tag, verbatim (e.g. `v2.0.4-rc.1`).
+    pub tag_name: String,
+    /// Whether the source flagged this as a pre-release.
+    #[serde(default)]
+    pub prerelease: bool,
+    /// Whether this is an unpublished draft. Never true on the CDN.
+    #[serde(default)]
+    pub draft: bool,
+    /// Release notes / body, if any.
+    #[serde(default)]
+    pub body: Option<String>,
+    /// Attached downloadable assets.
+    #[serde(default)]
+    pub assets: Vec<AssetEntry>,
+}
+
+/// One downloadable asset attached to a release.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssetEntry {
+    /// The asset filename (e.g. `Yerd_Linux_x86_64_v2-0-4.deb`).
+    pub name: String,
+    /// The download URL - pointed at the CDN once the asset is mirrored, else
+    /// left on GitHub.
+    pub browser_download_url: String,
+    /// Size in bytes (0 if unknown).
+    #[serde(default)]
+    pub size: u64,
+}
+
+/// The `latest.json` envelope: the latest stable and RC releases.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LatestManifest {
+    /// Envelope schema version ([`LATEST_SCHEMA`]).
+    pub schema: u32,
+    /// The highest non-pre-release, if any.
+    pub stable: Option<ReleaseEntry>,
+    /// The highest pre-release, but only when it is strictly newer than
+    /// `stable` (else `None` - an old RC is not worth surfacing). `None` when
+    /// there are no pre-releases newer than stable.
+    pub rc: Option<ReleaseEntry>,
+}
+
+impl ReleaseEntry {
+    /// The parsed semver version, or `None` if the tag is not valid semver
+    /// (such a release is dropped, mirroring the daemon's `fetch_releases`).
+    fn version(&self) -> Option<semver::Version> {
+        yerd_update::parse_tag(&self.tag_name)
+    }
+
+    /// True if this should be treated as a pre-release: the source flag is set
+    /// **or** the semver carries a pre-release component. Matches
+    /// `yerd_update::ReleaseMeta::is_prerelease`.
+    fn is_prerelease(&self, version: &semver::Version) -> bool {
+        self.prerelease || !version.pre.is_empty()
+    }
+}
+
+/// Rewrite `browser_download_url` to the CDN for every asset whose exact
+/// `(tag, name)` is present in `mirrored_assets`; leave the rest on GitHub.
+///
+/// Gating is **per-asset, not per-folder**: a partially-uploaded release folder
+/// (folder present, one file missing - reachable because the mirror job is
+/// non-fatal) must not get the missing file's URL rewritten to a CDN path that
+/// 404s. `mirrored_assets` comes from a recursive CDN listing, which yields
+/// per-object presence.
+fn rewrite_urls(
+    entry: &ReleaseEntry,
+    cdn_base: &str,
+    mirrored_assets: &BTreeSet<(String, String)>,
+) -> ReleaseEntry {
+    let base = cdn_base.trim_end_matches('/');
+    let assets = entry
+        .assets
+        .iter()
+        .map(|a| {
+            let key = (entry.tag_name.clone(), a.name.clone());
+            let url = if mirrored_assets.contains(&key) {
+                format!("{base}/releases/{}/{}", entry.tag_name, a.name)
+            } else {
+                a.browser_download_url.clone()
+            };
+            AssetEntry {
+                name: a.name.clone(),
+                browser_download_url: url,
+                size: a.size,
+            }
+        })
+        .collect();
+    ReleaseEntry {
+        tag_name: entry.tag_name.clone(),
+        prerelease: entry.prerelease,
+        draft: entry.draft,
+        body: entry.body.clone(),
+        assets,
+    }
+}
+
+/// Build `releases.json` (the returned vec) and `latest.json` from the GitHub
+/// release list.
+///
+/// Drafts and releases with an unparseable tag are dropped (mirroring the
+/// daemon). Every asset URL is rewritten to the CDN only when that exact
+/// `(tag, name)` is in `mirrored_assets` (see [`rewrite_urls`]). The vec is
+/// sorted newest-first by semver. `latest.stable` is the highest non-pre-release;
+/// `latest.rc` is the highest pre-release, exposed only when strictly newer than
+/// stable.
+#[must_use]
+pub fn build_manifests(
+    releases: Vec<ReleaseEntry>,
+    cdn_base: &str,
+    mirrored_assets: &BTreeSet<(String, String)>,
+) -> (Vec<ReleaseEntry>, LatestManifest) {
+    let mut kept: Vec<(semver::Version, ReleaseEntry)> = releases
+        .into_iter()
+        .filter(|r| !r.draft)
+        .filter_map(|r| {
+            let v = r.version()?;
+            let rewritten = rewrite_urls(&r, cdn_base, mirrored_assets);
+            Some((v, rewritten))
+        })
+        .collect();
+
+    // Newest-first. `sort_by` with a reversed comparison keeps it stable.
+    kept.sort_by(|a, b| b.0.cmp(&a.0));
+
+    let mut stable: Option<&(semver::Version, ReleaseEntry)> = None;
+    let mut highest_pre: Option<&(semver::Version, ReleaseEntry)> = None;
+    for item in &kept {
+        let (v, entry) = item;
+        if entry.is_prerelease(v) {
+            if highest_pre.map_or(true, |h| v > &h.0) {
+                highest_pre = Some(item);
+            }
+        } else if stable.map_or(true, |s| v > &s.0) {
+            stable = Some(item);
+        }
+    }
+
+    // Expose the RC only when it is strictly newer than the latest stable.
+    let rc = highest_pre.filter(|pre| stable.map_or(true, |s| pre.0 > s.0));
+
+    let latest = LatestManifest {
+        schema: LATEST_SCHEMA,
+        stable: stable.map(|s| s.1.clone()),
+        rc: rc.map(|r| r.1.clone()),
+    };
+    (kept.into_iter().map(|(_, e)| e).collect(), latest)
+}
+
+/// One expected asset: a file that a non-draft GitHub release attaches, plus its
+/// expected SHA-256 when that file is listed in the release's `SHA256SUMS`
+/// (`None` for `.minisig` / `.sig` / `SHA256SUMS` itself, which aren't hashed
+/// there).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedAsset {
+    /// The release tag the asset belongs to.
+    pub tag: String,
+    /// The asset filename.
+    pub name: String,
+    /// Size in bytes.
+    pub size: u64,
+    /// Lowercase-hex SHA-256, when known.
+    pub sha256: Option<String>,
+}
+
+impl ExpectedAsset {
+    /// The CDN object path this asset maps to (`releases/<tag>/<name>`).
+    #[must_use]
+    pub fn cdn_path(&self) -> String {
+        format!("releases/{}/{}", self.tag, self.name)
+    }
+}
+
+/// One object already present on the CDN under `releases/`, from a recursive
+/// listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CdnObject {
+    /// The object path (`releases/<tag>/<name>`).
+    pub path: String,
+    /// Size in bytes.
+    pub size: u64,
+    /// The storage checksum (uppercase hex) when the CDN populated it, else
+    /// `None`. Compared case-insensitively; `None` falls back to a size check.
+    pub checksum: Option<String>,
+}
+
+impl CdnObject {
+    /// The tag component of `releases/<tag>/<name>`, or `None` for any path that
+    /// is not exactly three `releases/<tag>/<name>` components (a malformed or
+    /// stray object we never keep-list for deletion).
+    fn tag(&self) -> Option<&str> {
+        let mut parts = self.path.split('/');
+        match (parts.next(), parts.next(), parts.next(), parts.next()) {
+            (Some("releases"), Some(tag), Some(name), None)
+                if !tag.is_empty() && !name.is_empty() =>
+            {
+                Some(tag)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// The reconcile decision: what to upload, re-upload, and delete to make the CDN
+/// match GitHub.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReconcilePlan {
+    /// Expected assets absent from the CDN.
+    pub to_upload: Vec<ExpectedAsset>,
+    /// Expected assets present but whose bytes differ (size, or a populated
+    /// checksum mismatch).
+    pub to_update: Vec<ExpectedAsset>,
+    /// CDN object paths under `releases/` to delete.
+    pub to_delete: Vec<String>,
+}
+
+/// True if `expected`'s checksum is known, the CDN checksum is known, and they
+/// disagree (case-insensitively). An unknown value on either side is not a
+/// mismatch - the caller falls back to the size comparison.
+fn checksum_mismatch(expected: Option<&str>, cdn: Option<&str>) -> bool {
+    match (expected, cdn) {
+        (Some(e), Some(c)) => !e.eq_ignore_ascii_case(c),
+        _ => false,
+    }
+}
+
+/// Diff the CDN against GitHub and produce the actions needed to sync.
+///
+/// `expected` is every non-draft release's assets; `cdn` is the recursive
+/// listing under `releases/`; `known_tags` is **every** GitHub tag including
+/// drafts; `public_tags` is the set of **non-draft** (published) tags. Rules:
+/// - expected-but-absent -> `to_upload`.
+/// - present with a size mismatch, or a populated checksum mismatch ->
+///   `to_update` (an unknown checksum on either side falls back to size).
+/// - a CDN object whose `(tag, name)` is not expected is deleted only when its
+///   tag is an orphan (`tag not in known_tags`) or published (`tag in
+///   public_tags`). A tag that is known but not published is a draft, and its
+///   objects are left alone - a public-then-reverted-to-draft folder is
+///   protected from surprise pruning. Publication is taken from `public_tags`
+///   (not from asset presence), so a published release that happens to attach no
+///   assets still has its stale objects pruned.
+///
+/// Safety: if `expected` is empty the delete set is forced empty, so a failed or
+/// empty GitHub read can never orphan everything.
+#[must_use]
+pub fn reconcile(
+    expected: &[ExpectedAsset],
+    cdn: &[CdnObject],
+    known_tags: &BTreeSet<String>,
+    public_tags: &BTreeSet<String>,
+) -> ReconcilePlan {
+    let mut plan = ReconcilePlan::default();
+
+    let cdn_by_path: std::collections::BTreeMap<&str, &CdnObject> =
+        cdn.iter().map(|o| (o.path.as_str(), o)).collect();
+
+    for exp in expected {
+        let path = exp.cdn_path();
+        match cdn_by_path.get(path.as_str()) {
+            None => plan.to_upload.push(exp.clone()),
+            Some(obj) => {
+                let differs = obj.size != exp.size
+                    || checksum_mismatch(exp.sha256.as_deref(), obj.checksum.as_deref());
+                if differs {
+                    plan.to_update.push(exp.clone());
+                }
+            }
+        }
+    }
+
+    // An empty expected set means we have nothing authoritative to compare
+    // against; never delete in that case.
+    if expected.is_empty() {
+        return plan;
+    }
+
+    let expected_paths: BTreeSet<String> = expected.iter().map(ExpectedAsset::cdn_path).collect();
+
+    for obj in cdn {
+        if expected_paths.contains(&obj.path) {
+            continue;
+        }
+        let Some(tag) = obj.tag() else {
+            continue;
+        };
+        let orphan = !known_tags.contains(tag);
+        let published = public_tags.contains(tag);
+        if orphan || published {
+            plan.to_delete.push(obj.path.clone());
+        }
+    }
+
+    plan
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn entry(tag: &str, prerelease: bool, draft: bool, assets: &[&str]) -> ReleaseEntry {
+        ReleaseEntry {
+            tag_name: tag.to_string(),
+            prerelease,
+            draft,
+            body: Some(format!("notes for {tag}")),
+            assets: assets
+                .iter()
+                .map(|n| AssetEntry {
+                    name: (*n).to_string(),
+                    browser_download_url: format!("https://github.test/{tag}/{n}"),
+                    size: 4,
+                })
+                .collect(),
+        }
+    }
+
+    fn mirrored(pairs: &[(&str, &str)]) -> BTreeSet<(String, String)> {
+        pairs
+            .iter()
+            .map(|(t, n)| ((*t).to_string(), (*n).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn drops_drafts_and_unparseable_and_sorts_newest_first() {
+        let releases = vec![
+            entry("v2.0.0", false, false, &["a.deb"]),
+            entry("v2.1.0", false, false, &["a.deb"]),
+            entry("draft", false, true, &["a.deb"]),
+            entry("not-semver", false, false, &["a.deb"]),
+        ];
+        let (list, _) = build_manifests(releases, "https://cdn.test", &BTreeSet::new());
+        let tags: Vec<_> = list.iter().map(|r| r.tag_name.as_str()).collect();
+        assert_eq!(tags, vec!["v2.1.0", "v2.0.0"]);
+    }
+
+    #[test]
+    fn per_asset_url_rewrite_gating() {
+        let releases = vec![entry("v2.0.4", false, false, &["a.deb", "b.dmg"])];
+        // Only a.deb is mirrored; b.dmg is missing from the folder.
+        let (list, _) = build_manifests(
+            releases,
+            "https://cdn.test/",
+            &mirrored(&[("v2.0.4", "a.deb")]),
+        );
+        let assets = &list.first().unwrap().assets;
+        let a = assets.iter().find(|x| x.name == "a.deb").unwrap();
+        let b = assets.iter().find(|x| x.name == "b.dmg").unwrap();
+        assert_eq!(
+            a.browser_download_url,
+            "https://cdn.test/releases/v2.0.4/a.deb"
+        );
+        assert_eq!(b.browser_download_url, "https://github.test/v2.0.4/b.dmg");
+    }
+
+    #[test]
+    fn latest_stable_and_rc_selection() {
+        let releases = vec![
+            entry("v2.0.5", false, false, &["a.deb"]),
+            entry("v2.1.0-rc.1", true, false, &["a.deb"]),
+            entry("v2.1.0-rc.2", false, false, &["a.deb"]), // pre via semver, flag off
+        ];
+        let (_, latest) = build_manifests(releases, "https://cdn.test", &BTreeSet::new());
+        assert_eq!(latest.schema, LATEST_SCHEMA);
+        assert_eq!(latest.stable.as_ref().unwrap().tag_name, "v2.0.5");
+        assert_eq!(latest.rc.as_ref().unwrap().tag_name, "v2.1.0-rc.2");
+    }
+
+    #[test]
+    fn rc_hidden_when_not_newer_than_stable() {
+        let releases = vec![
+            entry("v2.1.0", false, false, &["a.deb"]),
+            entry("v2.1.0-rc.1", true, false, &["a.deb"]),
+        ];
+        let (_, latest) = build_manifests(releases, "https://cdn.test", &BTreeSet::new());
+        assert_eq!(latest.stable.as_ref().unwrap().tag_name, "v2.1.0");
+        assert!(latest.rc.is_none(), "old rc must not surface");
+    }
+
+    /// The stable/rc versions must agree with `yerd_update::select_target`'s
+    /// `latest_stable` / `latest_edge` so this crate cannot drift from the
+    /// self-update decision logic.
+    #[test]
+    fn selection_agrees_with_select_target() {
+        // Helper: `latest.stable` must ALWAYS equal `select_target`'s
+        // `latest_stable`. `latest.rc` is pre-release-ONLY and does NOT track the
+        // pre-release-INCLUSIVE `latest_edge`; the two only coincide when the
+        // newest release is itself a pre-release, so we don't assert rc==edge.
+        fn stable_agrees(releases: Vec<ReleaseEntry>) {
+            let metas: Vec<yerd_update::ReleaseMeta> = releases
+                .iter()
+                .map(|r| yerd_update::ReleaseMeta {
+                    version: yerd_update::parse_tag(&r.tag_name).unwrap(),
+                    tag: r.tag_name.clone(),
+                    prerelease: r.prerelease,
+                    assets: Vec::new(),
+                    notes: None,
+                })
+                .collect();
+            let decision = yerd_update::select_target(
+                &metas,
+                yerd_update::Channel::Stable,
+                &semver::Version::new(0, 0, 1),
+            );
+            let (_, latest) = build_manifests(releases, "https://cdn.test", &BTreeSet::new());
+            assert_eq!(
+                latest
+                    .stable
+                    .as_ref()
+                    .and_then(|s| yerd_update::parse_tag(&s.tag_name)),
+                decision.latest_stable
+            );
+        }
+
+        // Newest is a pre-release.
+        stable_agrees(vec![
+            entry("v2.0.5", false, false, &["a.deb"]),
+            entry("v2.1.0-rc.1", true, false, &["a.deb"]),
+            entry("v2.1.0-rc.3", true, false, &["a.deb"]),
+        ]);
+        // Newest is stable: here select_target's `latest_edge` is the stable
+        // v2.1.0, but our `rc` is None (no pre-release newer than stable) - the
+        // exact case where rc and latest_edge diverge.
+        let releases = vec![
+            entry("v2.1.0", false, false, &["a.deb"]),
+            entry("v2.0.0-rc.1", true, false, &["a.deb"]),
+        ];
+        stable_agrees(releases.clone());
+        let (_, latest) = build_manifests(releases, "https://cdn.test", &BTreeSet::new());
+        assert!(
+            latest.rc.is_none(),
+            "rc is pre-release-only, not latest_edge (which would be the stable v2.1.0 here)"
+        );
+    }
+
+    /// A serialized `ReleaseEntry` must deserialize into a struct byte-identical
+    /// to the daemon's `GhRelease`/`GhAsset` (the whole point: `releases.json`
+    /// migration is a one-URL change, not a new parser).
+    #[test]
+    fn wire_compatible_with_daemon_ghrelease() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct GhRelease {
+            tag_name: String,
+            #[serde(default)]
+            prerelease: bool,
+            #[serde(default)]
+            draft: bool,
+            #[serde(default)]
+            body: Option<String>,
+            #[serde(default)]
+            assets: Vec<GhAsset>,
+        }
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct GhAsset {
+            name: String,
+            browser_download_url: String,
+            #[serde(default)]
+            size: u64,
+        }
+
+        let list = vec![entry(
+            "v2.0.4",
+            false,
+            false,
+            &["Yerd_Linux_x86_64_v2-0-4.deb"],
+        )];
+        let json = serde_json::to_string(&list).unwrap();
+        let parsed: Vec<GhRelease> = serde_json::from_str(&json).unwrap();
+        let r = parsed.first().unwrap();
+        assert_eq!(r.tag_name, "v2.0.4");
+        assert_eq!(
+            r.assets.first().unwrap().name,
+            "Yerd_Linux_x86_64_v2-0-4.deb"
+        );
+        assert_eq!(r.assets.first().unwrap().size, 4);
+    }
+
+    fn exp(tag: &str, name: &str, size: u64, sha: Option<&str>) -> ExpectedAsset {
+        ExpectedAsset {
+            tag: tag.to_string(),
+            name: name.to_string(),
+            size,
+            sha256: sha.map(str::to_string),
+        }
+    }
+
+    fn cdn(path: &str, size: u64, checksum: Option<&str>) -> CdnObject {
+        CdnObject {
+            path: path.to_string(),
+            size,
+            checksum: checksum.map(str::to_string),
+        }
+    }
+
+    fn tags(list: &[&str]) -> BTreeSet<String> {
+        list.iter().map(|t| (*t).to_string()).collect()
+    }
+
+    #[test]
+    fn reconcile_uploads_missing() {
+        let expected = vec![exp("v2.0.4", "a.deb", 4, None)];
+        let plan = reconcile(&expected, &[], &tags(&["v2.0.4"]), &tags(&["v2.0.4"]));
+        assert_eq!(plan.to_upload, expected);
+        assert!(plan.to_update.is_empty());
+        assert!(plan.to_delete.is_empty());
+    }
+
+    #[test]
+    fn reconcile_updates_on_size_diff() {
+        let expected = vec![exp("v2.0.4", "a.deb", 8, None)];
+        let cdn_objs = vec![cdn("releases/v2.0.4/a.deb", 4, None)];
+        let plan = reconcile(&expected, &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"]));
+        assert_eq!(plan.to_update, expected);
+        assert!(plan.to_upload.is_empty());
+    }
+
+    #[test]
+    fn reconcile_updates_on_checksum_diff_but_not_when_unknown() {
+        let cdn_objs = vec![cdn("releases/v2.0.4/a.deb", 4, Some("AABB"))];
+        // Same size, mismatching known checksum -> update.
+        let mismatch = vec![exp("v2.0.4", "a.deb", 4, Some("ccdd"))];
+        assert_eq!(
+            reconcile(&mismatch, &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"])).to_update,
+            mismatch
+        );
+        // Same size, matching checksum (case-insensitive) -> no action.
+        let matching = vec![exp("v2.0.4", "a.deb", 4, Some("aabb"))];
+        assert!(
+            reconcile(&matching, &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"]))
+                .to_update
+                .is_empty()
+        );
+        // Unknown expected checksum, same size -> size-only, no action.
+        let unknown = vec![exp("v2.0.4", "a.deb", 4, None)];
+        assert!(
+            reconcile(&unknown, &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"]))
+                .to_update
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn reconcile_deletes_orphan_tag() {
+        let expected = vec![exp("v2.0.4", "a.deb", 4, None)];
+        let cdn_objs = vec![
+            cdn("releases/v2.0.4/a.deb", 4, None),
+            cdn("releases/v1.9.9/old.deb", 4, None),
+        ];
+        let plan = reconcile(&expected, &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"]));
+        assert_eq!(plan.to_delete, vec!["releases/v1.9.9/old.deb".to_string()]);
+    }
+
+    #[test]
+    fn reconcile_deletes_stale_asset_in_public_tag() {
+        let expected = vec![exp("v2.0.4", "a.deb", 4, None)];
+        let cdn_objs = vec![
+            cdn("releases/v2.0.4/a.deb", 4, None),
+            cdn("releases/v2.0.4/removed.dmg", 4, None),
+        ];
+        let plan = reconcile(&expected, &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"]));
+        assert_eq!(
+            plan.to_delete,
+            vec!["releases/v2.0.4/removed.dmg".to_string()]
+        );
+    }
+
+    #[test]
+    fn reconcile_protects_draft_reverted_folder() {
+        // v2.0.4 is public; v2.1.0-rc.1 is a KNOWN draft (in known_tags) but
+        // contributes no expected asset. Its folder must be left alone.
+        let expected = vec![exp("v2.0.4", "a.deb", 4, None)];
+        let cdn_objs = vec![
+            cdn("releases/v2.0.4/a.deb", 4, None),
+            cdn("releases/v2.1.0-rc.1/a.deb", 4, None),
+        ];
+        // known_tags has both; public_tags (non-draft) has only v2.0.4.
+        let plan = reconcile(
+            &expected,
+            &cdn_objs,
+            &tags(&["v2.0.4", "v2.1.0-rc.1"]),
+            &tags(&["v2.0.4"]),
+        );
+        assert!(
+            plan.to_delete.is_empty(),
+            "known draft folder must not be pruned, got {:?}",
+            plan.to_delete
+        );
+    }
+
+    #[test]
+    fn reconcile_empty_expected_deletes_nothing() {
+        let cdn_objs = vec![cdn("releases/v2.0.4/a.deb", 4, None)];
+        let plan = reconcile(&[], &cdn_objs, &BTreeSet::new(), &BTreeSet::new());
+        assert!(plan.to_delete.is_empty());
+        assert!(plan.to_upload.is_empty());
+    }
+
+    #[test]
+    fn reconcile_prunes_assetless_published_release() {
+        // A published (non-draft) tag that attaches no assets still has its
+        // stale CDN objects pruned - publication is taken from public_tags, not
+        // from asset presence.
+        let cdn_objs = vec![cdn("releases/v2.0.4/leftover.deb", 4, None)];
+        let plan = reconcile(&[], &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"]));
+        // expected is empty here, so the empty-expected guard forces no deletes.
+        assert!(plan.to_delete.is_empty(), "empty-expected guard holds");
+
+        // With at least one other published release contributing an expected
+        // asset, the assetless published tag's leftover is pruned.
+        let expected = vec![exp("v2.0.5", "a.deb", 4, None)];
+        let cdn_objs = vec![
+            cdn("releases/v2.0.5/a.deb", 4, None),
+            cdn("releases/v2.0.4/leftover.deb", 4, None),
+        ];
+        let plan = reconcile(
+            &expected,
+            &cdn_objs,
+            &tags(&["v2.0.4", "v2.0.5"]),
+            &tags(&["v2.0.4", "v2.0.5"]),
+        );
+        assert_eq!(
+            plan.to_delete,
+            vec!["releases/v2.0.4/leftover.deb".to_string()]
+        );
+    }
+
+    #[test]
+    fn reconcile_ignores_malformed_paths() {
+        let expected = vec![exp("v2.0.4", "a.deb", 4, None)];
+        let cdn_objs = vec![
+            cdn("releases/v2.0.4/a.deb", 4, None),
+            cdn("releases/stray.txt", 4, None),
+            cdn("builds/2024/x.deb", 4, None),
+        ];
+        let plan = reconcile(&expected, &cdn_objs, &tags(&["v2.0.4"]), &tags(&["v2.0.4"]));
+        assert!(
+            plan.to_delete.is_empty(),
+            "malformed/other-prefix paths kept"
+        );
+    }
+}

--- a/crates/yerd-release-manifest/src/lib.rs
+++ b/crates/yerd-release-manifest/src/lib.rs
@@ -158,7 +158,6 @@ pub fn build_manifests(
         })
         .collect();
 
-    // Newest-first. `sort_by` with a reversed comparison keeps it stable.
     kept.sort_by(|a, b| b.0.cmp(&a.0));
 
     let mut stable: Option<&(semver::Version, ReleaseEntry)> = None;
@@ -174,7 +173,6 @@ pub fn build_manifests(
         }
     }
 
-    // Expose the RC only when it is strictly newer than the latest stable.
     let rc = highest_pre.filter(|pre| stable.map_or(true, |s| pre.0 > s.0));
 
     let latest = LatestManifest {
@@ -306,8 +304,6 @@ pub fn reconcile(
         }
     }
 
-    // An empty expected set means we have nothing authoritative to compare
-    // against; never delete in that case.
     if expected.is_empty() {
         return plan;
     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,8 +8,12 @@ publish.workspace      = true
 description            = "Build automation for Yerd (cargo xtask <cmd>)."
 
 [dependencies]
-anyhow = { workspace = true }
-clap   = { workspace = true }
+anyhow                = { workspace = true }
+clap                  = { workspace = true }
+serde                 = { workspace = true }
+serde_json            = { workspace = true }
+yerd-release-manifest = { path = "../crates/yerd-release-manifest" }
+yerd-update           = { path = "../crates/yerd-update" }
 
 [lints]
 workspace = true

--- a/xtask/src/cdn.rs
+++ b/xtask/src/cdn.rs
@@ -1,0 +1,186 @@
+//! CDN release-manifest generation and reconcile-plan computation.
+//!
+//! Thin I/O glue over the pure [`yerd_release_manifest`] crate: read the GitHub
+//! Releases API response and a CDN listing off disk, call the pure transforms,
+//! and write `latest.json` / `releases.json` / `plan.json`. All the decision
+//! logic (URL rewrite gating, stable/rc selection, the CDN<->GitHub diff) lives
+//! in the crate; this module never decides anything.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use yerd_release_manifest::{build_manifests, reconcile, CdnObject, ExpectedAsset, ReleaseEntry};
+
+/// One object from a CDN listing (`bunny-list.sh` output). Files only -
+/// directories are filtered out by the lister.
+#[derive(Debug, Deserialize)]
+struct ListingObject {
+    /// Object path, `releases/<tag>/<name>`.
+    path: String,
+    #[serde(default)]
+    size: u64,
+    #[serde(default)]
+    checksum: Option<String>,
+}
+
+/// Split a `releases/<tag>/<name>` path into its `(tag, name)`, or `None` for
+/// anything not exactly those three components.
+fn split_release_path(path: &str) -> Option<(String, String)> {
+    let mut parts = path.split('/');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("releases"), Some(tag), Some(name), None) if !tag.is_empty() && !name.is_empty() => {
+            Some((tag.to_string(), name.to_string()))
+        }
+        _ => None,
+    }
+}
+
+fn read_releases(path: &Path) -> Result<Vec<ReleaseEntry>> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing GitHub releases JSON at {}", path.display()))
+}
+
+fn read_listing(path: &Path) -> Result<Vec<ListingObject>> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing CDN listing JSON at {}", path.display()))
+}
+
+fn write_pretty<T: serde::Serialize>(dir: &Path, name: &str, value: &T) -> Result<()> {
+    fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    let path = dir.join(name);
+    let json = serde_json::to_vec_pretty(value).with_context(|| format!("serializing {name}"))?;
+    fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+    println!("wrote {}", path.display());
+    Ok(())
+}
+
+/// `cdn-manifests`: build `latest.json` + `releases.json`.
+pub fn run_manifests(
+    releases_json: &Path,
+    cdn_listing: &Path,
+    cdn_base: &str,
+    out_dir: &Path,
+) -> Result<()> {
+    let releases = read_releases(releases_json)?;
+    let listing = read_listing(cdn_listing)?;
+
+    let mirrored: BTreeSet<(String, String)> = listing
+        .iter()
+        .filter_map(|o| split_release_path(&o.path))
+        .collect();
+
+    let (list, latest) = build_manifests(releases, cdn_base, &mirrored);
+    write_pretty(out_dir, "releases.json", &list)?;
+    write_pretty(out_dir, "latest.json", &latest)?;
+    Ok(())
+}
+
+/// `cdn-reconcile-plan`: compute the CDN<->GitHub reconcile plan.
+///
+/// `sha256sums_dir` holds one `<tag>/SHA256SUMS` per downloaded release; each
+/// expected artifact's hash is looked up there (absent for `.minisig`/`.sig`/
+/// `SHA256SUMS`, which fall back to a size comparison).
+pub fn run_reconcile_plan(
+    releases_json: &Path,
+    cdn_listing: &Path,
+    sha256sums_dir: &Path,
+    out_dir: &Path,
+) -> Result<()> {
+    let releases = read_releases(releases_json)?;
+    let listing = read_listing(cdn_listing)?;
+
+    // Every GitHub tag, drafts included, protects known folders from deletion.
+    let known_tags: BTreeSet<String> = releases.iter().map(|r| r.tag_name.clone()).collect();
+    // Published (non-draft) tags: their stale CDN objects are eligible for
+    // pruning even when the release attaches no assets.
+    let public_tags: BTreeSet<String> = releases
+        .iter()
+        .filter(|r| !r.draft)
+        .map(|r| r.tag_name.clone())
+        .collect();
+
+    // Cache each tag's SHA256SUMS body so we parse it once per tag.
+    let mut sums_cache: std::collections::BTreeMap<String, Option<String>> =
+        std::collections::BTreeMap::new();
+
+    let mut expected: Vec<ExpectedAsset> = Vec::new();
+    for r in &releases {
+        if r.draft {
+            continue;
+        }
+        let sums = sums_cache.entry(r.tag_name.clone()).or_insert_with(|| {
+            let p = sha256sums_dir.join(&r.tag_name).join("SHA256SUMS");
+            fs::read_to_string(&p).ok()
+        });
+        for a in &r.assets {
+            let sha256 = sums
+                .as_deref()
+                .and_then(|s| yerd_update::sha256_for(s, &a.name))
+                .map(str::to_string);
+            expected.push(ExpectedAsset {
+                tag: r.tag_name.clone(),
+                name: a.name.clone(),
+                size: a.size,
+                sha256,
+            });
+        }
+    }
+
+    let cdn: Vec<CdnObject> = listing
+        .into_iter()
+        .filter(|o| split_release_path(&o.path).is_some())
+        .map(|o| CdnObject {
+            path: o.path,
+            size: o.size,
+            checksum: o.checksum,
+        })
+        .collect();
+
+    let plan = reconcile(&expected, &cdn, &known_tags, &public_tags);
+
+    // Serialize the plan as plain JSON the workflow can drive with jq. The pure
+    // types aren't serde, so map to a small local shape here.
+    let out = PlanJson {
+        to_upload: plan.to_upload.iter().map(action_json).collect(),
+        to_update: plan.to_update.iter().map(action_json).collect(),
+        to_delete: plan.to_delete,
+    };
+    write_pretty(out_dir, "plan.json", &out)?;
+
+    println!(
+        "plan: {} upload, {} update, {} delete",
+        out.to_upload.len(),
+        out.to_update.len(),
+        out.to_delete.len()
+    );
+    Ok(())
+}
+
+#[derive(serde::Serialize)]
+struct ActionJson {
+    tag: String,
+    name: String,
+    path: String,
+}
+
+// The `to_*` field names are the JSON contract the workflow drives with jq.
+#[derive(serde::Serialize)]
+#[allow(clippy::struct_field_names)]
+struct PlanJson {
+    to_upload: Vec<ActionJson>,
+    to_update: Vec<ActionJson>,
+    to_delete: Vec<String>,
+}
+
+fn action_json(a: &ExpectedAsset) -> ActionJson {
+    ActionJson {
+        tag: a.tag.clone(),
+        name: a.name.clone(),
+        path: a.cdn_path(),
+    }
+}

--- a/xtask/src/cdn.rs
+++ b/xtask/src/cdn.rs
@@ -94,17 +94,13 @@ pub fn run_reconcile_plan(
     let releases = read_releases(releases_json)?;
     let listing = read_listing(cdn_listing)?;
 
-    // Every GitHub tag, drafts included, protects known folders from deletion.
     let known_tags: BTreeSet<String> = releases.iter().map(|r| r.tag_name.clone()).collect();
-    // Published (non-draft) tags: their stale CDN objects are eligible for
-    // pruning even when the release attaches no assets.
     let public_tags: BTreeSet<String> = releases
         .iter()
         .filter(|r| !r.draft)
         .map(|r| r.tag_name.clone())
         .collect();
 
-    // Cache each tag's SHA256SUMS body so we parse it once per tag.
     let mut sums_cache: std::collections::BTreeMap<String, Option<String>> =
         std::collections::BTreeMap::new();
 
@@ -143,8 +139,6 @@ pub fn run_reconcile_plan(
 
     let plan = reconcile(&expected, &cdn, &known_tags, &public_tags);
 
-    // Serialize the plan as plain JSON the workflow can drive with jq. The pure
-    // types aren't serde, so map to a small local shape here.
     let out = PlanJson {
         to_upload: plan.to_upload.iter().map(action_json).collect(),
         to_update: plan.to_update.iter().map(action_json).collect(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@
 
 #![forbid(unsafe_code)]
 
+mod cdn;
 mod version;
 
 use std::fs;
@@ -40,6 +41,38 @@ pub enum Command {
     },
     /// Print the workspace version (bare, one line) for scripts/CI to consume.
     PrintVersion,
+    /// Build `latest.json` + `releases.json` from the GitHub Releases API and a
+    /// CDN listing (asset URLs are pointed at the CDN only for mirrored files).
+    CdnManifests {
+        /// Path to the `gh api .../releases` JSON response.
+        #[arg(long)]
+        releases_json: PathBuf,
+        /// Path to the CDN listing JSON (`bunny-list.sh` output).
+        #[arg(long)]
+        cdn_listing: PathBuf,
+        /// Public CDN base URL, e.g. `https://cdn.yerd.app`.
+        #[arg(long)]
+        cdn_base: String,
+        /// Directory to write `latest.json` / `releases.json` into.
+        #[arg(long)]
+        out_dir: PathBuf,
+    },
+    /// Compute the CDN<->GitHub reconcile plan (`plan.json`): files to upload,
+    /// re-upload, and delete so the CDN matches GitHub.
+    CdnReconcilePlan {
+        /// Path to the `gh api .../releases` JSON response.
+        #[arg(long)]
+        releases_json: PathBuf,
+        /// Path to the CDN listing JSON (`bunny-list.sh` output).
+        #[arg(long)]
+        cdn_listing: PathBuf,
+        /// Directory holding one `<tag>/SHA256SUMS` per downloaded release.
+        #[arg(long)]
+        sha256sums_dir: PathBuf,
+        /// Directory to write `plan.json` into.
+        #[arg(long)]
+        out_dir: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -48,6 +81,18 @@ fn main() -> Result<()> {
         Command::Bump { version } => run_bump(version),
         Command::VersionCheck { version } => run_version_check(version),
         Command::PrintVersion => run_print_version(),
+        Command::CdnManifests {
+            releases_json,
+            cdn_listing,
+            cdn_base,
+            out_dir,
+        } => cdn::run_manifests(releases_json, cdn_listing, cdn_base, out_dir),
+        Command::CdnReconcilePlan {
+            releases_json,
+            cdn_listing,
+            sha256sums_dir,
+            out_dir,
+        } => cdn::run_reconcile_plan(releases_json, cdn_listing, sha256sums_dir, out_dir),
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Uploads build and upgrade files, plus release+latest manifests to files.yerd.app

## Related issues

n/a

## Type of change

- [x] Build / CI / tooling

## Platforms tested

n/a

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic CDN mirroring for published release assets.
  - Added generated release and latest-version manifests for CDN clients.
  - Added manual CDN synchronization with dry-run previews, upload/update planning, optional orphan cleanup, and deletion safeguards.
  - Added support for identifying stable and release-candidate versions in the latest manifest.

- **Bug Fixes**
  - Improved upload verification and CDN cache purging to help ensure published assets and manifests are immediately available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->