### PR TITLE
[Feat] Pull updates and files from CDN

### DIFF
--- a/.github/scripts/sign-manifests.sh
+++ b/.github/scripts/sign-manifests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Sign one or more CDN root manifests (latest.json / releases.json) with the
+# release minisign key and verify each signature against the public key the
+# daemon EMBEDS, so a manifest can never ship a signature the shipped binary
+# cannot check. The daemon verifies latest.json against
+# `yerd_update::UPDATE_PUBLIC_KEY` before trusting it (see
+# `self_update::fetch_releases`), the same key that signs the release artifacts.
+#
+# Usage: sign-manifests.sh <file> [<file> ...]
+#   Writes <file>.minisig next to each input.
+#
+# Requires: MINISIGN_SECRET_KEY (an *unencrypted* key, as the release job uses,
+# to avoid a CI password prompt) and GITHUB_WORKSPACE (to read the embedded
+# public key from the source tree). RUNNER_TEMP is used for the transient key
+# file when set, falling back to a mktemp dir otherwise.
+set -euo pipefail
+
+[ "$#" -ge 1 ] || { echo "::error::sign-manifests: no files given" >&2; exit 1; }
+: "${MINISIGN_SECRET_KEY:?MINISIGN_SECRET_KEY is not set - cannot sign the manifests}"
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
+
+tmp=${RUNNER_TEMP:-$(mktemp -d)}
+
+# `minisign` isn't in the runner's apt repos, so install the official prebuilt
+# static binary from the canonical (pinned) release over HTTPS if it is not
+# already on PATH (the release job may have installed it earlier in the run).
+if ! command -v minisign >/dev/null 2>&1; then
+  MINISIGN_VERSION=0.11
+  curl -sSfL "https://github.com/jedisct1/minisign/releases/download/${MINISIGN_VERSION}/minisign-${MINISIGN_VERSION}-linux.tar.gz" \
+    | tar -xz -C "$tmp"
+  minisign_bin=$(find "$tmp/minisign-linux" -path '*x86_64*' -name minisign | head -n1)
+  [ -n "$minisign_bin" ] || { echo "::error::minisign x86_64 binary not found in release tarball" >&2; exit 1; }
+  sudo install -m0755 "$minisign_bin" /usr/local/bin/minisign
+fi
+command -v minisign >/dev/null
+
+# The trust anchor: read the key the daemon embeds and refuse to sign with a
+# secret whose public half is the placeholder test key (a mismatched secret
+# would produce signatures the shipped binary rejects).
+art="${GITHUB_WORKSPACE}/crates/yerd-update/src/artifact.rs"
+key=$(grep -oE 'UPDATE_PUBLIC_KEY: &str = "[^"]+"' "$art" | sed -E 's/.*"([^"]+)".*/\1/')
+[ -n "$key" ] || { echo "::error::could not read UPDATE_PUBLIC_KEY from $art" >&2; exit 1; }
+test_key="RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3"
+if [ "$key" = "$test_key" ]; then
+  echo "::error::UPDATE_PUBLIC_KEY is still the placeholder test key - wire the production key before signing" >&2
+  exit 1
+fi
+
+# Wipe the key on ANY exit (incl. a mid-loop failure), not just success.
+keyfile="${tmp}/minisign-manifest.key"
+trap 'rm -f "$keyfile"' EXIT
+umask 077; printf '%s\n' "$MINISIGN_SECRET_KEY" > "$keyfile"
+
+for f in "$@"; do
+  [ -f "$f" ] || { echo "::error::sign-manifests: no such file: $f" >&2; exit 1; }
+  # -H = prehashed, which `minisign-verify` (and the daemon) require.
+  minisign -S -H -s "$keyfile" -m "$f" -x "$f.minisig"
+  minisign -V -H -P "$key" -m "$f" -x "$f.minisig" \
+    || { echo "::error::embedded UPDATE_PUBLIC_KEY does not verify $f.minisig (key/secret mismatch)" >&2; exit 1; }
+  echo "signed + verified $f -> $f.minisig"
+done

--- a/.github/workflows/cdn-sync.yml
+++ b/.github/workflows/cdn-sync.yml
@@ -41,6 +41,7 @@ jobs:
       BUNNY_STORAGE_ZONE: ${{ vars.BUNNY_STORAGE_ZONE }}
       BUNNY_STORAGE_ENDPOINT: ${{ vars.BUNNY_STORAGE_ENDPOINT }}
       BUNNY_PURGE_API_KEY: ${{ secrets.BUNNY_PURGE_API_KEY }}
+      MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
       PULLZONE: ${{ vars.BUNNY_PULLZONE_HOST }}
       APPLY: ${{ inputs.apply }}
       INCLUDE_DELETES: ${{ inputs.include_deletes }}
@@ -182,9 +183,16 @@ jobs:
             --cdn-listing listing.post.json \
             --cdn-base "https://${PULLZONE}" \
             --out-dir cdn
+          # Sign the manifests with the release key; the daemon verifies
+          # latest.json against the embedded UPDATE_PUBLIC_KEY before trusting it.
+          bash .github/scripts/sign-manifests.sh cdn/releases.json cdn/latest.json
           put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
           bash "$put" cdn/releases.json releases.json
+          bash "$put" cdn/releases.json.minisig releases.json.minisig
           bash "$put" cdn/latest.json latest.json
+          bash "$put" cdn/latest.json.minisig latest.json.minisig
           bash .github/scripts/bunny-purge.sh \
             "https://${PULLZONE}/releases.json" \
-            "https://${PULLZONE}/latest.json"
+            "https://${PULLZONE}/releases.json.minisig" \
+            "https://${PULLZONE}/latest.json" \
+            "https://${PULLZONE}/latest.json.minisig"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,6 +408,7 @@ jobs:
       BUNNY_STORAGE_ZONE: ${{ vars.BUNNY_STORAGE_ZONE }}
       BUNNY_STORAGE_ENDPOINT: ${{ vars.BUNNY_STORAGE_ENDPOINT }}
       BUNNY_PURGE_API_KEY: ${{ secrets.BUNNY_PURGE_API_KEY }}
+      MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
       PULLZONE: ${{ vars.BUNNY_PULLZONE_HOST }}
       TAG: ${{ github.ref_name }}
     steps:
@@ -450,24 +451,40 @@ jobs:
             --cdn-base "https://${PULLZONE}" \
             --out-dir cdn
 
-      # 3. Upload releases.json BEFORE latest.json (latest.json must never
-      # reference a release absent from releases.json).
+      # 3. Sign the manifests with the release minisign key. The daemon verifies
+      # latest.json against the embedded UPDATE_PUBLIC_KEY before trusting it, so
+      # a tampered manifest cannot freeze/downgrade the advertised version.
+      - name: Sign root manifests
+        id: sign
+        run: |
+          set -euo pipefail
+          bash .github/scripts/sign-manifests.sh cdn/releases.json cdn/latest.json
+
+      # 4. Upload releases.json BEFORE latest.json (latest.json must never
+      # reference a release absent from releases.json), each immediately followed
+      # by its detached .minisig. A reader that races an in-flight overwrite may
+      # see a body/signature mismatch; verification fails safe (the daemon keeps
+      # its cache and retries), so the small non-atomic window is harmless.
       - name: Upload root manifests
         id: upload
         run: |
           set -euo pipefail
           put="${GITHUB_WORKSPACE}/.github/scripts/bunny-put.sh"
           bash "$put" cdn/releases.json releases.json
+          bash "$put" cdn/releases.json.minisig releases.json.minisig
           bash "$put" cdn/latest.json latest.json
+          bash "$put" cdn/latest.json.minisig latest.json.minisig
 
-      # 4. Purge the edge cache so the overwritten manifests are visible at once.
+      # 5. Purge the edge cache so the overwritten manifests are visible at once.
       - name: Purge manifest cache
         id: purge
         run: |
           set -euo pipefail
           bash .github/scripts/bunny-purge.sh \
             "https://${PULLZONE}/releases.json" \
-            "https://${PULLZONE}/latest.json"
+            "https://${PULLZONE}/releases.json.minisig" \
+            "https://${PULLZONE}/latest.json" \
+            "https://${PULLZONE}/latest.json.minisig"
 
       # Report the ACTUAL outcome of the steps above (any of which can fail while
       # the job stays green via continue-on-error). Mirrors build-cdn.yml's
@@ -477,6 +494,7 @@ jobs:
         env:
           MIRROR: ${{ steps.mirror.outcome }}
           REGEN: ${{ steps.regen.outcome }}
+          SIGN: ${{ steps.sign.outcome }}
           UPLOAD: ${{ steps.upload.outcome }}
           PURGE: ${{ steps.purge.outcome }}
         run: |
@@ -490,7 +508,7 @@ jobs:
             else
               echo "### CDN mirror did not complete"
               echo ""
-              echo "- mirror: ${MIRROR} / regenerate: ${REGEN} / upload: ${UPLOAD} / purge: ${PURGE}"
+              echo "- mirror: ${MIRROR} / regenerate: ${REGEN} / sign: ${SIGN} / upload: ${UPLOAD} / purge: ${PURGE}"
               echo "- GitHub Releases remains the source of truth; rerun \`cdn-sync.yml\` to reconcile."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6630,6 +6630,7 @@ dependencies = [
  "yerd-php",
  "yerd-platform",
  "yerd-proxy",
+ "yerd-release-manifest",
  "yerd-services",
  "yerd-supervise",
  "yerd-tls",

--- a/bin/yerdd/Cargo.toml
+++ b/bin/yerdd/Cargo.toml
@@ -40,6 +40,7 @@ yerd-proxy     = { path = "../../crates/yerd-proxy" }
 yerd-doctor    = { path = "../../crates/yerd-doctor" }
 yerd-mail      = { path = "../../crates/yerd-mail" }
 yerd-update    = { path = "../../crates/yerd-update" }
+yerd-release-manifest = { path = "../../crates/yerd-release-manifest" }
 thiserror      = { workspace = true }
 semver         = { workspace = true }
 serde          = { workspace = true }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -393,7 +393,8 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
         Request::UninstallTool { tool } => uninstall_tool(&tool, state).await,
         Request::CheckUpdate { channel } => {
             let dl = crate::php_install::ReqwestDownloader::new();
-            crate::self_update::check_update(channel, state, &dl).await
+            crate::self_update::check_update(channel, state, &dl, yerd_update::UPDATE_PUBLIC_KEY)
+                .await
         }
         Request::CachedUpdateStatus => crate::self_update::cached_update_status(state).await,
         Request::SetUpdateChannel { channel } => {
@@ -4659,32 +4660,44 @@ Subject: Captured\r\n\r\nhi\r\n";
         );
     }
 
-    /// Fake GitHub Releases downloader: returns the canned JSON for the first
-    /// page (the only page fetched, since the body has < 100 entries). The poll
-    /// loop stops after a short page.
-    struct ReleasesDl(&'static str);
-    #[async_trait::async_trait]
-    impl yerd_php::Downloader for ReleasesDl {
-        async fn download(&self, _url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
-            Ok(self.0.as_bytes().to_vec())
+    // A tiny `latest.json` payload. Far-future versions so the target is always
+    // newer than the daemon's compiled `current` version, regardless of the
+    // build.
+    const LATEST_MANIFEST: &str = r#"{
+        "schema": 1,
+        "stable": {"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[]},
+        "rc": {"tag_name":"v99.1.0-rc.1","prerelease":true,"draft":false,"assets":[]}
+    }"#;
+
+    /// Fake CDN downloader: serves a signed `latest.json` for the manifest URL
+    /// and its detached signature for the `.minisig` URL. Feed `key()` to the
+    /// self-update entry points as the verifying public key.
+    struct ManifestDl(crate::test_support::SignedManifest);
+    impl ManifestDl {
+        fn new(manifest: &str) -> Self {
+            Self(crate::test_support::sign_manifest(manifest))
+        }
+        fn key(&self) -> &str {
+            &self.0.public_key
         }
     }
-
-    // A tiny releases payload. Far-future versions so the target is always newer
-    // than the daemon's compiled `current` version, regardless of the build. The
-    // unparsable `nightly-garbage` tag must be skipped.
-    const RELEASES_JSON: &str = r#"[
-        {"tag_name":"v99.1.0-rc.1","prerelease":true,"draft":false,"assets":[]},
-        {"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[]},
-        {"tag_name":"v99.0.0","prerelease":false,"draft":false,"assets":[]},
-        {"tag_name":"nightly-garbage","prerelease":true,"draft":false,"assets":[]}
-    ]"#;
+    #[async_trait::async_trait]
+    impl yerd_php::Downloader for ManifestDl {
+        async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
+            if url.ends_with(".minisig") {
+                Ok(self.0.minisig.clone().into_bytes())
+            } else {
+                Ok(self.0.manifest.clone().into_bytes())
+            }
+        }
+    }
 
     #[tokio::test]
     async fn check_update_reports_both_channel_latests_live() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
-        let resp = crate::self_update::check_update(None, &state, &ReleasesDl(RELEASES_JSON)).await;
+        let dl = ManifestDl::new(LATEST_MANIFEST);
+        let resp = crate::self_update::check_update(None, &state, &dl, dl.key()).await;
         match resp {
             Response::UpdateStatus {
                 latest_stable,
@@ -4700,19 +4713,17 @@ Subject: Captured\r\n\r\nhi\r\n";
             }
             other => panic!("expected UpdateStatus, got {other:?}"),
         }
-        assert_eq!(state.yerd_update.read().await.len(), 3);
+        assert_eq!(state.yerd_update.read().await.len(), 2);
     }
 
     #[tokio::test]
     async fn check_update_edge_override_selects_prerelease_target() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
-        let resp = crate::self_update::check_update(
-            Some(yerd_ipc::Channel::Edge),
-            &state,
-            &ReleasesDl(RELEASES_JSON),
-        )
-        .await;
+        let dl = ManifestDl::new(LATEST_MANIFEST);
+        let resp =
+            crate::self_update::check_update(Some(yerd_ipc::Channel::Edge), &state, &dl, dl.key())
+                .await;
         match resp {
             Response::UpdateStatus {
                 channel,
@@ -4729,11 +4740,38 @@ Subject: Captured\r\n\r\nhi\r\n";
     }
 
     #[tokio::test]
+    async fn check_update_rejects_tampered_manifest_signature() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        // Sign the manifest with one key, but verify against a *different* key:
+        // the signature must fail and the live fetch must yield nothing.
+        let dl = ManifestDl::new(LATEST_MANIFEST);
+        let other = crate::test_support::sign_manifest(LATEST_MANIFEST);
+        let resp = crate::self_update::check_update(None, &state, &dl, &other.public_key).await;
+        match resp {
+            Response::UpdateStatus {
+                latest_stable,
+                source,
+                ..
+            } => {
+                assert_eq!(source, yerd_ipc::UpdateSource::Cached);
+                assert_eq!(
+                    latest_stable, None,
+                    "a bad-signature manifest must not be trusted"
+                );
+            }
+            other => panic!("expected UpdateStatus, got {other:?}"),
+        }
+        assert!(state.yerd_update.read().await.is_empty());
+    }
+
+    #[tokio::test]
     async fn check_update_falls_back_to_cache_when_offline() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
-        crate::self_update::poll_and_refresh(&state, &ReleasesDl(RELEASES_JSON)).await;
-        let resp = crate::self_update::check_update(None, &state, &FailingDl).await;
+        let dl = ManifestDl::new(LATEST_MANIFEST);
+        crate::self_update::poll_and_refresh(&state, &dl, dl.key()).await;
+        let resp = crate::self_update::check_update(None, &state, &FailingDl, dl.key()).await;
         match resp {
             Response::UpdateStatus {
                 latest_stable,
@@ -4747,28 +4785,45 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
     }
 
-    // Known-good minisign fixture (the `minisign-verify` crate's published test
-    // vector: a prehashed signature of the bytes `b"test"`).
-    const SIG_PUBKEY: &str = "RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3";
-    const SIG_FIXTURE: &str = "untrusted comment: signature from minisign secret key\nRUQf6LRCGA9i559r3g7V1qNyJDApGip8MfqcadIgT9CuhV3EMhHoN1mGTkUidF/z7SrlQgXdy8ofjb7bNJJylDOocrCo8KLzZwo=\ntrusted comment: timestamp:1556193335\tfile:test\ny/rUw2y8/hOUYjZU71eHp/Wo1KZ40fGy2VJEDl34XMJM+TX48Ss/17u3IvIfbVR1FkZZSNCisQbuQY+bHwhEBg==";
-
-    /// Fake downloader for the full stage flow. Serves the releases JSON for the
-    /// API URL; the signed fixture bytes (`b"test"`) for any artifact URL; the
-    /// fixture signature for any `.sig`/`.minisig` URL; and a matching
-    /// `SHA256SUMS`.
+    /// Fake downloader for the full stage flow. Serves the signed `latest.json`
+    /// (and its `.minisig`) for the manifest URLs; the signed bytes (`b"test"`)
+    /// for any artifact URL; the matching artifact signature for any `.sig` /
+    /// `.minisig` URL; and a `SHA256SUMS`. The manifest and the artifact bytes
+    /// are signed with a single key ([`StageDl::key`]), which is fed to
+    /// `stage_update` to verify both the manifest and the artifact.
     struct StageDl {
-        releases: String,
+        manifest: crate::test_support::SignedManifest,
+        artifact_sig: String,
         sums: String,
+    }
+    impl StageDl {
+        /// Build from a `stable` release object body and a `SHA256SUMS`. The
+        /// manifest wraps `stable` as `latest.json`; the artifact bytes `b"test"`
+        /// are signed with the same key so one public key verifies both.
+        fn new(stable: &str, sums: String) -> Self {
+            let manifest = format!(r#"{{"schema":1,"stable":{stable},"rc":null}}"#);
+            let (manifest, artifact) = crate::test_support::sign_manifest_pair(&manifest, "test");
+            Self {
+                manifest,
+                artifact_sig: artifact.minisig,
+                sums,
+            }
+        }
+        fn key(&self) -> &str {
+            &self.manifest.public_key
+        }
     }
     #[async_trait::async_trait]
     impl yerd_php::Downloader for StageDl {
         async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
-            if url.contains("api.github.com") {
-                Ok(self.releases.clone().into_bytes())
+            if url.contains("latest.json.minisig") {
+                Ok(self.manifest.minisig.clone().into_bytes())
+            } else if url.contains("latest.json") {
+                Ok(self.manifest.manifest.clone().into_bytes())
             } else if url.ends_with("SHA256SUMS") {
                 Ok(self.sums.clone().into_bytes())
             } else if url.ends_with(".minisig") || url.ends_with(".sig") {
-                Ok(SIG_FIXTURE.as_bytes().to_vec())
+                Ok(self.artifact_sig.clone().into_bytes())
             } else {
                 Ok(b"test".to_vec())
             }
@@ -4795,8 +4850,8 @@ Subject: Captured\r\n\r\nhi\r\n";
         let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
         let rpm = "Yerd_Linux_x86_64_v99-0-1.rpm";
         let rpm_arm = "Yerd_Linux_Arm64_v99-0-1.rpm";
-        let releases = format!(
-            r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
+        let stable = format!(
+            r#"{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
                 {{"name":"{mac}.minisig","browser_download_url":"https://h/{mac}.minisig","size":1}},
                 {{"name":"{deb}","browser_download_url":"https://h/{deb}","size":4}},
@@ -4812,15 +4867,15 @@ Subject: Captured\r\n\r\nhi\r\n";
                 {{"name":"{rpm_arm}","browser_download_url":"https://h/{rpm_arm}","size":4}},
                 {{"name":"{rpm_arm}.minisig","browser_download_url":"https://h/{rpm_arm}.minisig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
-            ]}}]"#
+            ]}}"#
         );
         let h = yerd_update::sha256_hex(b"test");
         let sums = format!(
             "{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n{h}  {pkg}\n{h}  {pkg_arm}\n{h}  {rpm}\n{h}  {rpm_arm}\n"
         );
-        let dl = StageDl { releases, sums };
+        let dl = StageDl::new(&stable, sums);
 
-        let resp = crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await;
+        let resp = crate::self_update::stage_update(None, &state, &dl, dl.key()).await;
         match resp {
             Response::Staged {
                 path,
@@ -4901,8 +4956,8 @@ Subject: Captured\r\n\r\nhi\r\n";
         let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
         let rpm = "Yerd_Linux_x86_64_v99-0-1.rpm";
         let rpm_arm = "Yerd_Linux_Arm64_v99-0-1.rpm";
-        let releases = format!(
-            r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
+        let stable = format!(
+            r#"{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
                 {{"name":"{mac}.sig","browser_download_url":"https://h/{mac}.sig","size":1}},
                 {{"name":"{deb}","browser_download_url":"https://h/{deb}","size":4}},
@@ -4918,15 +4973,15 @@ Subject: Captured\r\n\r\nhi\r\n";
                 {{"name":"{rpm_arm}","browser_download_url":"https://h/{rpm_arm}","size":4}},
                 {{"name":"{rpm_arm}.sig","browser_download_url":"https://h/{rpm_arm}.sig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
-            ]}}]"#
+            ]}}"#
         );
         let h = yerd_update::sha256_hex(b"test");
         let sums = format!(
             "{h}  {mac}\n{h}  {deb}\n{h}  {arm}\n{h}  {pkg}\n{h}  {pkg_arm}\n{h}  {rpm}\n{h}  {rpm_arm}\n"
         );
-        let dl = StageDl { releases, sums };
+        let dl = StageDl::new(&stable, sums);
 
-        match crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await {
+        match crate::self_update::stage_update(None, &state, &dl, dl.key()).await {
             Response::Staged { path, .. } => {
                 let p = std::path::Path::new(&path);
                 assert!(p.exists(), "staged file should exist at {path}");
@@ -4962,8 +5017,8 @@ Subject: Captured\r\n\r\nhi\r\n";
         let pkg_arm = "Yerd_Linux_Arm64_v99-0-1.pkg.tar.zst";
         let rpm = "Yerd_Linux_x86_64_v99-0-1.rpm";
         let rpm_arm = "Yerd_Linux_Arm64_v99-0-1.rpm";
-        let releases = format!(
-            r#"[{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
+        let stable = format!(
+            r#"{{"tag_name":"v99.0.1","prerelease":false,"draft":false,"assets":[
                 {{"name":"{mac}","browser_download_url":"https://h/{mac}","size":4}},
                 {{"name":"{mac}.minisig","browser_download_url":"https://h/{mac}.minisig","size":1}},
                 {{"name":"{deb}","browser_download_url":"https://h/{deb}","size":4}},
@@ -4979,14 +5034,14 @@ Subject: Captured\r\n\r\nhi\r\n";
                 {{"name":"{rpm_arm}","browser_download_url":"https://h/{rpm_arm}","size":4}},
                 {{"name":"{rpm_arm}.minisig","browser_download_url":"https://h/{rpm_arm}.minisig","size":1}},
                 {{"name":"SHA256SUMS","browser_download_url":"https://h/SHA256SUMS","size":1}}
-            ]}}]"#
+            ]}}"#
         );
         let bad = "0".repeat(64);
         let sums = format!(
             "{bad}  {mac}\n{bad}  {deb}\n{bad}  {arm}\n{bad}  {pkg}\n{bad}  {pkg_arm}\n{bad}  {rpm}\n{bad}  {rpm_arm}\n"
         );
-        let dl = StageDl { releases, sums };
-        match crate::self_update::stage_update(None, &state, &dl, SIG_PUBKEY).await {
+        let dl = StageDl::new(&stable, sums);
+        match crate::self_update::stage_update(None, &state, &dl, dl.key()).await {
             Response::Error { message, .. } => assert!(
                 message.contains("checksum verification failed"),
                 "expected a checksum verification failure, got: {message}"

--- a/bin/yerdd/src/lib.rs
+++ b/bin/yerdd/src/lib.rs
@@ -241,7 +241,8 @@ async fn run_until_shutdown(
                         .await;
                     }
                     _ = self_tick.tick() => {
-                        crate::self_update::poll_if_due(&state, &dl).await;
+                        crate::self_update::poll_if_due(&state, &dl, yerd_update::UPDATE_PUBLIC_KEY)
+                            .await;
                     }
                     _ = rx.changed() => break,
                 }

--- a/bin/yerdd/src/self_update.rs
+++ b/bin/yerdd/src/self_update.rs
@@ -1,19 +1,27 @@
 //! Yerd self-update version checking (notify-only, Phase A).
 //!
-//! The daemon polls the GitHub Releases API for `forjedio/yerd`, caches the
-//! parsed releases (`DaemonState::yerd_update`), and answers `CheckUpdate` by
-//! running the pure [`yerd_update::select_target`] decision over them. Like the
-//! PHP checker this is **notify-only**: it never installs anything (apply is a
-//! CLI/GUI-initiated, interactively-elevated path - see the feature plan).
+//! The daemon reads a signed release manifest from the Yerd CDN
+//! (`https://files.yerd.app/latest.json`), caches the parsed releases
+//! (`DaemonState::yerd_update`), and answers `CheckUpdate` by running the pure
+//! [`yerd_update::select_target`] decision over them. Like the PHP checker this
+//! is **notify-only**: it never installs anything (apply is a CLI/GUI-initiated,
+//! interactively-elevated path - see the feature plan).
+//!
+//! The manifest's detached minisign signature is verified against
+//! [`yerd_update::UPDATE_PUBLIC_KEY`] before it is trusted, so an attacker
+//! cannot advertise a version we did not sign. (A minisign signature binds
+//! content, not freshness, so it does not by itself defeat a replay of an older
+//! *validly-signed* manifest; but the check is notify-only and artifacts are
+//! still independently SHA-256 + minisign verified at stage time, so the bounded
+//! worst case is a suppressed notification, never a bad install.)
 //!
 //! Network failure is tolerated: the periodic poll leaves the cache untouched,
 //! and `CheckUpdate` falls back to the cache with [`UpdateSource::Cached`].
 
-use serde::Deserialize;
-
 use yerd_ipc::{Response, StagedArtifact, UpdateSource};
 use yerd_php::Downloader;
 use yerd_platform::PlatformDirs;
+use yerd_release_manifest::LatestManifest;
 use yerd_update::{
     select_asset, select_target, verify_minisign, verify_sha256, ArtifactKind, Asset, Channel,
     PkgFormat, Platform, ReleaseMeta,
@@ -22,14 +30,12 @@ use yerd_update::{
 use crate::ipc_server::internal;
 use crate::state::DaemonState;
 
-/// GitHub repository the release artifacts are published under.
-const GITHUB_OWNER: &str = "forjedio";
-const GITHUB_REPO: &str = "yerd";
-/// Releases per page (GitHub max is 100). One page covers stable + edge for any
-/// realistic release history; [`MAX_PAGES`] bounds the walk defensively.
-const PER_PAGE: usize = 100;
-/// Hard cap on pages walked, so a misbehaving API can never loop unbounded.
-const MAX_PAGES: u32 = 3;
+/// The signed release manifest the daemon reads to learn about releases. Its
+/// body is a [`LatestManifest`] (latest stable + RC); it is verified against
+/// [`yerd_update::UPDATE_PUBLIC_KEY`] before it is trusted.
+const LATEST_MANIFEST_URL: &str = "https://files.yerd.app/latest.json";
+/// The detached minisign signature over [`LATEST_MANIFEST_URL`].
+const LATEST_MANIFEST_SIG_URL: &str = "https://files.yerd.app/latest.json.minisig";
 
 /// The running daemon version (compile-time). Falls back to `0.0.0` if the
 /// crate version is ever not valid semver (it always is - the workspace pins it).
@@ -38,88 +44,83 @@ fn current_version() -> semver::Version {
         .unwrap_or_else(|_| semver::Version::new(0, 0, 0))
 }
 
-/// One GitHub release, as far as we parse it.
-#[derive(Deserialize)]
-struct GhRelease {
-    tag_name: String,
-    #[serde(default)]
-    prerelease: bool,
-    #[serde(default)]
-    draft: bool,
-    #[serde(default)]
-    body: Option<String>,
-    #[serde(default)]
-    assets: Vec<GhAsset>,
-}
-
-/// One asset attached to a GitHub release.
-#[derive(Deserialize)]
-struct GhAsset {
-    name: String,
-    browser_download_url: String,
-    #[serde(default)]
-    size: u64,
-}
-
-/// Fetch and parse the release list from GitHub. Returns `None` on any network
-/// or decode failure (caller falls back to the cache). Drafts and releases whose
-/// tag is not valid semver are skipped.
-async fn fetch_releases(dl: &dyn Downloader) -> Option<Vec<ReleaseMeta>> {
-    let mut out: Vec<ReleaseMeta> = Vec::new();
-    for page in 1..=MAX_PAGES {
-        let url = format!(
-            "https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases?per_page={PER_PAGE}&page={page}"
-        );
-        let bytes = match dl.download(&url).await {
-            Ok(b) => b,
-            Err(e) => {
-                if page == 1 {
-                    tracing::debug!(error = %e, "yerd self-update: releases fetch failed");
-                    return None;
-                }
-                tracing::debug!(error = %e, page, "yerd self-update: stopping pagination early");
-                break;
-            }
-        };
-        let releases: Vec<GhRelease> = match serde_json::from_slice(&bytes) {
-            Ok(r) => r,
-            Err(e) => {
-                if page == 1 {
-                    tracing::debug!(error = %e, "yerd self-update: releases decode failed");
-                    return None;
-                }
-                break;
-            }
-        };
-        let count = releases.len();
-        for r in releases {
-            if r.draft {
-                continue;
-            }
-            let Some(version) = yerd_update::parse_tag(&r.tag_name) else {
-                continue;
-            };
-            out.push(ReleaseMeta {
-                version,
-                tag: r.tag_name,
-                prerelease: r.prerelease,
-                assets: r
-                    .assets
-                    .into_iter()
-                    .map(|a| Asset {
-                        name: a.name,
-                        url: a.browser_download_url,
-                        size: a.size,
-                    })
-                    .collect(),
-                notes: r.body,
-            });
+/// Fetch, verify, and parse the signed release manifest from the CDN. Returns
+/// `None` on any network, signature, or decode failure (caller falls back to the
+/// cache).
+///
+/// The detached minisign signature is verified against `public_key` (production
+/// passes [`yerd_update::UPDATE_PUBLIC_KEY`]) **before** the body is parsed,
+/// mirroring the PHP listing's `fetch_verified_listing`, so a forged or tampered
+/// manifest advertising a version we did not publish is rejected. The manifest
+/// carries only the latest stable and RC releases - all the self-update decision
+/// needs - which are flattened into a `Vec<ReleaseMeta>` for [`select_target`];
+/// releases whose tag is not valid semver are dropped.
+async fn fetch_releases(dl: &dyn Downloader, public_key: &str) -> Option<Vec<ReleaseMeta>> {
+    let body = match dl.download(LATEST_MANIFEST_URL).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!(error = %e, "yerd self-update: manifest fetch failed");
+            return None;
         }
-        if count < PER_PAGE {
-            break;
+    };
+    let sig = match dl.download(LATEST_MANIFEST_SIG_URL).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!(error = %e, "yerd self-update: manifest signature fetch failed");
+            return None;
         }
+    };
+    let sig = String::from_utf8_lossy(&sig);
+    if let Err(e) = verify_minisign(public_key, &sig, &body) {
+        tracing::warn!(error = %e, "yerd self-update: manifest signature verification failed");
+        return None;
     }
-    Some(out)
+    let manifest: LatestManifest = match serde_json::from_slice(&body) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::debug!(error = %e, "yerd self-update: manifest decode failed");
+            return None;
+        }
+    };
+    Some(manifest_to_releases(manifest))
+}
+
+/// Flatten the manifest's `stable` + `rc` entries into the daemon's release
+/// model, dropping any whose tag is not valid semver. The two are distinct by
+/// construction (the generator only surfaces an `rc` strictly newer than
+/// `stable`), so no de-duplication is needed.
+fn manifest_to_releases(manifest: LatestManifest) -> Vec<ReleaseMeta> {
+    [manifest.stable, manifest.rc]
+        .into_iter()
+        .flatten()
+        .filter_map(entry_to_meta)
+        .collect()
+}
+
+/// Convert one manifest release entry into a [`ReleaseMeta`], or `None` if its
+/// tag is not valid semver or it is a draft. The trusted producer never emits a
+/// draft into `latest.json`; the draft skip is defensive parity with the old
+/// GitHub-API path.
+fn entry_to_meta(entry: yerd_release_manifest::ReleaseEntry) -> Option<ReleaseMeta> {
+    if entry.draft {
+        return None;
+    }
+    let version = yerd_update::parse_tag(&entry.tag_name)?;
+    Some(ReleaseMeta {
+        version,
+        tag: entry.tag_name,
+        prerelease: entry.prerelease,
+        assets: entry
+            .assets
+            .into_iter()
+            .map(|a| Asset {
+                name: a.name,
+                url: a.browser_download_url,
+                size: a.size,
+            })
+            .collect(),
+        notes: entry.body,
+    })
 }
 
 /// The effective channel from persisted config (defaulting to stable).
@@ -292,7 +293,7 @@ pub async fn cached_update_status(state: &DaemonState) -> Response {
 /// restarts, since `state.update_snapshot` is seeded from the persisted
 /// snapshot at startup, and across OS sleep, since this compares epoch time
 /// rather than trusting the caller's tick cadence.
-pub async fn poll_if_due(state: &DaemonState, dl: &dyn Downloader) {
+pub async fn poll_if_due(state: &DaemonState, dl: &dyn Downloader, public_key: &str) {
     let last_checked = state
         .update_snapshot
         .read()
@@ -300,7 +301,7 @@ pub async fn poll_if_due(state: &DaemonState, dl: &dyn Downloader) {
         .as_ref()
         .map(|s| s.checked_at);
     if yerd_update::is_check_due(last_checked, now_epoch()) {
-        poll_and_refresh(state, dl).await;
+        poll_and_refresh(state, dl, public_key).await;
     }
 }
 
@@ -308,8 +309,8 @@ pub async fn poll_if_due(state: &DaemonState, dl: &dyn Downloader) {
 /// fetch error logs at `debug` and leaves the cache untouched. Notify-only: logs
 /// (does not install) when a newer version is available on the configured
 /// channel. Called by [`poll_if_due`] on its wall-clock-gated cadence.
-pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader) {
-    let Some(releases) = fetch_releases(dl).await else {
+pub async fn poll_and_refresh(state: &DaemonState, dl: &dyn Downloader, public_key: &str) {
+    let Some(releases) = fetch_releases(dl, public_key).await else {
         return;
     };
     let channel = configured_channel(state).await;
@@ -333,13 +334,14 @@ pub async fn check_update(
     channel_override: Option<yerd_ipc::Channel>,
     state: &DaemonState,
     dl: &dyn Downloader,
+    public_key: &str,
 ) -> Response {
     let current = current_version();
     let channel = match channel_override {
         Some(c) => from_ipc(c),
         None => configured_channel(state).await,
     };
-    if let Some(releases) = fetch_releases(dl).await {
+    if let Some(releases) = fetch_releases(dl, public_key).await {
         let decision = select_target(&releases, channel, &current);
         *state.yerd_update.write().await = releases;
         let snap = snapshot_from(&decision, now_epoch());
@@ -360,8 +362,10 @@ pub async fn check_update(
 /// into the cache dir. Returns [`Response::Staged`] with the on-disk path.
 ///
 /// `public_key` is [`yerd_update::UPDATE_PUBLIC_KEY`] in production and a test
-/// key in unit tests. The privileged install/swap is the applier's job, not the
-/// daemon's - this only produces a verified local file.
+/// key in unit tests; it verifies both the release manifest (in
+/// [`fetch_releases`]) and the artifact signature here. The privileged
+/// install/swap is the applier's job, not the daemon's - this only produces a
+/// verified local file.
 pub async fn stage_update(
     channel_override: Option<yerd_ipc::Channel>,
     state: &DaemonState,
@@ -374,7 +378,7 @@ pub async fn stage_update(
         None => configured_channel(state).await,
     };
 
-    let Some(releases) = fetch_releases(dl).await else {
+    let Some(releases) = fetch_releases(dl, public_key).await else {
         return internal("could not fetch releases (offline or rate-limited)".to_owned());
     };
     let decision = select_target(&releases, channel, &current);
@@ -485,6 +489,44 @@ mod tests {
     #[test]
     fn current_version_parses() {
         assert_ne!(current_version(), semver::Version::new(0, 0, 0));
+    }
+
+    #[test]
+    fn manifest_to_releases_maps_and_drops_bad_entries() {
+        use yerd_release_manifest::{AssetEntry, ReleaseEntry};
+        let entry = |tag: &str, prerelease: bool, draft: bool| ReleaseEntry {
+            tag_name: tag.to_owned(),
+            prerelease,
+            draft,
+            body: Some("notes".to_owned()),
+            assets: vec![AssetEntry {
+                name: "a.deb".to_owned(),
+                browser_download_url: "https://cdn.test/a.deb".to_owned(),
+                size: 4,
+            }],
+        };
+
+        // Valid stable is kept and mapped; an unparseable-tag rc is dropped.
+        let out = manifest_to_releases(LatestManifest {
+            schema: 1,
+            stable: Some(entry("v2.0.5", false, false)),
+            rc: Some(entry("not-semver", true, false)),
+        });
+        assert_eq!(out.len(), 1);
+        let kept = out.first().unwrap();
+        assert_eq!(kept.tag, "v2.0.5");
+        assert_eq!(kept.version, semver::Version::parse("2.0.5").unwrap());
+        assert!(!kept.prerelease);
+        assert_eq!(kept.assets.len(), 1);
+        assert_eq!(kept.notes.as_deref(), Some("notes"));
+
+        // A draft entry (never emitted by the trusted producer) is dropped.
+        let out = manifest_to_releases(LatestManifest {
+            schema: 1,
+            stable: Some(entry("v2.0.5", false, true)),
+            rc: None,
+        });
+        assert!(out.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Pulls latest releases and files from the Yerd CDN, as well as signs the release files.

## Related issues

n/a

## Type of change

- [x] Refactor / internal change

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cryptographically signed update manifests for CDN-delivered releases.
  - Release workflows now upload signature files alongside update manifests and refresh their cache entries.
  - Update checks verify manifest signatures before processing release information.

- **Bug Fixes**
  - Rejects tampered or invalid manifests instead of trusting their contents.
  - Preserves cached update information when a fresh manifest cannot be retrieved.

- **Tests**
  - Added coverage for signature validation, tampered manifests, release filtering, and offline fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->