### PR TITLE
[Fix] MacOS port binding issue for lan expose

### DIFF
--- a/apps/yerd-gui/src/ipc/types.ts
+++ b/apps/yerd-gui/src/ipc/types.ts
@@ -292,6 +292,14 @@ export interface StatusReport {
   /** Whether `yerd mcp` serves Yerd's tools to local AI agents. Defaults to
    *  `false` (opt-in) when omitted by a daemon predating the field. */
   mcp_enabled?: boolean;
+  /** macOS: destination ports the installed loopback (`dev.yerd`) pf anchor
+   *  carries 80/443 to. Compare with `http.bound`/`https.bound` to detect a
+   *  stale redirect that black-holes on-host access. Omitted when not installed,
+   *  unreadable, or not macOS. */
+  port_redirect_targets?: { http: number; https: number } | null;
+  /** macOS: same as `port_redirect_targets` for the LAN (`dev.yerd.lan`) anchor.
+   *  A stale target here black-holes other devices while LAN mode is on. */
+  lan_redirect_targets?: { http: number; https: number } | null;
 }
 
 /** One apex-shadow relationship: `site`'s apex is claimed by `shadowed_by`. */
@@ -307,6 +315,7 @@ export type DiagnosisCode =
   | "port_fallback"
   | "web_ports_unbound"
   | "foreign_web_listener"
+  | "dns_port_unbound"
   | "ca_not_trusted"
   | "ca_not_trusted_by_browsers"
   | "resolver_not_installed"
@@ -320,6 +329,9 @@ export type DiagnosisCode =
   | "bin_dir_not_on_path"
   | "php_ca_not_trusted"
   | "symlink_protection_disabled"
+  | "domain_shadowed"
+  | "port_redirect_stale"
+  | "lan_redirect_stale"
   | "all_good";
 
 export interface Diagnosis {

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -303,6 +303,7 @@ mod unix_impl {
                             .to_owned(),
                     ));
                 }
+                require_rootless_web_facts(facts, PORTS_RESTART_REMEDY)?;
                 HelperInvocation::InstallPortRedirect {
                     http_from: 80,
                     http_to: facts.http_port,
@@ -335,6 +336,7 @@ mod unix_impl {
                             .to_owned(),
                     ));
                 }
+                require_rootless_web_facts(facts, LAN_RESTART_REMEDY)?;
                 let lan_ip = facts.lan_ip.ok_or_else(|| {
                     ClientError::Usage(
                         "LAN IP unknown — run `yerd lan enable` (and check `yerd lan status`) first"
@@ -352,6 +354,41 @@ mod unix_impl {
             #[cfg(target_os = "macos")]
             (ElevateTarget::Lan, true) => HelperInvocation::UninstallLanPortRedirect,
         })
+    }
+
+    /// Ports below this are privileged on every supported OS.
+    #[cfg(target_os = "macos")]
+    const PRIVILEGED_PORT_CEILING: u16 = 1024;
+
+    /// Recovery guidance for the `elevate ports` arm when the daemon still holds
+    /// a privileged port directly.
+    #[cfg(target_os = "macos")]
+    const PORTS_RESTART_REMEDY: &str =
+        "restart it (`yerd restart daemon`) so it binds its rootless ports, then re-run \
+         `sudo yerd elevate ports`; if LAN mode is on, also re-run `sudo yerd elevate lan`";
+
+    /// Recovery guidance for the `elevate lan` arm.
+    #[cfg(target_os = "macos")]
+    const LAN_RESTART_REMEDY: &str =
+        "restart it (`yerd restart daemon`) so it binds its rootless ports, then re-run \
+         `sudo yerd elevate lan` (and `sudo yerd elevate ports` if the host redirect has not \
+         been refreshed since the restart)";
+
+    /// Refuse to install a macOS pf redirect while the daemon is holding a
+    /// privileged web port directly. `facts.http_port`/`https_port` are the
+    /// daemon's *bound* ports; a redirect whose target is the privileged port
+    /// itself produces an identity rule (`80 -> 80`) that black-holes traffic
+    /// once the daemon moves to its rootless ports. Only reachable while a
+    /// pre-fix daemon still squats 80/443; `remedy` names the arm's own recovery.
+    #[cfg(target_os = "macos")]
+    fn require_rootless_web_facts(facts: &Facts, remedy: &str) -> Result<(), ClientError> {
+        if facts.http_port < PRIVILEGED_PORT_CEILING || facts.https_port < PRIVILEGED_PORT_CEILING {
+            return Err(ClientError::Usage(format!(
+                "the daemon is holding a privileged port directly (http {}, https {}); {remedy}",
+                facts.http_port, facts.https_port
+            )));
+        }
+        Ok(())
     }
 
     fn describe(target: ElevateTarget, undo: bool, facts: &Facts) -> String {
@@ -675,6 +712,26 @@ mod unix_impl {
             let undo = plan_invocation(ElevateTarget::Ports, &facts(), Path::new("/x/yerdd"), true)
                 .unwrap();
             assert_eq!(argv(&undo)[0], "uninstall-port-redirect");
+        }
+
+        #[cfg(target_os = "macos")]
+        #[test]
+        fn macos_elevate_rejects_privileged_bound_ports() {
+            let mut f = facts();
+            f.http_port = 80;
+            f.https_port = 443;
+
+            let ports_err = plan_invocation(ElevateTarget::Ports, &f, Path::new("/x/yerdd"), false)
+                .unwrap_err();
+            let ports_msg = ports_err.to_string();
+            assert!(ports_msg.contains("privileged port"), "{ports_msg}");
+            assert!(ports_msg.contains("elevate ports"), "{ports_msg}");
+
+            let lan_err =
+                plan_invocation(ElevateTarget::Lan, &f, Path::new("/x/yerdd"), false).unwrap_err();
+            let lan_msg = lan_err.to_string();
+            assert!(lan_msg.contains("privileged port"), "{lan_msg}");
+            assert!(lan_msg.contains("elevate lan"), "{lan_msg}");
         }
 
         #[test]

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -1425,6 +1425,9 @@ fn format_status(r: &StatusReport) -> String {
             "ports     conflict: another process is using 80/443 (run `yerd doctor`)"
         );
     }
+    if let Some(line) = redirect_stale_line(r) {
+        let _ = writeln!(s, "{line}");
+    }
     if let Some(port) = r.dns_unbound {
         let _ = writeln!(
             s,
@@ -1583,6 +1586,30 @@ fn fmt_tristate(b: Option<bool>) -> &'static str {
         Some(false) => "no",
         None => "unknown",
     }
+}
+
+/// A `ports` status line when an installed macOS pf redirect targets a port the
+/// daemon is no longer serving. The host (loopback) case takes precedence and
+/// names both elevate commands; a LAN-only mismatch (host fine) names the LAN
+/// step. `None` when nothing is stale. Mirrors the doctor's stale findings.
+fn redirect_stale_line(r: &StatusReport) -> Option<String> {
+    let mismatched =
+        |t: yerd_ipc::PortRedirectTargets| t.http != r.http.bound || t.https != r.https.bound;
+    if r.port_redirect_targets.is_some_and(mismatched) {
+        return Some(
+            "ports     stale redirect: pf targets a dead port (run `sudo yerd elevate ports`, \
+             then `sudo yerd elevate lan` if LAN is on; see `yerd doctor`)"
+                .to_owned(),
+        );
+    }
+    if r.lan_enabled && r.lan_redirect_targets.is_some_and(mismatched) {
+        return Some(
+            "ports     stale LAN redirect: other devices reach a dead port (run \
+             `sudo yerd elevate lan`; see `yerd doctor`)"
+                .to_owned(),
+        );
+    }
+    None
 }
 
 /// Render integer hundredths (e.g. `152`) as a decimal (`1.52`).
@@ -2732,6 +2759,8 @@ mod tests {
             lan_enabled: false,
             lan_ip: None,
             lan_setup_bound: None,
+            port_redirect_targets: None,
+            lan_redirect_targets: None,
         }
     }
 
@@ -2848,6 +2877,40 @@ mod tests {
             fell_back: false,
         };
         assert_eq!(fmt_port(bound, true), "80");
+    }
+
+    #[test]
+    fn status_shows_stale_redirect_lines() {
+        let mut r = sample_report();
+        r.http.bound = 8080;
+        r.https.bound = 8443;
+
+        r.port_redirect_targets = Some(yerd_ipc::PortRedirectTargets {
+            http: 9090,
+            https: 9443,
+        });
+        let out = format_status(&r);
+        assert!(out.contains("stale redirect"), "{out}");
+        assert!(out.contains("elevate ports"), "{out}");
+
+        r.port_redirect_targets = Some(yerd_ipc::PortRedirectTargets {
+            http: 8080,
+            https: 8443,
+        });
+        r.lan_enabled = true;
+        r.lan_redirect_targets = Some(yerd_ipc::PortRedirectTargets {
+            http: 80,
+            https: 443,
+        });
+        let out = format_status(&r);
+        assert!(out.contains("stale LAN redirect"), "{out}");
+
+        r.lan_redirect_targets = Some(yerd_ipc::PortRedirectTargets {
+            http: 8080,
+            https: 8443,
+        });
+        let out = format_status(&r);
+        assert!(!out.contains("stale"), "{out}");
     }
 
     #[test]

--- a/bin/yerd/src/mcp_cmd.rs
+++ b/bin/yerd/src/mcp_cmd.rs
@@ -402,6 +402,8 @@ mod tests {
             lan_enabled: false,
             lan_ip: None,
             lan_setup_bound: None,
+            port_redirect_targets: None,
+            lan_redirect_targets: None,
         }
     }
 

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -780,13 +780,19 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
     .ok()
     .flatten();
 
-    let (port_redirect, foreign_web_listener) = tokio::task::spawn_blocking(|| {
-        use yerd_platform::PortRedirector;
-        let r = yerd_platform::ActivePortRedirector::new();
-        (r.is_active(), r.foreign_web_listener())
-    })
-    .await
-    .unwrap_or((None, None));
+    let (port_redirect, foreign_web_listener, port_redirect_targets, lan_redirect_targets) =
+        tokio::task::spawn_blocking(|| {
+            use yerd_platform::PortRedirector;
+            let r = yerd_platform::ActivePortRedirector::new();
+            (
+                r.is_active(),
+                r.foreign_web_listener(),
+                r.redirect_targets().map(redirect_targets_to_wire),
+                r.lan_redirect_targets().map(redirect_targets_to_wire),
+            )
+        })
+        .await
+        .unwrap_or((None, None, None, None));
 
     let backup_tld = tld.clone();
     let resolver_backup = tokio::task::spawn_blocking(move || latest_resolver_backup(&backup_tld))
@@ -819,6 +825,8 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
         resolver_installed,
         port_redirect,
         foreign_web_listener,
+        port_redirect_targets,
+        lan_redirect_targets,
         resolver_backup,
         default_php,
         php,
@@ -844,6 +852,12 @@ async fn build_status_report(state: &DaemonState) -> yerd_ipc::StatusReport {
         lan_ip,
         lan_setup_bound,
     }
+}
+
+/// Map the platform layer's parsed anchor targets `(http, https)` to the wire
+/// type.
+fn redirect_targets_to_wire((http, https): (u16, u16)) -> yerd_ipc::PortRedirectTargets {
+    yerd_ipc::PortRedirectTargets { http, https }
 }
 
 /// The path of the most recent replaced-resolver backup for `tld`, if one was

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -343,7 +343,19 @@ fn port_findings(report: &StatusReport) -> Vec<Diagnosis> {
         ));
         return out;
     }
-    if privileged_fallback(report) && report.port_redirect != Some(true) && !foreign_listener {
+    let host_stale = redirect_stale_finding(report);
+    let host_stale_present = host_stale.is_some();
+    if let Some(finding) = host_stale {
+        out.push(finding);
+    }
+    if let Some(finding) = lan_redirect_stale_finding(report) {
+        out.push(finding);
+    }
+    if privileged_fallback(report)
+        && report.port_redirect != Some(true)
+        && !foreign_listener
+        && !host_stale_present
+    {
         out.push(warn(
             DiagnosisCode::PortFallback,
             "Privileged ports not bound",
@@ -358,6 +370,55 @@ fn port_findings(report: &StatusReport) -> Vec<Diagnosis> {
         ));
     }
     out
+}
+
+/// Warn when the installed macOS loopback (`dev.yerd`) pf redirect targets a
+/// port the daemon is no longer serving, so on-host 80/443 are black-holed even
+/// though the daemon is up. Not gated on `lan_enabled`: the loopback anchor
+/// governs host access regardless of LAN mode. `None` targets emit nothing (the
+/// anchor is not installed, unreadable, or this is not macOS).
+fn redirect_stale_finding(report: &StatusReport) -> Option<Diagnosis> {
+    let t = report.port_redirect_targets?;
+    if t.http == report.http.bound && t.https == report.https.bound {
+        return None;
+    }
+    Some(warn(
+        DiagnosisCode::PortRedirectStale,
+        "Port redirect is stale",
+        format!(
+            "The pf redirect sends 80→{} and 443→{}, but Yerd is listening on {} and {}, so \
+             http/https on this Mac fail even though the daemon is running.",
+            t.http, t.https, report.http.bound, report.https.bound
+        ),
+        "restart the daemon if it recently changed ports, then sudo yerd elevate ports; \
+         if LAN mode is on, also sudo yerd elevate lan",
+    ))
+}
+
+/// Warn when LAN mode is on and the installed macOS LAN (`dev.yerd.lan`) pf
+/// redirect targets a port the daemon is no longer serving, so other devices
+/// reach a dead port. Gated on `lan_enabled`: `yerd lan disable` leaves the
+/// anchor in place (only `yerd unelevate lan` removes it), and a deliberately
+/// disabled machine has no remote path left to break.
+fn lan_redirect_stale_finding(report: &StatusReport) -> Option<Diagnosis> {
+    if !report.lan_enabled {
+        return None;
+    }
+    let t = report.lan_redirect_targets?;
+    if t.http == report.http.bound && t.https == report.https.bound {
+        return None;
+    }
+    Some(warn(
+        DiagnosisCode::LanRedirectStale,
+        "LAN redirect is stale",
+        format!(
+            "The LAN pf redirect sends 80→{} and 443→{}, but Yerd is listening on {} and {}, so \
+             other devices on your network reach a dead port.",
+            t.http, t.https, report.http.bound, report.https.bound
+        ),
+        "sudo yerd elevate lan (and sudo yerd elevate ports if host 80/443 are also stale); \
+         if the daemon still holds a privileged port, restart it first",
+    ))
 }
 
 /// Remediation for the privileged-ports-not-bound warning. The loopback probe
@@ -431,7 +492,9 @@ fn fail(code: DiagnosisCode, title: &str, detail: String, remedy: Option<String>
 )]
 mod tests {
     use super::*;
-    use yerd_ipc::{CaStatus, PhpPoolStatus, PortStatus, SiteCounts, StatusReport};
+    use yerd_ipc::{
+        CaStatus, PhpPoolStatus, PortRedirectTargets, PortStatus, SiteCounts, StatusReport,
+    };
 
     /// A fully-healthy baseline report: privileged ports bound, CA trusted,
     /// resolver installed, default PHP running, one site.
@@ -492,6 +555,8 @@ mod tests {
             lan_enabled: false,
             lan_ip: None,
             lan_setup_bound: None,
+            port_redirect_targets: None,
+            lan_redirect_targets: None,
         }
     }
 
@@ -637,6 +702,102 @@ mod tests {
         assert!(cs.contains(&DiagnosisCode::WebPortsUnbound));
         assert!(!cs.contains(&DiagnosisCode::PortFallback));
         assert!(!cs.contains(&DiagnosisCode::AllGood));
+    }
+
+    /// Build the rootless-serving fallback state: the daemon requested 80/443 but
+    /// bound the rootless pair, with the pf redirect live.
+    fn rootless_fallback() -> StatusReport {
+        let mut r = healthy();
+        r.http = PortStatus {
+            requested: 80,
+            bound: 8080,
+            fell_back: true,
+        };
+        r.https = PortStatus {
+            requested: 443,
+            bound: 8443,
+            fell_back: true,
+        };
+        r.port_redirect = Some(true);
+        r
+    }
+
+    #[test]
+    fn matching_redirect_targets_stay_silent() {
+        let mut r = rootless_fallback();
+        r.port_redirect_targets = Some(PortRedirectTargets {
+            http: 8080,
+            https: 8443,
+        });
+        let cs = codes(&diagnose(&r, None));
+        assert!(!cs.contains(&DiagnosisCode::PortRedirectStale));
+        assert!(!cs.contains(&DiagnosisCode::LanRedirectStale));
+    }
+
+    #[test]
+    fn stale_loopback_target_warns_and_suppresses_port_fallback() {
+        let mut r = rootless_fallback();
+        r.port_redirect = Some(false);
+        r.port_redirect_targets = Some(PortRedirectTargets {
+            http: 9090,
+            https: 9443,
+        });
+        let ds = diagnose(&r, None);
+        let cs = codes(&ds);
+        assert!(cs.contains(&DiagnosisCode::PortRedirectStale));
+        assert!(!cs.contains(&DiagnosisCode::PortFallback));
+        assert!(!cs.contains(&DiagnosisCode::AllGood));
+        let remedy = ds
+            .iter()
+            .find(|d| d.code == DiagnosisCode::PortRedirectStale)
+            .and_then(|d| d.remedy.as_deref())
+            .expect("stale finding has a remedy");
+        assert!(remedy.contains("elevate ports"));
+        assert!(remedy.contains("elevate lan"));
+    }
+
+    /// The exact M2 transition state: host loopback anchor already matches the
+    /// bound rootless ports (so PortRedirectStale/PortFallback stay silent), but
+    /// the LAN identity anchor still points 80/443 at themselves.
+    #[test]
+    fn lan_identity_anchor_warns_only_lan_stale() {
+        let mut r = rootless_fallback();
+        r.lan_enabled = true;
+        r.port_redirect_targets = Some(PortRedirectTargets {
+            http: 8080,
+            https: 8443,
+        });
+        r.lan_redirect_targets = Some(PortRedirectTargets {
+            http: 80,
+            https: 443,
+        });
+        let ds = diagnose(&r, None);
+        let cs = codes(&ds);
+        assert!(cs.contains(&DiagnosisCode::LanRedirectStale));
+        assert!(!cs.contains(&DiagnosisCode::PortRedirectStale));
+        assert!(!cs.contains(&DiagnosisCode::PortFallback));
+        let remedy = ds
+            .iter()
+            .find(|d| d.code == DiagnosisCode::LanRedirectStale)
+            .and_then(|d| d.remedy.as_deref())
+            .expect("lan stale finding has a remedy");
+        assert!(remedy.contains("elevate lan"));
+    }
+
+    #[test]
+    fn lan_stale_is_gated_on_lan_enabled() {
+        let mut r = rootless_fallback();
+        r.lan_enabled = false;
+        r.port_redirect_targets = Some(PortRedirectTargets {
+            http: 8080,
+            https: 8443,
+        });
+        r.lan_redirect_targets = Some(PortRedirectTargets {
+            http: 80,
+            https: 443,
+        });
+        let cs = codes(&diagnose(&r, None));
+        assert!(!cs.contains(&DiagnosisCode::LanRedirectStale));
     }
 
     #[test]

--- a/crates/yerd-ipc/src/lib.rs
+++ b/crates/yerd-ipc/src/lib.rs
@@ -54,9 +54,9 @@ pub use status::{
     AddableServiceType, BrowserTrust, CaStatus, CloudflaredSource, CloudflaredStatus,
     DatabaseSummary, Diagnosis, DiagnosisCode, DomainShadow, FixReport, FixResult, MailAttachment,
     MailDetail, MailHeader, MailStatus, MailSummary, NamedTunnelMeta, PhpPoolStatus, PoolRunState,
-    PortStatus, ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts,
-    SiteHostname, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UnboundWeb,
-    WordPressVersionInfo,
+    PortRedirectTargets, PortStatus, ServiceAvailability, ServiceRunState, ServiceStatus, Severity,
+    SiteCounts, SiteHostname, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState,
+    UnboundWeb, WordPressVersionInfo,
 };
 pub use update::{Channel, StagedArtifact, UpdateSource};
 

--- a/crates/yerd-ipc/src/response.rs
+++ b/crates/yerd-ipc/src/response.rs
@@ -755,6 +755,8 @@ mod variant_name_pinning {
                 lan_enabled: false,
                 lan_ip: None,
                 lan_setup_bound: None,
+                port_redirect_targets: None,
+                lan_redirect_targets: None,
             }),
         });
         pin_response(Response::Diagnoses {

--- a/crates/yerd-ipc/src/status.rs
+++ b/crates/yerd-ipc/src/status.rs
@@ -166,6 +166,29 @@ pub struct StatusReport {
     /// is on but the listener couldn't bind (degraded).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lan_setup_bound: Option<bool>,
+    /// Destination ports of the installed macOS loopback (`dev.yerd`) pf anchor,
+    /// read from disk at status time. Compare with [`Self::http`]/[`Self::https`]
+    /// `bound` to detect a stale redirect that black-holes on-host 80/443. `None`
+    /// = not installed, unreadable, or not macOS. `#[serde(default,
+    /// skip_serializing_if)]` keeps the wire additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port_redirect_targets: Option<PortRedirectTargets>,
+    /// Same as [`Self::port_redirect_targets`] for the macOS LAN (`dev.yerd.lan`)
+    /// anchor. A stale target here black-holes other devices' access while LAN
+    /// mode is on. `None` = not installed, unreadable, or not macOS.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lan_redirect_targets: Option<PortRedirectTargets>,
+}
+
+/// Destination ports `(http, https)` an installed macOS pf redirect anchor
+/// carries 80/443 to. A wire-side mirror of the platform layer's parsed anchor
+/// targets (`yerd-ipc` must not depend on `yerd-platform`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PortRedirectTargets {
+    /// Port the anchor redirects inbound 80 to.
+    pub http: u16,
+    /// Port the anchor redirects inbound 443 to.
+    pub https: u16,
 }
 
 /// One shadow relationship, surfaced in [`StatusReport::shadows`] and by `yerd
@@ -647,6 +670,17 @@ pub enum DiagnosisCode {
     /// filesystem scan order of parked directories, so the winner may change
     /// across restarts. See [`StatusReport::shadows`].
     DomainShadowed,
+    /// The installed macOS loopback pf redirect targets a port the daemon is no
+    /// longer serving, so on-host 80/443 are black-holed even though the daemon
+    /// is up. Remedy: restart the daemon if it recently changed ports, then
+    /// `sudo yerd elevate ports`; if LAN mode is on, also `sudo yerd elevate lan`.
+    /// See [`StatusReport::port_redirect_targets`].
+    PortRedirectStale,
+    /// The installed macOS LAN pf redirect (`dev.yerd.lan`) targets a port the
+    /// daemon is no longer serving, so other devices reach a dead port while LAN
+    /// mode is on. Remedy: `sudo yerd elevate lan` (restart the daemon first if it
+    /// still holds a privileged port). See [`StatusReport::lan_redirect_targets`].
+    LanRedirectStale,
     /// Everything checks out.
     AllGood,
 }

--- a/crates/yerd-ipc/tests/roundtrip.rs
+++ b/crates/yerd-ipc/tests/roundtrip.rs
@@ -250,6 +250,8 @@ fn encode_then_decode_response_roundtrip() {
             lan_enabled: true,
             lan_ip: Some("192.168.1.42".parse().unwrap()),
             lan_setup_bound: Some(true),
+            port_redirect_targets: None,
+            lan_redirect_targets: None,
         }),
     });
     assert_response_roundtrips(Response::Diagnoses {

--- a/crates/yerd-ipc/tests/wire_stability.rs
+++ b/crates/yerd-ipc/tests/wire_stability.rs
@@ -21,9 +21,10 @@ use yerd_ipc::{
     AddableServiceType, CaStatus, Channel, CloudflaredSource, CloudflaredStatus, DatabaseSummary,
     Diagnosis, DiagnosisCode, DumpCategory, DumpCounts, DumpEvent, DumpExtStatus, ErrorCode,
     FixReport, FixResult, MailAttachment, MailDetail, MailHeader, MailStatus, MailSummary,
-    NamedTunnelMeta, PhpPoolStatus, PoolRunState, PortStatus, Request, Response,
-    ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts, SiteHostname,
-    StagedArtifact, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState, UpdateSource,
+    NamedTunnelMeta, PhpPoolStatus, PoolRunState, PortRedirectTargets, PortStatus, Request,
+    Response, ServiceAvailability, ServiceRunState, ServiceStatus, Severity, SiteCounts,
+    SiteHostname, StagedArtifact, StatusReport, ToolStatus, TunnelInfo, TunnelKind, TunnelRunState,
+    UpdateSource,
 };
 
 // ---------- Request ----------
@@ -1023,6 +1024,8 @@ fn response_status_byte_shape() {
             lan_enabled: false,
             lan_ip: None,
             lan_setup_bound: None,
+            port_redirect_targets: None,
+            lan_redirect_targets: None,
         }),
     };
     let s = serde_json::to_string(&r).unwrap();
@@ -1048,6 +1051,33 @@ fn status_port_redirect_appears_only_when_some() {
     report.port_redirect = None;
     let s = serde_json::to_string(&report).unwrap();
     assert!(!s.contains("port_redirect"), "{s}");
+}
+
+#[test]
+fn status_redirect_targets_appear_only_when_some() {
+    let mut report = sample_status_report();
+    report.port_redirect_targets = Some(PortRedirectTargets {
+        http: 8080,
+        https: 8443,
+    });
+    report.lan_redirect_targets = Some(PortRedirectTargets {
+        http: 8081,
+        https: 8444,
+    });
+    let s = serde_json::to_string(&report).unwrap();
+    assert!(
+        s.contains(r#""port_redirect_targets":{"http":8080,"https":8443}"#),
+        "{s}"
+    );
+    assert!(
+        s.contains(r#""lan_redirect_targets":{"http":8081,"https":8444}"#),
+        "{s}"
+    );
+
+    report.port_redirect_targets = None;
+    report.lan_redirect_targets = None;
+    let s = serde_json::to_string(&report).unwrap();
+    assert!(!s.contains("redirect_targets"), "{s}");
 }
 
 #[test]
@@ -1129,6 +1159,8 @@ fn sample_status_report() -> StatusReport {
         lan_enabled: false,
         lan_ip: None,
         lan_setup_bound: None,
+        port_redirect_targets: None,
+        lan_redirect_targets: None,
     }
 }
 
@@ -1273,6 +1305,8 @@ fn diagnosis_code_each_variant_byte_shape() {
             r#""symlink_protection_disabled""#,
         ),
         (DiagnosisCode::DomainShadowed, r#""domain_shadowed""#),
+        (DiagnosisCode::PortRedirectStale, r#""port_redirect_stale""#),
+        (DiagnosisCode::LanRedirectStale, r#""lan_redirect_stale""#),
         (DiagnosisCode::AllGood, r#""all_good""#),
     ];
     for (code, expected) in cases {

--- a/crates/yerd-mcp/src/render.rs
+++ b/crates/yerd-mcp/src/render.rs
@@ -62,7 +62,9 @@ fn render_error(tool: &str, code: ErrorCode, message: &str) -> Value {
 }
 
 /// Keep what an agent can act on; drop host/process detail (pid, RSS, load
-/// average, boot id, CA path and fingerprint, resolver backup, port redirect).
+/// average, boot id, CA path and fingerprint, resolver backup, port redirect and
+/// its anchor target ports). This is an allowlist projection, so new host-only
+/// `StatusReport` fields are excluded by default.
 fn trim_status(report: &StatusReport) -> Value {
     let php: Vec<Value> = report
         .php

--- a/crates/yerd-mcp/tests/render.rs
+++ b/crates/yerd-mcp/tests/render.rs
@@ -135,6 +135,14 @@ fn sample_report() -> yerd_ipc::StatusReport {
         lan_enabled: false,
         lan_ip: None,
         lan_setup_bound: None,
+        port_redirect_targets: Some(yerd_ipc::PortRedirectTargets {
+            http: 8080,
+            https: 8443,
+        }),
+        lan_redirect_targets: Some(yerd_ipc::PortRedirectTargets {
+            http: 8080,
+            https: 8443,
+        }),
     }
 }
 
@@ -334,6 +342,8 @@ fn status_is_trimmed_to_what_an_agent_can_act_on() {
         "ca",
         "resolver_backup",
         "port_redirect",
+        "port_redirect_targets",
+        "lan_redirect_targets",
         "shared_sites",
         "lan_enabled",
         "lan_ip",

--- a/crates/yerd-platform/src/os/macos.rs
+++ b/crates/yerd-platform/src/os/macos.rs
@@ -28,7 +28,7 @@ use crate::port_binder::{BoundPort, PortBinder, PortPair};
 use crate::port_redirect::{
     loopback_port_reachable, loopback_redirect_reaches_proxy, PortRedirector,
 };
-use crate::pure::{pem_match, port_plan, ps_metrics, resolver_file};
+use crate::pure::{pem_match, pf_anchor, port_plan, ps_metrics, resolver_file};
 use crate::resolver::ResolverInstaller;
 use crate::trust_store::{BrowserCaTrust, CaFingerprint, NssOutcome, TrustStore};
 use crate::{BindPairErrorReason, PlatformError, ResolverErrorReason, TrustStoreErrorReason};
@@ -376,11 +376,18 @@ impl PortBinder for MacosPortBinder {
 /// ports on `0.0.0.0`, and a privileged `pf rdr` (installed by `yerd elevate lan`)
 /// carries inbound 80/443 to `<lan_ip>:<rootless>`. So `lan` here only widens the
 /// bind address; the privileged-port redirect is a separate concern.
+///
+/// The daemon must never hold a privileged port directly, so a privileged
+/// `desired` pair is replaced by `fallback` before any bind is attempted (see
+/// [`port_plan::strip_privileged_desired`]). This keeps the daemon deterministically
+/// on the rootless ports the `pf rdr` targets, regardless of whether a privileged
+/// bind would have been permitted.
 fn bind_pair_impl(
     lan: bool,
     desired: (u16, u16),
     fallback: (u16, u16),
 ) -> Result<PortPair, PlatformError> {
+    let desired = port_plan::strip_privileged_desired(desired, fallback);
     let ip = if lan {
         Ipv4Addr::UNSPECIFIED
     } else {
@@ -534,6 +541,23 @@ impl PortRedirector for MacosPortRedirector {
         // redirect is live and ours.
         Some(loopback_redirect_reaches_proxy(80) && loopback_port_reachable(443))
     }
+
+    fn redirect_targets(&self) -> Option<(u16, u16)> {
+        anchor_targets_at(Path::new(pf_anchor::ANCHOR_PATH))
+    }
+
+    fn lan_redirect_targets(&self) -> Option<(u16, u16)> {
+        anchor_targets_at(Path::new(pf_anchor::LAN_ANCHOR_PATH))
+    }
+}
+
+/// Read and parse the destination ports of an installed pf anchor file. The
+/// helper writes both anchors world-readable, so the unprivileged daemon can
+/// read them; any read or parse failure collapses to `None` (never a false
+/// finding).
+fn anchor_targets_at(path: &Path) -> Option<(u16, u16)> {
+    let text = fs::read_to_string(path).ok()?;
+    pf_anchor::parse_anchor_targets(&text)
 }
 
 #[cfg(test)]
@@ -749,6 +773,42 @@ mod tests {
         let taken = occupied.local_addr().unwrap().port();
         let err = MacosPortBinder::new().bind(taken).unwrap_err();
         assert!(matches!(err, PlatformError::Bind { port, .. } if port == taken));
+    }
+
+    /// A privileged desired pair is never attempted: it is replaced by the
+    /// rootless fallback first, so the bind succeeds without root and lands on
+    /// non-privileged ports even though 80/443 were requested.
+    #[test]
+    fn bind_pair_impl_never_attempts_privileged_desired() {
+        let pair = bind_pair_impl(false, (80, 443), (0, 0)).unwrap();
+        let http = pair.http.port().unwrap();
+        let https = pair.https.port().unwrap();
+        assert!(http != 80 && http != 443 && http != 0);
+        assert!(https != 80 && https != 443 && https != 0);
+    }
+
+    // ---- PortRedirector anchor target reads ---------------------------
+
+    /// A composed anchor file parses to its rootless target ports.
+    #[test]
+    fn anchor_targets_at_reads_composed_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dev.yerd");
+        std::fs::write(&path, pf_anchor::compose_anchor_rules(80, 8080, 443, 8443)).unwrap();
+        assert_eq!(anchor_targets_at(&path), Some((8080, 8443)));
+    }
+
+    /// A missing or garbage anchor file collapses to `None`, never a false read.
+    #[test]
+    fn anchor_targets_at_missing_or_garbage_is_none() {
+        assert_eq!(
+            anchor_targets_at(Path::new("/etc/pf.anchors/yerd-absent-zzz")),
+            None
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("garbage");
+        std::fs::write(&path, "not a pf rule\n").unwrap();
+        assert_eq!(anchor_targets_at(&path), None);
     }
 
     // ---- SystemMetrics ------------------------------------------------

--- a/crates/yerd-platform/src/port_binder.rs
+++ b/crates/yerd-platform/src/port_binder.rs
@@ -58,6 +58,10 @@ pub trait PortBinder {
     /// [`PlatformError::Bind`] without trying the fallback. If both
     /// pairs fail, the error is
     /// [`PlatformError::BindPair`] carrying all four `ErrorKind`s.
+    ///
+    /// On macOS a privileged `desired` side is never attempted: the pair is
+    /// replaced by `fallback` first, so the daemon deterministically owns the
+    /// rootless ports the `pf` redirect targets and never squats 80/443.
     fn bind_pair(
         &self,
         lan: bool,

--- a/crates/yerd-platform/src/port_redirect.rs
+++ b/crates/yerd-platform/src/port_redirect.rs
@@ -51,6 +51,19 @@ pub trait PortRedirector {
         }
         Some(loopback_port_reachable(80) || loopback_port_reachable(443))
     }
+
+    /// Destination ports `(http_to, https_to)` of the installed loopback
+    /// (`dev.yerd`) pf anchor, read from disk. Compared against the daemon's
+    /// live bound ports to detect a stale redirect. `None` = not installed,
+    /// unreadable, or not applicable on this OS (only macOS uses a pf anchor).
+    fn redirect_targets(&self) -> Option<(u16, u16)> {
+        None
+    }
+
+    /// Same as [`Self::redirect_targets`] for the LAN (`dev.yerd.lan`) anchor.
+    fn lan_redirect_targets(&self) -> Option<(u16, u16)> {
+        None
+    }
 }
 
 /// Returns `true` iff a TCP connection to `127.0.0.1:port` succeeds within

--- a/crates/yerd-platform/src/pure/pf_anchor.rs
+++ b/crates/yerd-platform/src/pure/pf_anchor.rs
@@ -67,6 +67,52 @@ pub fn compose_anchor_rules(
     )
 }
 
+/// Parse the destination ports of an installed `dev.yerd` or `dev.yerd.lan`
+/// anchor file, returning `(http_to, https_to)`.
+///
+/// Handles both the loopback shape (`... to any port 80 -> 127.0.0.1 port 8080`)
+/// and the LAN shape (`... to <lan_ip> port 80 -> <lan_ip> port 8080`). For each
+/// `rdr` line the from-port is the number after the last `port` before `->` and
+/// the to-port the number after the last `port` after `->`; the line whose
+/// from-port is 80 gives `http_to` and 443 gives `https_to`. Returns `None`
+/// unless both are found (a partial or hand-edited file is treated as unknown).
+#[must_use]
+pub fn parse_anchor_targets(rules: &str) -> Option<(u16, u16)> {
+    let mut http_to: Option<u16> = None;
+    let mut https_to: Option<u16> = None;
+    for line in rules.lines() {
+        let Some((lhs, rhs)) = line.split_once("->") else {
+            continue;
+        };
+        let Some(from) = last_port_token(lhs) else {
+            continue;
+        };
+        let Some(to) = last_port_token(rhs) else {
+            continue;
+        };
+        match from {
+            80 => http_to = Some(to),
+            443 => https_to = Some(to),
+            _ => {}
+        }
+    }
+    Some((http_to?, https_to?))
+}
+
+/// The last `port <N>` value in `segment`, if any.
+fn last_port_token(segment: &str) -> Option<u16> {
+    let mut tokens = segment.split_whitespace().peekable();
+    let mut found: Option<u16> = None;
+    while let Some(tok) = tokens.next() {
+        if tok == "port" {
+            if let Some(value) = tokens.peek().and_then(|v| v.parse::<u16>().ok()) {
+                found = Some(value);
+            }
+        }
+    }
+    found
+}
+
 /// The `rdr-anchor` line for `name`, tagged with `marker`.
 fn rdr_anchor_line_for(name: &str, marker: &str) -> String {
     format!("rdr-anchor \"{name}\" {marker}")
@@ -384,5 +430,44 @@ load anchor \"com.apple\" from \"/etc/pf.anchors/com.apple\"
         let once = insert_lan_anchor_refs(APPLE_DEFAULT);
         let twice = insert_lan_anchor_refs(&once);
         assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn parse_roundtrips_loopback_anchor() {
+        let text = compose_anchor_rules(80, 8080, 443, 8443);
+        assert_eq!(parse_anchor_targets(&text), Some((8080, 8443)));
+    }
+
+    #[test]
+    fn parse_roundtrips_non_default_rootless_pair() {
+        let text = compose_anchor_rules(80, 9080, 443, 9443);
+        assert_eq!(parse_anchor_targets(&text), Some((9080, 9443)));
+    }
+
+    #[test]
+    fn parse_roundtrips_lan_anchor() {
+        let ip = std::net::Ipv4Addr::new(192, 168, 1, 42);
+        let text = compose_lan_anchor_rules(ip, 80, 8080, 443, 8443);
+        assert_eq!(parse_anchor_targets(&text), Some((8080, 8443)));
+    }
+
+    #[test]
+    fn parse_reads_identity_lan_rule() {
+        let ip = std::net::Ipv4Addr::new(192, 168, 0, 201);
+        let text = compose_lan_anchor_rules(ip, 80, 80, 443, 443);
+        assert_eq!(parse_anchor_targets(&text), Some((80, 443)));
+    }
+
+    #[test]
+    fn parse_none_when_https_rule_missing() {
+        let text =
+            "rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080\n";
+        assert_eq!(parse_anchor_targets(text), None);
+    }
+
+    #[test]
+    fn parse_none_on_empty_or_garbage() {
+        assert_eq!(parse_anchor_targets(""), None);
+        assert_eq!(parse_anchor_targets("not a rule at all\n# comment\n"), None);
     }
 }

--- a/crates/yerd-platform/src/pure/port_plan.rs
+++ b/crates/yerd-platform/src/pure/port_plan.rs
@@ -78,6 +78,42 @@ pub fn is_retry_kind(kind: ErrorKind) -> bool {
     )
 }
 
+/// Ports below this are privileged: binding one needs elevation on every
+/// supported OS.
+pub const PRIVILEGED_PORT_CEILING: u16 = 1024;
+
+/// Replace a privileged desired pair with the rootless fallback pair.
+///
+/// On macOS the daemon must never hold a privileged port directly: the
+/// invariant is that it binds its rootless pair and a privileged `pf rdr`
+/// (installed by `yerd elevate ports` / `yerd elevate lan`) carries 80/443 to
+/// it. A privileged desired bind normally fails with `PermissionDenied`, which
+/// [`is_retry_kind`] already routes to the fallback, so for most daemons this
+/// only formalizes the fallback that already happens. It additionally closes
+/// the path where a privileged bind occasionally succeeds and leaves the daemon
+/// squatting 80/443 in conflict with the redirect design, regardless of how
+/// that bind came to be permitted.
+///
+/// The substitution is pair-level, mirroring `bind_pair`'s pair-level fallback:
+/// if either side of `desired` is privileged, the whole `fallback` pair is
+/// returned. Port `0` (ephemeral, used by tests) is not privileged and passes
+/// through. For the default config the returned pair equals `fallback`, so
+/// `bind_pair_impl`'s two-stage desired/fallback retry collapses to a single
+/// effective attempt on macOS.
+#[must_use]
+pub fn strip_privileged_desired(desired: (u16, u16), fallback: (u16, u16)) -> (u16, u16) {
+    if is_privileged(desired.0) || is_privileged(desired.1) {
+        fallback
+    } else {
+        desired
+    }
+}
+
+/// True if `port` is non-zero and below [`PRIVILEGED_PORT_CEILING`].
+fn is_privileged(port: u16) -> bool {
+    port != 0 && port < PRIVILEGED_PORT_CEILING
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -188,5 +224,50 @@ mod tests {
         assert!(!is_retry_kind(ErrorKind::Unsupported));
         assert!(!is_retry_kind(ErrorKind::NotFound));
         assert!(!is_retry_kind(ErrorKind::Other));
+    }
+
+    #[test]
+    fn default_privileged_pair_collapses_to_fallback() {
+        assert_eq!(
+            strip_privileged_desired((80, 443), (8080, 8443)),
+            (8080, 8443)
+        );
+    }
+
+    #[test]
+    fn rootless_desired_passes_through() {
+        assert_eq!(
+            strip_privileged_desired((8080, 8443), (9080, 9443)),
+            (8080, 8443)
+        );
+    }
+
+    #[test]
+    fn either_privileged_side_collapses_whole_pair() {
+        assert_eq!(
+            strip_privileged_desired((80, 8443), (8080, 8443)),
+            (8080, 8443)
+        );
+        assert_eq!(
+            strip_privileged_desired((8080, 443), (8080, 8443)),
+            (8080, 8443)
+        );
+    }
+
+    #[test]
+    fn ephemeral_zero_is_not_privileged() {
+        assert_eq!(strip_privileged_desired((0, 0), (8080, 8443)), (0, 0));
+    }
+
+    #[test]
+    fn privileged_ceiling_is_exclusive() {
+        assert_eq!(
+            strip_privileged_desired((1023, 1023), (8080, 8443)),
+            (8080, 8443)
+        );
+        assert_eq!(
+            strip_privileged_desired((1024, 1024), (8080, 8443)),
+            (1024, 1024)
+        );
     }
 }


### PR DESCRIPTION
## What does this PR do?

Resolves an issue with MacOS pf port binding on lan expose. 

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS diagnostics for stale or broken web and LAN port redirects.
  * Status information now reports redirect destinations to improve troubleshooting.
  * Added new diagnosis codes for unbound DNS ports, shadowed domains, and stale redirects.

* **Bug Fixes**
  * Prevented macOS port redirects from being installed when the daemon occupies privileged ports.
  * Improved fallback port handling to avoid binding conflicts.
  * Added clearer recovery guidance when port configuration is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->