### PR TITLE
[Fix] Only parse pf rdr rules when reading macOS anchor port targets

### DIFF
--- a/crates/yerd-platform/src/pure/pf_anchor.rs
+++ b/crates/yerd-platform/src/pure/pf_anchor.rs
@@ -81,7 +81,11 @@ pub fn parse_anchor_targets(rules: &str) -> Option<(u16, u16)> {
     let mut http_to: Option<u16> = None;
     let mut https_to: Option<u16> = None;
     for line in rules.lines() {
-        let Some((lhs, rhs)) = line.split_once("->") else {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("rdr ") {
+            continue;
+        }
+        let Some((lhs, rhs)) = trimmed.split_once("->") else {
             continue;
         };
         let Some(from) = last_port_token(lhs) else {
@@ -469,5 +473,17 @@ load anchor \"com.apple\" from \"/etc/pf.anchors/com.apple\"
     fn parse_none_on_empty_or_garbage() {
         assert_eq!(parse_anchor_targets(""), None);
         assert_eq!(parse_anchor_targets("not a rule at all\n# comment\n"), None);
+    }
+
+    #[test]
+    fn parse_ignores_comments_and_unrelated_rules() {
+        let text = "\
+# rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 9999
+rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
+rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+# rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 1234
+pass in quick proto tcp from any to any port 80 -> 127.0.0.1 port 5555
+";
+        assert_eq!(parse_anchor_targets(text), Some((8080, 8443)));
     }
 }


### PR DESCRIPTION
## What does this PR do?

This pull request improves the robustness of the `parse_anchor_targets` function in `pf_anchor.rs` by ensuring that only relevant rules are processed and unrelated lines are ignored. Additionally, a new test is added to verify this behavior.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved anchor rule parsing to ignore commented-out and unrelated firewall rules.
  - Added support for lines with leading whitespace, ensuring valid redirect rules are recognized consistently.
  - Correctly extracts HTTP-to-HTTPS redirect targets from active rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->