### PR TITLE
[Fix] Harden LAN remote-device bootstrap resolver setup and CA trust

### DIFF
--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1932,9 +1932,16 @@ async fn set_mcp_enabled(enabled: bool, state: &DaemonState) -> Response {
     Response::Ok
 }
 
-/// Persist the `lan_enabled` flag. Persist-only: the actual re-bind happens on
-/// the daemon restart the CLI triggers next (a listen socket's bind address is
-/// fixed at bind time), so there is no live atomic to flip here.
+/// Persist the `lan_enabled` flag. Persist-only: the bootstrap listener only
+/// re-binds on the daemon restart the CLI triggers next (a listen socket's bind
+/// address is fixed at bind time), so there is no live atomic to flip here.
+///
+/// Disabling also revokes any pending one-time remote-setup code, since the
+/// listener lingers until that restart and an already-minted code would
+/// otherwise stay redeemable. The revocation happens while the `config` lock is
+/// held so it and [`mint_remote_setup_code`]'s check-and-publish cannot
+/// interleave - otherwise a mint that had already passed its `lan_enabled` check
+/// could store a live code *after* disablement completed.
 async fn set_lan_enabled(enabled: bool, state: &DaemonState) -> Response {
     let mut cfg_guard = state.config.lock().await;
     let mut new = cfg_guard.clone();
@@ -1943,13 +1950,10 @@ async fn set_lan_enabled(enabled: bool, state: &DaemonState) -> Response {
         return internal(format!("config save failed: {e}"));
     }
     *cfg_guard = new;
-    drop(cfg_guard);
     if !enabled {
-        // The bootstrap listener only unbinds on the restart the CLI triggers,
-        // so revoke any pending one-time code now - otherwise an already-minted
-        // code could still be redeemed against the lingering endpoint.
         *state.remote_setup_code.lock().await = None;
     }
+    drop(cfg_guard);
     tracing::info!(enabled, "set lan enabled");
     Response::Ok
 }
@@ -1961,18 +1965,19 @@ const REMOTE_SETUP_CODE_TTL: std::time::Duration = std::time::Duration::from_sec
 /// *and* the bootstrap listener bound), so a code is never handed out when
 /// nothing would serve it.
 ///
-/// The URL reuses the startup-discovered `lan_ip` so the printed host always
-/// matches what is actually served, and the returned `script_sha256` is the hash
-/// recorded when the endpoint bound - its absence means the endpoint isn't
-/// serving, so minting fails closed rather than hand out a useless code.
+/// The `config` lock is held across the whole check-and-publish so a concurrent
+/// [`set_lan_enabled`]`(false)` cannot slip between the `lan_enabled` check and
+/// storing the code (which would leave a live code after disablement). The URL
+/// reuses the startup-discovered `lan_ip` so the printed host always matches what
+/// is actually served, and the returned `script_sha256` is the hash recorded when
+/// the endpoint bound - its absence means the endpoint isn't serving, so minting
+/// fails closed rather than hand out a useless code.
 async fn mint_remote_setup_code(state: &DaemonState) -> Response {
-    let (lan_enabled, lan_setup_port) = {
-        let cfg = state.config.lock().await;
-        (cfg.lan_enabled, cfg.lan_setup_port)
-    };
-    if !lan_enabled {
+    let cfg_guard = state.config.lock().await;
+    if !cfg_guard.lan_enabled {
         return lan_not_ready("LAN mode is off - run `yerd lan enable` first".to_owned());
     }
+    let lan_setup_port = cfg_guard.lan_setup_port;
     if !state
         .lan_setup_bound
         .load(std::sync::atomic::Ordering::Relaxed)
@@ -2004,6 +2009,7 @@ async fn mint_remote_setup_code(state: &DaemonState) -> Response {
         expires_at: std::time::Instant::now() + REMOTE_SETUP_CODE_TTL,
         used: false,
     });
+    drop(cfg_guard);
 
     let url = format!("http://{lan_ip}:{lan_setup_port}/remote-setup?code={code}");
     Response::RemoteSetup {
@@ -5197,6 +5203,25 @@ Subject: Captured\r\n\r\nhi\r\n";
             Response::Ok
         );
         assert!(!state.config.lock().await.lan_enabled, "back off");
+    }
+
+    #[tokio::test]
+    async fn disabling_lan_revokes_a_pending_remote_setup_code() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_in(tmp.path());
+        *state.remote_setup_code.lock().await = Some(crate::state::RemoteSetupCode {
+            value: "abc".to_owned(),
+            expires_at: std::time::Instant::now() + std::time::Duration::from_secs(60),
+            used: false,
+        });
+        assert_eq!(
+            dispatch(Request::SetLanEnabled { enabled: false }, &state).await,
+            Response::Ok
+        );
+        assert!(
+            state.remote_setup_code.lock().await.is_none(),
+            "disabling LAN clears any pending one-time code"
+        );
     }
 
     #[tokio::test]

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -1943,6 +1943,13 @@ async fn set_lan_enabled(enabled: bool, state: &DaemonState) -> Response {
         return internal(format!("config save failed: {e}"));
     }
     *cfg_guard = new;
+    drop(cfg_guard);
+    if !enabled {
+        // The bootstrap listener only unbinds on the restart the CLI triggers,
+        // so revoke any pending one-time code now - otherwise an already-minted
+        // code could still be redeemed against the lingering endpoint.
+        *state.remote_setup_code.lock().await = None;
+    }
     tracing::info!(enabled, "set lan enabled");
     Response::Ok
 }

--- a/bin/yerdd/src/lan_setup.rs
+++ b/bin/yerdd/src/lan_setup.rs
@@ -310,6 +310,45 @@ nss_uninstall() {
   done
 }
 
+# True if NetworkManager is present and configured to run its own dnsmasq - the
+# only mode in which a dnsmasq.d snippet takes effect. A directory existing is
+# not proof the plugin is active (systemd-resolved hosts ship the dir unused).
+nm_uses_dnsmasq() {
+  command -v NetworkManager >/dev/null 2>&1 || return 1
+  NetworkManager --print-config 2>/dev/null \
+    | grep -Eq '^[[:space:]]*dns[[:space:]]*=[[:space:]]*dnsmasq([[:space:]]|$)'
+}
+
+# Remove every Yerd CA from the macOS System keychain by its exact SHA-1 hash
+# (clearing trust settings too). Used by both install (to stay idempotent - no
+# duplicate keychain entries on a re-run) and uninstall. Best-effort throughout.
+macos_remove_ca() {
+  security find-certificate -a -Z -c "Yerd Local CA" /Library/Keychains/System.keychain 2>/dev/null \
+    | awk '/SHA-1 hash:/ {print $NF}' \
+    | while read -r h; do
+        [ -n "$h" ] || continue
+        security remove-trusted-cert -d -Z "$h" 2>/dev/null || true
+        security delete-certificate -Z "$h" /Library/Keychains/System.keychain 2>/dev/null || true
+      done || true
+}
+
+# True once a probe name under the given TLD resolves through the system
+# resolver, retried briefly to let an async reload settle. The Yerd responder
+# answers any single-label name under the TLD, so this confirms the resolver
+# path we configured is actually live before reporting success. Skipped (treated
+# as success) when getent is unavailable.
+resolves() {
+  command -v getent >/dev/null 2>&1 || return 0
+  local probe="yerd-remote-probe.$1" i
+  for i in 1 2 3 4 5; do
+    if getent hosts "$probe" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 os="$(uname -s)"
 CA_TMP=""
 cleanup_tmp() { [ -n "$CA_TMP" ] && rm -f "$CA_TMP"; }
@@ -325,22 +364,42 @@ install)
   chmod 0644 "$CA_TMP"
   case "$os" in
   Darwin)
-    security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CA_TMP"
+    # Write the resolver first (cheap, reversible), then add trust under a
+    # rollback trap so a keychain failure never leaves .test pointed here with
+    # no matching CA. macos_remove_ca first keeps a re-run idempotent.
     mkdir -p /etc/resolver
     printf 'nameserver %s\nport %s\n' "$SERVER_IP" "$DNS_PORT" > "/etc/resolver/$TLD"
+    trap 'rm -f "/etc/resolver/$TLD"; cleanup_tmp' EXIT
+    macos_remove_ca
+    security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CA_TMP"
+    trap cleanup_tmp EXIT
+    # Flush any stale negative cache for a .test name queried before setup.
+    dscacheutil -flushcache 2>/dev/null || true
+    killall -HUP mDNSResponder 2>/dev/null || true
     echo "Installed. .$TLD now resolves via $SERVER_IP (DNS $DNS_PORT)."
     ;;
   Linux)
     # Decide the resolver target BEFORE touching the trust store, so an
-    # unsupported host fails without leaving a stranded CA behind.
-    if [ -d /etc/NetworkManager/dnsmasq.d ]; then
+    # unsupported host fails without leaving a stranded CA behind. Require the
+    # resolver to actually be ACTIVE, not merely have its drop-in directory: on a
+    # systemd-resolved host the NetworkManager dnsmasq.d dir often exists while no
+    # NM-spawned dnsmasq runs, so writing there would be inert.
+    if [ -d /etc/NetworkManager/dnsmasq.d ] && nm_uses_dnsmasq; then
       RESOLVER_CONF="/etc/NetworkManager/dnsmasq.d/yerd-$TLD.conf"
-      RESOLVER_RELOAD="systemctl reload NetworkManager"
-    elif [ -d /etc/dnsmasq.d ]; then
+      # SIGHUP (systemctl reload) does not reliably re-read dnsmasq.d; nmcli does.
+      if command -v nmcli >/dev/null 2>&1; then
+        RESOLVER_RELOAD="nmcli general reload dns"
+      else
+        RESOLVER_RELOAD="systemctl reload NetworkManager"
+      fi
+    elif [ -d /etc/dnsmasq.d ] && command -v systemctl >/dev/null 2>&1 \
+         && systemctl is-active --quiet dnsmasq; then
       RESOLVER_CONF="/etc/dnsmasq.d/yerd-$TLD.conf"
       RESOLVER_RELOAD="systemctl restart dnsmasq"
     else
-      echo "error: unsupported resolver setup - install dnsmasq or use NetworkManager." >&2
+      echo "error: no active resolver that can forward .$TLD to a custom port." >&2
+      echo "       Enable NetworkManager's dnsmasq plugin (set dns=dnsmasq), or" >&2
+      echo "       install and start dnsmasq (e.g. systemctl enable --now dnsmasq)." >&2
       echo "       (systemd-resolved alone cannot forward a single domain to a custom port.)" >&2
       exit 1
     fi
@@ -357,13 +416,20 @@ install)
       echo "error: no usable CA anchor directory found (expected Debian/Ubuntu, RHEL/Fedora or Arch layout)" >&2
       exit 1
     fi
-    # Roll the CA back if the resolver step below fails, so we don't leave the
-    # device trusting a CA whose .test names it can't resolve.
+    # Roll the CA and the resolver snippet back if any step below fails, so we
+    # never leave the device trusting a CA whose .test names it can't resolve.
     cp "$CA_TMP" "$CA_DEST"
-    trap 'rm -f "$CA_DEST"; $CA_REFRESH >/dev/null 2>&1 || true; cleanup_tmp' EXIT
+    trap 'rm -f "$CA_DEST" "$RESOLVER_CONF"; $CA_REFRESH >/dev/null 2>&1 || true; $RESOLVER_RELOAD >/dev/null 2>&1 || true; cleanup_tmp' EXIT
     $CA_REFRESH >/dev/null
     printf 'server=/%s/%s#%s\n' "$TLD" "$SERVER_IP" "$DNS_PORT" > "$RESOLVER_CONF"
-    $RESOLVER_RELOAD 2>/dev/null || true
+    $RESOLVER_RELOAD >/dev/null 2>&1 || true
+    # Confirm .test actually resolves through the resolver we picked before
+    # claiming success; if it does not, the trap above rolls everything back.
+    if ! resolves "$TLD"; then
+      echo "error: .$TLD still does not resolve after configuring $RESOLVER_CONF." >&2
+      echo "       The detected resolver may not be active; rolling back." >&2
+      exit 1
+    fi
     trap cleanup_tmp EXIT
     nss_install "$CA_TMP"
     echo "Installed. .$TLD now resolves via $SERVER_IP (DNS $DNS_PORT)."
@@ -378,15 +444,7 @@ uninstall)
   case "$os" in
   Darwin)
     rm -f "/etc/resolver/$TLD"
-    # Delete each matching Yerd CA by its exact SHA-1 hash (not just the common
-    # name), clearing that certificate's trust settings too.
-    security find-certificate -a -Z -c "Yerd Local CA" /Library/Keychains/System.keychain 2>/dev/null \
-      | awk '/SHA-1 hash:/ {print $NF}' \
-      | while read -r h; do
-          [ -n "$h" ] || continue
-          security remove-trusted-cert -d -Z "$h" 2>/dev/null || true
-          security delete-certificate -Z "$h" /Library/Keychains/System.keychain 2>/dev/null || true
-        done
+    macos_remove_ca
     ;;
   Linux)
     rm -f "/usr/local/share/ca-certificates/yerd-$TLD.crt" \
@@ -483,7 +541,7 @@ esac
         fn installer_script_linux_checks_resolver_before_installing_ca_and_rolls_back() {
             let s = installer_script(Ipv4Addr::new(10, 0, 0, 5), "test", 1053, SAMPLE_CA);
             let resolver_check = s
-                .find("unsupported resolver setup")
+                .find("no active resolver")
                 .expect("resolver support is validated");
             let ca_copy = s.find("cp \"$CA_TMP\"").expect("CA is installed");
             assert!(
@@ -491,8 +549,61 @@ esac
                 "resolver support must be checked before the CA is installed"
             );
             assert!(
-                s.contains("trap 'rm -f \"$CA_DEST\""),
-                "the CA is rolled back if the resolver step fails"
+                s.contains("trap 'rm -f \"$CA_DEST\" \"$RESOLVER_CONF\""),
+                "both the CA and the resolver snippet are rolled back on failure"
+            );
+        }
+
+        #[test]
+        fn installer_script_gates_on_an_active_resolver_and_verifies_resolution() {
+            let s = installer_script(Ipv4Addr::new(10, 0, 0, 5), "test", 1053, SAMPLE_CA);
+            assert!(
+                s.contains("nm_uses_dnsmasq"),
+                "the NetworkManager branch requires the dnsmasq plugin to be active"
+            );
+            assert!(
+                s.contains("systemctl is-active --quiet dnsmasq"),
+                "the standalone-dnsmasq branch requires the service to be running"
+            );
+            assert!(
+                s.contains("nmcli general reload dns"),
+                "NetworkManager is reloaded via nmcli, not an unreliable SIGHUP"
+            );
+            let reload = s
+                .find("$RESOLVER_RELOAD >/dev/null 2>&1 || true")
+                .expect("the resolver is reloaded");
+            let verify = s
+                .find("if ! resolves \"$TLD\"")
+                .expect("resolution is verified");
+            assert!(
+                reload < verify,
+                "resolution is smoke-tested after the reload, before reporting success"
+            );
+        }
+
+        #[test]
+        fn installer_script_macos_writes_resolver_before_trust_and_is_idempotent() {
+            let s = installer_script(Ipv4Addr::new(10, 0, 0, 5), "test", 1053, SAMPLE_CA);
+            let resolver = s
+                .find("printf 'nameserver %s\\nport %s\\n'")
+                .expect("the macOS resolver is written");
+            let add_trust = s
+                .find("security add-trusted-cert")
+                .expect("the CA is added to the keychain");
+            assert!(
+                resolver < add_trust,
+                "the reversible resolver write precedes the keychain change"
+            );
+            assert!(
+                s.contains("trap 'rm -f \"/etc/resolver/$TLD\"; cleanup_tmp' EXIT"),
+                "a keychain failure rolls the resolver file back"
+            );
+            let clean = s
+                .find("macos_remove_ca")
+                .expect("macos_remove_ca is defined");
+            assert!(
+                clean < add_trust,
+                "existing Yerd CAs are cleared before adding, keeping re-runs idempotent"
             );
         }
 
@@ -601,6 +712,47 @@ mod endpoint_tests {
             decide(&ctx, true, "/nope", Some("code=good")).await,
             Decision::Text(StatusCode::NOT_FOUND, _)
         ));
+    }
+
+    #[tokio::test]
+    async fn expired_code_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(state_in(tmp.path()));
+        *state.remote_setup_code.lock().await = Some(RemoteSetupCode {
+            value: "good".to_owned(),
+            expires_at: Instant::now(),
+            used: false,
+        });
+        let ctx = ctx_with_code(Arc::clone(&state));
+        assert!(
+            matches!(
+                decide(&ctx, true, "/remote-setup", Some("code=good")).await,
+                Decision::Text(StatusCode::FORBIDDEN, _)
+            ),
+            "a code past its expiry must be refused even with the right value"
+        );
+    }
+
+    #[test]
+    fn served_bytes_hash_to_the_advertised_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(state_in(tmp.path()));
+        let script = super::pure::installer_script(
+            std::net::Ipv4Addr::new(10, 0, 0, 5),
+            "test",
+            1053,
+            "-----BEGIN CERTIFICATE-----\nMIIByerdSAMPLE\n-----END CERTIFICATE-----\n",
+        );
+        let advertised = crate::ext_install::sha256_hex(script.as_bytes());
+        let ctx = SetupContext {
+            script: script.into_bytes(),
+            state,
+        };
+        assert_eq!(
+            crate::ext_install::sha256_hex(&ctx.script),
+            advertised,
+            "the exact bytes the endpoint serves must hash to the advertised SHA-256"
+        );
     }
 
     #[tokio::test]

--- a/bin/yerdd/src/lan_setup.rs
+++ b/bin/yerdd/src/lan_setup.rs
@@ -323,12 +323,20 @@ nm_uses_dnsmasq() {
 # (clearing trust settings too). Used by both install (to stay idempotent - no
 # duplicate keychain entries on a re-run) and uninstall. Best-effort throughout.
 macos_remove_ca() {
-  security find-certificate -a -Z -c "Yerd Local CA" /Library/Keychains/System.keychain 2>/dev/null \
+  local kc=/Library/Keychains/System.keychain
+  security find-certificate -a -Z -c "Yerd Local CA" "$kc" 2>/dev/null \
     | awk '/SHA-1 hash:/ {print $NF}' \
     | while read -r h; do
         [ -n "$h" ] || continue
-        security remove-trusted-cert -d -Z "$h" 2>/dev/null || true
-        security delete-certificate -Z "$h" /Library/Keychains/System.keychain 2>/dev/null || true
+        # remove-trusted-cert takes the certificate as a file, not a hash: export
+        # the first still-present Yerd CA, clear its trust, then delete it by hash
+        # (deleting the first each pass keeps the exported cert and $h aligned).
+        f="$(mktemp)"
+        if security find-certificate -c "Yerd Local CA" -p "$kc" > "$f" 2>/dev/null && [ -s "$f" ]; then
+          security remove-trusted-cert -d "$f" 2>/dev/null || true
+        fi
+        rm -f "$f"
+        security delete-certificate -Z "$h" "$kc" 2>/dev/null || true
       done || true
 }
 
@@ -386,9 +394,10 @@ install)
     # NM-spawned dnsmasq runs, so writing there would be inert.
     if [ -d /etc/NetworkManager/dnsmasq.d ] && nm_uses_dnsmasq; then
       RESOLVER_CONF="/etc/NetworkManager/dnsmasq.d/yerd-$TLD.conf"
-      # SIGHUP (systemctl reload) does not reliably re-read dnsmasq.d; nmcli does.
+      # SIGHUP (systemctl reload) does not reliably re-read dnsmasq.d; dns-full
+      # restarts NM's DNS plugin, which does.
       if command -v nmcli >/dev/null 2>&1; then
-        RESOLVER_RELOAD="nmcli general reload dns"
+        RESOLVER_RELOAD="nmcli general reload dns-full"
       else
         RESOLVER_RELOAD="systemctl reload NetworkManager"
       fi
@@ -566,8 +575,8 @@ esac
                 "the standalone-dnsmasq branch requires the service to be running"
             );
             assert!(
-                s.contains("nmcli general reload dns"),
-                "NetworkManager is reloaded via nmcli, not an unreliable SIGHUP"
+                s.contains("nmcli general reload dns-full"),
+                "NetworkManager's DNS plugin is restarted via nmcli dns-full, not an unreliable SIGHUP"
             );
             let reload = s
                 .find("$RESOLVER_RELOAD >/dev/null 2>&1 || true")
@@ -733,25 +742,48 @@ mod endpoint_tests {
         );
     }
 
-    #[test]
-    fn served_bytes_hash_to_the_advertised_value() {
+    #[tokio::test]
+    async fn endpoint_serves_the_exact_bytes_that_were_hashed_for_advertisement() {
         let tmp = tempfile::tempdir().unwrap();
         let state = Arc::new(state_in(tmp.path()));
+
+        // Mirror spawn_lan_setup: render once, publish the hash mint hands out,
+        // and give the same bytes to the endpoint context.
         let script = super::pure::installer_script(
             std::net::Ipv4Addr::new(10, 0, 0, 5),
             "test",
             1053,
             "-----BEGIN CERTIFICATE-----\nMIIByerdSAMPLE\n-----END CERTIFICATE-----\n",
         );
-        let advertised = crate::ext_install::sha256_hex(script.as_bytes());
+        *state.lan_setup_script_sha256.lock().await =
+            Some(crate::ext_install::sha256_hex(script.as_bytes()));
         let ctx = SetupContext {
             script: script.into_bytes(),
-            state,
+            state: Arc::clone(&state),
         };
+
+        // The endpoint returns ctx.script only for a valid code; confirm the
+        // device's request reaches the script route.
+        seed(&state, "good").await;
         assert_eq!(
-            crate::ext_install::sha256_hex(&ctx.script),
-            advertised,
-            "the exact bytes the endpoint serves must hash to the advertised SHA-256"
+            decide(&ctx, true, "/remote-setup", Some("code=good")).await,
+            Decision::Script,
+        );
+
+        // Independently hash the bytes the endpoint exposes and compare them to
+        // the value published for the device to verify. These flow from separate
+        // fields (ctx.script vs lan_setup_script_sha256), so a serving path that
+        // ever returned different bytes than were hashed would fail here.
+        let served = crate::ext_install::sha256_hex(&ctx.script);
+        let advertised = state
+            .lan_setup_script_sha256
+            .lock()
+            .await
+            .clone()
+            .expect("advertised hash was published");
+        assert_eq!(
+            served, advertised,
+            "the endpoint must serve the exact bytes whose SHA-256 mint hands out"
         );
     }
 


### PR DESCRIPTION
## What does this PR do?

Make the remote-setup installer verify .test actually resolves before reporting success (gating on an active NetworkManager-dnsmasq/dnsmasq resolver rather than a bare directory), roll back the CA and resolver snippet on any failure, keep the macOS keychain install idempotent and reversible, revoke pending bootstrap codes when LAN is disabled, and add tests for the new paths.

## Related issues


## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabling LAN mode now immediately invalidates any pending one-time remote-setup codes.
  * Expired one-time remote-setup codes are rejected.
* **Improvements**
  * Remote-setup installation now performs more reliable DNS resolver detection and certificate trust updates on macOS and Linux.
  * Installation verifies delegated domain resolution before completing and rolls back certificate/resolver changes on failure.
  * Uninstall more reliably removes the previously trusted certificate.
* **Tests**
  * Added/updated coverage for resolver ordering, rollback behavior, and remote-setup script hash consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->