### PR TITLE
[Fix] 301 redirect for directory requests without a trailing slash

### DIFF
--- a/crates/yerd-proxy/src/forward/script_file.rs
+++ b/crates/yerd-proxy/src/forward/script_file.rs
@@ -3,7 +3,10 @@
 //! controller policy, extending `pure::cgi_params`'s "everything to
 //! `index.php`" fallback to first check for a real, more specific script
 //! (`wp-admin/index.php`, `wp-login.php`, ...) before falling back to the
-//! site root's `index.php`.
+//! site root's `index.php`. It also decides the third outcome web servers
+//! have always had here: a path that names a real directory but arrived
+//! without its trailing slash earns a `301` to the slashed form rather than
+//! silently running the root front controller.
 //!
 //! Unlike [`crate::forward::static_file`], this applies to every HTTP method,
 //! not just GET/HEAD - a real script like `wp-login.php` handles POST too.
@@ -21,30 +24,63 @@ use std::path::{Path, PathBuf};
 use crate::forward::static_file::{canonical_within, Containment};
 use crate::pure::try_files::{directory_candidate, is_php_source, static_candidate};
 
-/// The real, on-disk PHP script - relative to `served_root` - that `uri_path`
-/// should execute, or `None` when there is no such real script and the
-/// caller should fall back to the site's root `index.php` (today's
-/// unconditional behavior, unchanged for every framework that has only one
-/// front controller).
+/// Outcome of resolving a direct-mode request against the on-disk tree.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScriptResolution {
+    /// A real, on-disk PHP script to execute, relative to `served_root`.
+    Script(PathBuf),
+    /// The path names a real directory without a trailing slash; answer
+    /// `301` to the trailing-slash form.
+    DirectoryRedirect,
+    /// Nothing matched - fall back to the site root's `index.php`.
+    Fallback,
+}
+
+/// How `uri_path` resolves against the site's real, on-disk tree: a specific
+/// script to execute, a trailing-slash redirect, or a fallback to the site
+/// root's `index.php` (today's unconditional behavior, unchanged for every
+/// framework that has only one front controller).
 ///
 /// Checks, in order: an exact non-directory match (`/wp-login.php` ->
-/// `wp-login.php`), then - for a directory-style request - that directory's
-/// own index (`/wp-admin/` -> `wp-admin/index.php`).
+/// `wp-login.php`), then that same path as a directory missing its trailing
+/// slash (`/sub` -> redirect to `/sub/`), then - for a directory-style request
+/// - that directory's own index (`/wp-admin/` -> `wp-admin/index.php`).
+///
+/// The redirect fires whether or not the directory holds an `index.php`, which
+/// is what Apache's `DirectorySlash` and nginx's `try_files $uri $uri/` do: a
+/// static-only `/assets` redirects to `/assets/`, where
+/// [`crate::forward::static_file::try_serve_index`] can serve its
+/// `index.html`.
 pub async fn resolve_script(
     uri_path: &str,
     served_root: &Path,
     allowed_root: &Path,
     symlink_protection: bool,
-) -> Option<PathBuf> {
-    let real_root = tokio::fs::canonicalize(allowed_root).await.ok()?;
+) -> ScriptResolution {
+    let Ok(real_root) = tokio::fs::canonicalize(allowed_root).await else {
+        return ScriptResolution::Fallback;
+    };
 
     if let Some(rel) = static_candidate(uri_path) {
-        return existing_php_file(served_root, &real_root, &rel, symlink_protection).await;
+        if let Some(script) =
+            existing_php_file(served_root, &real_root, &rel, symlink_protection).await
+        {
+            return ScriptResolution::Script(script);
+        }
+        if is_existing_directory(served_root, &real_root, &rel, symlink_protection).await {
+            return ScriptResolution::DirectoryRedirect;
+        }
+        return ScriptResolution::Fallback;
     }
 
-    let dir_rel = directory_candidate(uri_path)?;
+    let Some(dir_rel) = directory_candidate(uri_path) else {
+        return ScriptResolution::Fallback;
+    };
     let script_rel = dir_rel.join("index.php");
-    existing_php_file(served_root, &real_root, &script_rel, symlink_protection).await
+    match existing_php_file(served_root, &real_root, &script_rel, symlink_protection).await {
+        Some(script) => ScriptResolution::Script(script),
+        None => ScriptResolution::Fallback,
+    }
 }
 
 /// `rel` (relative to `served_root`) if it's a real, on-disk `.php` file that
@@ -77,6 +113,28 @@ async fn existing_php_file(
     Some(rel.to_path_buf())
 }
 
+/// Whether `rel` (relative to `served_root`) is a real, on-disk directory that
+/// canonicalises within `real_root`. Deliberately mirrors
+/// [`existing_php_file`]'s containment `match` so the two probes can't drift
+/// apart on symlink semantics: with protection on, a directory symlink
+/// escaping `real_root` is refused (no redirect - the request falls back to
+/// the root `index.php`); with it off, the symlink target is accepted.
+async fn is_existing_directory(
+    served_root: &Path,
+    real_root: &Path,
+    rel: &Path,
+    symlink_protection: bool,
+) -> bool {
+    let real_dir = match canonical_within(&served_root.join(rel), real_root).await {
+        Some(Containment::Ok(path)) => path,
+        Some(Containment::Escaped(path)) if !symlink_protection => path,
+        Some(Containment::Escaped(_)) | None => return false,
+    };
+    tokio::fs::metadata(&real_dir)
+        .await
+        .is_ok_and(|meta| meta.is_dir())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
@@ -88,7 +146,7 @@ mod tests {
         std::fs::write(root.path().join("wp-login.php"), b"<?php").unwrap();
 
         let rel = resolve_script("/wp-login.php", root.path(), root.path(), true).await;
-        assert_eq!(rel, Some(PathBuf::from("wp-login.php")));
+        assert_eq!(rel, ScriptResolution::Script(PathBuf::from("wp-login.php")));
     }
 
     #[tokio::test]
@@ -98,7 +156,10 @@ mod tests {
         std::fs::write(root.path().join("wp-admin/index.php"), b"<?php").unwrap();
 
         let rel = resolve_script("/wp-admin/", root.path(), root.path(), true).await;
-        assert_eq!(rel, Some(PathBuf::from("wp-admin/index.php")));
+        assert_eq!(
+            rel,
+            ScriptResolution::Script(PathBuf::from("wp-admin/index.php"))
+        );
     }
 
     #[tokio::test]
@@ -108,7 +169,64 @@ mod tests {
 
         assert_eq!(
             resolve_script("/empty/", root.path(), root.path(), true).await,
-            None
+            ScriptResolution::Fallback
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_without_trailing_slash_redirects() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("sub")).unwrap();
+        std::fs::write(root.path().join("sub/index.php"), b"<?php").unwrap();
+
+        assert_eq!(
+            resolve_script("/sub", root.path(), root.path(), true).await,
+            ScriptResolution::DirectoryRedirect
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_without_index_php_still_redirects() {
+        // Matches nginx/Apache: the 301 depends only on the path naming a real
+        // directory, not on what lives inside it.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("assets")).unwrap();
+        std::fs::write(root.path().join("assets/index.html"), b"<h1>").unwrap();
+
+        assert_eq!(
+            resolve_script("/assets", root.path(), root.path(), true).await,
+            ScriptResolution::DirectoryRedirect
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlinked_directory_escaping_document_root_falls_back() {
+        let docroot = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(outside.path().join("secrets")).unwrap();
+        std::os::unix::fs::symlink(outside.path().join("secrets"), docroot.path().join("sub"))
+            .unwrap();
+
+        assert_eq!(
+            resolve_script("/sub", docroot.path(), docroot.path(), true).await,
+            ScriptResolution::Fallback
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlinked_directory_escaping_document_root_redirects_when_protection_off() {
+        let docroot = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(outside.path().join("shared")).unwrap();
+        std::os::unix::fs::symlink(outside.path().join("shared"), docroot.path().join("sub"))
+            .unwrap();
+
+        assert_eq!(
+            resolve_script("/sub", docroot.path(), docroot.path(), false).await,
+            ScriptResolution::DirectoryRedirect,
+            "protection off treats the escaping symlink as the real directory it points at"
         );
     }
 
@@ -117,7 +235,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         assert_eq!(
             resolve_script("/wp-login.php", root.path(), root.path(), true).await,
-            None
+            ScriptResolution::Fallback
         );
     }
 
@@ -131,7 +249,7 @@ mod tests {
 
         assert_eq!(
             resolve_script("/app.css", root.path(), root.path(), true).await,
-            None
+            ScriptResolution::Fallback
         );
     }
 
@@ -141,7 +259,7 @@ mod tests {
         std::fs::write(root.path().join("index.php"), b"<?php").unwrap();
 
         let rel = resolve_script("/", root.path(), root.path(), true).await;
-        assert_eq!(rel, Some(PathBuf::from("index.php")));
+        assert_eq!(rel, ScriptResolution::Script(PathBuf::from("index.php")));
     }
 
     #[cfg(unix)]
@@ -158,7 +276,7 @@ mod tests {
 
         assert_eq!(
             resolve_script("/wp-login.php", docroot.path(), docroot.path(), true).await,
-            None
+            ScriptResolution::Fallback
         );
     }
 
@@ -176,7 +294,7 @@ mod tests {
 
         assert_eq!(
             resolve_script("/wp-login.php", docroot.path(), docroot.path(), false).await,
-            Some(PathBuf::from("wp-login.php")),
+            ScriptResolution::Script(PathBuf::from("wp-login.php")),
             "protection off resolves the escaping script by its served-root-relative path"
         );
     }
@@ -186,7 +304,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         assert_eq!(
             resolve_script("/../../etc/passwd", root.path(), root.path(), true).await,
-            None
+            ScriptResolution::Fallback
         );
     }
 }

--- a/crates/yerd-proxy/src/forward/script_file.rs
+++ b/crates/yerd-proxy/src/forward/script_file.rs
@@ -187,8 +187,6 @@ mod tests {
 
     #[tokio::test]
     async fn directory_without_index_php_still_redirects() {
-        // Matches nginx/Apache: the 301 depends only on the path naming a real
-        // directory, not on what lives inside it.
         let root = tempfile::tempdir().unwrap();
         std::fs::create_dir(root.path().join("assets")).unwrap();
         std::fs::write(root.path().join("assets/index.html"), b"<h1>").unwrap();

--- a/crates/yerd-proxy/src/forward/script_file.rs
+++ b/crates/yerd-proxy/src/forward/script_file.rs
@@ -17,7 +17,9 @@
 //! `index.php` policy) rather than handed to FastCGI, the same way a
 //! symlinked static asset is refused - otherwise a symlink inside a site's
 //! own tree could point FastCGI at an arbitrary `.php` file elsewhere on the
-//! host's filesystem.
+//! host's filesystem. (For GET/HEAD, `static_file::try_serve` will already
+//! have answered `403` for the escaping path before resolution runs; the
+//! fallback here is what the other methods observe.)
 
 use std::path::{Path, PathBuf};
 
@@ -117,8 +119,13 @@ async fn existing_php_file(
 /// canonicalises within `real_root`. Deliberately mirrors
 /// [`existing_php_file`]'s containment `match` so the two probes can't drift
 /// apart on symlink semantics: with protection on, a directory symlink
-/// escaping `real_root` is refused (no redirect - the request falls back to
-/// the root `index.php`); with it off, the symlink target is accepted.
+/// escaping `real_root` is never a redirect candidate; with it off, the
+/// symlink target is accepted. Note that a GET/HEAD request for such an
+/// escaping path never actually reaches this refusal:
+/// [`crate::forward::static_file::try_serve`] has already answered `403` for
+/// it before script resolution runs. Only non-GET/HEAD methods, which the
+/// caller never redirects anyway, get here and fall back to the root
+/// `index.php`.
 async fn is_existing_directory(
     served_root: &Path,
     real_root: &Path,
@@ -197,9 +204,14 @@ mod tests {
         );
     }
 
+    /// Unit-level contract only: `resolve_script` refuses to treat the
+    /// escaping symlink as a directory, so it is not a redirect candidate.
+    /// In the server, a GET/HEAD for this path never reaches
+    /// `resolve_script` at all - `static_file::try_serve` answers `403`
+    /// first (see `is_existing_directory`'s doc).
     #[cfg(unix)]
     #[tokio::test]
-    async fn symlinked_directory_escaping_document_root_falls_back() {
+    async fn symlinked_directory_escaping_document_root_is_not_a_redirect_candidate() {
         let docroot = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         std::fs::create_dir(outside.path().join("secrets")).unwrap();

--- a/crates/yerd-proxy/src/pure/redirect.rs
+++ b/crates/yerd-proxy/src/pure/redirect.rs
@@ -1,4 +1,6 @@
-//! Build HTTP → HTTPS redirect URIs.
+//! Build the `Location` values Yerd's own redirects use: the HTTP → HTTPS
+//! upgrade (absolute URI) and the trailing-slash directory redirect
+//! (path-relative).
 
 /// Build an HTTPS redirect URI from an inbound HTTP request.
 ///
@@ -21,6 +23,32 @@ pub fn build_redirect_uri(host: &str, path_and_query: &str, https_port: u16) -> 
     } else {
         format!("https://{host_lower}:{https_port}{pq}")
     }
+}
+
+/// The trailing-slash `Location` for a directory request that arrived without
+/// one: `/sub?x=1` -> `/sub/?x=1`. Path-relative, so it is scheme- and
+/// host-agnostic and works behind either listener.
+///
+/// An empty `path_and_query` degrades to `/`, and a path that already ends in
+/// `/` is returned unchanged, so the caller can never build a redirect loop.
+#[must_use]
+pub fn directory_redirect_location(path_and_query: &str) -> String {
+    let (path, query) = match path_and_query.split_once('?') {
+        Some((path, query)) => (path, Some(query)),
+        None => (path_and_query, None),
+    };
+    let mut out = if path.is_empty() {
+        String::from("/")
+    } else if path.ends_with('/') {
+        path.to_owned()
+    } else {
+        format!("{path}/")
+    };
+    if let Some(query) = query {
+        out.push('?');
+        out.push_str(query);
+    }
+    out
 }
 
 /// Strip the trailing `:port` from `host`, handling IPv6 literals `[...]`.
@@ -68,6 +96,22 @@ mod tests {
                 *want,
                 "case: host={host:?} pq={pq:?} port={port}"
             );
+        }
+    }
+
+    #[test]
+    fn directory_redirect_table() {
+        let cases: &[(&str, &str)] = &[
+            ("/sub", "/sub/"),
+            ("/sub?x=1", "/sub/?x=1"),
+            ("/a/b", "/a/b/"),
+            ("/sub/", "/sub/"),
+            ("/sub/?x=1", "/sub/?x=1"),
+            ("/sub?", "/sub/?"),
+            ("", "/"),
+        ];
+        for (pq, want) in cases {
+            assert_eq!(directory_redirect_location(pq), *want, "case: pq={pq:?}");
         }
     }
 

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -477,11 +477,14 @@ async fn dispatch<R: BackendResolver, L: LoginTokenConsumer>(
 ///
 /// The one-click `WordPress` login token is consumed here via
 /// [`consume_login_token_if_present`] - only ever on `/wp-admin`, only when a
-/// token is both present and valid for *this* site. This runs strictly after
-/// [`dispatch`]'s HTTP->HTTPS redirect check, so a secure site's token is
-/// never burned by the 301 itself. On success the token is stripped from the
-/// forwarded URI (never reaching PHP or logging) and `auto_prepend_file` plus
-/// the resolved target user are added for this one request only.
+/// token is both present and valid for *this* site, and only once every
+/// earlier answer (HTTP->HTTPS `301` in [`dispatch`], static file, symlink
+/// `403`, trailing-slash `301`) has been ruled out. A redirect must never
+/// burn the token: its `Location` keeps the query intact, so the token
+/// survives to the followed request and is consumed there. On success the
+/// token is stripped from the forwarded URI (never reaching PHP or logging)
+/// and `auto_prepend_file` plus the resolved target user are added for this
+/// one request only.
 #[allow(clippy::too_many_arguments)]
 async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
     mut req: Request<Incoming>,
@@ -497,15 +500,6 @@ async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
     https: bool,
     symlink_protection: bool,
 ) -> Result<Response<BoxBody>, ProxyError> {
-    let login_target_user = consume_login_token_if_present(&mut req, site.name(), login_tokens);
-    let auto_login = match (&login_target_user, login_prepend_script) {
-        (Some(target_user), Some(prepend_script)) => Some(cgi_params::AutoLoginParams {
-            prepend_script,
-            target_user: target_user.as_str(),
-        }),
-        _ => None,
-    };
-
     let outcome = static_file::try_serve(
         req.method(),
         req.uri().path(),
@@ -546,6 +540,14 @@ async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
         }
         script_file::ScriptResolution::DirectoryRedirect
         | script_file::ScriptResolution::Fallback => None,
+    };
+    let login_target_user = consume_login_token_if_present(&mut req, site.name(), login_tokens);
+    let auto_login = match (&login_target_user, login_prepend_script) {
+        (Some(target_user), Some(prepend_script)) => Some(cgi_params::AutoLoginParams {
+            prepend_script,
+            target_user: target_user.as_str(),
+        }),
+        _ => None,
     };
     fcgi::forward(
         req,
@@ -588,9 +590,11 @@ async fn resolve_script_if_allowed<R: BackendResolver>(
 
 /// One-click `WordPress` login: only ever considered on `/wp-admin`, only
 /// ever acted on when a token is both present and valid for `site_name`.
-/// Consuming happens here - the caller must only call this strictly after the
-/// HTTP->HTTPS redirect check, so a secure site's token is never burned by
-/// the 301 itself. On success, strips the token from `req`'s URI (so it never
+/// Consuming happens here - the caller must only call this once the request
+/// is definitely being forwarded to FastCGI, strictly after the HTTP->HTTPS
+/// redirect check and every other early answer (static file, symlink `403`,
+/// trailing-slash `301`), so no redirect or non-PHP response ever burns the
+/// token. On success, strips the token from `req`'s URI (so it never
 /// reaches PHP or request logging) and returns `Some(target_user)` (`""` = no
 /// preference); the caller decides what "success" means for its own request
 /// (adding `auto_prepend_file`/`YERD_LOGIN_USER`).
@@ -650,14 +654,24 @@ fn https_redirect(
 /// multi-directory PHP apps rely on: without it a subdirectory request
 /// silently executes the *root* `index.php`, so an app whose front page
 /// redirects into a subdirectory loops forever.
+///
+/// Sent with `Cache-Control: no-store`, deliberately diverging from
+/// Apache/nginx: a bare `301` is cached by browsers indefinitely, and on a
+/// dev box the answer stops being true the moment the directory is deleted
+/// or the site is switched to front-controller mode - Yerd has no way to
+/// evict it afterwards. The `Location` may also carry a one-shot login
+/// token, which has no business in a disk cache.
 fn trailing_slash_redirect(req: &Request<Incoming>) -> Result<Response<BoxBody>, ProxyError> {
-    moved_permanently(&directory_redirect_location(path_and_query_or_root(
+    let mut resp = moved_permanently(&directory_redirect_location(path_and_query_or_root(
         req.uri(),
-    )))
+    )))?;
+    resp.headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    Ok(resp)
 }
 
 /// A bodyless `301` to `location`. Shared by both redirect kinds so they can't
-/// drift in status or header handling.
+/// drift in status or `Location` handling.
 fn moved_permanently(location: &str) -> Result<Response<BoxBody>, ProxyError> {
     Response::builder()
         .status(StatusCode::MOVED_PERMANENTLY)

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -27,7 +27,7 @@ use crate::forward::{
 };
 use crate::pure::cgi_params;
 use crate::pure::query;
-use crate::pure::redirect::build_redirect_uri;
+use crate::pure::redirect::{build_redirect_uri, directory_redirect_location};
 use crate::pure::unbound::{self, PickerSite};
 use crate::tls::build_server_config;
 use crate::traits::{BackendResolver, CertStore, LoginTokenConsumer};
@@ -528,7 +528,7 @@ async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
     if let Some(resp) = resolve_static_outcome(outcome) {
         return Ok(resp);
     }
-    let script_rel = resolve_script_if_allowed(
+    let resolution = resolve_script_if_allowed(
         resolver,
         site,
         req.uri().path(),
@@ -537,6 +537,16 @@ async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
         symlink_protection,
     )
     .await;
+    let script_rel = match resolution {
+        script_file::ScriptResolution::Script(rel) => Some(rel),
+        script_file::ScriptResolution::DirectoryRedirect
+            if *req.method() == Method::GET || *req.method() == Method::HEAD =>
+        {
+            return trailing_slash_redirect(&req);
+        }
+        script_file::ScriptResolution::DirectoryRedirect
+        | script_file::ScriptResolution::Fallback => None,
+    };
     fcgi::forward(
         req,
         backend,
@@ -556,9 +566,12 @@ fn path_and_query_or_root(uri: &http::Uri) -> &str {
 }
 
 /// [`script_file::resolve_script`], gated by
-/// [`BackendResolver::allows_direct_script_execution`] - `None` (fall back to
-/// the site root's `index.php`) for any site the resolver hasn't opted in,
-/// without touching the filesystem to find out.
+/// [`BackendResolver::allows_direct_script_execution`] -
+/// [`script_file::ScriptResolution::Fallback`] (send the request to the site
+/// root's `index.php`) for any site the resolver hasn't opted in, without
+/// touching the filesystem to find out. Front-controller sites route `/foo`
+/// themselves, so they must get neither direct execution nor the
+/// trailing-slash redirect.
 async fn resolve_script_if_allowed<R: BackendResolver>(
     resolver: &R,
     site: &yerd_core::Site,
@@ -566,9 +579,9 @@ async fn resolve_script_if_allowed<R: BackendResolver>(
     served_root: &std::path::Path,
     allowed_root: &std::path::Path,
     symlink_protection: bool,
-) -> Option<std::path::PathBuf> {
+) -> script_file::ScriptResolution {
     if !resolver.allows_direct_script_execution(site).await {
-        return None;
+        return script_file::ScriptResolution::Fallback;
     }
     script_file::resolve_script(uri_path, served_root, allowed_root, symlink_protection).await
 }
@@ -628,12 +641,29 @@ fn https_redirect(
         .uri()
         .path_and_query()
         .map_or("/", http::uri::PathAndQuery::as_str);
-    let loc = build_redirect_uri(host, pq, port);
+    moved_permanently(&build_redirect_uri(host, pq, port))
+}
+
+/// `301` to the trailing-slash form of this request's path, for a path that
+/// names a real directory on disk (`/sub` -> `/sub/`). What Apache's
+/// `DirectorySlash` and nginx's `try_files $uri $uri/` do, and what legacy
+/// multi-directory PHP apps rely on: without it a subdirectory request
+/// silently executes the *root* `index.php`, so an app whose front page
+/// redirects into a subdirectory loops forever.
+fn trailing_slash_redirect(req: &Request<Incoming>) -> Result<Response<BoxBody>, ProxyError> {
+    moved_permanently(&directory_redirect_location(path_and_query_or_root(
+        req.uri(),
+    )))
+}
+
+/// A bodyless `301` to `location`. Shared by both redirect kinds so they can't
+/// drift in status or header handling.
+fn moved_permanently(location: &str) -> Result<Response<BoxBody>, ProxyError> {
     Response::builder()
         .status(StatusCode::MOVED_PERMANENTLY)
         .header(
             LOCATION,
-            HeaderValue::from_str(&loc).map_err(|_| ProxyError::BackendProtocol {
+            HeaderValue::from_str(location).map_err(|_| ProxyError::BackendProtocol {
                 source: std::io::Error::other("invalid redirect URI"),
             })?,
         )

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -917,9 +917,20 @@ async fn directory_request_without_trailing_slash_redirects() {
         .await;
     });
 
+    let (status, headers) = client_get_headers(proxy_addr, "legacy.test", "/sub").await;
+    assert_eq!(status, 301);
     assert_eq!(
-        client_get_status_and_location(proxy_addr, "legacy.test", "/sub").await,
-        (301, Some("/sub/".to_owned()))
+        headers
+            .get(hyper::header::LOCATION)
+            .and_then(|v| v.to_str().ok()),
+        Some("/sub/")
+    );
+    assert_eq!(
+        headers
+            .get(hyper::header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok()),
+        Some("no-store"),
+        "a cached 301 would outlive the directory and the site's routing mode"
     );
     assert_eq!(
         client_get_status_and_location(proxy_addr, "legacy.test", "/sub?x=1").await,
@@ -1008,6 +1019,201 @@ async fn front_controller_mode_does_not_redirect_directories() {
     assert_eq!(
         params.get("SCRIPT_NAME").map(String::as_str),
         Some("/index.php")
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
+/// The trailing-slash redirect is GET/HEAD-only: a `301` would make the
+/// client drop the body and retry as GET, so a POST to a directory path must
+/// instead keep reaching the root front controller exactly as it did before
+/// the redirect existed. `sub/index.php` is real here, proving it is the
+/// method gate deciding, not a missing directory.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_to_directory_is_not_redirected() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.php"), b"<?php /* root */").unwrap();
+    std::fs::create_dir(docroot.path().join("sub")).unwrap();
+    std::fs::write(docroot.path().join("sub/index.php"), b"<?php /* sub */").unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked(
+        "legacy",
+        docroot.path().to_path_buf(),
+        PhpVersion::new(8, 3),
+    )
+    .unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            Arc::new(NoLoginTokens),
+            None,
+            Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
+            false,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, body) = client_post(proxy_addr, "legacy.test", "/sub").await;
+    assert_eq!(status, 200, "a POST must never be answered with the 301");
+    assert_eq!(body, b"from fpm");
+
+    let params = captured.lock().await.clone();
+    assert_eq!(
+        params.get("REQUEST_METHOD").map(String::as_str),
+        Some("POST")
+    );
+    assert_eq!(
+        params.get("SCRIPT_NAME").map(String::as_str),
+        Some("/index.php"),
+        "the directory outcome must degrade to the root front controller for POST"
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
+/// A one-click login token on the slashless `/wp-admin` form must survive the
+/// trailing-slash `301` unconsumed and untouched in `Location`, then actually
+/// work on the slashed follow-up request. Companion to
+/// `secure_site_redirect_does_not_consume_login_token`, which pins the same
+/// no-redirect-burns-the-token invariant for the HTTP->HTTPS `301`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn directory_redirect_preserves_login_token_unconsumed() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.php"), b"<?php /* root */").unwrap();
+    std::fs::create_dir(docroot.path().join("wp-admin")).unwrap();
+    std::fs::write(docroot.path().join("wp-admin/index.php"), b"<?php").unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nadmin".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("blog", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+    let login_tokens = Arc::new(OneShotLoginToken {
+        site: "blog",
+        token: "sekrit",
+        target_user: "editor",
+        consumed: std::sync::atomic::AtomicBool::new(false),
+    });
+    let login_tokens_for_assert = login_tokens.clone();
+    let prepend_path = PathBuf::from("/opt/yerd/wordpress-autologin-prepend.php");
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            login_tokens,
+            Some(prepend_path),
+            Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
+            false,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, location) = client_get_status_and_location(
+        proxy_addr,
+        "blog.test",
+        "/wp-admin?yerd_login_token=sekrit",
+    )
+    .await;
+    assert_eq!(status, 301);
+    assert_eq!(
+        location.as_deref(),
+        Some("/wp-admin/?yerd_login_token=sekrit"),
+        "the token must still be in the redirect Location, untouched"
+    );
+    assert!(
+        !login_tokens_for_assert
+            .consumed
+            .load(std::sync::atomic::Ordering::SeqCst),
+        "the trailing-slash 301 must never consume the token"
+    );
+
+    let body = client_get(
+        proxy_addr,
+        "blog.test",
+        "/wp-admin/?yerd_login_token=sekrit",
+    )
+    .await;
+    assert_eq!(body, b"admin");
+    assert!(
+        login_tokens_for_assert
+            .consumed
+            .load(std::sync::atomic::Ordering::SeqCst),
+        "the followed redirect is where the token gets spent"
+    );
+
+    let params = captured.lock().await.clone();
+    assert_eq!(
+        params.get("PHP_VALUE").map(String::as_str),
+        Some("auto_prepend_file=/opt/yerd/wordpress-autologin-prepend.php"),
+        "autologin must actually engage on the slashed request"
+    );
+    assert_eq!(
+        params.get("REQUEST_URI").map(String::as_str),
+        Some("/wp-admin/"),
+        "the consumed token must be stripped before reaching PHP"
     );
 
     let _ = tx_shutdown.send(());
@@ -1640,4 +1846,50 @@ async fn client_get_status(addr: SocketAddr, host: &str, path: &str) -> u16 {
         .unwrap();
     let resp = sender.send_request(req).await.unwrap();
     resp.status().as_u16()
+}
+
+async fn client_get_headers(addr: SocketAddr, host: &str, path: &str) -> (u16, hyper::HeaderMap) {
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = Request::builder()
+        .method("GET")
+        .uri(path)
+        .header("Host", host)
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+    let resp = sender.send_request(req).await.unwrap();
+    (resp.status().as_u16(), resp.headers().clone())
+}
+
+async fn client_post(addr: SocketAddr, host: &str, path: &str) -> (u16, Vec<u8>) {
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("Host", host)
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+    let resp = sender.send_request(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    (status, body)
 }

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -854,6 +854,168 @@ async fn subdirectory_index_php_wins_over_root_index_php() {
     let _ = fake_task.await;
 }
 
+/// Issue #198: in direct mode a request for a real directory *without* a
+/// trailing slash must earn a `301` to the slashed form, the way Apache's
+/// `DirectorySlash` and nginx's `try_files $uri $uri/` answer it. Without the
+/// redirect the root `index.php` runs instead, and a legacy app whose front
+/// page redirects into a subdirectory loops until the browser gives up
+/// (`ERR_TOO_MANY_REDIRECTS`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn directory_request_without_trailing_slash_redirects() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.php"), b"<?php /* root */").unwrap();
+    std::fs::create_dir(docroot.path().join("sub")).unwrap();
+    std::fs::write(docroot.path().join("sub/index.php"), b"<?php /* sub */").unwrap();
+    std::fs::create_dir(docroot.path().join("static-only")).unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked(
+        "legacy",
+        docroot.path().to_path_buf(),
+        PhpVersion::new(8, 3),
+    )
+    .unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            Arc::new(NoLoginTokens),
+            None,
+            Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
+            false,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    assert_eq!(
+        client_get_status_and_location(proxy_addr, "legacy.test", "/sub").await,
+        (301, Some("/sub/".to_owned()))
+    );
+    assert_eq!(
+        client_get_status_and_location(proxy_addr, "legacy.test", "/sub?x=1").await,
+        (301, Some("/sub/?x=1".to_owned())),
+        "the query string must survive the redirect"
+    );
+    assert_eq!(
+        client_get_status_and_location(proxy_addr, "legacy.test", "/static-only").await,
+        (301, Some("/static-only/".to_owned())),
+        "the 301 depends on the directory existing, not on it holding an index.php"
+    );
+
+    // The slashed form still executes the subdirectory's own script - the
+    // redirect target must actually resolve, or the loop just moves.
+    let body = client_get(proxy_addr, "legacy.test", "/sub/").await;
+    assert_eq!(body, b"from fpm");
+    let params = captured.lock().await.clone();
+    assert_eq!(
+        params.get("SCRIPT_NAME").map(String::as_str),
+        Some("/sub/index.php")
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
+/// The trailing-slash redirect is direct-mode only. A front-controller site
+/// (Laravel, Symfony, ...) owns `/sub` as a framework route, so redirecting it
+/// would break the app - `/sub` must keep reaching the root `index.php`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn front_controller_mode_does_not_redirect_directories() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.php"), b"<?php /* root */").unwrap();
+    std::fs::create_dir(docroot.path().join("sub")).unwrap();
+    std::fs::write(docroot.path().join("sub/index.php"), b"<?php /* sub */").unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(NonWordPressResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            Arc::new(NoLoginTokens),
+            None,
+            Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
+            false,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let (status, _, body) = client_get_response(proxy_addr, "app.test", "/sub").await;
+    assert_eq!(status, 200, "a framework route must not be redirected");
+    assert_eq!(body, b"from fpm");
+
+    let params = captured.lock().await.clone();
+    assert_eq!(
+        params.get("SCRIPT_NAME").map(String::as_str),
+        Some("/index.php")
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
 /// A non-`WordPress` site must never get `resolve_script`'s direct-real-
 /// file-execution treatment: a stray real script under the document root
 /// (a debug `phpinfo.php`, an old admin tool) stays unreachable directly and

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -932,14 +932,13 @@ async fn directory_request_without_trailing_slash_redirects() {
         "the 301 depends on the directory existing, not on it holding an index.php"
     );
 
-    // The slashed form still executes the subdirectory's own script - the
-    // redirect target must actually resolve, or the loop just moves.
     let body = client_get(proxy_addr, "legacy.test", "/sub/").await;
     assert_eq!(body, b"from fpm");
     let params = captured.lock().await.clone();
     assert_eq!(
         params.get("SCRIPT_NAME").map(String::as_str),
-        Some("/sub/index.php")
+        Some("/sub/index.php"),
+        "the redirect target must itself resolve, or the loop just moves"
     );
 
     let _ = tx_shutdown.send(());


### PR DESCRIPTION
## What does this PR do?

In `direct` mode (`front_controller = false`), `GET /sub` where `sub/` is a real directory under the web root silently executed the **root** `index.php` instead of redirecting to `/sub/`. Legacy multi-directory PHP apps whose root `index.php` redirects into a subdirectory therefore looped until the browser gave up (`ERR_TOO_MANY_REDIRECTS`).

**Root cause:** `resolve_script` took the `static_candidate("/sub")` early-return branch, failed the `is_php_source` check (no `.php` extension), and returned `None` — the directory was never probed, so the request fell back to the root `index.php` via `pure/cgi_params.rs`. No trailing-slash redirect existed anywhere in the routing code.

**The fix**, in three small pieces:

- `pure/redirect.rs` — a new pure `directory_redirect_location()` builds the `Location` (`/sub?x=1` → `/sub/?x=1`). Path-relative, so it is scheme- and host-agnostic; an already-slashed path passes through unchanged, so it cannot construct a loop.
- `forward/script_file.rs` — `resolve_script` now returns a `ScriptResolution` enum (`Script` / `DirectoryRedirect` / `Fallback`) so the directory case is representable at all. A new `is_existing_directory` helper deliberately mirrors `existing_php_file`'s `Containment` match, keeping symlink semantics identical between the two probes.
- `server.rs` — `serve_php_fpm` answers `301` for `DirectoryRedirect`; `https_redirect` and the new `trailing_slash_redirect` now share an extracted `moved_permanently()` helper.

This matches Apache's `DirectorySlash` and nginx's `try_files $uri $uri/`. The redirect fires whether or not the directory holds an `index.php`, so a static-only `/assets` redirects to `/assets/`, where `try_serve_index` serves its `index.html`.

**Two deliberate scope limits:**

- **Direct mode only**, via the existing `BackendResolver::allows_direct_script_execution` gate. Front-controller sites (Laravel, Symfony, …) treat `/foo` as a framework route, so redirecting there would break those apps. This also keeps #196 (virtual-path routing) separate.
- **GET/HEAD only**, to avoid surprising POST semantics — the same gating Apache applies.

No trait changes, no IPC changes; `try_files.rs`, `cgi_params.rs`, and `static_file.rs` are untouched.

## Related issues

Closes #198

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Platforms tested

- [x] macOS
- [ ] Linux

Verified on macOS only — leaving Linux to CI. The one platform-specific addition is a `#[cfg(unix)]` symlinked-directory test pair, following the pattern of the existing symlink tests beside it.

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed

On `cargo test --workspace`: one **pre-existing, unrelated** failure, `yerdd`'s `tunnel::tests::resolved_cloudflared_reflects_a_fresh_install_without_restart`. It asserts `cloudflared` is absent from the host and so fails on any machine that has it installed; confirmed failing identically on a clean `main` checkout. All other tests pass.

On docs: no user-facing behaviour or CLI surface changed, so nothing needed updating. The redirect restores what web servers have always done here.

## Testing

Written test-first — each test was watched failing before the implementation existed.

**Unit** — `directory_redirect_location` gets a 7-case table test (query preservation, already-slashed paths, empty input). `script_file` grows from 9 to 13 tests: the 9 existing ones migrated to the new enum, plus a directory redirect, a static-only directory, and a `#[cfg(unix)]` symlinked-directory pair proving protection-on falls back while protection-off redirects.

**Integration** — two new tests in `integration_http.rs` drive the real `ProxyServer::serve`:

- `directory_request_without_trailing_slash_redirects` — asserts `GET /sub` → `(301, /sub/)`, query preservation, a static-only directory, and that `/sub/` still executes `sub/index.php`.
- `front_controller_mode_does_not_redirect_directories` — codifies that framework sites are untouched (`GET /sub` → `200`, `SCRIPT_NAME == /index.php`).

To confirm the integration test actually catches this bug rather than merely passing, I removed the `DirectoryRedirect` dispatch arm and re-ran it: `left: (200, None)` vs `right: (301, Some("/sub/"))` — exactly the reported symptom.

**End-to-end** against a from-source daemon and the issue's two-file repro, run on baseline `main` first for a real before/after:

| Request | `main` (before) | With fix |
|---|---|---|
| `GET /sub` | **`200`, body `root`** ← the bug | **`301 Location: /sub/`** |
| `GET /sub?x=1` | `200 root` | `301 Location: /sub/?x=1` |
| `GET /static-only` | `200 root` | `301 Location: /static-only/` |
| `GET /sub/` | `200 sub` | `200 sub` (unchanged) |
| `GET /` | `200 root` | `200 root` (unchanged) |

Plus three checks on the fixed build: `curl -L /sub` resolves in exactly **1 redirect** to body `sub` (no loop); `POST /sub` returns `200` with no redirect, confirming the method gate; and flipping the same site to `front-controller on` returns `200 root` with no redirect, confirming framework sites are unaffected.

**Login tokens** — no interaction. The GUI mints login URLs as `/wp-admin/?yerd_login_token=…` with a trailing slash (`apps/yerd-gui/src/lib/siteUrl.ts`), so a token is never burned by the new 301.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic trailing-slash redirects for directory URLs.
  * Preserved query parameters during directory redirects.
  * Directory requests now serve available index files.
  * Directories without index files still receive canonical redirects.
  * Front-controller routing continues to handle requests without directory redirects.

* **Bug Fixes**
  * Improved handling of directory paths and symlink-based requests.
  * Standardized redirect behavior for directory URL normalization.
  * Preserved login tokens across redirects and consumed them only when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->