### PR TITLE
[Fix] Find Homebrew/MacPorts certutil under the daemon's stripped PATH

### DIFF
--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -101,19 +101,13 @@ fn trust_findings(report: &StatusReport) -> Vec<Diagnosis> {
         Some(BrowserTrust::Untrusted) => out.push(warn(
             DiagnosisCode::CaNotTrustedByBrowsers,
             "Browsers don't trust the local CA",
-            "Brave, Chrome and Firefox keep their own certificate store, separate \
-             from the system store, so they show HTTPS warnings on .test sites \
-             until the CA is added there."
-                .to_owned(),
+            browser_untrusted_detail().to_owned(),
             "yerd elevate trust",
         )),
         Some(BrowserTrust::ToolMissing) => out.push(warn(
             DiagnosisCode::CaNotTrustedByBrowsers,
             "Can't establish browser trust (certutil missing)",
-            "Browsers won't trust the local CA until certutil is installed: \
-             libnss3-tools (Debian/Ubuntu/Zorin), nss-tools (Fedora), nss (Arch), \
-             or `brew install nss` (macOS). Install it, then run trust again."
-                .to_owned(),
+            certutil_missing_detail().to_owned(),
             "yerd elevate trust",
         )),
         _ => {}
@@ -140,6 +134,37 @@ fn trust_findings(report: &StatusReport) -> Vec<Diagnosis> {
         ));
     }
     out
+}
+
+/// Detail for the browsers-don't-trust-the-CA warning. On macOS only Firefox
+/// keeps its own NSS store; Chromium-family browsers there read the system
+/// keychain, so naming them would send users looking for a problem they do not
+/// have. Elsewhere all three keep separate stores.
+fn browser_untrusted_detail() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Firefox keeps its own certificate store, separate from the system \
+         keychain, so it shows HTTPS warnings on .test sites until the CA is \
+         added there."
+    } else {
+        "Brave, Chrome and Firefox keep their own certificate store, separate \
+         from the system store, so they show HTTPS warnings on .test sites \
+         until the CA is added there."
+    }
+}
+
+/// Detail for the certutil-missing warning, leading with the install hint that
+/// actually applies to the host: Homebrew or `MacPorts` on macOS, the distro
+/// packages elsewhere.
+fn certutil_missing_detail() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Browsers won't trust the local CA until certutil is installed: \
+         `brew install nss` (Homebrew) or `sudo port install nss` (MacPorts). \
+         Install it, then run trust again."
+    } else {
+        "Browsers won't trust the local CA until certutil is installed: \
+         libnss3-tools (Debian/Ubuntu/Zorin), nss-tools (Fedora), nss (Arch), \
+         or `brew install nss` (macOS). Install it, then run trust again."
+    }
 }
 
 /// PHP install-state findings: a missing install (which suppresses the
@@ -916,10 +941,38 @@ mod tests {
             .into_iter()
             .find(|d| d.code == DiagnosisCode::CaNotTrustedByBrowsers)
             .expect("tool-missing warns");
-        // The doctor is pure and cannot detect the host OS, so the hint is
-        // distro/OS-neutral: it names the tool and covers Linux and macOS.
         assert!(d.detail.contains("certutil"));
         assert!(d.detail.contains("brew install nss"));
+    }
+
+    #[test]
+    fn browser_trust_details_are_platform_aware() {
+        let untrusted = browser_untrusted_detail();
+        let missing = certutil_missing_detail();
+        assert!(untrusted.contains("Firefox"));
+        #[cfg(target_os = "macos")]
+        {
+            assert!(
+                !untrusted.contains("Chrome") && !untrusted.contains("Brave"),
+                "macOS Chromium-family browsers read the system keychain, not NSS"
+            );
+            assert!(
+                missing.starts_with(
+                    "Browsers won't trust the local CA until certutil is installed: \
+                     `brew install nss`"
+                ),
+                "macOS hint must lead with Homebrew"
+            );
+            assert!(!missing.contains("libnss3-tools"));
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(
+                untrusted.contains("Chrome") && untrusted.contains("Brave"),
+                "Linux Chromium-family browsers keep their own NSS store"
+            );
+            assert!(missing.contains("libnss3-tools"));
+        }
     }
 
     #[test]

--- a/crates/yerd-platform/src/nss_exec.rs
+++ b/crates/yerd-platform/src/nss_exec.rs
@@ -220,6 +220,25 @@ pub fn browser_trust(
     }
 }
 
+/// The first existing `certutil`: every absolute path in `candidates` in order,
+/// then `certutil` under each of `path_dirs`. The absolute list wins because a
+/// service manager hands the daemon a stripped `PATH` that hides the tool. The
+/// existence probe is injected so the walk is unit-tested against the real
+/// candidate lists on any host, without touching the filesystem.
+fn resolve_certutil(
+    candidates: &[PathBuf],
+    path_dirs: &[PathBuf],
+    is_file: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    if let Some(found) = candidates.iter().find(|c| is_file(c.as_path())) {
+        return Some(found.clone());
+    }
+    path_dirs
+        .iter()
+        .map(|dir| dir.join("certutil"))
+        .find(|c| is_file(c.as_path()))
+}
+
 // ---- real (edge) impls ----------------------------------------------------
 
 #[cfg(unix)]
@@ -231,6 +250,7 @@ mod real {
     use std::process::Command;
 
     use super::{CertutilRunner, NssFs, Os, RunResult};
+    use crate::pure::nss;
     use crate::trust_store::{BrowserCaTrust, CaFingerprint, NssOutcome};
 
     /// The layout of the host we are running on.
@@ -245,27 +265,27 @@ mod real {
         }
     }
 
-    /// `certutil` located at an absolute path (resolved once). Absolute-path
-    /// resolution mirrors the `/usr/bin/id` / `/bin/ps` precedent - a stripped
-    /// `PATH` under a service manager must not hide the tool.
+    /// `certutil` located at an absolute path (resolved once). The per-OS
+    /// candidate list is probed before `$PATH`, mirroring the `/usr/bin/id` /
+    /// `/bin/ps` precedent: a stripped `PATH` under a service manager must not
+    /// hide the tool. On macOS that means the Homebrew and `MacPorts` prefixes,
+    /// which the `LaunchAgent`'s `PATH` never contains.
     struct RealCertutil {
         path: Option<PathBuf>,
     }
 
     impl RealCertutil {
         fn resolve() -> Self {
-            let common = Path::new("/usr/bin/certutil");
-            if common.is_file() {
-                return Self {
-                    path: Some(common.to_path_buf()),
-                };
+            let path_dirs: Vec<PathBuf> = std::env::var_os("PATH")
+                .map(|paths| std::env::split_paths(&paths).collect())
+                .unwrap_or_default();
+            let candidates = match current_os() {
+                Os::Linux => nss::certutil_candidates_linux(),
+                Os::Macos => nss::certutil_candidates_macos(),
+            };
+            Self {
+                path: super::resolve_certutil(&candidates, &path_dirs, Path::is_file),
             }
-            let path = std::env::var_os("PATH").and_then(|paths| {
-                std::env::split_paths(&paths)
-                    .map(|dir| dir.join("certutil"))
-                    .find(|candidate| candidate.is_file())
-            });
-            Self { path }
         }
     }
 
@@ -663,6 +683,45 @@ mod tests {
                 stdout: vec![],
             }
         }
+    }
+
+    #[test]
+    fn resolve_certutil_finds_a_non_usr_bin_candidate() {
+        let present: HashSet<PathBuf> = [PathBuf::from("/opt/homebrew/bin/certutil")]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            resolve_certutil(&nss::certutil_candidates_macos(), &[], |p| present
+                .contains(p)),
+            Some(PathBuf::from("/opt/homebrew/bin/certutil"))
+        );
+    }
+
+    #[test]
+    fn resolve_certutil_falls_back_to_path_dirs() {
+        let present: HashSet<PathBuf> = [PathBuf::from("/home/alice/bin/certutil")]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            resolve_certutil(
+                &nss::certutil_candidates_macos(),
+                &[PathBuf::from("/home/alice/bin")],
+                |p| present.contains(p)
+            ),
+            Some(PathBuf::from("/home/alice/bin/certutil"))
+        );
+    }
+
+    #[test]
+    fn resolve_certutil_none_when_nothing_exists() {
+        assert_eq!(
+            resolve_certutil(
+                &nss::certutil_candidates_linux(),
+                &[PathBuf::from("/usr/local/bin")],
+                |_| false
+            ),
+            None
+        );
     }
 
     fn sample_ca_pem() -> String {

--- a/crates/yerd-platform/src/pure/nss.rs
+++ b/crates/yerd-platform/src/pure/nss.rs
@@ -174,6 +174,34 @@ pub fn macos_firefox_root(home: &Path) -> PathBuf {
     home.join("Library/Application Support/Firefox")
 }
 
+/// Absolute paths that may hold the `certutil` binary on Linux, in probe order.
+/// Every distro package that ships it (`libnss3-tools`, `nss-tools`, `nss`)
+/// installs to `/usr/bin`.
+#[must_use]
+pub fn certutil_candidates_linux() -> Vec<PathBuf> {
+    vec![PathBuf::from("/usr/bin/certutil")]
+}
+
+/// Absolute paths that may hold the `certutil` binary on macOS, in probe order.
+///
+/// The daemon runs as an `SMAppService` `LaunchAgent`, which gives it the
+/// stripped `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, so the Homebrew and
+/// `MacPorts` locations have to be probed absolutely or the tool looks missing.
+/// Linked Homebrew `bin` comes first for both architectures (current Homebrew
+/// links `nss`), then the keg-only `opt/nss/bin` variants, then `MacPorts`.
+/// `/usr/bin` is deliberately absent: macOS ships `certtool` there, never
+/// `certutil`.
+#[must_use]
+pub fn certutil_candidates_macos() -> Vec<PathBuf> {
+    vec![
+        PathBuf::from("/opt/homebrew/bin/certutil"),
+        PathBuf::from("/usr/local/bin/certutil"),
+        PathBuf::from("/opt/homebrew/opt/nss/bin/certutil"),
+        PathBuf::from("/usr/local/opt/nss/bin/certutil"),
+        PathBuf::from("/opt/local/bin/certutil"),
+    ]
+}
+
 /// Resolve the per-profile directories under a Firefox `profiles_root` from the
 /// text of its `profiles.ini`. Relative `Path=` entries are joined against
 /// `profiles_root`; absolute entries are used as-is. The edge then keeps only
@@ -293,6 +321,28 @@ mod tests {
         let ini = "[Profile0]\nIsRelative=0\nPath=/custom/profile\n";
         let dirs = firefox_profile_dirs(Path::new("/home/alice/.mozilla/firefox"), ini);
         assert_eq!(dirs, vec![PathBuf::from("/custom/profile")]);
+    }
+
+    #[test]
+    fn certutil_candidates_linux_is_usr_bin_only() {
+        assert_eq!(
+            certutil_candidates_linux(),
+            vec![PathBuf::from("/usr/bin/certutil")]
+        );
+    }
+
+    #[test]
+    fn certutil_candidates_macos_cover_homebrew_kegs_and_macports_in_order() {
+        assert_eq!(
+            certutil_candidates_macos(),
+            vec![
+                PathBuf::from("/opt/homebrew/bin/certutil"),
+                PathBuf::from("/usr/local/bin/certutil"),
+                PathBuf::from("/opt/homebrew/opt/nss/bin/certutil"),
+                PathBuf::from("/usr/local/opt/nss/bin/certutil"),
+                PathBuf::from("/opt/local/bin/certutil"),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Resolves certutil from per-OS absolute candidate paths before falling back to $PATH, so the macOS daemon — whose LaunchAgent gives it only /usr/bin:/bin:/usr/sbin:/sbin — stops reporting "certutil missing" and can actually populate Firefox's NSS store, with the two browser-trust doctor messages now worded per platform.

## Related issues

Closes #203 

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [ ] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser trust diagnostics with platform-specific guidance.
  * macOS warnings now focus on Firefox and recommend Homebrew or MacPorts for installing required tools.
  * Improved `certutil` detection across Linux and macOS, including nonstandard installation locations and `PATH`-based fallback.
  * Added clearer handling when `certutil` cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->