### PR TITLE
[Feat] Site-aware exec/which commands for pinned PHP versions

### DIFF
--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -264,8 +264,13 @@ pub enum Command {
     /// the global default is used. Everything after the tool is passed
     /// straight through, so `--site`/`--json` must come *before* it (e.g.
     /// `yerd exec --site blog php -v`). The bare `php` and `composer` shims are
-    /// unaffected and still use the global default. Local - execs PHP directly.
-    /// (Unix only.)
+    /// unaffected and still use the global default. `-h`/`--help` go to the
+    /// tool, so use `yerd help exec` for this command's own help. Local -
+    /// execs PHP directly. (Unix only.)
+    // `disable_help_flag` because clap otherwise matches `-h`/`--help` before
+    // `trailing_var_arg` starts collecting, so `yerd exec composer --help`
+    // would print yerd's help instead of Composer's.
+    #[command(disable_help_flag = true)]
     Exec {
         /// Run under this site's pinned version instead of the current
         /// directory's. Unlike the cwd lookup this never falls back: an

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -258,6 +258,42 @@ pub enum Command {
         )]
         args: Vec<std::ffi::OsString>,
     },
+    /// Run a tool under the PHP version pinned to a site - the one its web
+    /// requests use - instead of the global default. The site is the one
+    /// containing the current directory, or `--site <name>`; outside any site,
+    /// the global default is used. Everything after the tool is passed
+    /// straight through, so `--site`/`--json` must come *before* it (e.g.
+    /// `yerd exec --site blog php -v`). The bare `php` and `composer` shims are
+    /// unaffected and still use the global default. Local - execs PHP directly.
+    /// (Unix only.)
+    Exec {
+        /// Run under this site's pinned version instead of the current
+        /// directory's. Unlike the cwd lookup this never falls back: an
+        /// unknown name is an error.
+        #[arg(long, value_name = "NAME")]
+        site: Option<String>,
+        /// Which tool to run.
+        tool: ExecTool,
+        /// Arguments forwarded verbatim to the tool, e.g. `artisan test`.
+        #[arg(
+            trailing_var_arg = true,
+            allow_hyphen_values = true,
+            num_args = 0..,
+            value_name = "ARGS"
+        )]
+        args: Vec<std::ffi::OsString>,
+    },
+    /// Print the absolute path of the binary `yerd exec` would use, resolved
+    /// the same way (current directory's site, or `--site <name>`). With
+    /// `--json`, reports the version and which site it came from too. Local -
+    /// does not run anything. (Unix only.)
+    Which {
+        /// Which tool to report.
+        tool: WhichTool,
+        /// Report the binary for this site instead of the current directory's.
+        #[arg(long, value_name = "NAME")]
+        site: Option<String>,
+    },
     /// Serve Yerd's tools to AI agents over MCP on stdin/stdout. Not meant to be
     /// run by hand: an agent spawns it. Register it once, e.g.
     /// `claude mcp add --scope user yerd -- yerd mcp`. Tools are served only
@@ -285,6 +321,24 @@ pub enum LanAction {
     /// Show LAN exposure state: configured vs effective, the LAN IP, and the
     /// next privileged step if any.
     Status,
+}
+
+/// A tool `yerd exec` can run under a site's pinned PHP version.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecTool {
+    /// The PHP CLI itself.
+    Php,
+    /// The bundled Composer phar, run under that PHP.
+    Composer,
+}
+
+/// A tool `yerd which` can report the path of. Deliberately separate from
+/// [`ExecTool`] so `yerd which composer` - which would have to mean the phar,
+/// not a binary - is rejected at parse time rather than silently answered.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WhichTool {
+    /// The PHP CLI binary.
+    Php,
 }
 
 /// A binary on/off toggle argument (e.g. `yerd front-controller <name> on`).
@@ -896,4 +950,85 @@ pub enum ElevateTarget {
     /// only; on Linux this reuses the `ports` setcap grant). Run after
     /// `yerd lan enable`.
     Lan,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(args).unwrap()
+    }
+
+    /// `yerd exec php -v` must work without a `--` separator: the flags after
+    /// the tool belong to the tool, not to yerd.
+    #[test]
+    fn exec_captures_hyphenated_tool_args() {
+        let cli = parse(&["yerd", "exec", "php", "-v"]);
+        let Command::Exec { site, tool, args } = cli.command else {
+            panic!("expected Exec");
+        };
+        assert_eq!(site, None);
+        assert_eq!(tool, ExecTool::Php);
+        assert_eq!(args, vec!["-v"]);
+    }
+
+    #[test]
+    fn exec_takes_site_before_the_tool() {
+        let cli = parse(&["yerd", "exec", "--site", "blog", "composer", "install"]);
+        let Command::Exec { site, tool, args } = cli.command else {
+            panic!("expected Exec");
+        };
+        assert_eq!(site.as_deref(), Some("blog"));
+        assert_eq!(tool, ExecTool::Composer);
+        assert_eq!(args, vec!["install"]);
+    }
+
+    /// A `--json` *after* the tool is the tool's own flag - it must be
+    /// forwarded, not consumed by yerd's global one.
+    #[test]
+    fn exec_forwards_a_trailing_json_flag_to_the_tool() {
+        let cli = parse(&["yerd", "exec", "composer", "show", "--json"]);
+        assert!(!cli.json, "--json after the tool belongs to the tool");
+        let Command::Exec { args, .. } = cli.command else {
+            panic!("expected Exec");
+        };
+        assert_eq!(args, vec!["show", "--json"]);
+    }
+
+    #[test]
+    fn exec_takes_yerds_json_flag_before_the_tool() {
+        let cli = parse(&["yerd", "--json", "exec", "php", "-v"]);
+        assert!(cli.json);
+    }
+
+    #[test]
+    fn which_parses_php_with_an_optional_site() {
+        let cli = parse(&["yerd", "which", "php"]);
+        let Command::Which { tool, site } = cli.command else {
+            panic!("expected Which");
+        };
+        assert_eq!(tool, WhichTool::Php);
+        assert_eq!(site, None);
+
+        let cli = parse(&["yerd", "which", "php", "--site", "blog"]);
+        let Command::Which { site, .. } = cli.command else {
+            panic!("expected Which");
+        };
+        assert_eq!(site.as_deref(), Some("blog"));
+    }
+
+    /// `which` only knows how to report a binary, and Composer is a phar - so
+    /// it must be rejected at parse time rather than answered misleadingly.
+    #[test]
+    fn which_rejects_composer() {
+        assert!(Cli::try_parse_from(["yerd", "which", "composer"]).is_err());
+    }
+
+    #[test]
+    fn exec_rejects_an_unknown_tool() {
+        assert!(Cli::try_parse_from(["yerd", "exec", "artisan"]).is_err());
+    }
 }

--- a/bin/yerd/src/composer_shim.rs
+++ b/bin/yerd/src/composer_shim.rs
@@ -36,17 +36,9 @@ fn run() -> ExitCode {
         return fail(crate::shim::no_default_php_message(&dirs));
     };
 
-    let phar = dirs
-        .data
-        .join("tools")
-        .join("composer")
-        .join("composer.phar");
+    let phar = crate::shim::composer_phar(&dirs);
     if !phar.is_file() {
-        return fail(
-            "Composer is not installed — install it from the Tooling page \
-             (or run `yerd install tool composer`)"
-                .to_owned(),
-        );
+        return fail(crate::shim::composer_missing_message());
     }
 
     let err = Command::new(&php_bin)

--- a/bin/yerd/src/exec_cmd.rs
+++ b/bin/yerd/src/exec_cmd.rs
@@ -77,6 +77,11 @@ impl PhpSelection {
 /// running an unrelated one); outside any site - or with no reachable daemon -
 /// the global default.
 ///
+/// A daemon that can't be reached for the cwd lookup is *not* an error - it
+/// just means "not inside a site" - but it does warn on stderr, since silently
+/// demoting a site to the global default is the mismatch this command exists
+/// to prevent.
+///
 /// # Errors
 ///
 /// Returns a ready-to-print message for every unresolvable case.
@@ -102,17 +107,24 @@ pub fn select_php(
 
     let resolution = match cwd {
         Some(cwd) => site_scope(dirs, cwd),
-        None => ScopeResolution::NoScope,
+        None => ScopeResolution::NoScope {
+            daemon_unavailable: false,
+        },
     };
     match resolution {
         ScopeResolution::Scoped(scope) => Ok(PhpSelection::Site(scope)),
         ScopeResolution::MatchedPhpMissing { php_version } => {
             Err(missing_php_message(&php_version.to_string()))
         }
-        ScopeResolution::NoScope => match resolve_default_php(dirs) {
-            Some((php_bin, minor)) => Ok(PhpSelection::Default { php_bin, minor }),
-            None => Err(crate::shim::no_default_php_message(dirs)),
-        },
+        ScopeResolution::NoScope { daemon_unavailable } => {
+            if daemon_unavailable {
+                crate::site_scope::warn_daemon_unavailable();
+            }
+            match resolve_default_php(dirs) {
+                Some((php_bin, minor)) => Ok(PhpSelection::Default { php_bin, minor }),
+                None => Err(crate::shim::no_default_php_message(dirs)),
+            }
+        }
     }
 }
 

--- a/bin/yerd/src/exec_cmd.rs
+++ b/bin/yerd/src/exec_cmd.rs
@@ -260,7 +260,7 @@ mod tests {
             site_name: name.to_owned(),
             php_bin: PathBuf::from(format!("/d/php/php-{minor}/bin/php")),
             php_minor: minor.to_owned(),
-            served_root: PathBuf::from("/srv/blog"),
+            served_root: Some(PathBuf::from("/srv/blog")),
         })
     }
 

--- a/bin/yerd/src/exec_cmd.rs
+++ b/bin/yerd/src/exec_cmd.rs
@@ -25,10 +25,44 @@ use std::process::{Command, ExitCode};
 use yerd_platform::{ActivePaths, Paths, PlatformDirs};
 
 use crate::cli::{ExecTool, WhichTool};
-use crate::shim::{cli_phprc, fail, resolve_default_php};
+use crate::shim::{cli_phprc, resolve_default_php};
 use crate::site_scope::{
     site_scope, site_scope_by_name, NamedScopeError, ScopeResolution, SiteScope,
 };
+
+/// Why `yerd exec` / `yerd which` couldn't resolve a PHP to run.
+///
+/// Carries the exit code alongside the message because these are real
+/// subcommands, not shims: `docs/reference/cli/index.md` documents `2` for a
+/// client-side usage error and `69` for an unreachable daemon, and scripts
+/// branch on those. Collapsing everything to `1` (as the shims' `fail` does)
+/// would make a typo'd `--site` indistinguishable from a daemon-side failure.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SelectError {
+    /// The ready-to-print message, without the `yerd: ` prefix.
+    pub message: String,
+    /// The documented process exit code for this class of failure.
+    pub code: u8,
+}
+
+impl SelectError {
+    /// A client-side usage error - a name that doesn't resolve, a version that
+    /// isn't installed. Exit code `2`.
+    fn usage(message: String) -> Self {
+        Self { message, code: 2 }
+    }
+
+    /// The daemon was needed but unreachable. Exit code `69`.
+    fn daemon(message: String) -> Self {
+        Self { message, code: 69 }
+    }
+
+    /// Print to stderr and return the documented exit code.
+    fn report(&self) -> ExitCode {
+        eprintln!("yerd: {}", self.message);
+        ExitCode::from(self.code)
+    }
+}
 
 /// Which PHP a `yerd exec` / `yerd which` invocation resolved to.
 #[derive(Debug)]
@@ -79,29 +113,30 @@ impl PhpSelection {
 ///
 /// A daemon that can't be reached for the cwd lookup is *not* an error - it
 /// just means "not inside a site" - but it does warn on stderr, since silently
-/// demoting a site to the global default is the mismatch this command exists
-/// to prevent.
+/// demoting a pinned site to the global default is the mismatch this command
+/// exists to prevent.
 ///
 /// # Errors
 ///
-/// Returns a ready-to-print message for every unresolvable case.
+/// Returns a [`SelectError`] - message plus documented exit code - for every
+/// unresolvable case.
 pub fn select_php(
     dirs: &PlatformDirs,
     cwd: Option<&Path>,
     site: Option<&str>,
-) -> Result<PhpSelection, String> {
+) -> Result<PhpSelection, SelectError> {
     if let Some(name) = site {
         return match site_scope_by_name(dirs, name) {
             Ok(scope) => Ok(PhpSelection::Site(scope)),
-            Err(NamedScopeError::NotFound) => Err(format!(
+            Err(NamedScopeError::NotFound) => Err(SelectError::usage(format!(
                 "no site named '{name}' — run `yerd sites` to see the registered sites"
+            ))),
+            Err(NamedScopeError::PhpMissing { php_version }) => Err(SelectError::usage(
+                missing_php_message(&php_version.to_string()),
             )),
-            Err(NamedScopeError::PhpMissing { php_version }) => {
-                Err(missing_php_message(&php_version.to_string()))
-            }
-            Err(NamedScopeError::DaemonUnavailable) => {
-                Err("cannot reach the yerd daemon to look up that site — is it running?".to_owned())
-            }
+            Err(NamedScopeError::DaemonUnavailable) => Err(SelectError::daemon(
+                "cannot reach the yerd daemon to look up that site — is it running?".to_owned(),
+            )),
         };
     }
 
@@ -113,16 +148,18 @@ pub fn select_php(
     };
     match resolution {
         ScopeResolution::Scoped(scope) => Ok(PhpSelection::Site(scope)),
-        ScopeResolution::MatchedPhpMissing { php_version } => {
-            Err(missing_php_message(&php_version.to_string()))
-        }
+        ScopeResolution::MatchedPhpMissing { php_version } => Err(SelectError::usage(
+            missing_php_message(&php_version.to_string()),
+        )),
         ScopeResolution::NoScope { daemon_unavailable } => {
             if daemon_unavailable {
                 crate::site_scope::warn_daemon_unavailable();
             }
             match resolve_default_php(dirs) {
                 Some((php_bin, minor)) => Ok(PhpSelection::Default { php_bin, minor }),
-                None => Err(crate::shim::no_default_php_message(dirs)),
+                None => Err(SelectError::usage(crate::shim::no_default_php_message(
+                    dirs,
+                ))),
             }
         }
     }
@@ -144,10 +181,11 @@ fn missing_php_message(version: &str) -> String {
 /// runs on a thread already driving a runtime - which the CLI's `run()` is. So
 /// the resolution is moved to a blocking-pool thread, exactly as the self-update
 /// applier is.
-async fn resolve(site: Option<&str>) -> Result<(PlatformDirs, PhpSelection), String> {
-    let dirs = ActivePaths::new()
-        .resolve()
-        .map_err(|e| format!("cannot resolve yerd directories: {e}"))?;
+async fn resolve(site: Option<&str>) -> Result<(PlatformDirs, PhpSelection), SelectError> {
+    let dirs = ActivePaths::new().resolve().map_err(|e| SelectError {
+        message: format!("cannot resolve yerd directories: {e}"),
+        code: 74,
+    })?;
     let owned_site = site.map(ToOwned::to_owned);
     let for_lookup = dirs.clone();
     let selection = tokio::task::spawn_blocking(move || {
@@ -155,7 +193,10 @@ async fn resolve(site: Option<&str>) -> Result<(PlatformDirs, PhpSelection), Str
         select_php(&for_lookup, cwd.as_deref(), owned_site.as_deref())
     })
     .await
-    .map_err(|e| format!("php resolution task failed: {e}"))??;
+    .map_err(|e| SelectError {
+        message: format!("php resolution task failed: {e}"),
+        code: 74,
+    })??;
     Ok((dirs, selection))
 }
 
@@ -164,7 +205,7 @@ async fn resolve(site: Option<&str>) -> Result<(PlatformDirs, PhpSelection), Str
 pub async fn run_exec(tool: ExecTool, site: Option<&str>, args: &[OsString]) -> ExitCode {
     let (dirs, selection) = match resolve(site).await {
         Ok(pair) => pair,
-        Err(msg) => return fail(msg),
+        Err(e) => return e.report(),
     };
 
     let php_bin = selection.php_bin().to_path_buf();
@@ -172,7 +213,7 @@ pub async fn run_exec(tool: ExecTool, site: Option<&str>, args: &[OsString]) -> 
     if let ExecTool::Composer = tool {
         let phar = crate::shim::composer_phar(&dirs);
         if !phar.is_file() {
-            return fail(crate::shim::composer_missing_message());
+            return SelectError::usage(crate::shim::composer_missing_message()).report();
         }
         cmd.arg(&phar);
     }
@@ -183,12 +224,17 @@ pub async fn run_exec(tool: ExecTool, site: Option<&str>, args: &[OsString]) -> 
 
     let err = cmd.exec();
     if err.kind() == std::io::ErrorKind::NotFound {
-        return fail(format!(
+        return SelectError::usage(format!(
             "PHP binary not found at {} ({err}) — reinstall with `yerd install php`",
             php_bin.display()
-        ));
+        ))
+        .report();
     }
-    fail(format!("failed to exec {}: {err}", php_bin.display()))
+    SelectError {
+        message: format!("failed to exec {}: {err}", php_bin.display()),
+        code: 74,
+    }
+    .report()
 }
 
 /// `yerd which <tool>`: print the binary `yerd exec` would use. Resolution and
@@ -198,7 +244,7 @@ pub async fn run_which(tool: WhichTool, site: Option<&str>, json: bool) -> ExitC
     let WhichTool::Php = tool;
     let selection = match resolve(site).await {
         Ok((_dirs, selection)) => selection,
-        Err(msg) => return fail(msg),
+        Err(e) => return e.report(),
     };
     println!("{}", which_output(&selection, json));
     ExitCode::SUCCESS
@@ -346,7 +392,8 @@ mod tests {
     }
 
     /// An explicit `--site` never falls back: with no daemon it must fail, not
-    /// resolve to the default PHP.
+    /// resolve to the default PHP - and with `69`, the documented "daemon
+    /// unreachable" code, rather than a generic failure.
     #[test]
     fn select_php_named_site_errors_without_a_daemon() {
         let tmp = tempfile::tempdir().unwrap();
@@ -354,7 +401,12 @@ mod tests {
         std::fs::create_dir_all(&dirs.runtime).unwrap();
         fake_cli(&dirs, "8.3");
         let err = select_php(&dirs, None, Some("blog")).unwrap_err();
-        assert!(err.contains("cannot reach the yerd daemon"), "got: {err}");
+        assert!(
+            err.message.contains("cannot reach the yerd daemon"),
+            "got: {}",
+            err.message
+        );
+        assert_eq!(err.code, 69, "an unreachable daemon is exit 69");
     }
 
     #[test]
@@ -363,7 +415,21 @@ mod tests {
         let dirs = dirs_at(tmp.path());
         std::fs::create_dir_all(&dirs.runtime).unwrap();
         let err = select_php(&dirs, None, None).unwrap_err();
-        assert!(err.contains("no PHP installed"), "got: {err}");
+        assert!(
+            err.message.contains("no PHP installed"),
+            "got: {}",
+            err.message
+        );
+        assert_eq!(err.code, 2, "a client-side resolution failure is exit 2");
+    }
+
+    /// The two failure classes must not collapse onto one code: a bad `--site`
+    /// is a usage error (`2`), an unreachable daemon is `69`. Scripts branch on
+    /// the difference, and `docs/reference/cli/index.md` documents both.
+    #[test]
+    fn select_error_codes_match_the_documented_table() {
+        assert_eq!(SelectError::usage("x".to_owned()).code, 2);
+        assert_eq!(SelectError::daemon("x".to_owned()).code, 69);
     }
 
     #[test]

--- a/bin/yerd/src/exec_cmd.rs
+++ b/bin/yerd/src/exec_cmd.rs
@@ -1,0 +1,376 @@
+//! `yerd exec` and `yerd which` - run CLI tools under the PHP version pinned
+//! to a site, and report which binary that is.
+//!
+//! The bare `php` and `composer` shims always use the **global default**
+//! version, so inside a site pinned to something else a CLI run (artisan,
+//! Composer, a script) silently uses a different PHP than the site's own web
+//! requests. These two commands close that gap without changing the shims:
+//! `yerd exec php …` / `yerd exec composer …` run under the pinned version,
+//! and `yerd which php` prints the binary they would use.
+//!
+//! Resolution is [`crate::site_scope`]'s: the current directory's site by
+//! default, or `--site <name>` to name one explicitly. The two differ in how
+//! they fail, deliberately - see [`select_php`]. Both commands are local: they
+//! `exec` PHP directly rather than routing work through the daemon, exactly as
+//! the shims and `yerd coverage` do. The one daemon round-trip is the
+//! `ListSites` lookup behind the scoping.
+//!
+//! Unix-only (`exec` and the whole resolution chain are).
+
+use std::ffi::OsString;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use yerd_platform::{ActivePaths, Paths, PlatformDirs};
+
+use crate::cli::{ExecTool, WhichTool};
+use crate::shim::{cli_phprc, fail, resolve_default_php};
+use crate::site_scope::{
+    site_scope, site_scope_by_name, NamedScopeError, ScopeResolution, SiteScope,
+};
+
+/// Which PHP a `yerd exec` / `yerd which` invocation resolved to.
+#[derive(Debug)]
+pub enum PhpSelection {
+    /// A site's pinned version.
+    Site(SiteScope),
+    /// The global default, because the invocation isn't inside any site (or
+    /// the daemon couldn't be reached to say otherwise).
+    Default {
+        /// The default PHP CLI binary.
+        php_bin: PathBuf,
+        /// Its `"major.minor"` version - the [`cli_phprc`] key.
+        minor: String,
+    },
+}
+
+impl PhpSelection {
+    /// The PHP CLI binary to run.
+    #[must_use]
+    pub fn php_bin(&self) -> &Path {
+        match self {
+            PhpSelection::Site(scope) => &scope.php_bin,
+            PhpSelection::Default { php_bin, .. } => php_bin,
+        }
+    }
+
+    /// The `"major.minor"` version string.
+    #[must_use]
+    pub fn minor(&self) -> &str {
+        match self {
+            PhpSelection::Site(scope) => &scope.php_minor,
+            PhpSelection::Default { minor, .. } => minor,
+        }
+    }
+}
+
+/// Resolve which PHP to use. `cwd` and `site` are explicit parameters (rather
+/// than read from the process) so this is fully testable without mutating the
+/// process-global current directory.
+///
+/// With `site = Some(name)` the named site must resolve: an unknown name, an
+/// uninstalled pinned version, and an unreachable daemon are all errors, since
+/// the user asked for that site specifically and running something else would
+/// be wrong. Without it, resolution follows `cwd`: inside a site, its pinned
+/// version (erroring if that version isn't installed, rather than silently
+/// running an unrelated one); outside any site - or with no reachable daemon -
+/// the global default.
+///
+/// # Errors
+///
+/// Returns a ready-to-print message for every unresolvable case.
+pub fn select_php(
+    dirs: &PlatformDirs,
+    cwd: Option<&Path>,
+    site: Option<&str>,
+) -> Result<PhpSelection, String> {
+    if let Some(name) = site {
+        return match site_scope_by_name(dirs, name) {
+            Ok(scope) => Ok(PhpSelection::Site(scope)),
+            Err(NamedScopeError::NotFound) => Err(format!(
+                "no site named '{name}' — run `yerd sites` to see the registered sites"
+            )),
+            Err(NamedScopeError::PhpMissing { php_version }) => {
+                Err(missing_php_message(&php_version.to_string()))
+            }
+            Err(NamedScopeError::DaemonUnavailable) => {
+                Err("cannot reach the yerd daemon to look up that site — is it running?".to_owned())
+            }
+        };
+    }
+
+    let resolution = match cwd {
+        Some(cwd) => site_scope(dirs, cwd),
+        None => ScopeResolution::NoScope,
+    };
+    match resolution {
+        ScopeResolution::Scoped(scope) => Ok(PhpSelection::Site(scope)),
+        ScopeResolution::MatchedPhpMissing { php_version } => {
+            Err(missing_php_message(&php_version.to_string()))
+        }
+        ScopeResolution::NoScope => match resolve_default_php(dirs) {
+            Some((php_bin, minor)) => Ok(PhpSelection::Default { php_bin, minor }),
+            None => Err(crate::shim::no_default_php_message(dirs)),
+        },
+    }
+}
+
+/// The "pinned version isn't installed" message, worded exactly as the `wp`
+/// shim's so the two paths read identically.
+fn missing_php_message(version: &str) -> String {
+    format!(
+        "this site is pinned to PHP {version}, which is not installed — run \
+         `yerd install php {version}`"
+    )
+}
+
+/// Resolve dirs and PHP the way both entry points need to.
+///
+/// [`select_php`]'s site lookup drives its own one-shot tokio runtime (the
+/// shims that share it have none of their own), and `block_on` panics if it
+/// runs on a thread already driving a runtime - which the CLI's `run()` is. So
+/// the resolution is moved to a blocking-pool thread, exactly as the self-update
+/// applier is.
+async fn resolve(site: Option<&str>) -> Result<(PlatformDirs, PhpSelection), String> {
+    let dirs = ActivePaths::new()
+        .resolve()
+        .map_err(|e| format!("cannot resolve yerd directories: {e}"))?;
+    let owned_site = site.map(ToOwned::to_owned);
+    let for_lookup = dirs.clone();
+    let selection = tokio::task::spawn_blocking(move || {
+        let cwd = current_dir();
+        select_php(&for_lookup, cwd.as_deref(), owned_site.as_deref())
+    })
+    .await
+    .map_err(|e| format!("php resolution task failed: {e}"))??;
+    Ok((dirs, selection))
+}
+
+/// `yerd exec <tool> [args…]`: run `tool` under the resolved PHP, replacing
+/// this process. Only returns on failure.
+pub async fn run_exec(tool: ExecTool, site: Option<&str>, args: &[OsString]) -> ExitCode {
+    let (dirs, selection) = match resolve(site).await {
+        Ok(pair) => pair,
+        Err(msg) => return fail(msg),
+    };
+
+    let php_bin = selection.php_bin().to_path_buf();
+    let mut cmd = Command::new(&php_bin);
+    if let ExecTool::Composer = tool {
+        let phar = crate::shim::composer_phar(&dirs);
+        if !phar.is_file() {
+            return fail(crate::shim::composer_missing_message());
+        }
+        cmd.arg(&phar);
+    }
+    cmd.args(args);
+    if let Some(phprc) = cli_phprc(&dirs, selection.minor()) {
+        cmd.env("PHPRC", phprc);
+    }
+
+    let err = cmd.exec();
+    if err.kind() == std::io::ErrorKind::NotFound {
+        return fail(format!(
+            "PHP binary not found at {} ({err}) — reinstall with `yerd install php`",
+            php_bin.display()
+        ));
+    }
+    fail(format!("failed to exec {}: {err}", php_bin.display()))
+}
+
+/// `yerd which <tool>`: print the binary `yerd exec` would use. Resolution and
+/// every failure mode match [`run_exec`] exactly - this must never print a path
+/// that `exec` wouldn't actually run.
+pub async fn run_which(tool: WhichTool, site: Option<&str>, json: bool) -> ExitCode {
+    let WhichTool::Php = tool;
+    let selection = match resolve(site).await {
+        Ok((_dirs, selection)) => selection,
+        Err(msg) => return fail(msg),
+    };
+    println!("{}", which_output(&selection, json));
+    ExitCode::SUCCESS
+}
+
+/// The canonicalized current directory, or `None` if it can't be read (a
+/// deleted cwd, say) - treated as "not inside any site".
+fn current_dir() -> Option<PathBuf> {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| std::fs::canonicalize(cwd).ok())
+}
+
+/// Render `yerd which`'s output: the bare absolute path in human mode, or a
+/// `{path, version, site, source}` object under `--json`. Built with
+/// `serde_json` rather than `format!` because paths routinely contain
+/// characters that need escaping (every macOS data path runs through
+/// `Application Support`). Pure.
+#[must_use]
+pub fn which_output(selection: &PhpSelection, json: bool) -> String {
+    if !json {
+        return selection.php_bin().display().to_string();
+    }
+    let (site, source) = match selection {
+        PhpSelection::Site(scope) => (serde_json::Value::String(scope.site_name.clone()), "site"),
+        PhpSelection::Default { .. } => (serde_json::Value::Null, "default"),
+    };
+    let value = serde_json::json!({
+        "path": selection.php_bin().to_string_lossy(),
+        "version": selection.minor(),
+        "site": site,
+        "source": source,
+    });
+    value.to_string()
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::match_wildcard_for_single_variants
+)]
+mod tests {
+    use super::*;
+
+    fn dirs_at(tmp: &Path) -> PlatformDirs {
+        PlatformDirs {
+            config: tmp.join("c"),
+            data: tmp.join("d"),
+            state: tmp.join("s"),
+            cache: tmp.join("ca"),
+            runtime: tmp.join("r"),
+        }
+    }
+
+    fn fake_cli(dirs: &PlatformDirs, minor: &str) -> PathBuf {
+        let base = dirs
+            .data
+            .join("php")
+            .join(format!("php-{minor}"))
+            .join("bin");
+        std::fs::create_dir_all(&base).unwrap();
+        let php = base.join("php");
+        std::fs::write(&php, b"#!/bin/sh\n").unwrap();
+        php
+    }
+
+    fn site_selection(name: &str, minor: &str) -> PhpSelection {
+        PhpSelection::Site(SiteScope {
+            site_name: name.to_owned(),
+            php_bin: PathBuf::from(format!("/d/php/php-{minor}/bin/php")),
+            php_minor: minor.to_owned(),
+            served_root: PathBuf::from("/srv/blog"),
+        })
+    }
+
+    #[test]
+    fn which_output_human_is_the_bare_path() {
+        let selection = site_selection("blog", "8.3");
+        assert_eq!(which_output(&selection, false), "/d/php/php-8.3/bin/php");
+    }
+
+    #[test]
+    fn which_output_json_reports_the_site_as_the_source() {
+        let selection = site_selection("blog", "8.3");
+        let value: serde_json::Value =
+            serde_json::from_str(&which_output(&selection, true)).unwrap();
+        assert_eq!(value["path"], "/d/php/php-8.3/bin/php");
+        assert_eq!(value["version"], "8.3");
+        assert_eq!(value["site"], "blog");
+        assert_eq!(value["source"], "site");
+    }
+
+    /// On the default path there is no site, so `site` must be JSON `null`
+    /// rather than an empty string.
+    #[test]
+    fn which_output_json_reports_a_null_site_for_the_default() {
+        let selection = PhpSelection::Default {
+            php_bin: PathBuf::from("/d/php/php-8.4/bin/php"),
+            minor: "8.4".to_owned(),
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&which_output(&selection, true)).unwrap();
+        assert_eq!(value["site"], serde_json::Value::Null);
+        assert_eq!(value["source"], "default");
+        assert_eq!(value["version"], "8.4");
+    }
+
+    /// Every macOS data path contains a space (`Application Support`), so the
+    /// JSON must be built by a real serializer, not `format!`.
+    #[test]
+    fn which_output_json_escapes_a_space_containing_path() {
+        let selection = PhpSelection::Default {
+            php_bin: PathBuf::from(
+                "/Users/x/Library/Application Support/io.yerd.Yerd/php/php-8.4/bin/php",
+            ),
+            minor: "8.4".to_owned(),
+        };
+        let rendered = which_output(&selection, true);
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(
+            value["path"],
+            "/Users/x/Library/Application Support/io.yerd.Yerd/php/php-8.4/bin/php"
+        );
+    }
+
+    /// With no daemon and a cwd outside any site, resolution falls back to the
+    /// global default rather than erroring.
+    #[test]
+    fn select_php_falls_back_to_the_global_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        std::fs::create_dir_all(&dirs.runtime).unwrap();
+        let php = fake_cli(&dirs, "8.3");
+        let cwd = std::fs::canonicalize(tmp.path()).unwrap();
+
+        match select_php(&dirs, Some(&cwd), None).unwrap() {
+            PhpSelection::Default { php_bin, minor } => {
+                assert_eq!(php_bin, php);
+                assert_eq!(minor, "8.3");
+            }
+            other => panic!("expected Default, got {other:?}"),
+        }
+    }
+
+    /// An explicit `--site` never falls back: with no daemon it must fail, not
+    /// resolve to the default PHP.
+    #[test]
+    fn select_php_named_site_errors_without_a_daemon() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        std::fs::create_dir_all(&dirs.runtime).unwrap();
+        fake_cli(&dirs, "8.3");
+        let err = select_php(&dirs, None, Some("blog")).unwrap_err();
+        assert!(err.contains("cannot reach the yerd daemon"), "got: {err}");
+    }
+
+    #[test]
+    fn select_php_reports_no_installed_php() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        std::fs::create_dir_all(&dirs.runtime).unwrap();
+        let err = select_php(&dirs, None, None).unwrap_err();
+        assert!(err.contains("no PHP installed"), "got: {err}");
+    }
+
+    #[test]
+    fn composer_phar_sits_under_the_tools_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        assert_eq!(
+            crate::shim::composer_phar(&dirs),
+            dirs.data
+                .join("tools")
+                .join("composer")
+                .join("composer.phar")
+        );
+    }
+
+    #[test]
+    fn missing_php_message_names_the_install_command() {
+        let msg = missing_php_message("8.1");
+        assert!(msg.contains("pinned to PHP 8.1"));
+        assert!(msg.contains("yerd install php 8.1"));
+    }
+}

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -19,12 +19,16 @@ pub mod cover_shim;
 pub mod elevate;
 pub mod error;
 #[cfg(unix)]
+pub mod exec_cmd;
+#[cfg(unix)]
 pub mod laravel_shim;
 pub mod map;
 pub mod mcp_cmd;
 pub mod path_cmd;
 #[cfg(unix)]
 pub mod shim;
+#[cfg(unix)]
+pub mod site_scope;
 pub mod transport;
 pub mod uninstall;
 #[cfg(unix)]
@@ -56,6 +60,30 @@ pub async fn run(cli: Cli) -> ExitCode {
             #[cfg(not(unix))]
             {
                 eprintln!("yerd: coverage is only available on macOS and Linux");
+                return ExitCode::from(2);
+            }
+        }
+        #[cfg_attr(not(unix), allow(unused_variables))]
+        Command::Exec { site, tool, args } => {
+            #[cfg(unix)]
+            {
+                return exec_cmd::run_exec(*tool, site.as_deref(), args).await;
+            }
+            #[cfg(not(unix))]
+            {
+                eprintln!("yerd: exec is only available on macOS and Linux");
+                return ExitCode::from(2);
+            }
+        }
+        #[cfg_attr(not(unix), allow(unused_variables))]
+        Command::Which { tool, site } => {
+            #[cfg(unix)]
+            {
+                return exec_cmd::run_which(*tool, site.as_deref(), cli.json).await;
+            }
+            #[cfg(not(unix))]
+            {
+                eprintln!("yerd: which is only available on macOS and Linux");
                 return ExitCode::from(2);
             }
         }

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -248,6 +248,16 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
                 "coverage is handled locally, not over IPC".to_owned(),
             ));
         }
+        Command::Exec { .. } => {
+            return Err(ClientError::Usage(
+                "exec is handled locally, not over IPC".to_owned(),
+            ));
+        }
+        Command::Which { .. } => {
+            return Err(ClientError::Usage(
+                "which is handled locally, not over IPC".to_owned(),
+            ));
+        }
         Command::Mcp => {
             return Err(ClientError::Usage(
                 "mcp runs its own protocol loop, not a single IPC exchange".to_owned(),
@@ -4243,6 +4253,15 @@ mod tests {
                 action: crate::cli::PathAction::Install,
             },
             Command::Coverage { args: vec![] },
+            Command::Exec {
+                site: None,
+                tool: crate::cli::ExecTool::Php,
+                args: vec![],
+            },
+            Command::Which {
+                tool: crate::cli::WhichTool::Php,
+                site: None,
+            },
             Command::Mcp,
             Command::Link {
                 name_or_path: None,

--- a/bin/yerd/src/shim.rs
+++ b/bin/yerd/src/shim.rs
@@ -61,6 +61,26 @@ pub(crate) fn default_from_config(dirs: &PlatformDirs) -> Option<(PathBuf, Strin
     php.is_file().then_some((php, minor))
 }
 
+/// Path to the bundled Composer phar (`{data}/tools/composer/composer.phar`).
+/// Shared by the `composer` shim and `yerd exec composer`, which run the same
+/// phar under different PHP versions.
+#[must_use]
+pub(crate) fn composer_phar(dirs: &PlatformDirs) -> PathBuf {
+    dirs.data
+        .join("tools")
+        .join("composer")
+        .join("composer.phar")
+}
+
+/// Message for when [`composer_phar`] doesn't exist. Shared so the `composer`
+/// shim and `yerd exec composer` fail identically.
+#[must_use]
+pub(crate) fn composer_missing_message() -> String {
+    "Composer is not installed — install it from the Tooling page \
+     (or run `yerd install tool composer`)"
+        .to_owned()
+}
+
 /// Path to a version's generated CLI ini (`{data}/php-cli-<minor>.ini`).
 #[must_use]
 pub(crate) fn cli_ini_path(dirs: &PlatformDirs, minor: &str) -> PathBuf {

--- a/bin/yerd/src/site_scope.rs
+++ b/bin/yerd/src/site_scope.rs
@@ -54,7 +54,13 @@ pub struct SiteScope {
     /// The matched site's (canonicalized) served root - `document_root` joined
     /// with `web_subpath` - i.e. where the served files actually live, not
     /// necessarily the site's project root. Passed to `wp` as `--path=`.
-    pub served_root: PathBuf,
+    ///
+    /// `None` when that directory doesn't exist on disk (an unbuilt `public/`,
+    /// say). Matching never depends on it, so `yerd exec` still resolves the
+    /// site's pinned PHP; the `wp` shim instead declines to scope, since a
+    /// `--path=` pointing at the project root would aim WP-CLI somewhere
+    /// `WordPress` isn't served from.
+    pub served_root: Option<PathBuf>,
 }
 
 /// Outcome of resolving the current directory against the live site list.
@@ -100,12 +106,12 @@ pub enum NamedScopeError {
 /// live one level up, so matching on the served root would miss a cwd at the
 /// project root (by far the common case). `served_root` is carried through for
 /// the `wp` shim, whose `--path=` genuinely needs the directory `WordPress` is
-/// served from.
+/// served from - `None` if it doesn't exist on disk.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Candidate {
     name: String,
     document_root: PathBuf,
-    served_root: PathBuf,
+    served_root: Option<PathBuf>,
     php: PhpVersion,
 }
 
@@ -149,10 +155,16 @@ pub fn site_scope_by_name(dirs: &PlatformDirs, name: &str) -> Result<SiteScope, 
 }
 
 /// The live site list reduced to [`Candidate`]s with canonicalized roots, or
-/// `None` if the daemon didn't answer. Sites whose document root can't be
-/// canonicalized (e.g. deleted from disk) are skipped; a served root that
-/// can't be (an unbuilt `public/`, say) falls back to the document root, since
-/// it must never block matching.
+/// `None` if the daemon didn't answer.
+///
+/// Sites whose document root can't be canonicalized (e.g. deleted from disk)
+/// are skipped entirely - without a project root there is nothing to match a
+/// cwd against. A served root that can't be canonicalized (an unbuilt
+/// `public/`, say) is recorded as `None` rather than dropping the site:
+/// `yerd exec` only needs the document root, and a missing `public/` is no
+/// reason to demote a pinned site to the global default. The `wp` shim, which
+/// genuinely needs that directory for `--path=`, filters those out itself via
+/// [`SiteScope::served_root`] being `None`.
 fn candidates(dirs: &PlatformDirs) -> Option<Vec<Candidate>> {
     let sock = dirs.runtime.join("yerd.sock");
     let sites = list_sites_with_timeout(&sock)?;
@@ -161,8 +173,7 @@ fn candidates(dirs: &PlatformDirs) -> Option<Vec<Candidate>> {
             .iter()
             .filter_map(|entry| {
                 let document_root = std::fs::canonicalize(entry.site.document_root()).ok()?;
-                let served_root = std::fs::canonicalize(entry.site.served_root())
-                    .unwrap_or_else(|_| document_root.clone());
+                let served_root = std::fs::canonicalize(entry.site.served_root()).ok();
                 Some(Candidate {
                     name: entry.site.name().to_owned(),
                     document_root,
@@ -240,7 +251,7 @@ mod tests {
         Candidate {
             name: name.to_owned(),
             document_root: PathBuf::from(root),
-            served_root: PathBuf::from(root),
+            served_root: Some(PathBuf::from(root)),
             php: version,
         }
     }
@@ -255,7 +266,7 @@ mod tests {
         Candidate {
             name: name.to_owned(),
             document_root: PathBuf::from(document_root),
-            served_root: PathBuf::from(served),
+            served_root: Some(PathBuf::from(served)),
             php: version,
         }
     }
@@ -314,7 +325,7 @@ mod tests {
         assert_eq!(hit.php, php(8, 3));
         assert_eq!(
             hit.served_root,
-            PathBuf::from("/srv/my-app/public"),
+            Some(PathBuf::from("/srv/my-app/public")),
             "the served root still travels through for wp's --path="
         );
 
@@ -343,7 +354,7 @@ mod tests {
         let candidates = vec![Candidate {
             name: "real-site".to_owned(),
             document_root: canonical_root.clone(),
-            served_root: canonical_root.clone(),
+            served_root: Some(canonical_root.clone()),
             php: php(8, 4),
         }];
         let hit = match_site(&canonical_cwd, &candidates).unwrap();

--- a/bin/yerd/src/site_scope.rs
+++ b/bin/yerd/src/site_scope.rs
@@ -1,0 +1,378 @@
+//! Resolving "which site am I in, and which PHP is pinned to it".
+//!
+//! Shared by the `wp` shim (which scopes WP-CLI to the site containing the
+//! current directory) and `yerd exec` / `yerd which` (which run CLI PHP and
+//! Composer under a site's pinned version). Both ask the daemon for the live
+//! site list over a short-timeout `Request::ListSites` and match the current
+//! directory against the sites' document roots.
+//!
+//! Two entry points, with deliberately different failure behaviour:
+//!
+//! - [`site_scope`] resolves by current directory. Outside any site - or if the
+//!   daemon is unreachable or slow - it returns [`ScopeResolution::NoScope`] so
+//!   callers fall back to the global default PHP. A cwd that *is* inside a site
+//!   whose pinned version isn't installed returns
+//!   [`ScopeResolution::MatchedPhpMissing`] instead, so callers fail loudly
+//!   rather than silently running under an unrelated default.
+//! - [`site_scope_by_name`] resolves an explicitly named site and never falls
+//!   back: an unknown name, an uninstalled pinned version, and an unreachable
+//!   daemon are all errors. The user named a site, so quietly running something
+//!   else would be wrong.
+//!
+//! Unix-only.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use yerd_core::PhpVersion;
+use yerd_ipc::{Request, Response};
+use yerd_platform::PlatformDirs;
+
+use crate::shim::cli_binary;
+use crate::transport;
+
+/// How long to wait for the daemon to answer `ListSites` before giving up and
+/// falling back to the default PHP - this must stay short since it's on the
+/// critical path of every `wp` / `yerd exec` invocation.
+const SITE_LOOKUP_TIMEOUT: Duration = Duration::from_millis(300);
+
+/// A site the current invocation resolved as "inside" (or named explicitly),
+/// and the PHP binary pinned to it. `pub` (rather than `pub(crate)`) so the
+/// end-to-end integration tests in `tests/wp_shim_e2e.rs` and
+/// `tests/exec_e2e.rs` (separate crates) can exercise this against a real
+/// daemon - same reason [`crate::resolve_link`] is `pub`.
+#[derive(Debug)]
+pub struct SiteScope {
+    /// The matched site's name, as stored by the daemon (lowercased).
+    pub site_name: String,
+    /// The PHP CLI binary pinned to the matched site.
+    pub php_bin: PathBuf,
+    /// The matched site's pinned PHP version as `"major.minor"` - the
+    /// [`crate::shim::cli_phprc`] key for pointing `PHPRC` at that version's
+    /// generated CLI ini.
+    pub php_minor: String,
+    /// The matched site's (canonicalized) served root - `document_root` joined
+    /// with `web_subpath` - i.e. where the served files actually live, not
+    /// necessarily the site's project root. Passed to `wp` as `--path=`.
+    pub served_root: PathBuf,
+}
+
+/// Outcome of resolving the current directory against the live site list.
+/// `pub` for the same testability reason as [`SiteScope`].
+#[derive(Debug)]
+pub enum ScopeResolution {
+    /// cwd is inside a site whose pinned PHP is installed.
+    Scoped(SiteScope),
+    /// cwd is inside a site, but that site's pinned PHP version isn't
+    /// installed - this must fail loudly rather than silently falling back
+    /// to an unrelated default PHP (which could run under the wrong version
+    /// with no indication why site-scoping didn't apply).
+    MatchedPhpMissing {
+        /// The site's pinned (but not installed) PHP version.
+        php_version: PhpVersion,
+    },
+    /// No site matched (or no daemon/timeout/no-match) - callers fall back to
+    /// the global default PHP.
+    NoScope,
+}
+
+/// Why [`site_scope_by_name`] could not resolve an explicitly named site.
+/// Unlike [`ScopeResolution`] there is no "fall back to the default" variant:
+/// naming a site is an explicit instruction, so every failure is an error.
+#[derive(Debug, PartialEq, Eq)]
+pub enum NamedScopeError {
+    /// No registered site has that name.
+    NotFound,
+    /// The site exists but its pinned PHP version isn't installed.
+    PhpMissing {
+        /// The site's pinned (but not installed) PHP version.
+        php_version: PhpVersion,
+    },
+    /// The daemon didn't answer in time, so the site list is unknown.
+    DaemonUnavailable,
+}
+
+/// A registered site reduced to what matching needs.
+///
+/// The two roots are deliberately distinct. Matching uses `document_root` -
+/// the site's project directory - because that's where the work happens: a
+/// Laravel site is served from `public/`, but `artisan` and `composer.json`
+/// live one level up, so matching on the served root would miss a cwd at the
+/// project root (by far the common case). `served_root` is carried through for
+/// the `wp` shim, whose `--path=` genuinely needs the directory `WordPress` is
+/// served from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Candidate {
+    name: String,
+    document_root: PathBuf,
+    served_root: PathBuf,
+    php: PhpVersion,
+}
+
+/// Resolve the site (if any) `cwd` is inside, by asking the daemon for the
+/// live site list. `cwd` is taken as an explicit, already-canonicalized
+/// parameter (rather than reading `std::env::current_dir()` internally) so
+/// this is fully testable with an arbitrary directory - no process-global
+/// cwd mutation needed in tests. Returns `NoScope` on any daemon error,
+/// timeout, or no match - callers treat that identically to "no site-scoping
+/// available." `pub` for the same testability reason as [`SiteScope`].
+#[must_use]
+pub fn site_scope(dirs: &PlatformDirs, cwd: &Path) -> ScopeResolution {
+    let Some(candidates) = candidates(dirs) else {
+        return ScopeResolution::NoScope;
+    };
+    let Some(hit) = match_site(cwd, &candidates) else {
+        return ScopeResolution::NoScope;
+    };
+    match scope_from(dirs, &hit) {
+        Ok(scope) => ScopeResolution::Scoped(scope),
+        Err(php_version) => ScopeResolution::MatchedPhpMissing { php_version },
+    }
+}
+
+/// Resolve an explicitly named site. `name` is lowercased before comparison
+/// since site names are stored lowercased. `pub` for the same testability
+/// reason as [`SiteScope`].
+///
+/// # Errors
+///
+/// Returns [`NamedScopeError`] when the daemon is unreachable, no site has
+/// that name, or the named site's pinned PHP version isn't installed.
+pub fn site_scope_by_name(dirs: &PlatformDirs, name: &str) -> Result<SiteScope, NamedScopeError> {
+    let candidates = candidates(dirs).ok_or(NamedScopeError::DaemonUnavailable)?;
+    let wanted = name.to_lowercase();
+    let hit = candidates
+        .into_iter()
+        .find(|c| c.name == wanted)
+        .ok_or(NamedScopeError::NotFound)?;
+    scope_from(dirs, &hit).map_err(|php_version| NamedScopeError::PhpMissing { php_version })
+}
+
+/// The live site list reduced to [`Candidate`]s with canonicalized roots, or
+/// `None` if the daemon didn't answer. Sites whose document root can't be
+/// canonicalized (e.g. deleted from disk) are skipped; a served root that
+/// can't be (an unbuilt `public/`, say) falls back to the document root, since
+/// it must never block matching.
+fn candidates(dirs: &PlatformDirs) -> Option<Vec<Candidate>> {
+    let sock = dirs.runtime.join("yerd.sock");
+    let sites = list_sites_with_timeout(&sock)?;
+    Some(
+        sites
+            .iter()
+            .filter_map(|entry| {
+                let document_root = std::fs::canonicalize(entry.site.document_root()).ok()?;
+                let served_root = std::fs::canonicalize(entry.site.served_root())
+                    .unwrap_or_else(|_| document_root.clone());
+                Some(Candidate {
+                    name: entry.site.name().to_owned(),
+                    document_root,
+                    served_root,
+                    php: entry.site.php(),
+                })
+            })
+            .collect(),
+    )
+}
+
+/// Turn a matched candidate into a [`SiteScope`], or `Err(version)` if that
+/// version's CLI binary isn't installed.
+fn scope_from(dirs: &PlatformDirs, hit: &Candidate) -> Result<SiteScope, PhpVersion> {
+    let minor = hit.php.to_string();
+    let php_bin = cli_binary(dirs, &minor);
+    if php_bin.is_file() {
+        Ok(SiteScope {
+            site_name: hit.name.clone(),
+            php_bin,
+            php_minor: minor,
+            served_root: hit.served_root.clone(),
+        })
+    } else {
+        Err(hit.php)
+    }
+}
+
+/// Spin up a one-shot, single-threaded tokio runtime (the shims otherwise
+/// have none) to make a single timeout-bounded `ListSites` call against the
+/// daemon socket at `sock` (matching [`transport::exchange`]'s own derivation
+/// of `<runtime>/yerd.sock` - passed explicitly here so tests can point at an
+/// isolated socket instead of the real, active one).
+fn list_sites_with_timeout(sock: &Path) -> Option<Vec<yerd_ipc::SiteEntry>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()?;
+    let outcome = rt.block_on(async {
+        tokio::time::timeout(
+            SITE_LOOKUP_TIMEOUT,
+            transport::exchange_at(sock, &Request::ListSites),
+        )
+        .await
+    });
+    match outcome {
+        Ok(Ok(Response::Sites { sites })) => Some(sites),
+        _ => None,
+    }
+}
+
+/// Pick the site whose (already-canonicalized) document root is `cwd` or an
+/// ancestor of it, preferring the most specific (longest) root when more than
+/// one contains `cwd` (nested sites are unusual but not disallowed - and a
+/// parked root's children are each their own site, so the child must win).
+/// Pure: takes already-canonicalized paths, does no I/O itself.
+fn match_site(cwd: &Path, candidates: &[Candidate]) -> Option<Candidate> {
+    candidates
+        .iter()
+        .filter(|c| cwd.starts_with(&c.document_root))
+        .max_by_key(|c| c.document_root.as_os_str().len())
+        .cloned()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn php(major: u8, minor: u8) -> PhpVersion {
+        PhpVersion::new(major, minor)
+    }
+
+    fn candidate(name: &str, root: &str, version: PhpVersion) -> Candidate {
+        Candidate {
+            name: name.to_owned(),
+            document_root: PathBuf::from(root),
+            served_root: PathBuf::from(root),
+            php: version,
+        }
+    }
+
+    /// A site served from a subdirectory (`public/`, the Laravel layout).
+    fn candidate_with_subpath(
+        name: &str,
+        document_root: &str,
+        served: &str,
+        version: PhpVersion,
+    ) -> Candidate {
+        Candidate {
+            name: name.to_owned(),
+            document_root: PathBuf::from(document_root),
+            served_root: PathBuf::from(served),
+            php: version,
+        }
+    }
+
+    fn dirs_at(tmp: &Path) -> PlatformDirs {
+        PlatformDirs {
+            config: tmp.join("c"),
+            data: tmp.join("d"),
+            state: tmp.join("s"),
+            cache: tmp.join("ca"),
+            runtime: tmp.join("r"),
+        }
+    }
+
+    #[test]
+    fn match_site_finds_exact_root() {
+        let candidates = vec![candidate("blog", "/srv/blog", php(8, 3))];
+        let hit = match_site(Path::new("/srv/blog"), &candidates).unwrap();
+        assert_eq!(hit.document_root, PathBuf::from("/srv/blog"));
+        assert_eq!(hit.name, "blog");
+        assert_eq!(hit.php, php(8, 3));
+    }
+
+    #[test]
+    fn match_site_finds_nested_cwd() {
+        let candidates = vec![candidate("blog", "/srv/blog", php(8, 3))];
+        let hit = match_site(Path::new("/srv/blog/wp-content/themes"), &candidates).unwrap();
+        assert_eq!(hit.document_root, PathBuf::from("/srv/blog"));
+    }
+
+    #[test]
+    fn match_site_prefers_more_specific_nested_site() {
+        let candidates = vec![
+            candidate("srv", "/srv", php(8, 1)),
+            candidate("blog", "/srv/blog", php(8, 3)),
+        ];
+        let hit = match_site(Path::new("/srv/blog/wp-admin"), &candidates).unwrap();
+        assert_eq!(hit.name, "blog");
+        assert_eq!(hit.php, php(8, 3));
+    }
+
+    /// The common Laravel layout: served from `public/`, but `artisan` and
+    /// `composer.json` live at the project root, which is where the CLI is
+    /// actually run from. Matching on the served root would miss it entirely
+    /// and silently fall back to the global default.
+    #[test]
+    fn match_site_matches_the_project_root_of_a_subpath_served_site() {
+        let candidates = vec![candidate_with_subpath(
+            "my-app",
+            "/srv/my-app",
+            "/srv/my-app/public",
+            php(8, 3),
+        )];
+        let hit = match_site(Path::new("/srv/my-app"), &candidates).unwrap();
+        assert_eq!(hit.name, "my-app");
+        assert_eq!(hit.php, php(8, 3));
+        assert_eq!(
+            hit.served_root,
+            PathBuf::from("/srv/my-app/public"),
+            "the served root still travels through for wp's --path="
+        );
+
+        // ...and from inside the served directory itself.
+        let hit = match_site(Path::new("/srv/my-app/public"), &candidates).unwrap();
+        assert_eq!(hit.name, "my-app");
+    }
+
+    #[test]
+    fn match_site_none_outside_any_site() {
+        let candidates = vec![candidate("blog", "/srv/blog", php(8, 3))];
+        assert_eq!(match_site(Path::new("/home/dev/other"), &candidates), None);
+    }
+
+    #[test]
+    fn match_site_resolves_symlinked_cwd_once_canonicalized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real_root = tmp.path().join("real-site");
+        std::fs::create_dir(&real_root).unwrap();
+        let link = tmp.path().join("link-to-site");
+        std::os::unix::fs::symlink(&real_root, &link).unwrap();
+
+        let canonical_root = std::fs::canonicalize(&real_root).unwrap();
+        let canonical_cwd = std::fs::canonicalize(&link).unwrap();
+
+        let candidates = vec![Candidate {
+            name: "real-site".to_owned(),
+            document_root: canonical_root.clone(),
+            served_root: canonical_root.clone(),
+            php: php(8, 4),
+        }];
+        let hit = match_site(&canonical_cwd, &candidates).unwrap();
+        assert_eq!(hit.document_root, canonical_root);
+    }
+
+    #[test]
+    fn site_scope_falls_back_to_no_scope_when_daemon_unreachable() {
+        // No socket is ever created at `dirs.runtime` - this deterministically
+        // exercises the "daemon unreachable" fallback, with no real daemon or
+        // process-global cwd mutation required (`site_scope` takes `cwd` as a
+        // plain parameter).
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        std::fs::create_dir_all(&dirs.runtime).unwrap();
+        let cwd = std::fs::canonicalize(tmp.path()).unwrap();
+        assert!(matches!(site_scope(&dirs, &cwd), ScopeResolution::NoScope));
+    }
+
+    /// The by-name lookup never falls back: with no daemon it must report
+    /// `DaemonUnavailable`, not "not found" and not a default-PHP fallback.
+    #[test]
+    fn site_scope_by_name_errors_when_daemon_unreachable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dirs_at(tmp.path());
+        std::fs::create_dir_all(&dirs.runtime).unwrap();
+        assert!(matches!(
+            site_scope_by_name(&dirs, "blog"),
+            Err(NamedScopeError::DaemonUnavailable)
+        ));
+    }
+}

--- a/bin/yerd/src/site_scope.rs
+++ b/bin/yerd/src/site_scope.rs
@@ -10,7 +10,13 @@
 //!
 //! - [`site_scope`] resolves by current directory. Outside any site - or if the
 //!   daemon is unreachable or slow - it returns [`ScopeResolution::NoScope`] so
-//!   callers fall back to the global default PHP. A cwd that *is* inside a site
+//!   callers fall back to the global default PHP. The two are not the same
+//!   thing, though, so `NoScope` carries which one happened: "couldn't ask the
+//!   daemon" still falls back (the latency budget below leaves no alternative),
+//!   but `yerd exec` / `yerd which` warn on stderr, because otherwise a busy
+//!   daemon silently demotes a site to the global default - the exact mismatch
+//!   they exist to prevent. The `wp` shim stays quiet, where scoping is a
+//!   convenience rather than the point. A cwd that *is* inside a site
 //!   whose pinned version isn't installed returns
 //!   [`ScopeResolution::MatchedPhpMissing`] instead, so callers fail loudly
 //!   rather than silently running under an unrelated default.
@@ -77,10 +83,23 @@ pub enum ScopeResolution {
         /// The site's pinned (but not installed) PHP version.
         php_version: PhpVersion,
     },
-    /// No site matched (or no daemon/timeout/no-match) - callers fall back to
-    /// the global default PHP.
-    NoScope,
+    /// No site-scoping applies - callers fall back to the global default PHP.
+    NoScope {
+        /// Whether the fallback happened because the daemon didn't answer
+        /// (rather than because the cwd genuinely isn't inside any site).
+        /// Callers fall back either way; `yerd exec` / `yerd which` also warn
+        /// on stderr when this is set, since an unanswered lookup inside a site
+        /// looks exactly like "not in a site" while quietly running the wrong
+        /// PHP. See [`warn_daemon_unavailable`].
+        daemon_unavailable: bool,
+    },
 }
+
+/// The daemon didn't answer the `ListSites` lookup within
+/// [`SITE_LOOKUP_TIMEOUT`], so the live site list is unknown. Distinct from
+/// "the list came back and nothing matched" - see [`ScopeResolution::NoScope`].
+#[derive(Debug, PartialEq, Eq)]
+struct DaemonUnavailable;
 
 /// Why [`site_scope_by_name`] could not resolve an explicitly named site.
 /// Unlike [`ScopeResolution`] there is no "fall back to the default" variant:
@@ -120,15 +139,21 @@ struct Candidate {
 /// parameter (rather than reading `std::env::current_dir()` internally) so
 /// this is fully testable with an arbitrary directory - no process-global
 /// cwd mutation needed in tests. Returns `NoScope` on any daemon error,
-/// timeout, or no match - callers treat that identically to "no site-scoping
-/// available." `pub` for the same testability reason as [`SiteScope`].
+/// timeout, or no match - callers fall back to the default PHP in every one
+/// of those cases, but `NoScope::daemon_unavailable` distinguishes an
+/// unanswered lookup from a genuine no-match so they can warn about the
+/// former. `pub` for the same testability reason as [`SiteScope`].
 #[must_use]
 pub fn site_scope(dirs: &PlatformDirs, cwd: &Path) -> ScopeResolution {
-    let Some(candidates) = candidates(dirs) else {
-        return ScopeResolution::NoScope;
+    let Ok(candidates) = candidates(dirs) else {
+        return ScopeResolution::NoScope {
+            daemon_unavailable: true,
+        };
     };
     let Some(hit) = match_site(cwd, &candidates) else {
-        return ScopeResolution::NoScope;
+        return ScopeResolution::NoScope {
+            daemon_unavailable: false,
+        };
     };
     match scope_from(dirs, &hit) {
         Ok(scope) => ScopeResolution::Scoped(scope),
@@ -145,7 +170,8 @@ pub fn site_scope(dirs: &PlatformDirs, cwd: &Path) -> ScopeResolution {
 /// Returns [`NamedScopeError`] when the daemon is unreachable, no site has
 /// that name, or the named site's pinned PHP version isn't installed.
 pub fn site_scope_by_name(dirs: &PlatformDirs, name: &str) -> Result<SiteScope, NamedScopeError> {
-    let candidates = candidates(dirs).ok_or(NamedScopeError::DaemonUnavailable)?;
+    let candidates =
+        candidates(dirs).map_err(|DaemonUnavailable| NamedScopeError::DaemonUnavailable)?;
     let wanted = name.to_lowercase();
     let hit = candidates
         .into_iter()
@@ -155,7 +181,7 @@ pub fn site_scope_by_name(dirs: &PlatformDirs, name: &str) -> Result<SiteScope, 
 }
 
 /// The live site list reduced to [`Candidate`]s with canonicalized roots, or
-/// `None` if the daemon didn't answer.
+/// [`DaemonUnavailable`] if the daemon didn't answer in time.
 ///
 /// Sites whose document root can't be canonicalized (e.g. deleted from disk)
 /// are skipped entirely - without a project root there is nothing to match a
@@ -165,24 +191,39 @@ pub fn site_scope_by_name(dirs: &PlatformDirs, name: &str) -> Result<SiteScope, 
 /// reason to demote a pinned site to the global default. The `wp` shim, which
 /// genuinely needs that directory for `--path=`, filters those out itself via
 /// [`SiteScope::served_root`] being `None`.
-fn candidates(dirs: &PlatformDirs) -> Option<Vec<Candidate>> {
+fn candidates(dirs: &PlatformDirs) -> Result<Vec<Candidate>, DaemonUnavailable> {
     let sock = dirs.runtime.join("yerd.sock");
-    let sites = list_sites_with_timeout(&sock)?;
-    Some(
-        sites
-            .iter()
-            .filter_map(|entry| {
-                let document_root = std::fs::canonicalize(entry.site.document_root()).ok()?;
-                let served_root = std::fs::canonicalize(entry.site.served_root()).ok();
-                Some(Candidate {
-                    name: entry.site.name().to_owned(),
-                    document_root,
-                    served_root,
-                    php: entry.site.php(),
-                })
+    let sites = list_sites_with_timeout(&sock).ok_or(DaemonUnavailable)?;
+    Ok(sites
+        .iter()
+        .filter_map(|entry| {
+            let document_root = std::fs::canonicalize(entry.site.document_root()).ok()?;
+            let served_root = std::fs::canonicalize(entry.site.served_root()).ok();
+            Some(Candidate {
+                name: entry.site.name().to_owned(),
+                document_root,
+                served_root,
+                php: entry.site.php(),
             })
-            .collect(),
-    )
+        })
+        .collect())
+}
+
+/// Warn that site scoping was skipped because the daemon didn't answer.
+///
+/// The fallback to the global default still happens - the lookup sits on the
+/// critical path of every invocation, so waiting longer isn't an option - but
+/// for `yerd exec` / `yerd which` it must not be silent: inside a site this is
+/// indistinguishable from "not in a site" while running a different PHP than
+/// the site is served on, which is the mismatch those commands exist to catch.
+///
+/// The `wp` shim deliberately stays quiet in the same situation - see its
+/// `NoScope` arm.
+pub fn warn_daemon_unavailable() {
+    eprintln!(
+        "yerd: warning: could not reach the yerd daemon to check for a site-pinned PHP \
+         version — using the global default"
+    );
 }
 
 /// Turn a matched candidate into a [`SiteScope`], or `Err(version)` if that
@@ -371,7 +412,12 @@ mod tests {
         let dirs = dirs_at(tmp.path());
         std::fs::create_dir_all(&dirs.runtime).unwrap();
         let cwd = std::fs::canonicalize(tmp.path()).unwrap();
-        assert!(matches!(site_scope(&dirs, &cwd), ScopeResolution::NoScope));
+        assert!(matches!(
+            site_scope(&dirs, &cwd),
+            ScopeResolution::NoScope {
+                daemon_unavailable: true
+            }
+        ));
     }
 
     /// The by-name lookup never falls back: with no daemon it must report

--- a/bin/yerd/src/wp_shim.rs
+++ b/bin/yerd/src/wp_shim.rs
@@ -94,15 +94,25 @@ fn run() -> ExitCode {
         Some(cwd) => site_scope(&dirs, cwd),
         None => ScopeResolution::NoScope,
     };
-    let (php_bin, minor, scope) = match resolution {
-        ScopeResolution::Scoped(s) => (s.php_bin.clone(), s.php_minor.clone(), Some(s)),
+    let scoped = match resolution {
+        // A site whose served root is missing from disk can't be scoped: a
+        // `--path=` aimed at the project root would point WP-CLI somewhere
+        // WordPress isn't served from, so fall back exactly as an unmatched
+        // cwd does. (Such a site is still *matched*, unlike before, so an
+        // uninstalled pinned version now errors below rather than silently
+        // falling back - the loud failure the pin is there to produce.)
+        ScopeResolution::Scoped(s) => s.served_root.is_some().then_some(s),
         ScopeResolution::MatchedPhpMissing { php_version } => {
             return fail(format!(
                 "this site is pinned to PHP {php_version}, which is not installed — run \
                  `yerd install php {php_version}`"
             ));
         }
-        ScopeResolution::NoScope => match resolve_default_php(&dirs) {
+        ScopeResolution::NoScope => None,
+    };
+    let (php_bin, minor, scope) = match scoped {
+        Some(s) => (s.php_bin.clone(), s.php_minor.clone(), Some(s)),
+        None => match resolve_default_php(&dirs) {
             Some((php, minor)) => (php, minor, None),
             None => return fail(crate::shim::no_default_php_message(&dirs)),
         },
@@ -139,8 +149,8 @@ fn run() -> ExitCode {
     if let Some(phprc) = cli_phprc(&dirs, &minor) {
         cmd.env("PHPRC", phprc);
     }
-    if let Some(s) = &scope {
-        cmd.arg(format!("--path={}", s.served_root.display()));
+    if let Some(served_root) = scope.as_ref().and_then(|s| s.served_root.as_ref()) {
+        cmd.arg(format!("--path={}", served_root.display()));
     }
 
     let err = cmd.exec();

--- a/bin/yerd/src/wp_shim.rs
+++ b/bin/yerd/src/wp_shim.rs
@@ -92,7 +92,9 @@ fn run() -> ExitCode {
 
     let resolution = match &cwd {
         Some(cwd) => site_scope(&dirs, cwd),
-        None => ScopeResolution::NoScope,
+        None => ScopeResolution::NoScope {
+            daemon_unavailable: false,
+        },
     };
     let scoped = match resolution {
         // A site whose served root is missing from disk can't be scoped: a
@@ -108,7 +110,11 @@ fn run() -> ExitCode {
                  `yerd install php {php_version}`"
             ));
         }
-        ScopeResolution::NoScope => None,
+        // Deliberately silent on an unanswered lookup, unlike `yerd exec`:
+        // scoping is a convenience here (WP-CLI still runs, just unscoped),
+        // `wp` is invoked far more often, and a stray line would corrupt
+        // `wp ... --format=json` for anything parsing it.
+        ScopeResolution::NoScope { .. } => None,
     };
     let (php_bin, minor, scope) = match scoped {
         Some(s) => (s.php_bin.clone(), s.php_minor.clone(), Some(s)),

--- a/bin/yerd/src/wp_shim.rs
+++ b/bin/yerd/src/wp_shim.rs
@@ -8,32 +8,20 @@
 //!
 //! If the invocation's current directory is inside a registered site, `wp`
 //! runs under *that site's* pinned PHP version, scoped to the site's served
-//! root (`document_root` joined with `web_subpath`) via `--path=` (asking the
-//! daemon via a short-timeout `Request::ListSites`), so `wp option get
-//! siteurl` and friends behave the way the site itself is served. Outside any
-//! registered site, or if the
-//! daemon is unreachable or slow, this falls back to exactly the old
-//! behavior: the default managed PHP, no working-directory change. If cwd
-//! *is* inside a site but that site's pinned PHP version isn't installed,
-//! this fails with a clear error rather than silently running under an
-//! unrelated default PHP. Unix-only.
+//! root (`document_root` joined with `web_subpath`) via `--path=`, so `wp
+//! option get siteurl` and friends behave the way the site itself is served.
+//! The resolution itself lives in [`crate::site_scope`], shared with `yerd
+//! exec` / `yerd which`; see that module for the fallback and failure rules.
+//! Unix-only.
 
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
-use std::time::Duration;
 
-use yerd_core::PhpVersion;
-use yerd_ipc::{Request, Response};
 use yerd_platform::{ActivePaths, Paths, PlatformDirs};
 
-use crate::shim::{cli_binary, cli_phprc, fail, resolve_default_php};
-use crate::transport;
-
-/// How long to wait for the daemon to answer `ListSites` before giving up and
-/// falling back to the default PHP - this must stay short since it's on the
-/// critical path of every `wp` invocation.
-const SITE_LOOKUP_TIMEOUT: Duration = Duration::from_millis(300);
+use crate::shim::{cli_phprc, fail, resolve_default_php};
+use crate::site_scope::{site_scope, ScopeResolution};
 
 /// Silences PHP-engine `E_DEPRECATED` notices from WP-CLI's own bundled
 /// Composer dependencies (`react/promise`, `wp-cli/php-cli-tools`), which
@@ -185,119 +173,11 @@ fn split_boot_fs(boot_fs: &Path) -> Option<(&Path, &std::ffi::OsStr)> {
     Some((boot_fs.parent()?, boot_fs.file_name()?))
 }
 
-/// A site the current invocation resolved as "inside," and the PHP binary
-/// pinned to it. `pub` (rather than `pub(crate)`) solely so the end-to-end
-/// integration test in `tests/wp_shim_e2e.rs` (a separate crate) can exercise
-/// this against a real daemon - same reason [`crate::resolve_link`] is `pub`.
-#[derive(Debug)]
-pub struct SiteScope {
-    /// The PHP CLI binary pinned to the matched site.
-    pub php_bin: PathBuf,
-    /// The matched site's pinned PHP version as `"major.minor"` - the
-    /// [`cli_phprc`] key for pointing `PHPRC` at that version's generated CLI
-    /// ini.
-    pub php_minor: String,
-    /// The matched site's (canonicalized) served root - `document_root`
-    /// joined with `web_subpath` - i.e. where `WordPress` actually lives, not
-    /// necessarily the site's project root. Passed to `wp` as `--path=`.
-    pub served_root: PathBuf,
-}
-
-/// Outcome of resolving the current invocation against the live site list.
-/// `pub` for the same testability reason as [`SiteScope`].
-#[derive(Debug)]
-pub enum ScopeResolution {
-    /// cwd is inside a site whose pinned PHP is installed.
-    Scoped(SiteScope),
-    /// cwd is inside a site, but that site's pinned PHP version isn't
-    /// installed - this must fail loudly rather than silently falling back
-    /// to an unrelated default PHP (which could run under the wrong version
-    /// with no indication why site-scoping didn't apply).
-    MatchedPhpMissing {
-        /// The site's pinned (but not installed) PHP version.
-        php_version: PhpVersion,
-    },
-    /// No site matched (or no daemon/timeout/no-match) - falls back to
-    /// today's pre-existing default-PHP behavior.
-    NoScope,
-}
-
-/// Resolve the site (if any) `cwd` is inside, by asking the daemon for the
-/// live site list. `cwd` is taken as an explicit, already-canonicalized
-/// parameter (rather than reading `std::env::current_dir()` internally) so
-/// this is fully testable with an arbitrary directory - no process-global
-/// cwd mutation needed in tests. Returns `NoScope` on any daemon error,
-/// timeout, or no match - callers treat that identically to "no site-scoping
-/// available." `pub` for the same testability reason as [`SiteScope`].
-#[must_use]
-pub fn site_scope(dirs: &PlatformDirs, cwd: &Path) -> ScopeResolution {
-    let sock = dirs.runtime.join("yerd.sock");
-    let Some(sites) = list_sites_with_timeout(&sock) else {
-        return ScopeResolution::NoScope;
-    };
-    let candidates: Vec<(PathBuf, PhpVersion)> = sites
-        .iter()
-        .filter_map(|entry| {
-            let root = std::fs::canonicalize(entry.site.served_root()).ok()?;
-            Some((root, entry.site.php()))
-        })
-        .collect();
-
-    let Some((root, php_version)) = match_site(cwd, &candidates) else {
-        return ScopeResolution::NoScope;
-    };
-    let minor = php_version.to_string();
-    let php_bin = cli_binary(dirs, &minor);
-    if php_bin.is_file() {
-        ScopeResolution::Scoped(SiteScope {
-            php_bin,
-            php_minor: minor,
-            served_root: root,
-        })
-    } else {
-        ScopeResolution::MatchedPhpMissing { php_version }
-    }
-}
-
-/// Spin up a one-shot, single-threaded tokio runtime (this shim otherwise
-/// has none) to make a single timeout-bounded `ListSites` call against the
-/// daemon socket at `sock` (matching [`transport::exchange`]'s own derivation
-/// of `<runtime>/yerd.sock` - passed explicitly here so tests can point at an
-/// isolated socket instead of the real, active one).
-fn list_sites_with_timeout(sock: &Path) -> Option<Vec<yerd_ipc::SiteEntry>> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .ok()?;
-    let outcome = rt.block_on(async {
-        tokio::time::timeout(
-            SITE_LOOKUP_TIMEOUT,
-            transport::exchange_at(sock, &Request::ListSites),
-        )
-        .await
-    });
-    match outcome {
-        Ok(Ok(Response::Sites { sites })) => Some(sites),
-        _ => None,
-    }
-}
-
-/// Pick the site whose (already-canonicalized) document root is `cwd` or an
-/// ancestor of it, preferring the most specific (longest) root when more than
-/// one contains `cwd` (nested sites are unusual but not disallowed). Pure:
-/// takes already-canonicalized paths, does no I/O itself.
-fn match_site(cwd: &Path, candidates: &[(PathBuf, PhpVersion)]) -> Option<(PathBuf, PhpVersion)> {
-    candidates
-        .iter()
-        .filter(|(root, _)| cwd.starts_with(root))
-        .max_by_key(|(root, _)| root.as_os_str().len())
-        .cloned()
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+    use yerd_platform::PlatformDirs;
 
     #[test]
     fn quiet_deprecations_scan_dir_env_prefixes_the_default_scan_separator() {
@@ -346,77 +226,5 @@ mod tests {
     fn dispatch_ignores_non_wp_argv0() {
         assert_eq!(Path::new("/x/wp").file_name().unwrap(), "wp");
         assert_ne!(Path::new("/x/wpcli").file_name().unwrap(), "wp");
-    }
-
-    fn php(major: u8, minor: u8) -> PhpVersion {
-        PhpVersion::new(major, minor)
-    }
-
-    #[test]
-    fn match_site_finds_exact_root() {
-        let candidates = vec![(PathBuf::from("/srv/blog"), php(8, 3))];
-        let hit = match_site(Path::new("/srv/blog"), &candidates);
-        assert_eq!(hit, Some((PathBuf::from("/srv/blog"), php(8, 3))));
-    }
-
-    #[test]
-    fn match_site_finds_nested_cwd() {
-        let candidates = vec![(PathBuf::from("/srv/blog"), php(8, 3))];
-        let hit = match_site(Path::new("/srv/blog/wp-content/themes"), &candidates);
-        assert_eq!(hit, Some((PathBuf::from("/srv/blog"), php(8, 3))));
-    }
-
-    #[test]
-    fn match_site_prefers_more_specific_nested_site() {
-        let candidates = vec![
-            (PathBuf::from("/srv"), php(8, 1)),
-            (PathBuf::from("/srv/blog"), php(8, 3)),
-        ];
-        let hit = match_site(Path::new("/srv/blog/wp-admin"), &candidates);
-        assert_eq!(hit, Some((PathBuf::from("/srv/blog"), php(8, 3))));
-    }
-
-    #[test]
-    fn match_site_none_outside_any_site() {
-        let candidates = vec![(PathBuf::from("/srv/blog"), php(8, 3))];
-        assert_eq!(match_site(Path::new("/home/dev/other"), &candidates), None);
-    }
-
-    #[test]
-    fn site_scope_falls_back_to_no_scope_when_daemon_unreachable() {
-        // No socket is ever created at `dirs.runtime` - this deterministically
-        // exercises the "daemon unreachable" fallback the plan calls out as
-        // needing its own explicit test, with no real daemon or process-global
-        // cwd mutation required (`site_scope` takes `cwd` as a plain parameter).
-        let tmp = tempfile::tempdir().unwrap();
-        let dirs = PlatformDirs {
-            config: tmp.path().join("c"),
-            data: tmp.path().join("d"),
-            state: tmp.path().join("s"),
-            cache: tmp.path().join("ca"),
-            runtime: tmp.path().join("r"),
-        };
-        std::fs::create_dir_all(&dirs.runtime).unwrap();
-        let cwd = std::fs::canonicalize(tmp.path()).unwrap();
-        assert!(matches!(site_scope(&dirs, &cwd), ScopeResolution::NoScope));
-    }
-
-    #[test]
-    fn match_site_resolves_symlinked_cwd_once_canonicalized() {
-        let tmp = tempfile::tempdir().unwrap();
-        let real_root = tmp.path().join("real-site");
-        std::fs::create_dir(&real_root).unwrap();
-        let link = tmp.path().join("link-to-site");
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&real_root, &link).unwrap();
-
-        let canonical_root = std::fs::canonicalize(&real_root).unwrap();
-        let canonical_cwd = std::fs::canonicalize(&link).unwrap();
-
-        let candidates = vec![(canonical_root.clone(), php(8, 4))];
-        assert_eq!(
-            match_site(&canonical_cwd, &candidates),
-            Some((canonical_root, php(8, 4)))
-        );
     }
 }

--- a/bin/yerd/tests/exec_e2e.rs
+++ b/bin/yerd/tests/exec_e2e.rs
@@ -71,7 +71,7 @@ mod tests {
         dirs: yerd_platform::PlatformDirs,
         cwd: Option<PathBuf>,
         site: Option<String>,
-    ) -> Result<PhpSelection, String> {
+    ) -> Result<PhpSelection, yerd::exec_cmd::SelectError> {
         tokio::task::spawn_blocking(move || select_php(&dirs, cwd.as_deref(), site.as_deref()))
             .await
             .unwrap()
@@ -212,21 +212,26 @@ mod tests {
         let err = scoped_select(dirs.clone(), Some(cwd), None)
             .await
             .unwrap_err();
-        assert!(err.contains("pinned to PHP 7.4"), "got: {err}");
-        assert!(err.contains("yerd install php 7.4"), "got: {err}");
+        assert!(err.message.contains("pinned to PHP 7.4"), "got: {err:?}");
+        assert!(err.message.contains("yerd install php 7.4"), "got: {err:?}");
+        assert_eq!(err.code, 2, "a pinned-but-uninstalled version is exit 2");
 
         // ...and the same via `--site`, from outside the site.
         let cwd = std::fs::canonicalize(&outside_dir).unwrap();
         let err = scoped_select(dirs.clone(), Some(cwd.clone()), Some("legacy".to_owned()))
             .await
             .unwrap_err();
-        assert!(err.contains("pinned to PHP 7.4"), "got: {err}");
+        assert!(err.message.contains("pinned to PHP 7.4"), "got: {err:?}");
+        assert_eq!(err.code, 2);
 
-        // An unknown `--site` name is an error, never a default fallback.
+        // An unknown `--site` name is an error, never a default fallback - and
+        // a *usage* error (exit 2), not the exit 1 every shim failure returns.
+        // With the daemon up, this must not be mistaken for exit 69 either.
         let err = scoped_select(dirs.clone(), Some(cwd), Some("nope".to_owned()))
             .await
             .unwrap_err();
-        assert!(err.contains("no site named 'nope'"), "got: {err}");
+        assert!(err.message.contains("no site named 'nope'"), "got: {err:?}");
+        assert_eq!(err.code, 2, "an unknown site name is a usage error");
 
         shutdown_tx.send_replace(true);
         let _ = tokio::time::timeout(Duration::from_secs(5), ipc_task).await;

--- a/bin/yerd/tests/exec_e2e.rs
+++ b/bin/yerd/tests/exec_e2e.rs
@@ -1,0 +1,235 @@
+//! End-to-end: exercise `exec_cmd::select_php` against a real daemon booted on
+//! a tempdir, mirroring `wp_shim_e2e.rs`'s pattern. Covers the resolution the
+//! unit tests in `exec_cmd.rs` can't reach without a real `ListSites`
+//! response: a cwd inside a registered site, an explicit `--site` override
+//! from outside every site, and both forms of the missing-pinned-PHP failure.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::match_wildcard_for_single_variants
+)]
+
+#[cfg(unix)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    use tokio::sync::watch;
+
+    use yerd::exec_cmd::{select_php, PhpSelection};
+    use yerd_core::PhpVersion;
+    use yerd_ipc::Request;
+
+    fn make_dirs(tmp: &Path) -> yerd_platform::PlatformDirs {
+        yerd_platform::PlatformDirs {
+            config: tmp.join("c"),
+            data: tmp.join("d"),
+            state: tmp.join("s"),
+            cache: tmp.join("ca"),
+            runtime: tmp.join("r"),
+        }
+    }
+
+    /// Two distinct, currently-free, non-zero ports (see `cli_e2e.rs`'s
+    /// identical helper for why: `validate()` rejects port 0 / equal ports).
+    fn valid_config() -> yerd_config::Config {
+        let a = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let b = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let (pa, pb) = (
+            a.local_addr().unwrap().port(),
+            b.local_addr().unwrap().port(),
+        );
+        drop(a);
+        drop(b);
+        let mut cfg = yerd_config::Config::default();
+        cfg.ports.http = pa;
+        cfg.ports.https = pb;
+        cfg.dns_port = 0;
+        cfg
+    }
+
+    /// Lay down a fake, executable-looking PHP CLI binary where
+    /// `shim::cli_binary` expects one, so a version counts as "installed"
+    /// without needing a real PHP build.
+    fn fake_php_cli(dirs: &yerd_platform::PlatformDirs, version: PhpVersion) {
+        let bin = dirs
+            .data
+            .join("php")
+            .join(format!("php-{}.{}", version.major, version.minor))
+            .join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("php"), b"#!/bin/sh\n").unwrap();
+    }
+
+    /// Run `select_php` on a blocking-pool thread - the site lookup builds its
+    /// own ad-hoc tokio runtime internally, which panics if called from inside
+    /// this test's own async runtime.
+    async fn scoped_select(
+        dirs: yerd_platform::PlatformDirs,
+        cwd: Option<PathBuf>,
+        site: Option<String>,
+    ) -> Result<PhpSelection, String> {
+        tokio::task::spawn_blocking(move || select_php(&dirs, cwd.as_deref(), site.as_deref()))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::too_many_lines)]
+    async fn select_php_against_a_real_daemon() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = make_dirs(tmp.path());
+        let cfg_path = dirs.config.join("yerd.toml");
+
+        let pinned_php = PhpVersion::new(8, 3);
+        let config_default = PhpVersion::new(8, 4);
+        let missing_php = PhpVersion::new(7, 4);
+        // The pinned version must differ from the global default, or "resolved
+        // the site's version" and "fell back to the default" would be
+        // indistinguishable.
+        assert_ne!(pinned_php, config_default);
+        let mut cfg = valid_config();
+        cfg.php.default = config_default;
+        fake_php_cli(&dirs, pinned_php);
+        fake_php_cli(&dirs, config_default);
+
+        let site_dir = tmp.path().join("blog");
+        std::fs::create_dir_all(site_dir.join("app")).unwrap();
+        let outside_dir = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        let missing_php_dir = tmp.path().join("legacy");
+        std::fs::create_dir_all(&missing_php_dir).unwrap();
+
+        let daemon = yerdd::startup::bring_up_with_dirs(dirs.clone(), cfg, cfg_path.clone())
+            .await
+            .expect("bring_up_with_dirs");
+        let sock = dirs.runtime.join("yerd.sock");
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let state = daemon.state.clone();
+        let ipc_task = tokio::spawn(yerdd::ipc_server::run(
+            daemon.ipc_listener,
+            state,
+            shutdown_rx,
+        ));
+        let keep_alive = (
+            daemon.lock,
+            daemon.dns_bound,
+            daemon.http_listener,
+            daemon.https_listener,
+            daemon.php_manager,
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Link "blog", pinned to an installed version.
+        let req = yerd::resolve_link(Some("blog"), Some(&site_dir)).expect("resolve_link");
+        assert!(matches!(
+            yerd::transport::exchange_at(&sock, &req).await.unwrap(),
+            yerd_ipc::Response::Ok
+        ));
+        assert!(matches!(
+            yerd::transport::exchange_at(
+                &sock,
+                &Request::SetPhp {
+                    name: "blog".into(),
+                    version: pinned_php,
+                },
+            )
+            .await
+            .unwrap(),
+            yerd_ipc::Response::Ok
+        ));
+
+        // Link "legacy", pinned to a version with no binary laid down.
+        let req = yerd::resolve_link(Some("legacy"), Some(&missing_php_dir)).expect("resolve_link");
+        assert!(matches!(
+            yerd::transport::exchange_at(&sock, &req).await.unwrap(),
+            yerd_ipc::Response::Ok
+        ));
+        assert!(matches!(
+            yerd::transport::exchange_at(
+                &sock,
+                &Request::SetPhp {
+                    name: "legacy".into(),
+                    version: missing_php,
+                },
+            )
+            .await
+            .unwrap(),
+            yerd_ipc::Response::Ok
+        ));
+
+        // cwd inside the site (a subdirectory, not the root itself) -> its
+        // pinned version, not the global default.
+        let cwd = std::fs::canonicalize(site_dir.join("app")).unwrap();
+        match scoped_select(dirs.clone(), Some(cwd), None).await.unwrap() {
+            PhpSelection::Site(scope) => {
+                assert_eq!(scope.site_name, "blog");
+                assert_eq!(scope.php_minor, "8.3");
+                assert!(scope.php_bin.ends_with("php-8.3/bin/php"));
+            }
+            other => panic!("expected Site, got {other:?}"),
+        }
+
+        // `--site` resolves the named site even from outside every site.
+        let cwd = std::fs::canonicalize(&outside_dir).unwrap();
+        match scoped_select(dirs.clone(), Some(cwd.clone()), Some("blog".to_owned()))
+            .await
+            .unwrap()
+        {
+            PhpSelection::Site(scope) => {
+                assert_eq!(scope.site_name, "blog");
+                assert_eq!(scope.php_minor, "8.3");
+            }
+            other => panic!("expected Site, got {other:?}"),
+        }
+
+        // A site name is stored lowercased, so the lookup must be too.
+        match scoped_select(dirs.clone(), Some(cwd.clone()), Some("BLOG".to_owned()))
+            .await
+            .unwrap()
+        {
+            PhpSelection::Site(scope) => assert_eq!(scope.site_name, "blog"),
+            other => panic!("expected Site, got {other:?}"),
+        }
+
+        // cwd outside every site -> the global default (whichever version the
+        // config names), no error.
+        match scoped_select(dirs.clone(), Some(cwd), None).await.unwrap() {
+            PhpSelection::Default { php_bin, minor } => {
+                assert_eq!(minor, config_default.to_string());
+                assert!(php_bin.ends_with(format!("php-{config_default}/bin/php")));
+            }
+            other => panic!("expected Default, got {other:?}"),
+        }
+
+        // cwd inside a site pinned to an uninstalled version -> a loud failure,
+        // not a silent fall-through to the default PHP.
+        let cwd = std::fs::canonicalize(&missing_php_dir).unwrap();
+        let err = scoped_select(dirs.clone(), Some(cwd), None)
+            .await
+            .unwrap_err();
+        assert!(err.contains("pinned to PHP 7.4"), "got: {err}");
+        assert!(err.contains("yerd install php 7.4"), "got: {err}");
+
+        // ...and the same via `--site`, from outside the site.
+        let cwd = std::fs::canonicalize(&outside_dir).unwrap();
+        let err = scoped_select(dirs.clone(), Some(cwd.clone()), Some("legacy".to_owned()))
+            .await
+            .unwrap_err();
+        assert!(err.contains("pinned to PHP 7.4"), "got: {err}");
+
+        // An unknown `--site` name is an error, never a default fallback.
+        let err = scoped_select(dirs.clone(), Some(cwd), Some("nope".to_owned()))
+            .await
+            .unwrap_err();
+        assert!(err.contains("no site named 'nope'"), "got: {err}");
+
+        shutdown_tx.send_replace(true);
+        let _ = tokio::time::timeout(Duration::from_secs(5), ipc_task).await;
+        drop(keep_alive);
+    }
+}

--- a/bin/yerd/tests/wp_shim_e2e.rs
+++ b/bin/yerd/tests/wp_shim_e2e.rs
@@ -279,11 +279,16 @@ mod tests {
             other => panic!("expected MatchedPhpMissing, got {other:?}"),
         }
 
-        // cwd outside every registered site -> NoScope.
+        // cwd outside every registered site -> NoScope, and explicitly *not*
+        // flagged as a daemon failure: the daemon answered, nothing matched.
+        // Conflating the two is what makes a timed-out lookup silently run the
+        // global default inside a pinned site.
         let cwd = std::fs::canonicalize(&unscoped_dir).unwrap();
         assert!(matches!(
             scoped_site_scope(dirs.clone(), cwd).await,
-            ScopeResolution::NoScope
+            ScopeResolution::NoScope {
+                daemon_unavailable: false
+            }
         ));
 
         shutdown_tx.send_replace(true);

--- a/bin/yerd/tests/wp_shim_e2e.rs
+++ b/bin/yerd/tests/wp_shim_e2e.rs
@@ -163,7 +163,7 @@ mod tests {
             ScopeResolution::Scoped(scope) => {
                 assert_eq!(
                     scope.served_root,
-                    std::fs::canonicalize(&scoped_dir).unwrap()
+                    Some(std::fs::canonicalize(&scoped_dir).unwrap())
                 );
                 assert!(scope.php_bin.ends_with("php-8.3/bin/php"));
             }
@@ -209,8 +209,62 @@ mod tests {
             ScopeResolution::Scoped(scope) => {
                 assert_eq!(
                     scope.served_root,
-                    std::fs::canonicalize(sub_dir.join("public")).unwrap()
+                    Some(std::fs::canonicalize(sub_dir.join("public")).unwrap())
                 );
+            }
+            other => panic!("expected Scoped, got {other:?}"),
+        }
+
+        // A site whose served root doesn't exist on disk (an unbuilt `public/`)
+        // still resolves - matching is on the document root, so `yerd exec`
+        // gets the pinned PHP - but `served_root` is `None`, which is how the
+        // `wp` shim knows to decline scoping rather than aim `--path=` at the
+        // project root, where WordPress isn't served from.
+        //
+        // `SetWebRoot` validates that the directory exists, so the subpath is
+        // set while `public/` is present and the directory removed afterwards -
+        // which is the only way to reach this state, and matches the real case
+        // (a `public/` that was deleted, or never built after a fresh clone).
+        let unbuilt_dir = tmp.path().join("unbuilt");
+        std::fs::create_dir_all(unbuilt_dir.join("public")).unwrap();
+        let req = yerd::resolve_link(Some("unbuilt"), Some(&unbuilt_dir)).expect("resolve_link");
+        assert!(matches!(
+            yerd::transport::exchange_at(&sock, &req).await.unwrap(),
+            yerd_ipc::Response::Ok
+        ));
+        assert!(matches!(
+            yerd::transport::exchange_at(
+                &sock,
+                &Request::SetPhp {
+                    name: "unbuilt".into(),
+                    version: installed_php,
+                },
+            )
+            .await
+            .unwrap(),
+            yerd_ipc::Response::Ok
+        ));
+        assert!(matches!(
+            yerd::transport::exchange_at(
+                &sock,
+                &Request::SetWebRoot {
+                    name: "unbuilt".into(),
+                    path: Some("public".into()),
+                },
+            )
+            .await
+            .unwrap(),
+            yerd_ipc::Response::Ok
+        ));
+        std::fs::remove_dir(unbuilt_dir.join("public")).unwrap();
+        let cwd = std::fs::canonicalize(&unbuilt_dir).unwrap();
+        match scoped_site_scope(dirs.clone(), cwd).await {
+            ScopeResolution::Scoped(scope) => {
+                assert_eq!(
+                    scope.served_root, None,
+                    "a served root that isn't on disk must not fall back to the document root"
+                );
+                assert!(scope.php_bin.ends_with("php-8.3/bin/php"));
             }
             other => panic!("expected Scoped, got {other:?}"),
         }

--- a/bin/yerd/tests/wp_shim_e2e.rs
+++ b/bin/yerd/tests/wp_shim_e2e.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use tokio::sync::watch;
 
-    use yerd::wp_shim::{site_scope, ScopeResolution};
+    use yerd::site_scope::{site_scope, ScopeResolution};
     use yerd_core::PhpVersion;
     use yerd_ipc::Request;
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -184,6 +184,7 @@ export default withMermaid({
             { text: 'Routing rules', link: '/reference/cli/routes' },
             { text: 'HTTPS', link: '/reference/cli/https' },
             { text: 'PHP', link: '/reference/cli/php' },
+            { text: 'Exec and Which', link: '/reference/cli/exec' },
             { text: 'Coverage', link: '/reference/cli/coverage' },
             { text: 'Tooling', link: '/reference/cli/tooling' },
             { text: 'Services', link: '/reference/cli/services' },

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -411,6 +411,8 @@ Two deliberate failure rules:
 `php`, `php<version>`, and `composer` behave exactly as before - `php` still means the global default everywhere. `yerd exec` is an addition, not a change in what your existing commands do.
 :::
 
+Because everything after the tool is forwarded, `-h`/`--help` reach the tool too: `yerd exec composer --help` prints Composer's help. Use `yerd help exec` for the command's own. See the [Exec and Which reference](../reference/cli/exec) for the full flag surface and exit codes.
+
 ### Listing versions
 
 ```sh

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -342,6 +342,57 @@ Check what each site resolves to with `yerd sites`, which lists every site with 
 Pinning a site (or the default) to an uninstalled version means there's no FPM binary to start when a request arrives. Install it first (`yerd install php 8.3`), then pin. `yerd doctor` flags a pool that can't start.
 :::
 
+### Site-aware CLI: `yerd exec` and `yerd which`
+
+A pin governs how a site is **served**, but the bare `php` and `composer` shims always use the **global default**. So inside a site pinned to 8.3 while your default is 8.5, `php artisan` and `composer install` run on 8.5 - a different version than the site's own web requests.
+
+`yerd exec` closes that gap. It runs a tool under the version pinned to the site containing your current directory:
+
+```sh
+cd ~/Sites/my-app     # pinned to 8.3
+yerd exec php -v      # PHP 8.3.x
+yerd exec php artisan migrate
+yerd exec composer install
+```
+
+Everything after the tool is passed straight through, so no `--` separator is needed - which also means yerd's own flags (`--site`, `--json`) must come **before** the tool:
+
+```sh
+yerd exec --site my-app php -v      # from anywhere
+yerd exec composer show --json      # --json here belongs to Composer
+```
+
+`yerd which php` prints the absolute path of the binary `yerd exec` would use, resolved identically:
+
+```sh
+$ cd ~/Sites/my-app && yerd which php
+/Users/you/Library/Application Support/io.yerd.Yerd/php/php-8.3/bin/php
+
+$ yerd --json which php
+{"path":"…/php-8.3/bin/php","version":"8.3","site":"my-app","source":"site"}
+```
+
+`source` is `site` when a pin applied and `default` otherwise (with `site` then `null`), so scripts can tell the two apart.
+
+How resolution falls out:
+
+| Where you run it | Which PHP |
+|---|---|
+| Inside a pinned site | that site's pinned version |
+| Inside an unpinned site, or outside every site | the global default |
+| With `--site <name>` | that site's pinned version, from anywhere |
+
+Two deliberate failure rules:
+
+- **A pinned-but-uninstalled version is an error**, not a silent fallback: running under an unrelated default PHP with no indication why is worse than stopping. Install it (`yerd install php 8.3`) and retry.
+- **`--site` never falls back.** You named a site, so an unknown name - or a daemon that isn't running to resolve it - is an error rather than a quiet switch to the default. Without `--site`, an unreachable daemon just means "not inside a site", and the global default is used.
+
+`yerd exec composer` runs the same bundled phar the `composer` shim does, just under the site's PHP (and that version's CLI ini).
+
+::: tip The shims are unchanged
+`php`, `php<version>`, and `composer` behave exactly as before - `php` still means the global default everywhere. `yerd exec` is an addition, not a change in what your existing commands do.
+:::
+
 ### Listing versions
 
 ```sh
@@ -460,6 +511,8 @@ and the denylist of directives Yerd manages elsewhere.
 | `yerd install php <version>` | Download + install the latest patch of a minor. |
 | `yerd use <version>` | Set the global default version (and the `php` shim). |
 | `yerd use <site> <version>` | Pin one site to a version. |
+| `yerd exec [--site <name>] <php\|composer> [args…]` | Run a tool under the site's pinned version instead of the global default. |
+| `yerd which [--site <name>] php` | Print the PHP binary `yerd exec` would use. |
 | `yerd list php [--check]` | List installed versions; `--check` refreshes update flags. |
 | `yerd list php --available` | List versions installable from the distribution. |
 | `yerd update php [<version>]` | Update one (or all) versions to the latest patch. |

--- a/docs/guide/php-versions.md
+++ b/docs/guide/php-versions.md
@@ -344,12 +344,12 @@ Pinning a site (or the default) to an uninstalled version means there's no FPM b
 
 ### Site-aware CLI: `yerd exec` and `yerd which`
 
-A pin governs how a site is **served**, but the bare `php` and `composer` shims always use the **global default**. So inside a site pinned to 8.3 while your default is 8.5, `php artisan` and `composer install` run on 8.5 - a different version than the site's own web requests.
+A site's version governs how it is **served**, but the bare `php` and `composer` shims always use the **global default**. So inside a site on 8.3 while your default is 8.5, `php artisan` and `composer install` run on 8.5 - a different version than the site's own web requests.
 
-`yerd exec` closes that gap. It runs a tool under the version pinned to the site containing your current directory:
+`yerd exec` closes that gap. It runs a tool under the version of the site containing your current directory:
 
 ```sh
-cd ~/Sites/my-app     # pinned to 8.3
+cd ~/Sites/my-app     # served on 8.3
 yerd exec php -v      # PHP 8.3.x
 yerd exec php artisan migrate
 yerd exec composer install
@@ -372,20 +372,38 @@ $ yerd --json which php
 {"path":"…/php-8.3/bin/php","version":"8.3","site":"my-app","source":"site"}
 ```
 
-`source` is `site` when a pin applied and `default` otherwise (with `site` then `null`), so scripts can tell the two apart.
+`source` is `site` when the version came from a site and `default` otherwise (with `site` then `null`), so scripts can tell the two apart.
 
 How resolution falls out:
 
 | Where you run it | Which PHP |
 |---|---|
-| Inside a pinned site | that site's pinned version |
-| Inside an unpinned site, or outside every site | the global default |
-| With `--site <name>` | that site's pinned version, from anywhere |
+| Inside a registered site | that site's stored version |
+| Outside every site | the global default |
+| With `--site <name>` | that site's stored version, from anywhere |
+
+::: warning A linked site's version doesn't follow the default
+Every registered site resolves to a concrete version, so `source` is `site` even for one you never ran `yerd use <site> <version>` against - there is no "unpinned" state to report.
+
+The two site kinds get that version differently, which matters when you change the global default:
+
+- **Linked** sites **snapshot** the default at link time. Changing the default later does not move them.
+- **Parked** sites follow the current default, unless you've pinned one explicitly.
+
+```sh
+yerd link my-app      # default is 8.4 → my-app stores 8.4
+yerd use 8.5          # global default moves to 8.5
+php -v                # 8.5 - the bare shim follows the default
+yerd exec php -v      # 8.4 - my-app is still *served* on 8.4
+```
+
+`yerd exec` is right here: it matches how the site actually runs. But it is deliberately not the same as "inherits the default". To move a linked site too, pin it explicitly with `yerd use my-app 8.5`. `yerd sites` shows what each site currently resolves to.
+:::
 
 Two deliberate failure rules:
 
-- **A pinned-but-uninstalled version is an error**, not a silent fallback: running under an unrelated default PHP with no indication why is worse than stopping. Install it (`yerd install php 8.3`) and retry.
-- **`--site` never falls back.** You named a site, so an unknown name - or a daemon that isn't running to resolve it - is an error rather than a quiet switch to the default. Without `--site`, an unreachable daemon just means "not inside a site", and the global default is used.
+- **A stored-but-uninstalled version is an error**, not a silent fallback: running under an unrelated default PHP with no indication why is worse than stopping. Install it (`yerd install php 8.3`) and retry.
+- **`--site` never falls back.** You named a site, so an unknown name - or a daemon that isn't running to resolve it - is an error rather than a quiet switch to the default. Without `--site`, an unreachable daemon just means "not inside a site", and the global default is used - with a warning on stderr, since inside a site that would otherwise silently run the wrong version.
 
 `yerd exec composer` runs the same bundled phar the `composer` shim does, just under the site's PHP (and that version's CLI ini).
 
@@ -511,7 +529,7 @@ and the denylist of directives Yerd manages elsewhere.
 | `yerd install php <version>` | Download + install the latest patch of a minor. |
 | `yerd use <version>` | Set the global default version (and the `php` shim). |
 | `yerd use <site> <version>` | Pin one site to a version. |
-| `yerd exec [--site <name>] <php\|composer> [args…]` | Run a tool under the site's pinned version instead of the global default. |
+| `yerd exec [--site <name>] <php\|composer> [args…]` | Run a tool under the site's own version instead of the global default. |
 | `yerd which [--site <name>] php` | Print the PHP binary `yerd exec` would use. |
 | `yerd list php [--check]` | List installed versions; `--check` refreshes update flags. |
 | `yerd list php --available` | List versions installable from the distribution. |

--- a/docs/guide/tooling.md
+++ b/docs/guide/tooling.md
@@ -175,6 +175,12 @@ your [default PHP version](./php-versions). Install at least one PHP version
 first (`yerd install php 8.4`); otherwise `composer` reports that no PHP is
 available. Node and Bun are standalone and have no such dependency.
 
+The `composer` shim always uses the **global default**, including inside a site
+pinned to another version. To run Composer under a site's pinned version instead,
+use `yerd exec composer …` - it runs the same phar under that site's PHP. See
+[Site-aware CLI](./php-versions#site-aware-cli-yerd-exec-and-yerd-which). The
+shim itself is unchanged.
+
 ::: tip ext-intl and friends
 Yerd's PHP builds ship the **bulk** extension set, including
 `intl`, `sodium`, `mysqli`, and more - so Composer packages that require them

--- a/docs/reference/cli/exec.md
+++ b/docs/reference/cli/exec.md
@@ -1,0 +1,123 @@
+# Exec and Which
+
+`yerd exec` runs a CLI tool under the PHP version a **site** uses, rather than
+the [global default](../../guide/php-versions#the-global-default). `yerd which`
+reports which binary that would be, without running anything.
+
+A site's version governs how it is **served**, but the bare `php` and `composer`
+shims always resolve to the global default. Inside a site on 8.3 while your
+default is 8.5, `php artisan` and `composer install` therefore run on a different
+PHP than the site's own web requests. These two commands close that gap; the
+shims themselves are unchanged.
+
+Like `coverage`, `path`, and `elevate`, neither command maps to an IPC request:
+`exec` replaces itself with PHP directly (inheriting your stdin/stdout/stderr,
+arguments, and exit code), and `which` only prints a path. (Attempting to route
+either over IPC is an explicit usage error.) The one daemon round-trip is the
+site lookup behind the scenes.
+
+```sh
+yerd exec [--site <NAME>] <php|composer> [ARGS...]
+yerd which [--json] [--site <NAME>] php
+```
+
+| Command | Description |
+| --- | --- |
+| `yerd exec php [ARGS...]` | Run the site's PHP CLI, passing `ARGS` to PHP. |
+| `yerd exec composer [ARGS...]` | Run the bundled Composer phar under the site's PHP. |
+| `yerd exec --site <NAME> …` | Use the named site's version instead of the current directory's. |
+| `yerd which php` | Print the absolute path of the PHP binary `yerd exec` would use. |
+| `yerd which --json php` | Print `{path, version, site, source}` for that binary. |
+
+| Flag | Description |
+| --- | --- |
+| `--site <NAME>` | Resolve against this site instead of the current directory. Never falls back: an unknown name is an error. |
+| `--json` | `which` only. Emit the resolved path plus its version and origin as JSON. |
+
+```sh
+cd ~/Sites/my-app                # served on 8.3
+yerd exec php -v                 # PHP 8.3.x
+yerd exec php artisan migrate
+yerd exec composer install       # the bundled phar, under 8.3
+yerd exec --site blog php -v     # blog's version, from anywhere
+
+yerd which php                   # /…/php/php-8.3/bin/php
+yerd --json which php            # {"path":"…","version":"8.3","site":"my-app","source":"site"}
+```
+
+`which` shares `exec`'s resolution path exactly, so it can never print a path
+that `exec` wouldn't actually run.
+
+## Resolution
+
+| Where you run it | Which PHP |
+| --- | --- |
+| Inside a registered site | that site's stored version |
+| Outside every site | the global default |
+| With `--site <NAME>` | that site's stored version, from anywhere |
+
+Nested sites resolve to the **most specific** match, and matching is on the
+site's project root, not its served root - so a Laravel site served from
+`public/` still resolves from the project root, where `artisan` and
+`composer.json` live.
+
+Every registered site resolves to a concrete version, so `source` is `site` even
+for a site you never explicitly pinned - there is no "unpinned" state. A
+**linked** site snapshots the global default at link time and does **not** move
+when you change the default afterwards; a **parked** site follows the current
+default unless pinned. See
+[Site-aware CLI](../../guide/php-versions#site-aware-cli-yerd-exec-and-yerd-which)
+for why, and how to move a site's version deliberately.
+
+In `--json` mode, `source` is `site` when the version came from a site and
+`default` otherwise, with `site` then `null`.
+
+## Passthrough behaviour
+
+Everything after the tool is handed straight to that tool, so no `--` separator
+is needed - and yerd's own flags must come **before** it:
+
+```sh
+yerd exec --site blog php -v     # --site is yerd's
+yerd exec composer show --json   # --json is Composer's
+yerd exec php -r 'echo PHP_VERSION;'
+```
+
+- **`-h` / `--help` go to the tool**, so `yerd exec composer --help` prints
+  Composer's help, not yerd's. Use `yerd help exec` for this command's own help.
+  This differs from [`coverage`](./coverage), where a leading `--help` is yerd's.
+- The global `--json` is **not** interpreted by `yerd exec` - it reaches the
+  tool, since `yerd exec composer show --json` has to produce Composer's JSON.
+  Along with `coverage`, this is an exception to the "`--json` on every command"
+  note in the [overview](./). `yerd which --json` is unaffected: `which` runs
+  nothing, so `--json` is yerd's there.
+- `yerd exec` exits with the tool's own exit code, so it composes in CI exactly
+  like the interpreter it wraps.
+
+`yerd exec composer` runs the same bundled phar the `composer` shim does, just
+under the site's PHP - and additionally points `PHPRC` at that version's
+generated CLI ini.
+
+## Failure modes
+
+Both commands fail rather than quietly running the wrong PHP:
+
+- **A stored-but-uninstalled version is an error** (exit `2`), not a silent
+  fallback to the default - that silent mismatch is what these commands exist to
+  prevent. Install it (`yerd install php 8.3`) and retry.
+- **`--site` never falls back.** An unknown name is a usage error (exit `2`);
+  a daemon that isn't running to resolve it exits `69`. Naming a site is an
+  instruction, not a hint.
+- **Without `--site`, an unreachable daemon just means "not inside a site"** and
+  the global default is used - but with a warning on stderr, since inside a site
+  that would otherwise silently resolve to the wrong version.
+- **Unix only.** Both commands are available on macOS and Linux.
+
+See [Exit codes](./#exit-codes) for the full table.
+
+## See also
+
+- [PHP versions guide](../../guide/php-versions#site-aware-cli-yerd-exec-and-yerd-which) - the narrative version of this page.
+- [PHP](./php) - installing versions, the global default, and pinning a site.
+- [Tooling](./tooling) - the `composer` shim and the rest of the shim directory.
+- [Coverage](./coverage) - the other passthrough command.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -18,11 +18,13 @@ yerd [--json] <COMMAND> [ARGS...]
 
 | Flag | Description |
 | --- | --- |
-| `--json` | Emit machine-readable JSON instead of human-readable text. Available on every command except [`coverage`](./coverage), which forwards everything after it (including `--json`) to PHP. |
+| `--json` | Emit machine-readable JSON instead of human-readable text. Available on every command except [`coverage`](./coverage) and [`exec`](./exec), which forward everything after them (including `--json`) to the tool they run. |
 | `--help`, `-h` | Print help for the command. |
 | `--version`, `-V` | Print the `yerd` version. |
 
-`--json` is a global flag, so you can place it before or after the subcommand: `yerd --json status` and `yerd status --json` are equivalent. In JSON mode the entire daemon response is printed as pretty JSON; the process exit code still reflects success or failure (see [Exit codes](#exit-codes)). The one exception is [`coverage`](./coverage), which is a passthrough to PHP: anything after `coverage` - `--json` included - goes to PHP rather than to `yerd`.
+`--json` is a global flag, so you can place it before or after the subcommand: `yerd --json status` and `yerd status --json` are equivalent. In JSON mode the entire daemon response is printed as pretty JSON; the process exit code still reflects success or failure (see [Exit codes](#exit-codes)).
+
+The exceptions are the two passthrough commands. Anything after [`coverage`](./coverage) - `--json` included - goes to PHP, and anything after [`exec`](./exec)'s tool goes to that tool, so `yerd exec composer show --json` produces Composer's JSON rather than a daemon response. `yerd which --json` is *not* an exception: `which` runs nothing, so `--json` is `yerd`'s there.
 
 ::: info
 `yerd` is the command-line front end. The daemon (`yerdd`) does the real work: running the proxy, DNS responder, PHP-FPM pools, and certificate authority. See [The Daemon](../../guide/daemon) for how it runs, and the [IPC Protocol](../../developer/ipc-protocol) for the request/response wire format.
@@ -37,6 +39,7 @@ yerd [--json] <COMMAND> [ARGS...]
 | [Proxies](./proxies) | `proxy add`, `proxy remove`, `proxy list` |
 | [HTTPS](./https) | `secure`, `unsecure` |
 | [PHP](./php) | `use`, `install php`, `uninstall php`, `update php`, `restart php`, `list php`, `list parked`, `set php`, `unset php`, `php ext add`/`remove`/`list`, [`coverage`](./coverage) |
+| [Exec and Which](./exec) | `exec php`, `exec composer`, `which php` |
 | [Tooling](./tooling) | `tools`, `install tool`, `uninstall tool`, `path install`, `path uninstall`, `path print` |
 | [Services](./services) | `services`, `service available`, `service install`, `service change-version`, `service uninstall`, `service start`, `service stop`, `service restart`, `service set-port`, `service logs` |
 | [Databases](./db) | `db list`, `db create`, `db drop`, `db backup`, `db restore` |


### PR DESCRIPTION
## What does this PR do?

Adds `yerd exec <php|composer> [args…]` and `yerd which php`: run CLI tools under the PHP version a site uses, and report which binary that is.

A site's version governs how it is served, but the bare `php` and `composer` shims always resolve to the **global default** - so inside a site on 8.3 with a default of 8.5, `php artisan` and `composer install` silently run on a different PHP than the site's own web requests.

```sh
cd ~/Sites/my-app          # served on 8.3
yerd exec php -v           # PHP 8.3.x
yerd exec composer install # the bundled phar, under 8.3, with 8.3's CLI ini
yerd which php             # /…/php/php-8.3/bin/php
yerd --json which php      # {"path":"…","version":"8.3","site":"my-app","source":"site"}
```

**The existing shims are unchanged.** `php`, `php<version>`, `composer`, and `yerd php` (ext/ini/pool settings) all behave exactly as before; this is purely additive. `yerd php` was already taken, hence `exec`/`which`.

### Behaviour

| Situation | Result |
|---|---|
| Inside a registered site | that site's stored version |
| Outside every site | the global default |
| `--site <name>` | that site's version, from anywhere |
| Stored version not installed | **error** (both forms), exit `2` |
| `--site` names an unknown site | **error**, exit `2` - never falls back |
| `--site` with the daemon down | **error**, exit `69` - never falls back |
| Daemon unreachable, no `--site` | treated as "not in a site" → global default, **with a warning on stderr** |

There is no "unpinned" site: `Site::php()` returns a concrete `PhpVersion`, so every registered site reports `source: "site"` whether or not anyone ran `yerd use <site> <ver>`. The two site kinds get that version differently, which matters when the default moves: a **linked** site snapshots the default at link time and does not track it afterwards, while a **parked** site is rebuilt from the live default unless explicitly overridden. `yerd exec` follows the site's stored version either way, because that is what the site is actually served on.

Three failure rules are deliberate. A stored-but-uninstalled version fails loudly rather than silently running an unrelated default (that silent mismatch is the bug this feature exists to prevent). An explicit `--site` never falls back, because naming a site is an instruction, not a hint. And a cwd lookup the daemon doesn't answer still falls back - the lookup is on the critical path of every invocation - but warns, since inside a site that is indistinguishable from "not in a site" while running the wrong PHP.

`yerd which` shares `yerd exec`'s resolution path exactly, so it can never print a path that `exec` wouldn't actually run.

### Implementation notes

- **New `bin/yerd/src/site_scope.rs`** extracts the site resolution that lived in `wp_shim.rs` (timeout-bounded `Request::ListSites`, longest-ancestor match, fail-loudly on a missing pin) and adds a by-name lookup with its own non-falling-back error type. `wp_shim.rs` now imports it.
- **Matching moved from served root to document root.** A Laravel site is served from `public/`, but `artisan` and `composer.json` sit at the project root - which is where the CLI is actually run from. Matching on the served root (what the wp shim needed for `--path=`) missed that entirely; I hit this in manual testing, where a site on 8.3 reported the default until I `cd`'d into `public/`. `Candidate` now carries both roots: document root for matching, served root still passed through for wp-cli's `--path=`.
- **No new IPC and no daemon changes** - the site lookup reuses `ListSites`. Local execution follows the existing `yerd coverage` / shim precedent.
- **`composer_phar` factored into `shim.rs`** and shared with `composer_shim.rs`, so both run the same phar. `yerd exec composer` additionally sets `PHPRC` to the selected version's CLI ini, which the bare shim does not.
- **`map::to_request` refuses both commands** with `ClientError::Usage`, next to the existing `Path`/`Coverage`/`Mcp` refusals, keeping the mapping pure.
- Resolution runs via `spawn_blocking`: the shared site lookup drives its own one-shot runtime (the shims have none), which panics on a thread already driving one - as the CLI's async `run()` is. Caught by manual testing, not by the unit tests, which call the pure resolver directly.

### `wp` shim: one intentional behaviour change

Sharing the resolution touches the `wp` shim, and one difference from `main` survives by design. Previously a site whose served root couldn't be canonicalized was dropped from the candidate list entirely. `served_root` is now `Option<PathBuf>`, so such a site is still **matched** - `yerd exec` resolves its version, since only the document root matters there - while the shim declines to scope it, landing on the same "default PHP, no `--path=`" outcome as before rather than aiming `--path=` at the project root.

The residual delta: because the site is now matched, one that has *both* a missing served root *and* an uninstalled version errors where `main` silently fell back. That is the loud failure a pin is supposed to produce, but it is a real change to `wp` and is commented at the call site. Only reachable for a site whose `public/` is missing, which is already broken.

## Review round

Six findings from @RichardAnderson, each verified against the code and fixed in its own commit:

| Commit | Finding |
|---|---|
| `eb89062` | **`-h`/`--help` didn't reach the tool.** clap matched the subcommand help flag before `trailing_var_arg` started collecting, so `yerd exec composer --help` printed yerd's help. `disable_help_flag` on the variant fixes it; `yerd help exec` still prints the command's own. |
| `59c826d` | **The `wp` shim behaviour change** - fixed rather than only disclosed; see the section above. |
| `26d7dfc` | **A timed-out lookup was indistinguishable from a genuine no-match.** `NoScope` now carries `daemon_unavailable`; the timeout and fallback are unchanged, and `exec`/`which` warn on stderr so `--json` stdout stays parseable. The `wp` shim deliberately stays quiet. |
| `5cdb309` | **Exit codes all collapsed to `1`.** Failures now carry the documented code: `2` usage-class, `69` unreachable daemon, `74` exec I/O. |
| `49081ab` | **The "unpinned site" row was misleading** - reworded, with the linked-vs-parked distinction above. |
| `baf5e2a` | **`exec`/`which` were missing from the CLI reference**, which promises to document every command and flag. Added a page plus sidebar entry, and recorded `exec` as a second `--json` exception. |

Each commit builds and passes `cargo test -p yerd` on its own.

## Related issues

Closes #207

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Platforms tested

- [x] macOS
- [ ] Linux <!-- not run locally; left to CI -->

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean (`--workspace`, `-D warnings`)
- [x] `cargo test` passes — see note below
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed

### Test note

`cargo test --workspace` passes except one **pre-existing, unrelated** failure: `yerdd`'s `tunnel::tests::resolved_cloudflared_reflects_a_fresh_install_without_restart`, which asserts no `cloudflared` is resolvable and fails on any machine that has one installed. Re-verified failing on `main` in a scratch worktree during this review round.

Added coverage:

- **Unit** — `site_scope.rs`: ancestor matching (exact / nested / most-specific / outside / symlinked-cwd), the document-root-vs-served-root case above, daemon-unreachable fallback (now asserting `daemon_unavailable: true`), and by-name-never-falls-back. `exec_cmd.rs`: `which_output` human + JSON (null site, space-containing path - built with `serde_json`, since every macOS data path runs through `Application Support`), default fallback, `--site` erroring without a daemon *with exit `69`*, no-PHP-installed *with exit `2`*, and the code table itself. `cli.rs`: hyphen-arg capture (`yerd exec php -v` needs no `--`), `--site` before the tool, a trailing `--json` forwarded rather than consumed, `which composer` rejected at parse time. `map.rs`: both refusals.
- **E2E** — `bin/yerd/tests/exec_e2e.rs` against a real daemon on a tempdir (mirroring `wp_shim_e2e.rs`): cwd-scoped resolution, `--site` override from outside the site, case-insensitive name lookup, default fallback, missing-pin failing loudly in both forms *with exit `2`*, unknown-name error *proved `2` and not `69` with the daemon up*. `wp_shim_e2e.rs` adds a site whose served root is deleted after `SetWebRoot` (the only way to reach that state, since the daemon validates the directory at set time), asserting `served_root: None` and that a no-match with a live daemon reports `daemon_unavailable: false`.

Not unit-testable: the `exec` syscall and the child's environment (~6 lines mirroring the existing shims). Verified manually against a live daemon and real sites — `yerd exec php -i | grep 'Loaded Configuration'` reports the pinned version's CLI ini inside a site and the default's outside it, and `yerd exec composer --version` self-reports running on 8.3. The review-round fixes were re-verified by hand: `exec composer --help` prints Composer's help, `exec php --help` prints PHP's, `which --site nope php` exits `69` with the daemon down, the warning appears on stderr only, and `--json which` stdout still parses as JSON.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `yerd exec` to run PHP or Composer with forwarded arguments and optional site selection.
  - Added `yerd which` to display the resolved PHP path in text or JSON.
  - Commands automatically select the current or explicitly named site’s pinned PHP version, including nested sites.
  - Added clear errors for unavailable sites, PHP versions, and daemon connections.

- **Documentation**
  - Documented site-aware commands, Composer version behavior, JSON output, and platform support.

- **Bug Fixes**
  - Standardized Composer installation error handling and path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
