### PR TITLE
[Feat] Add native Windows support

### DIFF
--- a/apps/yerd-gui/README.md
+++ b/apps/yerd-gui/README.md
@@ -85,16 +85,21 @@ for b in yerd yerdd yerd-helper; do
   cp ../../target/release/$b src-tauri/binaries/$b-aarch64-apple-darwin
 done
 # Linux: use the -x86_64-unknown-linux-gnu suffix instead.
+# Windows: use the -x86_64-pc-windows-msvc.exe suffix.
 
 # 2) Build with the platform overlay (externalBin + macOS plist / Linux postinst).
 #    `--config` is resolved relative to this dir, so the path is src-tauri/-relative.
 npm run tauri build -- --config src-tauri/tauri.bundle-macos.conf.json   # macOS
 # npm run tauri build -- --config src-tauri/tauri.bundle-linux.conf.json # Linux
+# npm run tauri build -- --config src-tauri/tauri.bundle-windows.conf.json # Windows
 
 # 3) macOS only: package the styled .dmg (headless - no Finder/AppleScript).
 #    Set APPLE_SIGNING_IDENTITY to also codesign it; omit for an unsigned test dmg.
 ./scripts/build-macos-dmg.sh
 ```
+
+On Windows, `scripts/build-windows.ps1` performs both build steps and creates
+the NSIS installer.
 
 Without step 1 a release build fails (`externalBin` not found). CI does both
 steps automatically (`.github/workflows/release.yml`, `gui` job). The macOS floor
@@ -121,6 +126,7 @@ Login Items → Allow in the Background).
   the same `env SUDO_UID=<uid> <yerd> elevate <t>`. The macOS daemon socket lives
   at the deterministic `/tmp/yerd-$UID` so the root-elevated CLI can locate it
   from `SUDO_UID` alone.
-- **Windows** is out of scope: the daemon's pipe name isn't client-derivable yet.
+- **Windows** uses the fixed `yerd-daemon` named pipe and bundles the three
+  sidecars in an NSIS installer.
 - macOS release bundles are **Developer ID signed and notarised**, so they open
   without a Gatekeeper prompt (signing/notarisation is wired up on this branch).

--- a/apps/yerd-gui/README.md
+++ b/apps/yerd-gui/README.md
@@ -126,7 +126,7 @@ Login Items → Allow in the Background).
   the same `env SUDO_UID=<uid> <yerd> elevate <t>`. The macOS daemon socket lives
   at the deterministic `/tmp/yerd-$UID` so the root-elevated CLI can locate it
   from `SUDO_UID` alone.
-- **Windows** uses the fixed `yerd-daemon` named pipe and bundles the three
-  sidecars in an NSIS installer.
+- **Windows** derives a per-user `yerd-daemon-<scope>` named pipe from the
+  runtime directory and bundles the three sidecars in an NSIS installer.
 - macOS release bundles are **Developer ID signed and notarised**, so they open
   without a Gatekeeper prompt (signing/notarisation is wired up on this branch).

--- a/apps/yerd-gui/scripts/build-windows.ps1
+++ b/apps/yerd-gui/scripts/build-windows.ps1
@@ -1,0 +1,36 @@
+$ErrorActionPreference = "Stop"
+
+$gui = Split-Path -Parent $PSScriptRoot
+$workspace = Resolve-Path (Join-Path $gui "..\..")
+$target = "x86_64-pc-windows-msvc"
+$binaries = Join-Path $gui "src-tauri\binaries"
+$cargo = (Get-Command cargo -ErrorAction Stop).Source
+$cargoBin = Split-Path -Parent $cargo
+$managedBin = Join-Path $env:APPDATA "yerd\Yerd\data\bin"
+$npm = Get-Command npm.cmd -ErrorAction SilentlyContinue
+if ($npm) {
+    $npm = $npm.Source
+    $nodeBin = Split-Path -Parent (Get-Command node -ErrorAction Stop).Source
+} else {
+    $npm = Join-Path $managedBin "npm.cmd"
+    $nodeBin = $managedBin
+}
+$env:PATH = "$cargoBin;$nodeBin;$env:SystemRoot\System32;$env:SystemRoot"
+
+& $cargo build --release --target $target -p yerd -p yerdd -p yerd-helper
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+New-Item -ItemType Directory -Force -Path $binaries | Out-Null
+foreach ($name in @("yerd", "yerdd", "yerd-helper")) {
+    $source = Join-Path $workspace "target\$target\release\$name.exe"
+    $destination = Join-Path $binaries "$name-$target.exe"
+    Copy-Item -Force -LiteralPath $source -Destination $destination
+}
+
+Push-Location $gui
+try {
+    & $npm run tauri build -- --config src-tauri/tauri.bundle-windows.conf.json
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/apps/yerd-gui/src-tauri/src/autostart.rs
+++ b/apps/yerd-gui/src-tauri/src/autostart.rs
@@ -247,9 +247,12 @@ fn service_registered() -> bool {
     {
         unit_path().map(|p| p.exists()).unwrap_or(false)
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(windows)]
     {
-        false
+        Command::new("schtasks.exe")
+            .args(["/Query", "/TN", "Yerd Daemon"])
+            .output()
+            .is_ok_and(|output| output.status.success())
     }
 }
 
@@ -442,9 +445,9 @@ pub(crate) fn manager_available() -> bool {
     {
         true
     }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(windows)]
     {
-        false
+        true
     }
 }
 
@@ -1097,6 +1100,7 @@ pub(crate) struct StartStep {
 }
 
 /// Writing a unit/plist + service-manager start.
+#[cfg(unix)]
 const INSTALL_BUDGET: std::time::Duration = std::time::Duration::from_secs(12);
 /// The macOS SMAppService ensure/register step: unregister + register_repairing +
 /// kickstart is the slowest single action (XPC), so it gets the largest slice
@@ -1225,12 +1229,14 @@ pub(crate) fn plan_start(nudge: bool) -> Result<Vec<StartStep>, GuiError> {
             ])
         }
     }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(windows)]
     {
         let _ = nudge;
-        Err(GuiError::internal(
-            "starting the daemon is not supported on this platform",
-        ))
+        Ok(vec![StartStep {
+            phase: StartPhase::Starting,
+            budget: START_BUDGET,
+            run: Box::new(crate::daemon::spawn_detached),
+        }])
     }
 }
 
@@ -1301,12 +1307,33 @@ fn daemon_set_login(on: bool, nudge: bool) -> Result<(), GuiError> {
             )
         }
     }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(windows)]
     {
-        let _ = (on, nudge);
-        Err(GuiError::internal(
-            "daemon autostart is not supported on this platform",
-        ))
+        let _ = nudge;
+        if on {
+            let yerdd = crate::daemon::resolve_yerdd()
+                .ok_or_else(|| GuiError::internal("yerdd is not installed"))?;
+            let task_command = format!("\"{}\" serve", yerdd.display());
+            run_ok(
+                "schtasks.exe",
+                &[
+                    "/Create",
+                    "/TN",
+                    "Yerd Daemon",
+                    "/TR",
+                    &task_command,
+                    "/SC",
+                    "ONLOGON",
+                    "/RL",
+                    "LIMITED",
+                    "/F",
+                ],
+            )
+        } else if service_registered() {
+            run_ok("schtasks.exe", &["/Delete", "/TN", "Yerd Daemon", "/F"])
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/apps/yerd-gui/src-tauri/src/daemon.rs
+++ b/apps/yerd-gui/src-tauri/src/daemon.rs
@@ -48,9 +48,13 @@ fn search_dirs() -> Vec<PathBuf> {
 /// [`lib_sidecar`]; otherwise a postinst hiccup would leave `yerdd` on disk but
 /// unfindable and the daemon "won't start".
 pub(crate) fn resolve_binary(name: &str) -> Option<PathBuf> {
+    #[cfg(windows)]
+    let name = format!("{name}.exe");
+    #[cfg(not(windows))]
+    let name = name.to_owned();
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
-            let cand = dir.join(name);
+            let cand = dir.join(&name);
             if cand.is_file() {
                 return Some(cand);
             }
@@ -58,14 +62,14 @@ pub(crate) fn resolve_binary(name: &str) -> Option<PathBuf> {
     }
     if let Some(found) = search_dirs()
         .into_iter()
-        .map(|d| d.join(name))
+        .map(|d| d.join(&name))
         .find(|c| c.is_file())
     {
         return Some(found);
     }
     #[cfg(target_os = "linux")]
     {
-        lib_sidecar(name)
+        lib_sidecar(&name)
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -303,6 +307,7 @@ async fn running_pid() -> Option<u32> {
 }
 
 /// Send SIGTERM to `pid` (best-effort; an already-dead pid is fine).
+#[cfg(unix)]
 fn sigterm(pid: u32) {
     if let Ok(pid) = i32::try_from(pid) {
         // SAFETY: `kill` is a libc syscall with no memory effects; sending
@@ -311,6 +316,13 @@ fn sigterm(pid: u32) {
             libc::kill(pid, libc::SIGTERM);
         }
     }
+}
+
+#[cfg(windows)]
+fn sigterm(pid: u32) {
+    let _ = std::process::Command::new("taskkill.exe")
+        .args(["/PID", &pid.to_string(), "/T"])
+        .status();
 }
 
 /// Build the detached daemon's stdout/stderr targets: a truncate-on-start
@@ -362,6 +374,23 @@ pub(crate) fn spawn_detached() -> Result<(), GuiError> {
         }
     }
     cmd.spawn()
+        .map(|_| ())
+        .map_err(|e| GuiError::internal(format!("could not start {}: {e}", yerdd.display())))
+}
+
+/// Spawn `yerdd serve` detached on Windows.
+#[cfg(windows)]
+pub(crate) fn spawn_detached() -> Result<(), GuiError> {
+    use std::os::windows::process::CommandExt as _;
+
+    let yerdd = resolve_yerdd().ok_or_else(|| GuiError::internal("yerdd is not installed"))?;
+    std::process::Command::new(&yerdd)
+        .arg("serve")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .creation_flags(0x0000_0200 | 0x0800_0000)
+        .spawn()
         .map(|_| ())
         .map_err(|e| GuiError::internal(format!("could not start {}: {e}", yerdd.display())))
 }

--- a/apps/yerd-gui/src-tauri/src/ipc.rs
+++ b/apps/yerd-gui/src-tauri/src/ipc.rs
@@ -74,18 +74,25 @@ pub async fn exchange_at(sock: &std::path::Path, req: &Request) -> Result<Respon
 }
 
 #[cfg(windows)]
+/// Exchange one GUI request with the per-user Windows daemon pipe.
 pub async fn exchange(req: &Request) -> Result<Response, GuiError> {
     use interprocess::local_socket::tokio::Stream as IpcStream;
     use interprocess::local_socket::traits::tokio::Stream as _;
     use interprocess::local_socket::{GenericNamespaced, ToNsName};
     use yerd_ipc::{read_message, write_message, FrameDecoder, DEFAULT_MAX_FRAME};
+    use yerd_platform::{ActivePaths, Paths};
 
-    let name = "yerd-daemon"
+    let dirs = ActivePaths::new()
+        .resolve()
+        .map_err(|e| GuiError::unreachable(e.to_string()))?;
+    let pipe = yerd_platform::paths::daemon_pipe_name(&dirs);
+    let name = pipe
+        .as_str()
         .to_ns_name::<GenericNamespaced>()
-        .map_err(|e| GuiError::unreachable(format!("yerd-daemon: {e}")))?;
+        .map_err(|e| GuiError::unreachable(format!("{pipe}: {e}")))?;
     let stream = IpcStream::connect(name)
         .await
-        .map_err(|e| GuiError::unreachable(format!("yerd-daemon: {e}")))?;
+        .map_err(|e| GuiError::unreachable(format!("{pipe}: {e}")))?;
     let (reader, writer) = stream.split();
     let mut reader = reader;
     let mut writer = writer;

--- a/apps/yerd-gui/src-tauri/src/ipc.rs
+++ b/apps/yerd-gui/src-tauri/src/ipc.rs
@@ -73,12 +73,33 @@ pub async fn exchange_at(sock: &std::path::Path, req: &Request) -> Result<Respon
     }
 }
 
-/// The Windows named-pipe name is non-deterministic for clients today (a tracked
-/// Phase-2 follow-up), so the GUI is macOS/Linux-only for now - exactly as the
-/// CLI's transport is.
-#[cfg(not(unix))]
-pub async fn exchange(_req: &Request) -> Result<Response, GuiError> {
-    Err(GuiError::unreachable(
-        "the Windows IPC client is not yet supported (daemon pipe name is non-deterministic)",
-    ))
+#[cfg(windows)]
+pub async fn exchange(req: &Request) -> Result<Response, GuiError> {
+    use interprocess::local_socket::tokio::Stream as IpcStream;
+    use interprocess::local_socket::traits::tokio::Stream as _;
+    use interprocess::local_socket::{GenericNamespaced, ToNsName};
+    use yerd_ipc::{read_message, write_message, FrameDecoder, DEFAULT_MAX_FRAME};
+
+    let name = "yerd-daemon"
+        .to_ns_name::<GenericNamespaced>()
+        .map_err(|e| GuiError::unreachable(format!("yerd-daemon: {e}")))?;
+    let stream = IpcStream::connect(name)
+        .await
+        .map_err(|e| GuiError::unreachable(format!("yerd-daemon: {e}")))?;
+    let (reader, writer) = stream.split();
+    let mut reader = reader;
+    let mut writer = writer;
+    write_message(&mut writer, req, DEFAULT_MAX_FRAME)
+        .await
+        .map_err(|e| GuiError::internal(format!("write: {e}")))?;
+    let mut decoder = FrameDecoder::new();
+    match read_message::<_, Response>(&mut reader, &mut decoder)
+        .await
+        .map_err(|e| GuiError::internal(format!("read: {e}")))?
+    {
+        Some(resp) => Ok(resp),
+        None => Err(GuiError::unreachable(
+            "daemon closed the connection without responding",
+        )),
+    }
 }

--- a/apps/yerd-gui/src-tauri/tauri.bundle-windows.conf.json
+++ b/apps/yerd-gui/src-tauri/tauri.bundle-windows.conf.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": ["nsis"],
+    "externalBin": ["binaries/yerd", "binaries/yerdd", "binaries/yerd-helper"]
+  }
+}

--- a/apps/yerd-gui/src/views/ToolingView.vue
+++ b/apps/yerd-gui/src/views/ToolingView.vue
@@ -104,7 +104,6 @@ async function doInstall(t: ToolStatus): Promise<void> {
       const composerFinal = await pollJobToEnd(
         composerJob,
         (lines) => void appendLog(lines),
-        () => logOpen.value,
       );
       if (composerFinal.state !== "succeeded") {
         if (composerFinal.state !== "running") {

--- a/apps/yerd-gui/src/views/ToolingView.vue
+++ b/apps/yerd-gui/src/views/ToolingView.vue
@@ -48,11 +48,7 @@ const composerInstalled = computed(() =>
   tools.value.some((t) => t.id === "composer" && t.installed),
 );
 
-const COMPOSER_REQUIRED_HINT =
-  "Yerd's own Composer is required to build this tool - install Yerd's Composer first.";
-
-/** The Laravel installer and WP-CLI are built via Composer, so they can't install without it. */
-function blockedNoComposer(t: ToolStatus): boolean {
+function needsComposer(t: ToolStatus): boolean {
   return (t.id === "laravel" || t.id === "wp-cli") && !composerInstalled.value;
 }
 
@@ -97,11 +93,30 @@ async function load(): Promise<void> {
 
 async function doInstall(t: ToolStatus): Promise<void> {
   busy.value = `install:${t.id}`;
-  const verb = t.installed ? "Updated" : "Installed";
+  const verb = t.installed ? "Reinstalled" : "Installed";
   logTool.value = t;
   installLog.value = [];
   logOpen.value = true;
   try {
+    if (needsComposer(t)) {
+      await appendLog([`Installing Composer prerequisite for ${t.display_name}...`]);
+      const composerJob = await installToolStreamed("composer");
+      const composerFinal = await pollJobToEnd(
+        composerJob,
+        (lines) => void appendLog(lines),
+        () => logOpen.value,
+      );
+      if (composerFinal.state !== "succeeded") {
+        if (composerFinal.state !== "running") {
+          toast.error(
+            "Composer prerequisite failed",
+            composerFinal.error ?? "Composer install failed",
+          );
+        }
+        return;
+      }
+      await appendLog(["Composer installed. Continuing..."]);
+    }
     const jobId = await installToolStreamed(t.id);
     const final = await pollJobToEnd(
       jobId,
@@ -223,11 +238,10 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
                       <Button
                         variant="outline"
                         size="sm"
-                        :disabled="busy !== null || blockedNoComposer(t)"
-                        :title="blockedNoComposer(t) ? COMPOSER_REQUIRED_HINT : ''"
+                        :disabled="busy !== null"
                         @click="doInstall(t)"
                       >
-                        <RefreshCw class="mr-1.5 size-3.5" /> Update
+                        <RefreshCw class="mr-1.5 size-3.5" /> Reinstall
                       </Button>
                       <Button
                         variant="ghost"
@@ -250,8 +264,7 @@ onUnmounted(registerViewActions({ refresh: () => void load() }));
                       </span>
                       <Button
                         size="sm"
-                        :disabled="busy !== null || blockedNoComposer(t)"
-                        :title="blockedNoComposer(t) ? COMPOSER_REQUIRED_HINT : ''"
+                        :disabled="busy !== null"
                         @click="doInstall(t)"
                       >
                         <Download class="mr-1.5 size-3.5" /> Install

--- a/bin/yerd-helper/src/main.rs
+++ b/bin/yerd-helper/src/main.rs
@@ -18,19 +18,19 @@ mod validate;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
         eprintln!("yerd-helper: not supported on this OS");
         return ExitCode::from(78);
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     {
         run()
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn run() -> ExitCode {
     let parsed = match cli::parse(std::env::args_os()) {
         Ok(p) => p,
@@ -40,6 +40,7 @@ fn run() -> ExitCode {
         }
     };
 
+    #[cfg(unix)]
     let _ = std::env::set_current_dir("/");
 
     if !parsed.skip_priv_check && !privilege::is_privileged() {

--- a/bin/yerd-helper/src/ops/ca.rs
+++ b/bin/yerd-helper/src/ops/ca.rs
@@ -1,5 +1,7 @@
 //! `install-ca` and `uninstall-ca` implementations.
 
+#[cfg(windows)]
+use std::ffi::OsStr;
 use std::path::Path;
 #[cfg(target_os = "linux")]
 use std::path::PathBuf;
@@ -31,7 +33,12 @@ pub fn install_ca(pem_path: &Path, fp: &CaFingerprint) -> Result<(), HelperError
     run_command(
         "certutil",
         r"C:\Windows\System32\certutil.exe",
-        ["-addstore", "-f", "Root", &pem_path.to_string_lossy()],
+        [
+            OsStr::new("-addstore"),
+            OsStr::new("-f"),
+            OsStr::new("Root"),
+            pem_path.as_os_str(),
+        ],
     )
     .map(|_| ())
 }

--- a/bin/yerd-helper/src/ops/ca.rs
+++ b/bin/yerd-helper/src/ops/ca.rs
@@ -1,8 +1,12 @@
-//! `install-ca` and `uninstall-ca` for Linux + macOS.
+//! `install-ca` and `uninstall-ca` implementations.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
 
-use yerd_platform::pure::{cert_identity, pem_match};
+use yerd_platform::pure::cert_identity;
+#[cfg(target_os = "linux")]
+use yerd_platform::pure::pem_match;
 use yerd_platform::CaFingerprint;
 
 #[cfg(target_os = "macos")]
@@ -12,6 +16,32 @@ use crate::error::{HelperError, ValidationReason};
 use crate::ops::atomic_write;
 use crate::ops::run_command;
 use crate::validate;
+
+#[cfg(windows)]
+pub fn install_ca(pem_path: &Path, fp: &CaFingerprint) -> Result<(), HelperError> {
+    validate::require_existing_file(pem_path)?;
+    let der = validate::require_pem_matches_fingerprint(pem_path, fp)?;
+    if !cert_is_yerd_owned(&der) {
+        return Err(HelperError::Validation {
+            reason: ValidationReason::CertNotYerdOwned {
+                found_cn: cert_identity::subject_common_name(&der),
+            },
+        });
+    }
+    run_command(
+        "certutil",
+        r"C:\Windows\System32\certutil.exe",
+        ["-addstore", "-f", "Root", &pem_path.to_string_lossy()],
+    )
+    .map(|_| ())
+}
+
+#[cfg(windows)]
+pub fn uninstall_ca(_fp: &CaFingerprint) -> Result<(), HelperError> {
+    Err(HelperError::Unsupported {
+        operation: yerd_platform::error::ops::UNINSTALL_CA,
+    })
+}
 
 /// True iff `cert_der` is yerd's own CA - its Subject CN equals
 /// [`yerd_core::CA_COMMON_NAME`]. This is the ownership guard the privileged

--- a/bin/yerd-helper/src/ops/mod.rs
+++ b/bin/yerd-helper/src/ops/mod.rs
@@ -15,7 +15,10 @@ use crate::error::{CommandReason, HelperError};
 
 /// Pinned `PATH` for every subprocess invocation. Matches
 /// `/usr/sbin:/usr/bin:/sbin:/bin` on both Linux and macOS.
+#[cfg(unix)]
 const PINNED_PATH: &str = "/usr/sbin:/usr/bin:/sbin:/bin";
+#[cfg(windows)]
+const PINNED_PATH: &str = r"C:\Windows\System32;C:\Windows";
 
 /// Spawn `program` with `args`, with `env_clear()` plus the pinned
 /// `PATH`. Returns the process output on success; maps every failure
@@ -31,6 +34,13 @@ where
 {
     let mut cmd = Command::new(program);
     cmd.env_clear().env("PATH", PINNED_PATH);
+    #[cfg(windows)]
+    cmd.env("SystemRoot", r"C:\Windows")
+        .env("WINDIR", r"C:\Windows")
+        .env(
+            "PSModulePath",
+            r"C:\Windows\system32\WindowsPowerShell\v1.0\Modules",
+        );
     for a in args {
         cmd.arg(a);
     }
@@ -135,6 +145,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn run_command_propagates_nonzero_exit() {
         let err = run_command("false", "/usr/bin/false", Vec::<&str>::new()).unwrap_err();
         match err {
@@ -147,6 +158,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn run_command_succeeds_for_true() {
         let out = run_command("true", "/usr/bin/true", Vec::<&str>::new()).unwrap();
         assert!(out.status.success());

--- a/bin/yerd-helper/src/ops/resolver.rs
+++ b/bin/yerd-helper/src/ops/resolver.rs
@@ -1,6 +1,7 @@
-//! `install-resolver` and `uninstall-resolver` for Linux + macOS.
+//! `install-resolver` and `uninstall-resolver` implementations.
 
 use std::net::SocketAddr;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::path::PathBuf;
 
 #[cfg(target_os = "macos")]
@@ -14,6 +15,47 @@ use crate::ops::atomic_write;
 #[cfg(target_os = "linux")]
 use crate::ops::{atomic_write, run_command};
 use crate::validate;
+
+#[cfg(windows)]
+pub fn install_resolver(tld: &str, addr: SocketAddr) -> Result<(), HelperError> {
+    let tld = validate::require_valid_tld(tld)?;
+    if addr
+        != "127.0.0.1:53"
+            .parse()
+            .map_err(|_| HelperError::Unsupported {
+                operation: yerd_platform::error::ops::INSTALL_RESOLVER,
+            })?
+    {
+        return Err(HelperError::Unsupported {
+            operation: yerd_platform::error::ops::INSTALL_RESOLVER,
+        });
+    }
+    let command = format!(
+        "Add-DnsClientNrptRule -Namespace '.{}' -NameServers '127.0.0.1' -Comment 'Yerd managed'",
+        tld.as_str()
+    );
+    crate::ops::run_command(
+        "powershell",
+        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", &command],
+    )
+    .map(|_| ())
+}
+
+#[cfg(windows)]
+pub fn uninstall_resolver(tld: &str) -> Result<(), HelperError> {
+    let tld = validate::require_valid_tld(tld)?;
+    let command = format!(
+        "Get-DnsClientNrptRule | Where-Object {{ $_.Namespace -contains '.{}' -and $_.Comment -eq 'Yerd managed' }} | Remove-DnsClientNrptRule -Force",
+        tld.as_str()
+    );
+    crate::ops::run_command(
+        "powershell",
+        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", &command],
+    )
+    .map(|_| ())
+}
 
 #[cfg(target_os = "linux")]
 fn drop_in_path(tld: &str) -> PathBuf {
@@ -356,6 +398,7 @@ fn macos_try_restore_backup(tld: &str, dest: &std::path::Path) -> Result<bool, H
     clippy::indexing_slicing
 )]
 mod tests {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     use super::*;
 
     #[cfg(target_os = "linux")]

--- a/bin/yerd-helper/src/ops/setcap.rs
+++ b/bin/yerd-helper/src/ops/setcap.rs
@@ -21,7 +21,7 @@ pub fn setcap(binary: &Path) -> Result<(), HelperError> {
     .map(|_| ())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(not(target_os = "linux"))]
 pub fn setcap(_binary: &Path) -> Result<(), HelperError> {
     Err(HelperError::Unsupported {
         operation: yerd_platform::error::ops::SETCAP,

--- a/bin/yerd-helper/src/privilege.rs
+++ b/bin/yerd-helper/src/privilege.rs
@@ -12,10 +12,22 @@
 #[cfg(target_os = "linux")]
 use std::fs;
 
-/// True iff the helper's effective UID is 0.
+/// True iff the helper has OS administrator privileges.
 #[must_use]
+#[cfg(unix)]
 pub fn is_privileged() -> bool {
     effective_uid() == Some(0)
+}
+
+/// True iff the helper has OS administrator privileges.
+#[must_use]
+#[cfg(windows)]
+pub fn is_privileged() -> bool {
+    std::process::Command::new("net.exe")
+        .arg("session")
+        .env_clear()
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 #[cfg(target_os = "linux")]
@@ -47,7 +59,7 @@ fn effective_uid() -> Option<u32> {
     s.trim().parse().ok()
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 fn effective_uid() -> Option<u32> {
     None
 }

--- a/bin/yerd-helper/src/privilege.rs
+++ b/bin/yerd-helper/src/privilege.rs
@@ -23,7 +23,7 @@ pub fn is_privileged() -> bool {
 #[must_use]
 #[cfg(windows)]
 pub fn is_privileged() -> bool {
-    std::process::Command::new("net.exe")
+    std::process::Command::new(r"C:\Windows\System32\net.exe")
         .arg("session")
         .env_clear()
         .status()

--- a/bin/yerd-helper/src/validate.rs
+++ b/bin/yerd-helper/src/validate.rs
@@ -126,7 +126,8 @@ mod tests {
 
     #[test]
     fn require_existing_file_rejects_missing() {
-        let err = require_existing_file(Path::new("/tmp/yerd-no-such-file-xyz")).unwrap_err();
+        let missing = std::env::temp_dir().join("yerd-no-such-file-xyz");
+        let err = require_existing_file(&missing).unwrap_err();
         assert!(matches!(
             err,
             HelperError::Validation {
@@ -137,7 +138,7 @@ mod tests {
 
     #[test]
     fn require_existing_file_rejects_directory() {
-        let err = require_existing_file(Path::new("/tmp")).unwrap_err();
+        let err = require_existing_file(&std::env::temp_dir()).unwrap_err();
         assert!(matches!(
             err,
             HelperError::Validation {

--- a/bin/yerd-helper/src/validate.rs
+++ b/bin/yerd-helper/src/validate.rs
@@ -126,7 +126,8 @@ mod tests {
 
     #[test]
     fn require_existing_file_rejects_missing() {
-        let missing = std::env::temp_dir().join("yerd-no-such-file-xyz");
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing");
         let err = require_existing_file(&missing).unwrap_err();
         assert!(matches!(
             err,
@@ -247,11 +248,10 @@ mod tests {
 
     #[test]
     fn require_pem_matches_fingerprint_io_error_on_missing() {
-        let err = require_pem_matches_fingerprint(
-            Path::new("/tmp/yerd-no-such-pem-xyz"),
-            &CaFingerprint::new([0u8; 32]),
-        )
-        .unwrap_err();
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.pem");
+        let err =
+            require_pem_matches_fingerprint(&missing, &CaFingerprint::new([0u8; 32])).unwrap_err();
         assert!(matches!(err, HelperError::Io { .. }));
     }
 }

--- a/bin/yerd/src/apply.rs
+++ b/bin/yerd/src/apply.rs
@@ -48,7 +48,9 @@
 //! (move the swap into a small unsafe-permitting module or `yerd-helper`).
 
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitCode};
+#[cfg(unix)]
+use std::process::Command;
+use std::process::ExitCode;
 
 use yerd_ipc::StagedArtifact;
 use yerd_update::{verify_minisign, UPDATE_PUBLIC_KEY};
@@ -287,6 +289,7 @@ fn sibling_minisig(staged: &Path) -> PathBuf {
 
 /// The `yerdd` binary beside the running `yerd` (same bundle / install dir),
 /// used by the restart step.
+#[cfg(unix)]
 fn sibling_yerdd() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let dir = exe.parent()?;
@@ -295,6 +298,7 @@ fn sibling_yerdd() -> Option<PathBuf> {
 }
 
 /// Restart the daemon and (optionally) relaunch the GUI after an install.
+#[cfg(unix)]
 fn restart_services(relaunch_gui: bool) {
     restart_daemon();
     if relaunch_gui {
@@ -304,6 +308,7 @@ fn restart_services(relaunch_gui: bool) {
 
 /// Restart the daemon so it picks up the freshly-swapped binary. Best-effort: a
 /// failure is logged, and launchd's `KeepAlive`/`RunAtLoad` may still bring it up.
+#[cfg(unix)]
 fn restart_daemon() {
     if let Some(yerdd) = sibling_yerdd() {
         let ctl = yerd_service_ctl::ServiceCtl::new(yerdd);
@@ -972,6 +977,7 @@ mod tests {
     /// which may be coarse), and the value carries this process's pid so
     /// concurrent stagers can't collide.
     #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn unique_suffix_is_per_call_distinct() {
         let a = unique_suffix();
         let b = unique_suffix();

--- a/bin/yerd/src/cli.rs
+++ b/bin/yerd/src/cli.rs
@@ -163,6 +163,18 @@ pub enum Command {
     },
     /// Show a snapshot of daemon, proxy, DNS, ports, CA, and PHP health.
     Status,
+    /// Set rootless HTTP and HTTPS fallback ports. Takes effect after restart.
+    Ports {
+        /// Rootless HTTP port.
+        http: u16,
+        /// Rootless HTTPS port.
+        https: u16,
+    },
+    /// Set the embedded DNS responder port. Takes effect after restart.
+    DnsPort {
+        /// DNS port.
+        port: u16,
+    },
     /// Diagnose common problems; `yerd doctor fix` attempts safe repairs.
     Doctor {
         /// Optional action; omit to only report, `fix` to attempt repairs.

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -33,23 +33,24 @@ mod windows_impl {
 
     /// Apply or remove Windows privilege integrations through UAC.
     pub async fn run_elevate(target: Option<ElevateTarget>, undo: bool) -> ExitCode {
-        let info = match crate::transport::exchange(&Request::DaemonInfo).await {
-            Ok(Response::Info {
-                dns_addr,
-                tld,
-                ca_path,
-                ca_fingerprint,
-                ..
-            }) => (dns_addr, tld, ca_path, ca_fingerprint),
-            Ok(other) => {
-                eprintln!("yerd: unexpected daemon response: {other:?}");
-                return ExitCode::from(69);
-            }
-            Err(error) => {
-                eprintln!("yerd: {error}");
-                return ExitCode::from(69);
-            }
-        };
+        let (dns_addr, tld, ca_path, ca_fingerprint) =
+            match crate::transport::exchange(&Request::DaemonInfo).await {
+                Ok(Response::Info {
+                    dns_addr,
+                    tld,
+                    ca_path,
+                    ca_fingerprint,
+                    ..
+                }) => (dns_addr, tld, ca_path, ca_fingerprint),
+                Ok(other) => {
+                    eprintln!("yerd: unexpected daemon response: {other:?}");
+                    return ExitCode::from(69);
+                }
+                Err(error) => {
+                    eprintln!("yerd: {error}");
+                    return ExitCode::from(69);
+                }
+            };
         let Some(helper) = std::env::current_exe()
             .ok()
             .and_then(|path| path.parent().map(|parent| parent.join("yerd-helper.exe")))
@@ -65,7 +66,7 @@ mod windows_impl {
         for target in targets {
             let invocation = match (target, undo) {
                 (ElevateTarget::Trust, false) => {
-                    let fp = match CaFingerprint::from_hex(&info.3) {
+                    let fp = match CaFingerprint::from_hex(&ca_fingerprint) {
                         Ok(fp) => fp,
                         Err(error) => {
                             eprintln!("yerd: invalid daemon CA fingerprint: {error}");
@@ -73,17 +74,17 @@ mod windows_impl {
                         }
                     };
                     HelperInvocation::InstallCa {
-                        ca_pem_path: info.2.clone(),
+                        ca_pem_path: ca_path.clone(),
                         fp,
                     }
                 }
                 (ElevateTarget::Resolver, false) => HelperInvocation::InstallResolver {
-                    tld: info.1.clone(),
-                    addr: info.0,
+                    tld: tld.clone(),
+                    addr: dns_addr,
                 },
-                (ElevateTarget::Resolver, true) => HelperInvocation::UninstallResolver {
-                    tld: info.1.clone(),
-                },
+                (ElevateTarget::Resolver, true) => {
+                    HelperInvocation::UninstallResolver { tld: tld.clone() }
+                }
                 (ElevateTarget::Trust, true) => {
                     eprintln!("yerd: Windows CA removal is not available yet");
                     return ExitCode::from(78);
@@ -92,7 +93,10 @@ mod windows_impl {
             };
             match spawn_elevated(&helper, &invocation) {
                 Ok(true) => {}
-                Ok(false) => return ExitCode::from(75),
+                Ok(false) => {
+                    eprintln!("yerd: elevated helper failed or UAC elevation was cancelled");
+                    return ExitCode::from(75);
+                }
                 Err(error) => {
                     eprintln!("yerd: could not launch elevated helper: {error}");
                     return ExitCode::from(74);
@@ -103,15 +107,30 @@ mod windows_impl {
     }
 
     fn spawn_elevated(helper: &Path, invocation: &HelperInvocation) -> std::io::Result<bool> {
-        let arguments = invocation
-            .to_argv()
-            .iter()
-            .map(|arg| ps_quote(&arg.to_string_lossy()))
-            .collect::<Vec<_>>()
-            .join(",");
+        let arguments = invocation.to_argv().iter().try_fold(
+            Vec::new(),
+            |mut args, arg| -> std::io::Result<Vec<String>> {
+                let arg = arg.to_str().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "helper arguments must be valid Unicode",
+                    )
+                })?;
+                args.push(windows_quote_arg(arg));
+                Ok(args)
+            },
+        )?;
+        let helper = helper.to_str().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "helper path must be valid Unicode",
+            )
+        })?;
+        let arguments = arguments.join(" ");
         let script = format!(
-            "$p=Start-Process -FilePath {} -Verb RunAs -ArgumentList @({arguments}) -Wait -PassThru; exit $p.ExitCode",
-            ps_quote(&helper.to_string_lossy())
+            "try {{ $p=Start-Process -FilePath {} -Verb RunAs -ArgumentList {} -Wait -PassThru -ErrorAction Stop; if ($null -eq $p) {{ exit 1 }}; exit $p.ExitCode }} catch {{ [Console]::Error.WriteLine($_.Exception.Message); exit 1 }}",
+            ps_quote(helper),
+            ps_quote(&arguments)
         );
         Command::new(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")
             .args(["-NoProfile", "-NonInteractive", "-Command", &script])
@@ -121,6 +140,50 @@ mod windows_impl {
 
     fn ps_quote(value: &str) -> String {
         format!("'{}'", value.replace('\'', "''"))
+    }
+
+    fn windows_quote_arg(value: &str) -> String {
+        if !value.is_empty()
+            && !value
+                .bytes()
+                .any(|byte| byte.is_ascii_whitespace() || byte == b'"')
+        {
+            return value.to_owned();
+        }
+        let mut quoted = String::from("\"");
+        let mut backslashes = 0;
+        for ch in value.chars() {
+            if ch == '\\' {
+                backslashes += 1;
+            } else if ch == '"' {
+                quoted.push_str(&"\\".repeat(backslashes * 2 + 1));
+                quoted.push('"');
+                backslashes = 0;
+            } else {
+                quoted.push_str(&"\\".repeat(backslashes));
+                backslashes = 0;
+                quoted.push(ch);
+            }
+        }
+        quoted.push_str(&"\\".repeat(backslashes * 2));
+        quoted.push('"');
+        quoted
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn quotes_windows_arguments() {
+            assert_eq!(windows_quote_arg("install-ca"), "install-ca");
+            assert_eq!(windows_quote_arg(""), "\"\"");
+            assert_eq!(
+                windows_quote_arg(r"C:\Users\Jane Doe\ca.pem"),
+                r#""C:\Users\Jane Doe\ca.pem""#
+            );
+            assert_eq!(windows_quote_arg("a\"b"), r#""a\"b""#);
+        }
     }
 }
 

--- a/bin/yerd/src/elevate.rs
+++ b/bin/yerd/src/elevate.rs
@@ -8,14 +8,8 @@
 //! `current_exe` sibling - never from the daemon - and (b) owner-checks the CA
 //! path before trusting it. The daemon itself is never restarted as root.
 
-#[cfg(not(unix))]
-pub async fn run_elevate(
-    _target: Option<crate::cli::ElevateTarget>,
-    _undo: bool,
-) -> std::process::ExitCode {
-    eprintln!("yerd: elevate is only supported on Unix (macOS/Linux)");
-    std::process::ExitCode::from(78)
-}
+#[cfg(windows)]
+pub use windows_impl::run_elevate;
 
 #[cfg(unix)]
 pub use unix_impl::run_elevate;
@@ -26,6 +20,109 @@ pub use unix_impl::run_elevate;
 // without a running daemon.
 #[cfg(unix)]
 pub(crate) use unix_impl::{is_root, sibling_binaries, spawn_helper, sudo_uid};
+
+#[cfg(windows)]
+mod windows_impl {
+    use std::path::Path;
+    use std::process::{Command, ExitCode};
+
+    use yerd_ipc::{Request, Response};
+    use yerd_platform::{CaFingerprint, HelperInvocation};
+
+    use crate::cli::ElevateTarget;
+
+    /// Apply or remove Windows privilege integrations through UAC.
+    pub async fn run_elevate(target: Option<ElevateTarget>, undo: bool) -> ExitCode {
+        let info = match crate::transport::exchange(&Request::DaemonInfo).await {
+            Ok(Response::Info {
+                dns_addr,
+                tld,
+                ca_path,
+                ca_fingerprint,
+                ..
+            }) => (dns_addr, tld, ca_path, ca_fingerprint),
+            Ok(other) => {
+                eprintln!("yerd: unexpected daemon response: {other:?}");
+                return ExitCode::from(69);
+            }
+            Err(error) => {
+                eprintln!("yerd: {error}");
+                return ExitCode::from(69);
+            }
+        };
+        let Some(helper) = std::env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(|parent| parent.join("yerd-helper.exe")))
+            .filter(|path| path.is_file())
+        else {
+            eprintln!("yerd: yerd-helper.exe must be beside yerd.exe");
+            return ExitCode::from(74);
+        };
+        let targets = target.map_or_else(
+            || vec![ElevateTarget::Trust, ElevateTarget::Resolver],
+            |target| vec![target],
+        );
+        for target in targets {
+            let invocation = match (target, undo) {
+                (ElevateTarget::Trust, false) => {
+                    let fp = match CaFingerprint::from_hex(&info.3) {
+                        Ok(fp) => fp,
+                        Err(error) => {
+                            eprintln!("yerd: invalid daemon CA fingerprint: {error}");
+                            return ExitCode::from(65);
+                        }
+                    };
+                    HelperInvocation::InstallCa {
+                        ca_pem_path: info.2.clone(),
+                        fp,
+                    }
+                }
+                (ElevateTarget::Resolver, false) => HelperInvocation::InstallResolver {
+                    tld: info.1.clone(),
+                    addr: info.0,
+                },
+                (ElevateTarget::Resolver, true) => HelperInvocation::UninstallResolver {
+                    tld: info.1.clone(),
+                },
+                (ElevateTarget::Trust, true) => {
+                    eprintln!("yerd: Windows CA removal is not available yet");
+                    return ExitCode::from(78);
+                }
+                (ElevateTarget::Ports | ElevateTarget::Lan, _) => continue,
+            };
+            match spawn_elevated(&helper, &invocation) {
+                Ok(true) => {}
+                Ok(false) => return ExitCode::from(75),
+                Err(error) => {
+                    eprintln!("yerd: could not launch elevated helper: {error}");
+                    return ExitCode::from(74);
+                }
+            }
+        }
+        ExitCode::SUCCESS
+    }
+
+    fn spawn_elevated(helper: &Path, invocation: &HelperInvocation) -> std::io::Result<bool> {
+        let arguments = invocation
+            .to_argv()
+            .iter()
+            .map(|arg| ps_quote(&arg.to_string_lossy()))
+            .collect::<Vec<_>>()
+            .join(",");
+        let script = format!(
+            "$p=Start-Process -FilePath {} -Verb RunAs -ArgumentList @({arguments}) -Wait -PassThru; exit $p.ExitCode",
+            ps_quote(&helper.to_string_lossy())
+        );
+        Command::new(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .status()
+            .map(|status| status.success())
+    }
+
+    fn ps_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "''"))
+    }
+}
 
 #[cfg(unix)]
 mod unix_impl {

--- a/bin/yerd/src/lib.rs
+++ b/bin/yerd/src/lib.rs
@@ -1185,6 +1185,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn canonicalize_db_paths_backup_absolute_is_unchanged() {
         let abs = PathBuf::from("/var/tmp/app.sql");
         let req = Request::BackupDatabase {
@@ -1208,6 +1209,7 @@ mod tests {
     // ─── absolutise ─────────────────────────────────────────────────
 
     #[test]
+    #[cfg(unix)]
     fn absolutise_returns_absolute_path_unchanged() {
         let abs = Path::new("/etc/hosts");
         assert_eq!(absolutise(abs).unwrap(), abs.to_path_buf());

--- a/bin/yerd/src/map.rs
+++ b/bin/yerd/src/map.rs
@@ -201,6 +201,11 @@ pub fn to_request(cmd: &Command) -> Result<Request, ClientError> {
         | Command::Lan {
             action: crate::cli::LanAction::Status,
         } => Request::Status,
+        Command::Ports { http, https } => Request::SetFallbackPorts {
+            http: *http,
+            https: *https,
+        },
+        Command::DnsPort { port } => Request::SetDnsPort { port: *port },
         Command::Doctor { action: None } => Request::Diagnose,
         Command::Doctor {
             action: Some(crate::cli::DoctorAction::Fix),

--- a/bin/yerd/src/path_cmd.rs
+++ b/bin/yerd/src/path_cmd.rs
@@ -21,10 +21,10 @@ pub fn run(action: PathAction) -> ExitCode {
 #[cfg(not(unix))]
 pub fn run(_action: PathAction) -> ExitCode {
     use yerd_platform::{ActivePaths, Paths};
-    let hint = ActivePaths::new()
-        .resolve()
-        .map(|d| d.data.join("bin").display().to_string())
-        .unwrap_or_else(|_| "yerd's bin directory".to_owned());
+    let hint = ActivePaths::new().resolve().map_or_else(
+        |_| "yerd's bin directory".to_owned(),
+        |d| d.data.join("bin").display().to_string(),
+    );
     eprintln!(
         "yerd: `yerd path` is not yet supported on this platform — add {hint} to PATH manually"
     );

--- a/bin/yerd/src/shim.rs
+++ b/bin/yerd/src/shim.rs
@@ -18,11 +18,11 @@ fn minor_is_legacy(minor: &str) -> bool {
 /// `{data}/php/php-<minor>/bin/php`.
 #[must_use]
 pub(crate) fn cli_binary(dirs: &PlatformDirs, minor: &str) -> PathBuf {
-    dirs.data
-        .join("php")
-        .join(format!("php-{minor}"))
-        .join("bin")
-        .join("php")
+    let root = dirs.data.join("php").join(format!("php-{minor}"));
+    #[cfg(unix)]
+    return root.join("bin").join("php");
+    #[cfg(windows)]
+    root.join("php.exe")
 }
 
 /// The default PHP `(binary, "major.minor")` via the `php` shim's target, if the

--- a/bin/yerd/src/transport.rs
+++ b/bin/yerd/src/transport.rs
@@ -54,13 +54,17 @@ pub async fn exchange(req: &Request) -> Result<Response, ClientError> {
     use interprocess::local_socket::traits::tokio::Stream as _;
     use interprocess::local_socket::{GenericNamespaced, ToNsName};
     use yerd_ipc::{read_message, write_message, FrameDecoder, DEFAULT_MAX_FRAME};
+    use yerd_platform::{ActivePaths, Paths};
 
-    let name = "yerd-daemon"
+    let dirs = ActivePaths::new().resolve()?;
+    let pipe = yerd_platform::paths::daemon_pipe_name(&dirs);
+    let name = pipe
+        .as_str()
         .to_ns_name::<GenericNamespaced>()
-        .map_err(|e| ClientError::DaemonUnreachable(format!("yerd-daemon: {e}")))?;
+        .map_err(|e| ClientError::DaemonUnreachable(format!("{pipe}: {e}")))?;
     let stream = IpcStream::connect(name)
         .await
-        .map_err(|e| ClientError::DaemonUnreachable(format!("yerd-daemon: {e}")))?;
+        .map_err(|e| ClientError::DaemonUnreachable(format!("{pipe}: {e}")))?;
     let (reader, writer) = stream.split();
     let mut reader = reader;
     let mut writer = writer;

--- a/bin/yerd/src/transport.rs
+++ b/bin/yerd/src/transport.rs
@@ -10,9 +10,6 @@ use yerd_ipc::{Request, Response};
 
 /// Resolve the daemon socket path and exchange one request/response.
 ///
-/// On non-Unix targets this returns [`ClientError::DaemonUnreachable`]: the
-/// daemon's Windows pipe name is currently PID-based and not derivable by a
-/// client (tracked as a Phase-2 follow-up).
 #[cfg(unix)]
 pub async fn exchange(req: &Request) -> Result<Response, ClientError> {
     use yerd_platform::{ActivePaths, Paths};
@@ -50,10 +47,29 @@ pub async fn exchange_at(sock: &std::path::Path, req: &Request) -> Result<Respon
     }
 }
 
-#[cfg(not(unix))]
-pub async fn exchange(_req: &Request) -> Result<Response, ClientError> {
-    Err(ClientError::DaemonUnreachable(
-        "the Windows IPC client is not yet supported (daemon pipe name is non-deterministic)"
-            .to_owned(),
-    ))
+#[cfg(windows)]
+/// Exchange one request over the Windows named pipe.
+pub async fn exchange(req: &Request) -> Result<Response, ClientError> {
+    use interprocess::local_socket::tokio::Stream as IpcStream;
+    use interprocess::local_socket::traits::tokio::Stream as _;
+    use interprocess::local_socket::{GenericNamespaced, ToNsName};
+    use yerd_ipc::{read_message, write_message, FrameDecoder, DEFAULT_MAX_FRAME};
+
+    let name = "yerd-daemon"
+        .to_ns_name::<GenericNamespaced>()
+        .map_err(|e| ClientError::DaemonUnreachable(format!("yerd-daemon: {e}")))?;
+    let stream = IpcStream::connect(name)
+        .await
+        .map_err(|e| ClientError::DaemonUnreachable(format!("yerd-daemon: {e}")))?;
+    let (reader, writer) = stream.split();
+    let mut reader = reader;
+    let mut writer = writer;
+    write_message(&mut writer, req, DEFAULT_MAX_FRAME).await?;
+    let mut decoder = FrameDecoder::new();
+    match read_message::<_, Response>(&mut reader, &mut decoder).await? {
+        Some(resp) => Ok(resp),
+        None => Err(ClientError::ConnectionClosed(
+            "daemon closed the connection without responding".to_owned(),
+        )),
+    }
 }

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -242,7 +242,7 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
                 &build_status_report(state).await,
                 path_needs_setup(state),
                 &crate::services::local_override_files(&state.dirs),
-                foreign_web_listener_detail().as_deref(),
+                foreign_web_listener_detail().await.as_deref(),
             ),
         },
         Request::DoctorFix => run_doctor_fix(state).await,
@@ -1000,7 +1000,7 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
         &after,
         path_needs_setup(state),
         &crate::services::local_override_files(&state.dirs),
-        foreign_web_listener_detail().as_deref(),
+        foreign_web_listener_detail().await.as_deref(),
     )
     .into_iter()
     .filter(|d| {
@@ -1017,18 +1017,21 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
 }
 
 #[cfg(windows)]
-fn foreign_web_listener_detail() -> Option<String> {
-    probe_windows_web_listeners()
+async fn foreign_web_listener_detail() -> Option<String> {
+    tokio::task::spawn_blocking(probe_windows_web_listeners)
+        .await
+        .ok()
+        .flatten()
 }
 
 #[cfg(not(windows))]
-const fn foreign_web_listener_detail() -> Option<String> {
+const async fn foreign_web_listener_detail() -> Option<String> {
     None
 }
 
 #[cfg(windows)]
 fn probe_windows_web_listeners() -> Option<String> {
-    let output = std::process::Command::new("netstat.exe")
+    let output = std::process::Command::new(r"C:\Windows\System32\netstat.exe")
         .args(["-ano", "-p", "tcp"])
         .output()
         .ok()?;
@@ -1046,7 +1049,11 @@ fn probe_windows_web_listeners() -> Option<String> {
         let Some(port) = local.rsplit(':').next().and_then(|p| p.parse::<u16>().ok()) else {
             continue;
         };
-        if !matches!(port, 80 | 443) || fields.get(3) != Some(&"LISTENING") {
+        let foreign_port = fields
+            .get(2)
+            .and_then(|foreign| foreign.rsplit(':').next())
+            .and_then(|port| port.parse::<u16>().ok());
+        if !matches!(port, 80 | 443) || foreign_port != Some(0) {
             continue;
         }
         let Some(pid) = fields.last().and_then(|p| p.parse::<u32>().ok()) else {
@@ -1064,7 +1071,7 @@ fn probe_windows_web_listeners() -> Option<String> {
 #[cfg(windows)]
 fn windows_process_name(pid: u32) -> Option<String> {
     let filter = format!("PID eq {pid}");
-    let output = std::process::Command::new("tasklist.exe")
+    let output = std::process::Command::new(r"C:\Windows\System32\tasklist.exe")
         .args(["/FI", &filter, "/FO", "CSV", "/NH"])
         .output()
         .ok()?;

--- a/bin/yerdd/src/ipc_server.rs
+++ b/bin/yerdd/src/ipc_server.rs
@@ -238,10 +238,11 @@ async fn dispatch(req: Request, state: &DaemonState) -> Response {
             report: Box::new(build_status_report(state).await),
         },
         Request::Diagnose => Response::Diagnoses {
-            items: yerd_doctor::diagnose(
+            items: yerd_doctor::diagnose_with_port_owner(
                 &build_status_report(state).await,
                 path_needs_setup(state),
                 &crate::services::local_override_files(&state.dirs),
+                foreign_web_listener_detail().as_deref(),
             ),
         },
         Request::DoctorFix => run_doctor_fix(state).await,
@@ -524,32 +525,55 @@ async fn available_php_with(
     dl: &dyn yerd_php::Downloader,
     public_key: &str,
 ) -> Response {
-    let (os, arch) = match yerd_php::current_os_arch() {
-        Ok(p) => p,
-        Err(e) => {
-            return Response::Error {
-                code: php_error_code(&e),
-                message: e.to_string(),
+    #[cfg(windows)]
+    #[allow(clippy::needless_return)]
+    {
+        let _ = public_key;
+        let listing = match dl.download(crate::php_install::WINDOWS_RELEASES_URL).await {
+            Ok(body) => body,
+            Err(e) => return internal(format!("couldn't load the PHP listing: {e}")),
+        };
+        return match crate::php_install::available_windows_minors(&listing) {
+            Ok(available) => Response::AvailablePhp {
+                available,
+                installed: installed_versions(state),
+                legacy: Vec::new(),
+            },
+            Err(e) => internal(format!("couldn't load the PHP listing: {e}")),
+        };
+    }
+    #[cfg(not(windows))]
+    {
+        let (os, arch) = match yerd_php::current_os_arch() {
+            Ok(p) => p,
+            Err(e) => {
+                return Response::Error {
+                    code: php_error_code(&e),
+                    message: e.to_string(),
+                }
             }
-        }
-    };
-    let listing =
-        match crate::php_install::fetch_verified_listing(dl, public_key, yerd_php::Channel::Stable)
-            .await
+        };
+        let listing = match crate::php_install::fetch_verified_listing(
+            dl,
+            public_key,
+            yerd_php::Channel::Stable,
+        )
+        .await
         {
             Ok(body) => body,
             Err(e) => return internal(format!("couldn't load the PHP listing: {e}")),
         };
-    let legacy =
-        crate::php_install::fetch_verified_listing(dl, public_key, yerd_php::Channel::Legacy)
-            .await
-            .ok()
-            .map(|body| yerd_php::available_minors(&body, os, arch, yerd_php::Channel::Legacy))
-            .unwrap_or_default();
-    Response::AvailablePhp {
-        available: yerd_php::available_minors(&listing, os, arch, yerd_php::Channel::Stable),
-        installed: installed_versions(state),
-        legacy,
+        let legacy =
+            crate::php_install::fetch_verified_listing(dl, public_key, yerd_php::Channel::Legacy)
+                .await
+                .ok()
+                .map(|body| yerd_php::available_minors(&body, os, arch, yerd_php::Channel::Legacy))
+                .unwrap_or_default();
+        Response::AvailablePhp {
+            available: yerd_php::available_minors(&listing, os, arch, yerd_php::Channel::Stable),
+            installed: installed_versions(state),
+            legacy,
+        }
     }
 }
 
@@ -972,10 +996,11 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
     }
 
     let after = build_status_report(state).await;
-    let manual = yerd_doctor::diagnose(
+    let manual = yerd_doctor::diagnose_with_port_owner(
         &after,
         path_needs_setup(state),
         &crate::services::local_override_files(&state.dirs),
+        foreign_web_listener_detail().as_deref(),
     )
     .into_iter()
     .filter(|d| {
@@ -989,6 +1014,68 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
     Response::DoctorFix {
         report: yerd_ipc::FixReport { performed, manual },
     }
+}
+
+#[cfg(windows)]
+fn foreign_web_listener_detail() -> Option<String> {
+    probe_windows_web_listeners()
+}
+
+#[cfg(not(windows))]
+const fn foreign_web_listener_detail() -> Option<String> {
+    None
+}
+
+#[cfg(windows)]
+fn probe_windows_web_listeners() -> Option<String> {
+    let output = std::process::Command::new("netstat.exe")
+        .args(["-ano", "-p", "tcp"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut listeners = Vec::new();
+    for line in text.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() < 5 || fields.first() != Some(&"TCP") {
+            continue;
+        }
+        let Some(local) = fields.get(1) else { continue };
+        let Some(port) = local.rsplit(':').next().and_then(|p| p.parse::<u16>().ok()) else {
+            continue;
+        };
+        if !matches!(port, 80 | 443) || fields.get(3) != Some(&"LISTENING") {
+            continue;
+        }
+        let Some(pid) = fields.last().and_then(|p| p.parse::<u32>().ok()) else {
+            continue;
+        };
+        let name = windows_process_name(pid).unwrap_or_else(|| "unknown process".to_owned());
+        let entry = format!("port {port}: {name} (PID {pid})");
+        if !listeners.contains(&entry) {
+            listeners.push(entry);
+        }
+    }
+    (!listeners.is_empty()).then(|| listeners.join(", "))
+}
+
+#[cfg(windows)]
+fn windows_process_name(pid: u32) -> Option<String> {
+    let filter = format!("PID eq {pid}");
+    let output = std::process::Command::new("tasklist.exe")
+        .args(["/FI", &filter, "/FO", "CSV", "/NH"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout);
+    line.trim()
+        .strip_prefix('"')?
+        .split_once('"')
+        .map(|(name, _)| name.to_owned())
 }
 
 /// `update php [<ver>]` - upgrade the given minor (or all installed) to the
@@ -1008,15 +1095,6 @@ async fn run_doctor_fix(state: &DaemonState) -> Response {
 #[allow(clippy::too_many_lines)]
 async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState) -> Response {
     let dl = crate::php_install::ReqwestDownloader::new();
-    let (os, arch) = match yerd_php::current_os_arch() {
-        Ok(p) => p,
-        Err(e) => {
-            return Response::Error {
-                code: php_error_code(&e),
-                message: e.to_string(),
-            }
-        }
-    };
     let targets: Vec<yerd_core::PhpVersion> = match version {
         Some(v) => {
             if crate::php_install::installed_patch(&state.dirs, v).is_none() {
@@ -1028,6 +1106,15 @@ async fn update_php(version: Option<yerd_core::PhpVersion>, state: &DaemonState)
             vec![v]
         }
         None => crate::php_updates::installed_minors(state),
+    };
+    let (os, arch) = match yerd_php::current_os_arch() {
+        Ok(p) => p,
+        Err(e) => {
+            return Response::Error {
+                code: php_error_code(&e),
+                message: e.to_string(),
+            }
+        }
     };
     let key = yerd_update::PHP_LISTING_PUBLIC_KEY;
     let has_stable = targets.iter().any(|v| !v.is_legacy());
@@ -1608,8 +1695,12 @@ pub(crate) async fn install_tool_streamed(tool: String, state: Arc<DaemonState>)
             .await;
         let dl = crate::php_install::ReqwestDownloader::new();
         let guard = state.tool_mutate.lock().await;
+        let install = tokio::time::timeout(
+            std::time::Duration::from_secs(15 * 60),
+            crate::tools::install(t, &state.dirs, &dl, Some(&tx)),
+        );
         let result = tokio::select! {
-            r = crate::tools::install(t, &state.dirs, &dl, Some(&tx)) => Some(r),
+            r = install => Some(r),
             _ = cancel.changed() => None,
         };
         drop(guard);
@@ -1617,17 +1708,27 @@ pub(crate) async fn install_tool_streamed(tool: String, state: Arc<DaemonState>)
         let _ = drain.await;
 
         match result {
-            Some(Ok(())) => {
+            Some(Ok(Ok(()))) => {
                 reconcile_tool_shims_now(&state).await;
                 state
                     .jobs
                     .finish(&id, yerd_ipc::JobState::Succeeded, None)
                     .await;
             }
-            Some(Err(e)) => {
+            Some(Ok(Err(e))) => {
                 state
                     .jobs
                     .finish(&id, yerd_ipc::JobState::Failed, Some(e.to_string()))
+                    .await;
+            }
+            Some(Err(_)) => {
+                state
+                    .jobs
+                    .finish(
+                        &id,
+                        yerd_ipc::JobState::Failed,
+                        Some(format!("installing {} timed out", t.display_name())),
+                    )
                     .await;
             }
             None => {
@@ -2837,6 +2938,7 @@ fn detect_web_subpath(doc_root: &Path) -> String {
 /// **linked** site stores the chosen subpath on its `Site`; a **parked** site
 /// stores it in `overrides[doc_root].web_root`. `path = None` resets to
 /// auto-detect: re-detect now for linked, clear the override for parked.
+#[allow(clippy::result_large_err)]
 fn resolve_web_root_mutation(
     new: &mut yerd_config::Config,
     router: &yerd_core::SiteRouter,
@@ -2900,6 +3002,7 @@ fn web_root_summary(name: &str, rel: &str) -> String {
 /// before comparison so a `\\?\` verbatim prefix from `fs::canonicalize` on
 /// Windows doesn't spuriously fail the containment check against the
 /// non-verbatim stored `document_root`.
+#[allow(clippy::result_large_err)]
 fn resolve_web_root_within(doc_root: &Path, input: &str) -> Result<String, Response> {
     let candidate = {
         let p = Path::new(input);
@@ -2930,6 +3033,7 @@ fn resolve_web_root_within(doc_root: &Path, input: &str) -> Result<String, Respo
 
 /// Canonicalise `path` and require it to be an existing directory, or return a
 /// ready-made `InvalidPath` error response.
+#[allow(clippy::result_large_err)]
 fn canonicalize_dir(path: &Path) -> Result<PathBuf, Response> {
     match std::fs::canonicalize(path) {
         Ok(p) if p.is_dir() => Ok(p),
@@ -3913,7 +4017,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
     }
 
-    /// Lay down a fake installed version: `data/php/php-<v>/{sbin/php-fpm,bin/php}`.
+    /// Lay down a fake installed version using the host platform's binary layout.
     fn fake_install(dirs: &PlatformDirs, v: PhpVersion) {
         fake_install_patch(dirs, v, &format!("{}.{}.0", v.major, v.minor));
     }
@@ -3924,10 +4028,19 @@ Subject: Captured\r\n\r\nhi\r\n";
             .data
             .join("php")
             .join(format!("php-{}.{}", v.major, v.minor));
-        std::fs::create_dir_all(base.join("sbin")).unwrap();
-        std::fs::create_dir_all(base.join("bin")).unwrap();
-        std::fs::write(base.join("sbin").join("php-fpm"), b"x").unwrap();
-        std::fs::write(base.join("bin").join("php"), b"x").unwrap();
+        #[cfg(unix)]
+        {
+            std::fs::create_dir_all(base.join("sbin")).unwrap();
+            std::fs::create_dir_all(base.join("bin")).unwrap();
+            std::fs::write(base.join("sbin").join("php-fpm"), b"x").unwrap();
+            std::fs::write(base.join("bin").join("php"), b"x").unwrap();
+        }
+        #[cfg(windows)]
+        {
+            std::fs::create_dir_all(&base).unwrap();
+            std::fs::write(base.join("php-cgi.exe"), b"x").unwrap();
+            std::fs::write(base.join("php.exe"), b"x").unwrap();
+        }
         std::fs::write(base.join(".yerd-version"), full).unwrap();
     }
 
@@ -3996,11 +4109,14 @@ Subject: Captured\r\n\r\nhi\r\n";
         .await;
         assert!(matches!(resp, Response::Ok), "got {resp:?}");
         assert_eq!(state.config.lock().await.php.default, PhpVersion::new(8, 4));
-        let shim = state.dirs.data.join("bin").join("php");
-        assert_eq!(
-            std::fs::read_link(shim).unwrap(),
-            yerd_sibling().expect("yerd sibling resolves in tests")
-        );
+        #[cfg(unix)]
+        {
+            let shim = state.dirs.data.join("bin").join("php");
+            assert_eq!(
+                std::fs::read_link(shim).unwrap(),
+                yerd_sibling().expect("yerd sibling resolves in tests")
+            );
+        }
     }
 
     #[tokio::test]
@@ -4777,6 +4893,7 @@ Subject: Captured\r\n\r\nhi\r\n";
     /// A `php.json` body with the given `(php, minor, revision)` builds for the
     /// host platform. Tarball shas are placeholders (`"00"`) - the poll /
     /// available paths never download tarballs.
+    #[cfg(unix)]
     fn listing_body(builds: &[(&str, &str, u32)]) -> String {
         let (os, arch) = yerd_php::current_os_arch().unwrap();
         let entries: Vec<String> = builds
@@ -4795,17 +4912,20 @@ Subject: Captured\r\n\r\nhi\r\n";
     }
 
     /// Build + sign a `php.json` for the host platform (see [`listing_body`]).
+    #[cfg(unix)]
     fn signed_listing(builds: &[(&str, &str, u32)]) -> crate::test_support::SignedManifest {
         crate::test_support::sign_manifest(&listing_body(builds))
     }
 
     /// Routes stable `php.json` to `stable` and legacy `php-legacy.json` to
     /// `legacy`, so `available_php_with` sees a distinct manifest per channel.
+    #[cfg(unix)]
     struct TwoChannelDl {
         stable: ListingDl,
         legacy: ListingDl,
     }
     #[async_trait::async_trait]
+    #[cfg(unix)]
     impl yerd_php::Downloader for TwoChannelDl {
         async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
             if url.contains("php-legacy.json") {
@@ -4840,10 +4960,12 @@ Subject: Captured\r\n\r\nhi\r\n";
     /// Serves a valid legacy `php-legacy.json` but errors on every stable
     /// `php.json` request, modelling a reachable legacy manifest behind an
     /// unreachable stable one.
+    #[cfg(unix)]
     struct LegacyOnlyDl {
         legacy: ListingDl,
     }
     #[async_trait::async_trait]
+    #[cfg(unix)]
     impl yerd_php::Downloader for LegacyOnlyDl {
         async fn download(&self, url: &str) -> Result<Vec<u8>, yerd_php::DownloadError> {
             if url.contains("php-legacy.json") {
@@ -4857,6 +4979,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         }
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn poll_and_refresh_populates_cache_from_listing() {
         let tmp = tempfile::tempdir().unwrap();
@@ -4878,6 +5001,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn poll_and_refresh_is_channel_aware_for_legacy() {
         let tmp = tempfile::tempdir().unwrap();
@@ -4908,6 +5032,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn poll_and_refresh_tolerates_untrusted_legacy_manifest() {
         let tmp = tempfile::tempdir().unwrap();
@@ -4938,6 +5063,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn poll_and_refresh_preserves_cached_legacy_update_when_legacy_fetch_fails() {
         let tmp = tempfile::tempdir().unwrap();
@@ -4973,6 +5099,7 @@ Subject: Captured\r\n\r\nhi\r\n";
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn poll_and_refresh_checks_legacy_when_stable_is_unreachable() {
         let tmp = tempfile::tempdir().unwrap();
@@ -5602,6 +5729,7 @@ Subject: Captured\r\n\r\nhi\r\n";
     }
 
     #[tokio::test]
+    #[cfg(not(windows))]
     async fn available_php_lists_distribution_minors_and_installed() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());
@@ -5629,6 +5757,7 @@ Subject: Captured\r\n\r\nhi\r\n";
     }
 
     #[tokio::test]
+    #[cfg(not(windows))]
     async fn available_php_lists_legacy_from_second_manifest() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state_in(tmp.path());

--- a/bin/yerdd/src/mutate.rs
+++ b/bin/yerdd/src/mutate.rs
@@ -1225,21 +1225,19 @@ mod tests {
     #[test]
     fn unpark_drops_proxy_rules_under_root() {
         let mut cfg = Config::default();
+        let root = "srv";
+        let child = Path::new(root).join("app").to_string_lossy().into_owned();
         let rule = yerd_core::ProxyRule::new(
             "/ws",
             yerd_core::UpstreamTarget::from_url_str("http://127.0.0.1:3000").unwrap(),
         )
         .unwrap();
-        cfg.parked.paths.insert("/srv".to_string());
-        cfg.proxy_rules
-            .parked
-            .insert("/srv/app".to_string(), vec![rule]);
+        cfg.parked.paths.insert(root.to_string());
+        cfg.proxy_rules.parked.insert(child, vec![rule]);
         apply(
             &mut cfg,
             &empty_router(),
-            &Request::Unpark {
-                path: "/srv".into(),
-            },
+            &Request::Unpark { path: root.into() },
             None,
             v(8, 3),
         )
@@ -1429,17 +1427,15 @@ mod tests {
     #[test]
     fn unpark_drops_route_rules_under_root() {
         let mut cfg = Config::default();
+        let root = "srv";
+        let child = Path::new(root).join("app").to_string_lossy().into_owned();
         let rule = yerd_core::RouteRule::new("/api", "api/index.php").unwrap();
-        cfg.parked.paths.insert("/srv".to_string());
-        cfg.route_rules
-            .parked
-            .insert("/srv/app".to_string(), vec![rule]);
+        cfg.parked.paths.insert(root.to_string());
+        cfg.route_rules.parked.insert(child, vec![rule]);
         apply(
             &mut cfg,
             &empty_router(),
-            &Request::Unpark {
-                path: "/srv".into(),
-            },
+            &Request::Unpark { path: root.into() },
             None,
             v(8, 3),
         )

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -9,19 +9,30 @@
 //! Integrity is anchored by the manifest's minisign signature (verified here)
 //! and each tarball's published SHA-256.
 
+#[cfg(any(unix, test))]
 use std::io::Read;
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
 
 use yerd_core::PhpVersion;
-use yerd_php::{
-    current_os_arch, is_safe_member, listing_sig_url, listing_url, Artifact, BinaryKind,
-    DownloadError, Downloader, PhpError,
-};
+#[cfg(unix)]
+use yerd_php::current_os_arch;
+#[cfg(any(unix, test))]
+use yerd_php::is_safe_member;
+#[cfg(unix)]
+use yerd_php::Artifact;
+#[cfg(any(unix, test))]
+use yerd_php::BinaryKind;
+use yerd_php::{listing_sig_url, listing_url, DownloadError, Downloader, PhpError};
 use yerd_platform::PlatformDirs;
+
+#[cfg(windows)]
+pub(crate) const WINDOWS_RELEASES_URL: &str =
+    "https://windows.php.net/downloads/releases/releases.json";
 
 /// `reqwest`-backed downloader (rustls, no OpenSSL; follows redirects).
 pub struct ReqwestDownloader {
@@ -32,10 +43,12 @@ pub struct ReqwestDownloader {
 /// first call and completion), so a 40 MB+ download streams "X / Y MB" updates
 /// into the job log without flooding it. `last` tracks the last *emitted* byte
 /// count (`u64::MAX` = nothing emitted yet).
+#[cfg(unix)]
 const PROGRESS_STEP: u64 = 4 * 1024 * 1024;
 
 /// Byte counts are formatted as integer tenths-of-a-MB to avoid a float cast and
 /// its precision lint.
+#[cfg(unix)]
 fn emit_byte_progress(
     tx: &ProgressTx,
     label: &str,
@@ -187,41 +200,181 @@ pub async fn install(
     public_key: &str,
     progress: Option<&ProgressTx>,
 ) -> Result<(), PhpError> {
-    let (os, arch) = current_os_arch()?;
-    let channel = yerd_php::Channel::of(version);
-    note(progress, format!("Resolving PHP {version}…"));
-    let listing = fetch_verified_listing(dl, public_key, channel).await?;
-    let artifact = yerd_php::resolve_from_listing(&listing, version, os, arch, channel)?;
-    tracing::info!(%version, patch = %artifact.full_version, revision = artifact.revision, "resolved PHP build; downloading");
-    note(
-        progress,
-        format!("Found PHP {} — downloading…", artifact.full_version),
-    );
+    #[cfg(windows)]
+    {
+        let _ = public_key;
+        return install_windows(version, dirs, dl, progress).await;
+    }
+    #[cfg(unix)]
+    {
+        let (os, arch) = current_os_arch()?;
+        let channel = yerd_php::Channel::of(version);
+        note(progress, format!("Resolving PHP {version}…"));
+        let listing = fetch_verified_listing(dl, public_key, channel).await?;
+        let artifact = yerd_php::resolve_from_listing(&listing, version, os, arch, channel)?;
+        tracing::info!(%version, patch = %artifact.full_version, revision = artifact.revision, "resolved PHP build; downloading");
+        note(
+            progress,
+            format!("Found PHP {} — downloading…", artifact.full_version),
+        );
+
+        let php_root = dirs.data.join("php");
+        fs_ctx(std::fs::create_dir_all(&php_root), &php_root)?;
+
+        let staging = php_root.join(format!(
+            ".staging-{}-{}",
+            artifact.install_dir_name,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&staging);
+
+        if let Err(e) = stage(&artifact, dl, &staging, progress).await {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
+
+        note(progress, "Finalising install…");
+        let final_dir = php_root.join(&artifact.install_dir_name);
+        if final_dir.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&final_dir) {
+                let _ = std::fs::remove_dir_all(&staging);
+                return Err(fs_err(&final_dir, &e));
+            }
+        }
+        fs_ctx(std::fs::rename(&staging, &final_dir), &final_dir)
+    }
+}
+
+#[cfg(windows)]
+async fn install_windows(
+    version: PhpVersion,
+    dirs: &PlatformDirs,
+    dl: &dyn Downloader,
+    progress: Option<&ProgressTx>,
+) -> Result<(), PhpError> {
+    const DOWNLOAD_BASE: &str = "https://windows.php.net/downloads/releases";
+    note(progress, format!("Resolving PHP {version} for Windows..."));
+    let listing = dl.download(WINDOWS_RELEASES_URL).await?;
+    let listing: serde_json::Value =
+        serde_json::from_slice(&listing).map_err(|e| PhpError::ListingParse {
+            detail: e.to_string(),
+        })?;
+    let minor = version.to_string();
+    let release = listing
+        .get(&minor)
+        .and_then(serde_json::Value::as_object)
+        .ok_or(PhpError::VersionUnavailable { version })?;
+    let full_version = release
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| PhpError::ListingParse {
+            detail: format!("Windows PHP {minor} has no version"),
+        })?;
+    let build = release
+        .iter()
+        .find(|(name, _)| name.starts_with("nts-") && name.ends_with("-x64"))
+        .and_then(|(_, value)| value.get("zip"))
+        .ok_or(PhpError::VersionUnavailable { version })?;
+    let file = build
+        .get("path")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| PhpError::ListingParse {
+            detail: format!("Windows PHP {minor} ZIP has no path"),
+        })?;
+    let sha256 = build
+        .get("sha256")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| PhpError::ListingParse {
+            detail: format!("Windows PHP {minor} ZIP has no sha256"),
+        })?;
+    let url = format!("{DOWNLOAD_BASE}/{file}");
+    note(progress, format!("Downloading PHP {full_version}..."));
+    let bytes = dl.download(&url).await?;
+    if !yerd_update::sha256_hex(&bytes).eq_ignore_ascii_case(sha256) {
+        return Err(PhpError::ShaMismatch { file: url });
+    }
 
     let php_root = dirs.data.join("php");
     fs_ctx(std::fs::create_dir_all(&php_root), &php_root)?;
-
-    let staging = php_root.join(format!(
-        ".staging-{}-{}",
-        artifact.install_dir_name,
-        std::process::id()
-    ));
+    let staging = php_root.join(format!(".staging-php-{minor}-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&staging);
-
-    if let Err(e) = stage(&artifact, dl, &staging, progress).await {
+    fs_ctx(std::fs::create_dir_all(&staging), &staging)?;
+    if let Err(error) = extract_windows_runtime(&bytes, &staging, &url) {
         let _ = std::fs::remove_dir_all(&staging);
-        return Err(e);
+        return Err(error);
     }
-
-    note(progress, "Finalising install…");
-    let final_dir = php_root.join(&artifact.install_dir_name);
-    if final_dir.exists() {
-        if let Err(e) = std::fs::remove_dir_all(&final_dir) {
+    for required in ["php.exe", "php-cgi.exe"] {
+        if !staging.join(required).is_file() {
             let _ = std::fs::remove_dir_all(&staging);
-            return Err(fs_err(&final_dir, &e));
+            return Err(extract_msg(
+                &url,
+                format!("{required} missing from archive"),
+            ));
         }
     }
+    let marker = staging.join(VERSION_MARKER);
+    fs_ctx(std::fs::write(&marker, full_version), &marker)?;
+    let revision = staging.join(REVISION_MARKER);
+    fs_ctx(std::fs::write(&revision, "1"), &revision)?;
+    let final_dir = php_root.join(format!("php-{minor}"));
+    if final_dir.exists() {
+        fs_ctx(std::fs::remove_dir_all(&final_dir), &final_dir)?;
+    }
     fs_ctx(std::fs::rename(&staging, &final_dir), &final_dir)
+}
+
+#[cfg(windows)]
+pub(crate) fn available_windows_minors(listing: &[u8]) -> Result<Vec<PhpVersion>, PhpError> {
+    let listing: serde_json::Value =
+        serde_json::from_slice(listing).map_err(|e| PhpError::ListingParse {
+            detail: e.to_string(),
+        })?;
+    let releases = listing.as_object().ok_or_else(|| PhpError::ListingParse {
+        detail: "Windows PHP listing is not an object".to_owned(),
+    })?;
+    let mut versions: Vec<PhpVersion> = releases
+        .iter()
+        .filter(|(_, release)| {
+            release.as_object().is_some_and(|release| {
+                release.iter().any(|(name, build)| {
+                    name.starts_with("nts-") && name.ends_with("-x64") && build.get("zip").is_some()
+                })
+            })
+        })
+        .filter_map(|(minor, _)| {
+            let (major, minor) = minor.split_once('.')?;
+            Some(PhpVersion::new(major.parse().ok()?, minor.parse().ok()?))
+        })
+        .collect();
+    versions.sort_unstable();
+    versions.dedup();
+    Ok(versions)
+}
+
+#[cfg(windows)]
+fn extract_windows_runtime(bytes: &[u8], staging: &Path, url: &str) -> Result<(), PhpError> {
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+        .map_err(|e| extract_msg(url, e.to_string()))?;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|e| extract_msg(url, e.to_string()))?;
+        let relative = entry
+            .enclosed_name()
+            .ok_or_else(|| extract_msg(url, format!("unsafe ZIP member {:?}", entry.name())))?
+            .clone();
+        let target = staging.join(relative);
+        if entry.is_dir() {
+            fs_ctx(std::fs::create_dir_all(&target), &target)?;
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            fs_ctx(std::fs::create_dir_all(parent), parent)?;
+        }
+        let mut output = std::fs::File::create(&target).map_err(|e| fs_err(&target, &e))?;
+        std::io::copy(&mut entry, &mut output).map_err(|e| fs_err(&target, &e))?;
+    }
+    Ok(())
 }
 
 /// Write the CLI `php.ini` files the version-aware `php`/`php<ver>` shims point
@@ -261,7 +414,7 @@ pub fn write_cli_ini(
     let no_overrides = std::collections::BTreeMap::new();
     let installed =
         yerd_php::discover_bundled(dirs).map_err(|e| std::io::Error::other(e.to_string()))?;
-    for (v, _) in installed {
+    for (v, binary) in installed {
         let refs: Vec<(&str, bool)> = extensions
             .get(&v)
             .map(|es| {
@@ -276,6 +429,16 @@ pub fn write_cli_ini(
             version_settings.get(&v).unwrap_or(&no_overrides),
         );
         let mut body = yerd_core::php_settings::render_cli_ini_with_ext(&effective, &refs);
+        #[cfg(windows)]
+        {
+            use std::fmt::Write as _;
+            let runtime = binary.parent().unwrap_or(&binary);
+            let extension_dir = runtime.join("ext").to_string_lossy().replace('\\', "/");
+            let _ = writeln!(body, "extension_dir={extension_dir}");
+            for extension in yerd_php::pure::cgi_ini::windows_extensions() {
+                let _ = writeln!(body, "extension={extension}");
+            }
+        }
         if let Some(dirs_for_v) = directives.get(&v) {
             body.push_str(&yerd_core::php_directives::render_ini_lines(dirs_for_v));
         }
@@ -310,6 +473,7 @@ const VERSION_MARKER: &str = ".yerd-version";
 /// suffix). Absent for pre-cutover installs, which read as revision 0.
 const REVISION_MARKER: &str = ".yerd-revision";
 
+#[cfg(unix)]
 async fn stage(
     artifact: &Artifact,
     dl: &dyn Downloader,
@@ -388,6 +552,7 @@ pub fn installed_revision(dirs: &PlatformDirs, minor: PhpVersion) -> u32 {
 /// silent path; a download error converts to `PhpError` via `#[from]`. The
 /// SHA-256 check happens on both paths (this is the single fetch site) - bytes
 /// that don't match `expected_sha256` are never extracted.
+#[cfg(unix)]
 async fn fetch_and_extract(
     dl: &dyn Downloader,
     url: &str,
@@ -431,6 +596,7 @@ async fn fetch_and_extract(
 /// Extract the single expected `Regular`-file member from a `.tar.gz`,
 /// rejecting traversal, non-regular entries (symlink/hardlink/dir), unexpected
 /// names, and duplicates - closes zip-slip and link-target escapes.
+#[cfg(any(unix, test))]
 fn extract_member(gz_bytes: &[u8], kind: BinaryKind, url: &str) -> Result<Vec<u8>, PhpError> {
     let want = kind.archive_member();
     let decoder = flate2::read::GzDecoder::new(gz_bytes);
@@ -478,11 +644,6 @@ fn make_executable(path: &Path) -> Result<(), PhpError> {
     )
 }
 
-#[cfg(not(unix))]
-fn make_executable(_path: &Path) -> Result<(), PhpError> {
-    Ok(())
-}
-
 fn fs_ctx<T>(r: std::io::Result<T>, path: &Path) -> Result<T, PhpError> {
     r.map_err(|e| fs_err(path, &e))
 }
@@ -494,6 +655,7 @@ fn fs_err(path: &Path, e: &std::io::Error) -> PhpError {
     }
 }
 
+#[cfg(any(unix, test))]
 fn extract_err(url: &str, e: &dyn std::fmt::Display) -> PhpError {
     extract_msg(url, e.to_string())
 }
@@ -505,17 +667,25 @@ fn extract_msg(url: &str, detail: String) -> PhpError {
     }
 }
 
-/// Absolute path to a version's CLI binary (`data/php/php-<minor>/bin/php`).
+/// Absolute path to a version's platform-specific CLI binary.
 #[must_use]
 pub fn cli_binary_path(dirs: &PlatformDirs, version: PhpVersion) -> PathBuf {
-    let mut p = dirs
+    let p = dirs
         .data
         .join("php")
         .join(format!("php-{}.{}", version.major, version.minor));
-    for seg in BinaryKind::Cli.install_segments() {
-        p.push(seg);
+    #[cfg(windows)]
+    {
+        p.join("php.exe")
     }
-    p
+    #[cfg(unix)]
+    {
+        let mut p = p;
+        for seg in BinaryKind::Cli.install_segments() {
+            p.push(seg);
+        }
+        p
+    }
 }
 
 /// The `PHPRC` target for a version's CLI: its per-version ini
@@ -580,6 +750,7 @@ pub fn set_default_shim(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<PathBuf,
 }
 
 #[cfg(not(unix))]
+/// Return the default Windows PHP executable path.
 pub fn set_default_shim(dirs: &PlatformDirs, _yerd_bin: &Path) -> Result<PathBuf, PhpError> {
     Ok(shim_dir(dirs))
 }
@@ -693,6 +864,7 @@ pub fn reconcile_shims(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<(), PhpEr
 }
 
 #[cfg(not(unix))]
+/// Windows does not use Unix symlink-based PHP shims.
 pub fn reconcile_shims(_dirs: &PlatformDirs, _yerd_bin: &Path) -> Result<(), PhpError> {
     Ok(())
 }
@@ -702,6 +874,22 @@ pub fn reconcile_shims(_dirs: &PlatformDirs, _yerd_bin: &Path) -> Result<(), Php
 mod tests {
     use super::*;
     use std::io::Write as _;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_available_minors_require_nts_x64_zip() {
+        let listing = br#"{
+            "8.3": {"version":"8.3.25","nts-vs17-x64":{"zip":{"path":"php-8.3.zip","sha256":"aa"}}},
+            "8.4": {"version":"8.4.12","ts-vs17-x64":{"zip":{"path":"php-8.4.zip","sha256":"bb"}}},
+            "8.5": {"version":"8.5.0","nts-vs17-x64":{"zip":{"path":"php-8.5.zip","sha256":"cc"}}},
+            "invalid": {}
+        }"#;
+
+        assert_eq!(
+            available_windows_minors(listing).unwrap(),
+            vec![PhpVersion::new(8, 3), PhpVersion::new(8, 5)]
+        );
+    }
 
     fn gzip_tar_single(name: &str, body: &[u8], mode: u32) -> Vec<u8> {
         let mut header = tar::Header::new_gnu();
@@ -855,6 +1043,7 @@ mod tests {
     /// `php.json` or legacy `php-legacy.json`) → the single `manifest`;
     /// `-cli-`/`-fpm-` → the respective tarball. Each test drives one channel, so
     /// serving the same manifest for whichever `.json` is requested is enough.
+    #[cfg(unix)]
     struct FakeDownloader {
         manifest: String,
         minisig: String,
@@ -862,6 +1051,7 @@ mod tests {
         fpm: Vec<u8>,
     }
 
+    #[cfg(unix)]
     #[async_trait]
     impl Downloader for FakeDownloader {
         async fn download(&self, url: &str) -> Result<Vec<u8>, DownloadError> {
@@ -884,6 +1074,7 @@ mod tests {
 
     /// Build a one-build `php.json` for the host platform whose `cli`/`fpm`
     /// sha256 match the given tarball bytes, then sign it.
+    #[cfg(unix)]
     fn signed_manifest_for(
         php: &str,
         minor: &str,
@@ -908,9 +1099,11 @@ mod tests {
         crate::test_support::sign_manifest(&manifest)
     }
 
+    #[cfg(unix)]
     const KEY: &str = yerd_update::PHP_LISTING_PUBLIC_KEY;
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn install_lays_down_both_binaries_executable() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
@@ -956,6 +1149,7 @@ mod tests {
     /// The manifest is signed over the correct shas, but the fake serves
     /// different tarball bytes, so the post-download sha check must abort.
     #[tokio::test]
+    #[cfg(unix)]
     async fn install_rejects_sha_mismatch_and_writes_nothing() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
@@ -978,6 +1172,7 @@ mod tests {
     /// A manifest signed by a throwaway key fails when verified against the
     /// production `PHP_LISTING_PUBLIC_KEY`, and nothing is installed.
     #[tokio::test]
+    #[cfg(unix)]
     async fn install_rejects_untrusted_listing() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
@@ -1003,6 +1198,7 @@ mod tests {
     /// signing: the original signature no longer covers the served bytes, so
     /// `fetch_verified_listing` returns `ListingUntrusted` before any resolve.
     #[tokio::test]
+    #[cfg(unix)]
     async fn fetch_verified_listing_rejects_tampered_body() {
         let cli = gzip_tar_single("php", b"CLI-BYTES", 0o755);
         let fpm = gzip_tar_single("php-fpm", b"FPM-BYTES", 0o755);
@@ -1022,6 +1218,7 @@ mod tests {
     /// A legacy (7.4) build installs from the `php-legacy.json` channel into
     /// `php-7.4/bin/php`, exercising the channel-aware `install` path.
     #[tokio::test]
+    #[cfg(unix)]
     async fn install_legacy_version_lands_in_versioned_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
@@ -1047,6 +1244,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn install_errors_when_version_not_published_and_writes_nothing() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = dirs_in(tmp.path());
@@ -1078,10 +1276,12 @@ mod tests {
             cache: "/ca".into(),
             runtime: "/r".into(),
         };
-        assert_eq!(
-            cli_binary_path(&dirs, PhpVersion::new(8, 5)),
-            PathBuf::from("/d/php/php-8.5/bin/php")
-        );
+        let base = dirs.data.join("php").join("php-8.5");
+        #[cfg(unix)]
+        let expected = base.join("bin").join("php");
+        #[cfg(windows)]
+        let expected = base.join("php.exe");
+        assert_eq!(cli_binary_path(&dirs, PhpVersion::new(8, 5)), expected);
     }
 
     #[test]

--- a/bin/yerdd/src/php_install.rs
+++ b/bin/yerdd/src/php_install.rs
@@ -3,11 +3,14 @@
 //!
 //! The `reqwest`-backed [`Downloader`] lives here (a binary) so `yerd-php`
 //! stays dependency-light. Version resolution + tar-member safety are pure
-//! helpers from `yerd_php::release`; this module is the I/O edge: fetch +
-//! **verify** the signed `php.json` manifest → resolve → fetch tarballs →
+//! helpers from `yerd_php::release`; this module is the I/O edge. Unix fetches
+//! and verifies the signed `php.json` manifest, resolves, then fetches tarballs,
 //! **SHA-256-verify** and safe-extract the single binary → atomic install.
 //! Integrity is anchored by the manifest's minisign signature (verified here)
 //! and each tarball's published SHA-256.
+//! Windows PHP publishes no vendor PGP, GPG, or minisign signatures for its
+//! binary listing or ZIPs. That path relies on HTTPS/TLS authenticity and
+//! verifies each ZIP against the SHA-256 supplied by `releases.json`.
 
 #[cfg(any(unix, test))]
 use std::io::Read;
@@ -246,6 +249,7 @@ pub async fn install(
 }
 
 #[cfg(windows)]
+/// Install an official Windows PHP ZIP using HTTPS and its unsigned listing's SHA-256.
 async fn install_windows(
     version: PhpVersion,
     dirs: &PlatformDirs,
@@ -435,7 +439,7 @@ pub fn write_cli_ini(
             let runtime = binary.parent().unwrap_or(&binary);
             let extension_dir = runtime.join("ext").to_string_lossy().replace('\\', "/");
             let _ = writeln!(body, "extension_dir={extension_dir}");
-            for extension in yerd_php::pure::cgi_ini::windows_extensions() {
+            for extension in yerd_php::pure::cgi_ini::windows_extensions(v) {
                 let _ = writeln!(body, "extension={extension}");
             }
         }

--- a/bin/yerdd/src/secure_fs.rs
+++ b/bin/yerdd/src/secure_fs.rs
@@ -49,6 +49,7 @@ fn set_mode(path: &Path, mode: u32) -> io::Result<()> {
 }
 
 #[cfg(not(unix))]
+#[allow(clippy::unnecessary_wraps)]
 fn set_mode(_path: &Path, _mode: u32) -> io::Result<()> {
     Ok(())
 }

--- a/bin/yerdd/src/services.rs
+++ b/bin/yerdd/src/services.rs
@@ -1246,6 +1246,7 @@ fn installed_versions(type_id: &str, dirs: &PlatformDirs) -> Vec<ServiceVersion>
 
 /// Resolve the version to run: the configured one if installed, else the latest
 /// installed; error if nothing is installed.
+#[allow(clippy::result_large_err)]
 pub(crate) fn resolve_version(
     def: &Arc<dyn ServiceDefinition>,
     configured: Option<&str>,
@@ -1486,6 +1487,7 @@ mod tests {
 
     /// Grab a currently-free loopback port so `ensure`'s port pre-flight passes
     /// on a machine that may already run the real service.
+    #[cfg(unix)]
     fn free_port() -> u16 {
         let l = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
         l.local_addr().unwrap().port()
@@ -1624,6 +1626,7 @@ mod tests {
         assert_eq!(reverb.port, 8081);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn available_services_excludes_versionless_types() {
         let tmp = tempfile::tempdir().unwrap();

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -822,10 +822,11 @@ fn build_ipc_listener(dirs: &PlatformDirs) -> Result<IpcListener, DaemonError> {
     #[cfg(windows)]
     let name = {
         use interprocess::local_socket::{GenericNamespaced, ToNsName};
-        let pipe = "yerd-daemon";
+        let pipe = yerd_platform::paths::daemon_pipe_name(dirs);
+        let err_path = PathBuf::from(&pipe);
         pipe.to_ns_name::<GenericNamespaced>()
             .map_err(|source| DaemonError::Io {
-                path: PathBuf::from(pipe),
+                path: err_path,
                 source,
             })?
     };

--- a/bin/yerdd/src/startup.rs
+++ b/bin/yerdd/src/startup.rs
@@ -822,11 +822,10 @@ fn build_ipc_listener(dirs: &PlatformDirs) -> Result<IpcListener, DaemonError> {
     #[cfg(windows)]
     let name = {
         use interprocess::local_socket::{GenericNamespaced, ToNsName};
-        let pipe = format!("yerd-{}", std::process::id());
-        pipe.clone()
-            .to_ns_name::<GenericNamespaced>()
+        let pipe = "yerd-daemon";
+        pipe.to_ns_name::<GenericNamespaced>()
             .map_err(|source| DaemonError::Io {
-                path: PathBuf::from(&pipe),
+                path: PathBuf::from(pipe),
                 source,
             })?
     };

--- a/bin/yerdd/src/tools/bun.rs
+++ b/bin/yerdd/src/tools/bun.rs
@@ -6,16 +6,18 @@
 //! the GitHub "latest release" API (`tag_name`, e.g. `bun-v1.3.14`).
 
 use std::io::{Cursor, Read as _};
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 
 use serde::Deserialize;
 
 use yerd_php::{current_os_arch, is_safe_member, Arch, Downloader, Os};
 use yerd_platform::PlatformDirs;
 
-use super::{
-    extract_root_dir, sha_for_asset, stage_and_swap, tool_dir, verify_sha256, Tool, ToolError,
-};
+#[cfg(unix)]
+use super::{extract_root_dir, tool_dir};
+use super::{sha_for_asset, stage_and_swap, verify_sha256, Tool, ToolError};
 
 const LATEST_API: &str = "https://api.github.com/repos/oven-sh/bun/releases/latest";
 const RELEASE_BASE: &str = "https://github.com/oven-sh/bun/releases/download";
@@ -158,6 +160,7 @@ mod tests {
         assert_eq!(display_version("weird"), "weird");
     }
 
+    #[cfg(unix)]
     #[test]
     fn host_platform_known() {
         assert!(host_platform().is_some());

--- a/bin/yerdd/src/tools/composer.rs
+++ b/bin/yerdd/src/tools/composer.rs
@@ -5,7 +5,9 @@
 //! `composer.phar.sha256sum` sidecar (the `/versions` JSON carries no digest).
 //! Installed on demand from the Tooling page - not auto-fetched.
 
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
 
 use serde::Deserialize;
 

--- a/bin/yerdd/src/tools/external.rs
+++ b/bin/yerdd/src/tools/external.rs
@@ -144,6 +144,7 @@ async fn capture_path_string() -> Option<String> {
 }
 
 #[cfg(not(unix))]
+#[allow(clippy::unused_async)]
 async fn capture_path_string() -> Option<String> {
     None
 }

--- a/bin/yerdd/src/tools/laravel.rs
+++ b/bin/yerdd/src/tools/laravel.rs
@@ -64,7 +64,8 @@ pub async fn install(dirs: &PlatformDirs, progress: Option<&ProgressTx>) -> Resu
     let build = tools_root.join(format!(".laravel-build-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&build);
 
-    let mut child = tokio::process::Command::new(&php)
+    let mut command = tokio::process::Command::new(&php);
+    command
         .arg(&phar)
         .arg("create-project")
         .arg("--prefer-dist")
@@ -76,7 +77,11 @@ pub async fn install(dirs: &PlatformDirs, progress: Option<&ProgressTx>) -> Resu
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
+        .kill_on_drop(true);
+    if let Some(phprc) = crate::php_install::cli_phprc(dirs, php_version) {
+        command.env("PHPRC", phprc);
+    }
+    let mut child = command
         .spawn()
         .map_err(|e| ToolError::Io(format!("spawn composer: {e}")))?;
 

--- a/bin/yerdd/src/tools/mod.rs
+++ b/bin/yerdd/src/tools/mod.rs
@@ -294,7 +294,7 @@ pub fn reconcile_tool_shims(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<(), 
 }
 
 #[cfg(windows)]
-/// Reconcile Windows Node shims without requiring symlink privileges.
+/// Reconcile Windows tool shims without requiring symlink privileges.
 pub fn reconcile_tool_shims(dirs: &PlatformDirs, _yerd_bin: &Path) -> Result<(), ToolError> {
     let bin = bin_dir(dirs);
     std::fs::create_dir_all(&bin).map_err(|e| ToolError::Io(format!("{}: {e}", bin.display())))?;
@@ -303,34 +303,34 @@ pub fn reconcile_tool_shims(dirs: &PlatformDirs, _yerd_bin: &Path) -> Result<(),
         for name in names {
             let _ = std::fs::remove_file(bin.join(name));
         }
-        return Ok(());
-    }
-    let root = extract_root_dir(&tool_dir(dirs, Tool::Node))?;
-    for name in names {
-        let source = root.join(name);
-        let destination = bin.join(name);
-        let _ = std::fs::remove_file(&destination);
-        if name == "node.exe" {
-            std::fs::hard_link(&source, &destination)
-                .or_else(|_| std::fs::copy(&source, &destination).map(|_| ()))
-                .map_err(|e| ToolError::Io(format!("{}: {e}", destination.display())))?;
-        } else {
-            let cli = if name == "npm.cmd" {
-                "npm-cli.js"
+    } else {
+        let root = extract_root_dir(&tool_dir(dirs, Tool::Node))?;
+        for name in names {
+            let source = root.join(name);
+            let destination = bin.join(name);
+            let _ = std::fs::remove_file(&destination);
+            if name == "node.exe" {
+                std::fs::hard_link(&source, &destination)
+                    .or_else(|_| std::fs::copy(&source, &destination).map(|_| ()))
+                    .map_err(|e| ToolError::Io(format!("{}: {e}", destination.display())))?;
             } else {
-                "npx-cli.js"
-            };
-            let script = format!(
-                "@ECHO OFF\r\n\"{}\" \"{}\" %*\r\n",
-                root.join("node.exe").display(),
-                root.join("node_modules")
-                    .join("npm")
-                    .join("bin")
-                    .join(cli)
-                    .display()
-            );
-            std::fs::write(&destination, script)
-                .map_err(|e| ToolError::Io(format!("{}: {e}", destination.display())))?;
+                let cli = if name == "npm.cmd" {
+                    "npm-cli.js"
+                } else {
+                    "npx-cli.js"
+                };
+                let script = format!(
+                    "@ECHO OFF\r\n\"{}\" \"{}\" %*\r\n",
+                    root.join("node.exe").display(),
+                    root.join("node_modules")
+                        .join("npm")
+                        .join("bin")
+                        .join(cli)
+                        .display()
+                );
+                std::fs::write(&destination, script)
+                    .map_err(|e| ToolError::Io(format!("{}: {e}", destination.display())))?;
+            }
         }
     }
     for (tool, name, script) in [

--- a/bin/yerdd/src/tools/mod.rs
+++ b/bin/yerdd/src/tools/mod.rs
@@ -227,7 +227,7 @@ pub async fn install(
     note(progress, format!("Installing {}…", tool.display_name()));
     let result = match tool {
         Tool::Composer => composer::install(dirs, dl).await,
-        Tool::Node => node::install(dirs, dl).await,
+        Tool::Node => node::install(dirs, dl, progress).await,
         Tool::Bun => bun::install(dirs, dl).await,
         Tool::Laravel => laravel::install(dirs, progress).await,
         Tool::WpCli => wp_cli::install(dirs, progress).await,
@@ -293,7 +293,78 @@ pub fn reconcile_tool_shims(dirs: &PlatformDirs, yerd_bin: &Path) -> Result<(), 
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+/// Reconcile Windows Node shims without requiring symlink privileges.
+pub fn reconcile_tool_shims(dirs: &PlatformDirs, _yerd_bin: &Path) -> Result<(), ToolError> {
+    let bin = bin_dir(dirs);
+    std::fs::create_dir_all(&bin).map_err(|e| ToolError::Io(format!("{}: {e}", bin.display())))?;
+    let names = ["node.exe", "npm.cmd", "npx.cmd"];
+    if installed_version(dirs, Tool::Node).is_none() {
+        for name in names {
+            let _ = std::fs::remove_file(bin.join(name));
+        }
+        return Ok(());
+    }
+    let root = extract_root_dir(&tool_dir(dirs, Tool::Node))?;
+    for name in names {
+        let source = root.join(name);
+        let destination = bin.join(name);
+        let _ = std::fs::remove_file(&destination);
+        if name == "node.exe" {
+            std::fs::hard_link(&source, &destination)
+                .or_else(|_| std::fs::copy(&source, &destination).map(|_| ()))
+                .map_err(|e| ToolError::Io(format!("{}: {e}", destination.display())))?;
+        } else {
+            let cli = if name == "npm.cmd" {
+                "npm-cli.js"
+            } else {
+                "npx-cli.js"
+            };
+            let script = format!(
+                "@ECHO OFF\r\n\"{}\" \"{}\" %*\r\n",
+                root.join("node.exe").display(),
+                root.join("node_modules")
+                    .join("npm")
+                    .join("bin")
+                    .join(cli)
+                    .display()
+            );
+            std::fs::write(&destination, script)
+                .map_err(|e| ToolError::Io(format!("{}: {e}", destination.display())))?;
+        }
+    }
+    for (tool, name, script) in [
+        (Tool::Composer, "composer.cmd", composer::phar_path(dirs)),
+        (Tool::Laravel, "laravel.cmd", laravel::installer_bin(dirs)),
+        (Tool::WpCli, "wp.cmd", wp_cli::boot_path(dirs)),
+    ] {
+        let destination = bin.join(name);
+        if installed_version(dirs, tool).is_none() {
+            let _ = std::fs::remove_file(destination);
+            continue;
+        }
+        let version = crate::ext_install::installed_versions(dirs)
+            .into_iter()
+            .max_by_key(|v| (v.major, v.minor))
+            .ok_or(ToolError::UnsupportedHost("PHP"))?;
+        let php = crate::php_install::cli_binary_path(dirs, version);
+        let phprc = crate::php_install::cli_phprc(dirs, version);
+        let ini = phprc.map_or_else(String::new, |path| {
+            format!("SET \"PHPRC={}\"\r\n", path.display())
+        });
+        let body = format!(
+            "@ECHO OFF\r\n{ini}\"{}\" \"{}\" %*\r\n",
+            php.display(),
+            script.display()
+        );
+        std::fs::write(&destination, body)
+            .map_err(|e| ToolError::Io(format!("{}: {e}", destination.display())))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+/// Unsupported platforms have no tool shim mechanism.
 pub fn reconcile_tool_shims(_dirs: &PlatformDirs, _yerd_bin: &Path) -> Result<(), ToolError> {
     Ok(())
 }
@@ -334,6 +405,7 @@ pub(crate) fn verify_sha256(bytes: &[u8], want_sha: &str, label: &str) -> Result
 /// The single child **directory** of `dir` (Node/Bun archives wrap their payload
 /// in one top-level dir whose name encodes the version). Errors unless exactly
 /// one directory entry exists - never reconstructed from a version string.
+#[cfg(any(unix, windows, test))]
 pub(crate) fn extract_root_dir(dir: &Path) -> Result<PathBuf, ToolError> {
     let mut found: Option<PathBuf> = None;
     let entries =

--- a/bin/yerdd/src/tools/node.rs
+++ b/bin/yerdd/src/tools/node.rs
@@ -4,16 +4,20 @@
 //! Node's `.tar.gz` bundles `node` plus npm/npx (relative symlinks into
 //! `lib/node_modules/npm`). Integrity uses the per-release `SHASUMS256.txt`.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 
 use serde::Deserialize;
 
-use yerd_php::{current_os_arch, is_safe_member, Arch, Downloader, Os};
+use yerd_php::Downloader;
+#[cfg(unix)]
+use yerd_php::{current_os_arch, is_safe_member, Arch, Os};
 use yerd_platform::PlatformDirs;
 
-use super::{
-    extract_root_dir, sha_for_asset, stage_and_swap, tool_dir, verify_sha256, Tool, ToolError,
-};
+#[cfg(unix)]
+use super::{extract_root_dir, tool_dir};
+use super::{note, sha_for_asset, stage_and_swap, verify_sha256, ProgressTx, Tool, ToolError};
 
 const DIST_INDEX: &str = "https://nodejs.org/dist/index.json";
 const DIST_BASE: &str = "https://nodejs.org/dist";
@@ -29,13 +33,18 @@ struct Release {
 /// The platform token Node uses in artifact names for the host, e.g.
 /// `darwin-arm64`. `None` if Node publishes no build for this OS/arch.
 fn host_platform() -> Option<&'static str> {
-    let (os, arch) = current_os_arch().ok()?;
-    Some(match (os, arch) {
-        (Os::Macos, Arch::Aarch64) => "darwin-arm64",
-        (Os::Macos, Arch::X86_64) => "darwin-x64",
-        (Os::Linux, Arch::X86_64) => "linux-x64",
-        (Os::Linux, Arch::Aarch64) => "linux-arm64",
-    })
+    #[cfg(windows)]
+    return (std::env::consts::ARCH == "x86_64").then_some("win-x64");
+    #[cfg(unix)]
+    {
+        let (os, arch) = current_os_arch().ok()?;
+        Some(match (os, arch) {
+            (Os::Macos, Arch::Aarch64) => "darwin-arm64",
+            (Os::Macos, Arch::X86_64) => "darwin-x64",
+            (Os::Linux, Arch::X86_64) => "linux-x64",
+            (Os::Linux, Arch::Aarch64) => "linux-arm64",
+        })
+    }
 }
 
 /// Latest LTS version (`v24.17.0`) from a dist `index.json` body. The index is
@@ -49,8 +58,13 @@ fn latest_lts(index_json: &[u8]) -> Option<String> {
 }
 
 /// Install the latest Node LTS for the host into `{data}/tools/node/`.
-pub async fn install(dirs: &PlatformDirs, dl: &dyn Downloader) -> Result<(), ToolError> {
+pub async fn install(
+    dirs: &PlatformDirs,
+    dl: &dyn Downloader,
+    progress: Option<&ProgressTx>,
+) -> Result<(), ToolError> {
     let plat = host_platform().ok_or(ToolError::UnsupportedHost("Node.js"))?;
+    note(progress, "Checking the latest Node.js LTS release...");
     let index = dl
         .download(DIST_INDEX)
         .await
@@ -58,10 +72,14 @@ pub async fn install(dirs: &PlatformDirs, dl: &dyn Downloader) -> Result<(), Too
     let version = latest_lts(&index)
         .ok_or_else(|| ToolError::Download("node: no LTS release found".to_owned()))?;
 
+    #[cfg(windows)]
+    let asset = format!("node-{version}-{plat}.zip");
+    #[cfg(unix)]
     let asset = format!("node-{version}-{plat}.tar.gz");
     let tarball_url = format!("{DIST_BASE}/{version}/{asset}");
     let sums_url = format!("{DIST_BASE}/{version}/SHASUMS256.txt");
 
+    note(progress, format!("Verifying {asset}..."));
     let sums = dl
         .download(&sums_url)
         .await
@@ -69,13 +87,26 @@ pub async fn install(dirs: &PlatformDirs, dl: &dyn Downloader) -> Result<(), Too
     let want_sha = sha_for_asset(&String::from_utf8_lossy(&sums), &asset)
         .ok_or_else(|| ToolError::Download(format!("node: {asset} not in SHASUMS256.txt")))?;
 
+    note(progress, format!("Downloading {asset}..."));
     let bytes = dl
-        .download(&tarball_url)
+        .download_with_progress(&tarball_url, &|done, total| {
+            if done == 0 || total.is_some_and(|total| done >= total) {
+                let message = total.map_or_else(
+                    || format!("Downloaded {done} bytes"),
+                    |total| format!("Downloaded {done} / {total} bytes"),
+                );
+                note(progress, message);
+            }
+        })
         .await
         .map_err(|e| ToolError::Download(format!("{asset}: {e}")))?;
     verify_sha256(&bytes, &want_sha, &asset)?;
 
+    note(progress, "Installing Node.js...");
     stage_and_swap(dirs, Tool::Node, &version, |staging| {
+        #[cfg(windows)]
+        return unpack_zip(&bytes, staging, &asset);
+        #[cfg(unix)]
         unpack_tar_gz(&bytes, staging, &asset)
     })?;
     tracing::info!(version = %version, "installed Node.js");
@@ -99,6 +130,7 @@ pub(crate) fn shim_links(dirs: &PlatformDirs) -> Vec<(String, PathBuf)> {
 /// Safely unpack a Node `.tar.gz` full tree into `dest`, preserving permissions
 /// and the internal npm/npx symlinks. Member *names* are validated against
 /// traversal; the sha256 verification above is the integrity boundary.
+#[cfg(unix)]
 fn unpack_tar_gz(gz_bytes: &[u8], dest: &Path, label: &str) -> Result<(), ToolError> {
     let decoder = flate2::read::GzDecoder::new(gz_bytes);
     let mut archive = tar::Archive::new(decoder);
@@ -124,6 +156,36 @@ fn unpack_tar_gz(gz_bytes: &[u8], dest: &Path, label: &str) -> Result<(), ToolEr
         entry
             .unpack(&out)
             .map_err(|e| ToolError::Unpack(format!("{name}: {e}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn unpack_zip(bytes: &[u8], dest: &Path, label: &str) -> Result<(), ToolError> {
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+        .map_err(|e| ToolError::Unpack(format!("{label}: {e}")))?;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|e| ToolError::Unpack(format!("{label}: {e}")))?;
+        let path = entry
+            .enclosed_name()
+            .ok_or_else(|| ToolError::Unpack(format!("unsafe archive member {:?}", entry.name())))?
+            .clone();
+        let out = dest.join(path);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out)
+                .map_err(|e| ToolError::Unpack(format!("{}: {e}", out.display())))?;
+            continue;
+        }
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| ToolError::Unpack(format!("{}: {e}", parent.display())))?;
+        }
+        let mut file = std::fs::File::create(&out)
+            .map_err(|e| ToolError::Unpack(format!("{}: {e}", out.display())))?;
+        std::io::copy(&mut entry, &mut file)
+            .map_err(|e| ToolError::Unpack(format!("{}: {e}", out.display())))?;
     }
     Ok(())
 }

--- a/bin/yerdd/src/tools/wp_cli.rs
+++ b/bin/yerdd/src/tools/wp_cli.rs
@@ -123,7 +123,8 @@ pub async fn install(dirs: &PlatformDirs, progress: Option<&ProgressTx>) -> Resu
     let build = tools_root.join(format!(".wp-cli-build-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&build);
 
-    let mut child = tokio::process::Command::new(&php)
+    let mut command = tokio::process::Command::new(&php);
+    command
         .arg(&phar)
         .arg("create-project")
         .arg("--prefer-dist")
@@ -136,7 +137,11 @@ pub async fn install(dirs: &PlatformDirs, progress: Option<&ProgressTx>) -> Resu
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
+        .kill_on_drop(true);
+    if let Some(phprc) = crate::php_install::cli_phprc(dirs, php_version) {
+        command.env("PHPRC", phprc);
+    }
+    let mut child = command
         .spawn()
         .map_err(|e| ToolError::Io(format!("spawn composer: {e}")))?;
 

--- a/bin/yerdd/src/tunnel/install.rs
+++ b/bin/yerdd/src/tunnel/install.rs
@@ -511,6 +511,7 @@ fn set_executable(path: &Path) -> Result<(), CloudflaredInstallError> {
 }
 
 #[cfg(not(unix))]
+#[allow(clippy::unnecessary_wraps)]
 fn set_executable(_path: &Path) -> Result<(), CloudflaredInstallError> {
     Ok(())
 }
@@ -688,6 +689,7 @@ mod tests {
         assert_eq!(find_in_paths(&path_var), Some(second.join("cloudflared")));
     }
 
+    #[cfg(unix)]
     #[test]
     fn find_in_paths_ignores_non_executable_file() {
         let tmp = tempfile::tempdir().unwrap();

--- a/bin/yerdd/src/tunnel/mod.rs
+++ b/bin/yerdd/src/tunnel/mod.rs
@@ -525,6 +525,7 @@ mod tests {
         let state = state_in(tmp.path());
         let candidate = tmp.path().join("cloudflared");
         std::fs::write(&candidate, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
             std::fs::set_permissions(&candidate, std::fs::Permissions::from_mode(0o755)).unwrap();

--- a/crates/yerd-dns/tests/server_smoke.rs
+++ b/crates/yerd-dns/tests/server_smoke.rs
@@ -38,7 +38,19 @@ async fn serves_multi_label_tld() {
 }
 
 async fn serve_and_query(tld: Tld, site_fqdn: &str, apex_fqdn: &str) {
-    let bound = Bound::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+    let addr = "127.0.0.1:0".parse().unwrap();
+    let mut attempts = 0;
+    let bound = loop {
+        match Bound::bind(addr).await {
+            Ok(bound) => break bound,
+            Err(error) if attempts < 4 => {
+                attempts += 1;
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                drop(error);
+            }
+            Err(error) => panic!("could not bind DNS test sockets: {error}"),
+        }
+    };
     let addr = bound.local_addr();
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
     let handle = tokio::spawn(bound.serve(

--- a/crates/yerd-doctor/src/lib.rs
+++ b/crates/yerd-doctor/src/lib.rs
@@ -57,9 +57,20 @@ pub fn diagnose(
     path_needs_setup: Option<bool>,
     local_override_files: &[(String, String, String)],
 ) -> Vec<Diagnosis> {
+    diagnose_with_port_owner(report, path_needs_setup, local_override_files, None)
+}
+
+/// Run every check with optional host-probed detail about foreign web listeners.
+#[must_use]
+pub fn diagnose_with_port_owner(
+    report: &StatusReport,
+    path_needs_setup: Option<bool>,
+    local_override_files: &[(String, String, String)],
+    foreign_web_listener_detail: Option<&str>,
+) -> Vec<Diagnosis> {
     let mut out = Vec::new();
 
-    out.extend(port_findings(report));
+    out.extend(port_findings(report, foreign_web_listener_detail));
     out.extend(trust_findings(report));
     out.extend(php_state_findings(report));
     out.extend(service_findings(report));
@@ -371,7 +382,10 @@ pub fn is_auto_fixable(code: DiagnosisCode) -> bool {
 /// another process owns). On macOS the daemon still binds the rootless ports
 /// even once elevated, so an active pf redirect (`port_redirect == Some(true)`)
 /// means 80/443 are in fact reachable - also suppressing the fallback warning.
-fn port_findings(report: &StatusReport) -> Vec<Diagnosis> {
+fn port_findings(
+    report: &StatusReport,
+    foreign_web_listener_detail: Option<&str>,
+) -> Vec<Diagnosis> {
     let mut out = Vec::new();
     if let Some(dns_port) = report.dns_unbound {
         out.push(warn(
@@ -387,13 +401,27 @@ fn port_findings(report: &StatusReport) -> Vec<Diagnosis> {
     }
     let foreign_listener = report.foreign_web_listener == Some(true);
     if foreign_listener {
+        let detail = foreign_web_listener_detail.map_or_else(
+            || {
+                "A program other than Yerd is listening on port 80 or 443. Yerd can't serve your .test sites there until it's stopped."
+                    .to_owned()
+            },
+            |owner| {
+                format!(
+                    "A program other than Yerd is listening on a required web port: {owner}"
+                )
+            },
+        );
+        let remedy = if cfg!(windows) {
+            "Stop the listed process, then restart Yerd. For wslrelay.exe, stop the affected WSL service or run `wsl --shutdown`."
+        } else {
+            "Stop the other web server (e.g. Apache, nginx, Valet), then `sudo yerd elevate ports`"
+        };
         out.push(warn(
             DiagnosisCode::ForeignWebListener,
-            "Another process is using port 80/443",
-            "A program other than Yerd is listening on a privileged web port (80/443). \
-             Yerd can't serve your .test sites there until it's stopped."
-                .to_owned(),
-            "Stop the other web server (e.g. Apache, nginx, Valet), then `sudo yerd elevate ports`",
+            "Another process is using a web port",
+            detail,
+            remedy,
         ));
     }
     if let Some(unbound) = report.web_unbound {

--- a/crates/yerd-php/src/io/fastcgi_probe.rs
+++ b/crates/yerd-php/src/io/fastcgi_probe.rs
@@ -1,9 +1,9 @@
-//! Real `HealthProbe` impl: sends a single `FCGI_GET_VALUES` record and
-//! reads back any record-shaped reply.
+//! Real `HealthProbe` impl. Unix sends a single `FCGI_GET_VALUES` record and
+//! reads back any record-shaped reply. Windows uses a weaker connect-only check
+//! because `php-cgi.exe -b` does not answer `FCGI_GET_VALUES`.
 //!
-//! The probe distinguishes "TCP accept queue with no FPM behind it"
-//! (Windows edge case) from "FPM responded" by validating the FCGI header
-//! version on the reply.
+//! The Unix probe distinguishes a TCP accept queue with no FPM behind it from a
+//! responding FPM process by validating the FCGI header version on the reply.
 
 use std::io;
 

--- a/crates/yerd-php/src/io/fastcgi_probe.rs
+++ b/crates/yerd-php/src/io/fastcgi_probe.rs
@@ -8,12 +8,15 @@
 use std::io;
 
 use async_trait::async_trait;
+#[cfg(any(unix, test))]
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::listen::Listen;
 use crate::traits::HealthProbe;
 
+#[cfg(any(unix, test))]
 const FCGI_VERSION_1: u8 = 1;
+#[cfg(any(unix, test))]
 const FCGI_GET_VALUES: u8 = 9;
 
 /// Production [`HealthProbe`] impl.
@@ -35,15 +38,23 @@ impl HealthProbe for FastCgiProbe {
                 "UnixSocket listen on non-Unix",
             )),
             Listen::TcpLoopback(addr) => {
-                let mut s = tokio::net::TcpStream::connect(addr).await?;
-                send_get_values(&mut s).await?;
-                read_one_record_header(&mut s).await
+                #[cfg(windows)]
+                {
+                    tokio::net::TcpStream::connect(addr).await.map(|_| ())
+                }
+                #[cfg(unix)]
+                {
+                    let mut s = tokio::net::TcpStream::connect(addr).await?;
+                    send_get_values(&mut s).await?;
+                    read_one_record_header(&mut s).await
+                }
             }
         }
     }
 }
 
 /// Write an 8-byte `FCGI_GET_VALUES` request with an empty body.
+#[cfg(any(unix, test))]
 async fn send_get_values<S>(s: &mut S) -> io::Result<()>
 where
     S: tokio::io::AsyncWrite + Unpin,
@@ -58,6 +69,7 @@ where
 
 /// Read exactly 8 bytes and validate the version byte. Anything shorter
 /// or with `version != 1` is reported as `io::ErrorKind::Other`.
+#[cfg(any(unix, test))]
 async fn read_one_record_header<S>(s: &mut S) -> io::Result<()>
 where
     S: tokio::io::AsyncRead + Unpin,

--- a/crates/yerd-php/src/listen.rs
+++ b/crates/yerd-php/src/listen.rs
@@ -88,6 +88,7 @@ impl AllocatedListen {
     clippy::indexing_slicing
 )]
 mod tests {
+    #[cfg(unix)]
     use super::*;
     #[cfg(unix)]
     use std::path::PathBuf;

--- a/crates/yerd-php/src/manager.rs
+++ b/crates/yerd-php/src/manager.rs
@@ -41,11 +41,13 @@ use crate::error::{ExitReason, PhpError, SpawnFailureReason};
 use crate::io::atomic_write;
 use crate::listen::{AllocatedListen, Listen};
 use crate::pool::{ExtLoad, PoolConfig};
+use crate::pure::env_scrub;
+#[cfg(unix)]
+use crate::pure::fpm_conf;
 use crate::pure::supervisor::{
     transition, Action, Elapsed, ErrorTag, Event, KillSignal, PoolState, StopProtocol,
     SupervisorPolicy,
 };
-use crate::pure::{env_scrub, fpm_conf};
 use crate::traits::{ChildHandle, Clock, HealthProbe, ProcessSpawner};
 
 /// Number of `AllocatedListen::plan` attempts when the kernel-assigned
@@ -342,7 +344,7 @@ where
             }
         }
 
-        let rendered = fpm_conf::render_fpm_conf(&cfg);
+        let rendered = render_runtime_config(&cfg, &binary);
         atomic_write::write(&cfg.config_path, rendered.as_bytes()).map_err(|source| {
             PhpError::ConfigWrite {
                 path: cfg.config_path.clone(),
@@ -358,6 +360,7 @@ where
             build_cmd(
                 &binary,
                 &cfg.config_path,
+                &cfg.listen,
                 &env,
                 extension.as_deref(),
                 &ini_defines,
@@ -764,9 +767,20 @@ async fn wait_after_kill<Ch: ChildHandle>(
     }
 }
 
+#[cfg(unix)]
+fn render_runtime_config(cfg: &PoolConfig, _binary: &std::path::Path) -> String {
+    fpm_conf::render_fpm_conf(cfg)
+}
+
+#[cfg(windows)]
+fn render_runtime_config(cfg: &PoolConfig, binary: &std::path::Path) -> String {
+    crate::pure::cgi_ini::render(cfg, binary.parent().unwrap_or(std::path::Path::new(".")))
+}
+
 fn build_cmd(
     binary: &PathBuf,
     config_path: &PathBuf,
+    listen: &Listen,
     env: &[(String, String)],
     extension: Option<&std::path::Path>,
     ini_defines: &[(String, String)],
@@ -788,7 +802,15 @@ fn build_cmd(
         cmd.arg("-d")
             .arg(format!("{directive}={}", ext.path.display()));
     }
+    #[cfg(unix)]
     cmd.arg("--fpm-config").arg(config_path);
+    #[cfg(windows)]
+    {
+        cmd.arg("-c").arg(config_path);
+        if let Listen::TcpLoopback(addr) = listen {
+            cmd.arg("-b").arg(addr.to_string());
+        }
+    }
     cmd.env_clear();
     for (k, val) in env {
         cmd.env(k, val);
@@ -827,7 +849,9 @@ fn failed_reason(s: PoolState) -> (ExitReason, u32) {
 )]
 mod pure_helper_tests {
     use super::*;
+    #[cfg(unix)]
     use std::ffi::OsStr;
+    #[cfg(unix)]
     use std::path::Path;
 
     fn args_of(cmd: &StdCommand) -> Vec<String> {
@@ -837,11 +861,13 @@ mod pure_helper_tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn build_cmd_without_extension_only_passes_fpm_config() {
         let binary = PathBuf::from("/opt/php/bin/php");
         let config = PathBuf::from("/run/yerd/fpm-8.3.conf");
         let env = vec![("PATH".to_owned(), "/usr/bin".to_owned())];
-        let cmd = build_cmd(&binary, &config, &env, None, &[], &[]);
+        let listen = Listen::UnixSocket(PathBuf::from("/run/yerd/php.sock"));
+        let cmd = build_cmd(&binary, &config, &listen, &env, None, &[], &[]);
 
         assert_eq!(cmd.get_program(), OsStr::new("/opt/php/bin/php"));
         let args = args_of(&cmd);
@@ -861,13 +887,15 @@ mod pure_helper_tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn build_cmd_with_extension_emits_defines_before_fpm_config() {
         let binary = PathBuf::from("/opt/php/bin/php");
         let config = PathBuf::from("/run/yerd/fpm-8.3.conf");
         let env: Vec<(String, String)> = vec![];
         let so = Path::new("/lib/yerd-dump.so");
         let defines = vec![("yerd_dump.state_path".to_owned(), "/var/state".to_owned())];
-        let cmd = build_cmd(&binary, &config, &env, Some(so), &defines, &[]);
+        let listen = Listen::UnixSocket(PathBuf::from("/run/yerd/php.sock"));
+        let cmd = build_cmd(&binary, &config, &listen, &env, Some(so), &defines, &[]);
 
         let args = args_of(&cmd);
         assert_eq!(
@@ -890,6 +918,7 @@ mod pure_helper_tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn build_cmd_emits_user_extensions_with_and_without_dump_ext() {
         let binary = PathBuf::from("/opt/php/bin/php");
         let config = PathBuf::from("/run/yerd/fpm-8.5.conf");
@@ -904,7 +933,8 @@ mod pure_helper_tests {
                 zend: true,
             },
         ];
-        let cmd = build_cmd(&binary, &config, &env, None, &[], &user);
+        let listen = Listen::UnixSocket(PathBuf::from("/run/yerd/php.sock"));
+        let cmd = build_cmd(&binary, &config, &listen, &env, None, &[], &user);
         let args = args_of(&cmd);
         assert_eq!(
             args,
@@ -919,7 +949,7 @@ mod pure_helper_tests {
         );
 
         let so = Path::new("/lib/yerd-dump.so");
-        let cmd = build_cmd(&binary, &config, &env, Some(so), &[], &user);
+        let cmd = build_cmd(&binary, &config, &listen, &env, Some(so), &[], &user);
         let args = args_of(&cmd);
         assert_eq!(
             args,
@@ -933,6 +963,19 @@ mod pure_helper_tests {
                 "--fpm-config",
                 "/run/yerd/fpm-8.5.conf",
             ]
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn build_cmd_runs_php_cgi_on_tcp() {
+        let binary = PathBuf::from(r"C:\Yerd\php-cgi.exe");
+        let config = PathBuf::from(r"C:\Yerd\php.ini");
+        let listen = Listen::TcpLoopback("127.0.0.1:9000".parse().unwrap());
+        let cmd = build_cmd(&binary, &config, &listen, &[], None, &[], &[]);
+        assert_eq!(
+            args_of(&cmd),
+            vec!["-c", r"C:\Yerd\php.ini", "-b", "127.0.0.1:9000"]
         );
     }
 

--- a/crates/yerd-php/src/manager.rs
+++ b/crates/yerd-php/src/manager.rs
@@ -803,7 +803,10 @@ fn build_cmd(
             .arg(format!("{directive}={}", ext.path.display()));
     }
     #[cfg(unix)]
-    cmd.arg("--fpm-config").arg(config_path);
+    {
+        let _ = listen;
+        cmd.arg("--fpm-config").arg(config_path);
+    }
     #[cfg(windows)]
     {
         cmd.arg("-c").arg(config_path);

--- a/crates/yerd-php/src/pure/cgi_ini.rs
+++ b/crates/yerd-php/src/pure/cgi_ini.rs
@@ -1,0 +1,95 @@
+//! Pure PHP CGI ini rendering for Windows.
+
+use std::fmt::Write;
+use std::path::Path;
+
+use crate::pool::PoolConfig;
+
+/// Render the Windows `php-cgi.exe` ini file.
+#[must_use]
+pub fn render(cfg: &PoolConfig, runtime_dir: &Path) -> String {
+    let mut out = String::with_capacity(512);
+    let _ = writeln!(out, "cgi.force_redirect=0");
+    let _ = writeln!(out, "cgi.fix_pathinfo=1");
+    let extension_dir = runtime_dir.join("ext").to_string_lossy().replace('\\', "/");
+    let _ = writeln!(out, "extension_dir={extension_dir}");
+    for extension in windows_extensions() {
+        let _ = writeln!(out, "extension={extension}");
+    }
+
+    if let Some(path) = &cfg.ca_bundle {
+        if let Some(path) = yerd_core::php_settings::sanitize_ca_bundle_path(path) {
+            let _ = writeln!(out, "openssl.cafile={path}");
+            let _ = writeln!(out, "curl.cainfo={path}");
+        }
+    }
+    for (key, value) in &cfg.ini {
+        if yerd_core::php_settings::directive(key).is_some()
+            && yerd_core::php_settings::validate_value(key, value).is_ok()
+        {
+            let _ = writeln!(out, "{key}={value}");
+        }
+    }
+    for (key, value) in &cfg.directives {
+        if yerd_core::php_directives::validate_name(key).is_ok()
+            && yerd_core::php_directives::validate_value(value).is_ok()
+            && yerd_core::php_directives::reserved(key).is_none()
+        {
+            let _ = writeln!(out, "{key}={value}");
+        }
+    }
+    out
+}
+
+/// Extensions bundled by official Windows PHP builds that local development expects.
+#[must_use]
+pub const fn windows_extensions() -> &'static [&'static str] {
+    &[
+        "php_curl.dll",
+        "php_fileinfo.dll",
+        "php_mbstring.dll",
+        "php_mysqli.dll",
+        "php_openssl.dll",
+        "php_pdo_mysql.dll",
+        "php_pdo_pgsql.dll",
+        "php_pdo_sqlite.dll",
+        "php_sodium.dll",
+        "php_zip.dll",
+    ]
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::listen::Listen;
+    use crate::pool::PoolConfig;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+    use std::path::PathBuf;
+    use yerd_core::PhpVersion;
+    use yerd_platform::PlatformDirs;
+
+    #[test]
+    fn renders_windows_cgi_settings() {
+        let dirs = PlatformDirs {
+            config: PathBuf::from(r"C:\Users\Dev\App Data\Yerd"),
+            data: PathBuf::new(),
+            state: PathBuf::new(),
+            cache: PathBuf::new(),
+            runtime: PathBuf::new(),
+        };
+        let mut cfg = PoolConfig::dev_defaults(
+            PhpVersion::new(8, 4),
+            Listen::TcpLoopback(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9000).into()),
+            &dirs,
+            1,
+        );
+        cfg.ini.push(("memory_limit".into(), "512M".into()));
+        cfg.ca_bundle = Some(PathBuf::from(r"C:\Users\Dev\App Data\ca.pem"));
+        let rendered = render(&cfg, Path::new(r"C:\php-8.4"));
+        assert!(rendered.contains("cgi.force_redirect=0"));
+        assert!(rendered.contains("memory_limit=512M"));
+        assert!(rendered.contains(r"openssl.cafile=C:\Users\Dev\App Data\ca.pem"));
+        assert!(rendered.contains("extension=php_openssl.dll"));
+    }
+}

--- a/crates/yerd-php/src/pure/cgi_ini.rs
+++ b/crates/yerd-php/src/pure/cgi_ini.rs
@@ -13,7 +13,7 @@ pub fn render(cfg: &PoolConfig, runtime_dir: &Path) -> String {
     let _ = writeln!(out, "cgi.fix_pathinfo=1");
     let extension_dir = runtime_dir.join("ext").to_string_lossy().replace('\\', "/");
     let _ = writeln!(out, "extension_dir={extension_dir}");
-    for extension in windows_extensions() {
+    for extension in windows_extensions(cfg.version) {
         let _ = writeln!(out, "extension={extension}");
     }
 
@@ -43,8 +43,8 @@ pub fn render(cfg: &PoolConfig, runtime_dir: &Path) -> String {
 
 /// Extensions bundled by official Windows PHP builds that local development expects.
 #[must_use]
-pub const fn windows_extensions() -> &'static [&'static str] {
-    &[
+pub fn windows_extensions(version: yerd_core::PhpVersion) -> Vec<&'static str> {
+    let mut extensions = vec![
         "php_curl.dll",
         "php_fileinfo.dll",
         "php_mbstring.dll",
@@ -54,8 +54,11 @@ pub const fn windows_extensions() -> &'static [&'static str] {
         "php_pdo_pgsql.dll",
         "php_pdo_sqlite.dll",
         "php_sodium.dll",
-        "php_zip.dll",
-    ]
+    ];
+    if (version.major, version.minor) >= (8, 2) {
+        extensions.push("php_zip.dll");
+    }
+    extensions
 }
 
 #[cfg(test)]
@@ -91,5 +94,12 @@ mod tests {
         assert!(rendered.contains("memory_limit=512M"));
         assert!(rendered.contains(r"openssl.cafile=C:\Users\Dev\App Data\ca.pem"));
         assert!(rendered.contains("extension=php_openssl.dll"));
+        assert!(rendered.contains("extension=php_zip.dll"));
+    }
+
+    #[test]
+    fn omits_zip_before_php_82() {
+        assert!(!windows_extensions(PhpVersion::new(8, 1)).contains(&"php_zip.dll"));
+        assert!(windows_extensions(PhpVersion::new(8, 2)).contains(&"php_zip.dll"));
     }
 }

--- a/crates/yerd-php/src/pure/env_scrub.rs
+++ b/crates/yerd-php/src/pure/env_scrub.rs
@@ -7,7 +7,7 @@
 /// allowlist.
 ///
 /// Retained:
-///   - Exact: `PATH`, `HOME`, `USER`, `LANG`
+///   - Exact: common user, locale, and platform process variables
 ///   - Prefix: `LC_`, `XDEBUG_`, `PHP_`
 ///
 /// Order of returned pairs matches the order of `snapshot`.
@@ -33,6 +33,8 @@ fn keep(key: &str) -> bool {
             | "COMSPEC"
             | "APPDATA"
             | "LOCALAPPDATA"
+            | "PATHEXT"
+            | "USERNAME"
     ) || key.starts_with("LC_")
         || key.starts_with("XDEBUG_")
         || key.starts_with("PHP_")

--- a/crates/yerd-php/src/pure/env_scrub.rs
+++ b/crates/yerd-php/src/pure/env_scrub.rs
@@ -16,6 +16,29 @@ pub fn allowlist(snapshot: &[(String, String)]) -> Vec<(String, String)> {
     snapshot.iter().filter(|(k, _)| keep(k)).cloned().collect()
 }
 
+#[cfg(windows)]
+fn keep(key: &str) -> bool {
+    let key = key.to_ascii_uppercase();
+    matches!(
+        key.as_str(),
+        "PATH"
+            | "HOME"
+            | "USER"
+            | "LANG"
+            | "SYSTEMROOT"
+            | "WINDIR"
+            | "TEMP"
+            | "TMP"
+            | "USERPROFILE"
+            | "COMSPEC"
+            | "APPDATA"
+            | "LOCALAPPDATA"
+    ) || key.starts_with("LC_")
+        || key.starts_with("XDEBUG_")
+        || key.starts_with("PHP_")
+}
+
+#[cfg(unix)]
 fn keep(key: &str) -> bool {
     matches!(key, "PATH" | "HOME" | "USER" | "LANG")
         || key.starts_with("LC_")
@@ -91,6 +114,20 @@ mod tests {
             s("xdebug_lower", "no"),
         ];
         let out = allowlist(&input);
+        #[cfg(unix)]
         assert!(out.is_empty());
+        #[cfg(windows)]
+        assert_eq!(out, vec![s("xdebug_lower", "no")]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn keeps_windows_runtime_environment_case_insensitively() {
+        let input = vec![
+            s("SystemRoot", r"C:\Windows"),
+            s("TEMP", r"C:\Temp"),
+            s("userprofile", r"C:\Users\dev"),
+        ];
+        assert_eq!(allowlist(&input), input);
     }
 }

--- a/crates/yerd-php/src/pure/mod.rs
+++ b/crates/yerd-php/src/pure/mod.rs
@@ -5,6 +5,8 @@
 //! helpers under `io/` are the only places that touch `tokio` / sockets
 //! / the filesystem.
 
+#[cfg(windows)]
+pub mod cgi_ini;
 pub mod env_scrub;
 pub mod ext_probe;
 pub mod fpm_conf;

--- a/crates/yerd-php/src/version.rs
+++ b/crates/yerd-php/src/version.rs
@@ -11,19 +11,19 @@ use yerd_platform::PlatformDirs;
 
 use crate::error::PhpError;
 
-/// Filename of the FPM binary inside each per-version install dir.
+/// Path of the web SAPI binary inside each per-version install dir.
 #[cfg(unix)]
-const FPM_BINARY_PATH: &[&str] = &["sbin", "php-fpm"];
-#[cfg(not(unix))]
-const FPM_BINARY_PATH: &[&str] = &["php-fpm.exe"];
+const WEB_BINARY_PATH: &[&str] = &["sbin", "php-fpm"];
+#[cfg(windows)]
+const WEB_BINARY_PATH: &[&str] = &["php-cgi.exe"];
 
-/// Walk `dirs.data / "php"` looking for per-version FPM binaries.
+/// Walk `dirs.data / "php"` looking for per-version web SAPI binaries.
 ///
 /// Layout the caller is expected to ship (produced by `xtask` Phase 2):
 ///
 /// ```text
 /// {dirs.data}/php/php-8.3/sbin/php-fpm        (Unix)
-/// {dirs.data}\php\php-8.3\php-fpm.exe         (Windows)
+/// {dirs.data}\php\php-8.3\php-cgi.exe         (Windows)
 /// ```
 ///
 /// Error policy:
@@ -48,7 +48,7 @@ pub fn discover_bundled(dirs: &PlatformDirs) -> Result<Vec<(PhpVersion, PathBuf)
             continue;
         };
         let mut binary = entry.path();
-        for segment in FPM_BINARY_PATH {
+        for segment in WEB_BINARY_PATH {
             binary.push(segment);
         }
         if !binary.exists() {
@@ -106,19 +106,30 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn discover_bundled_finds_versions_and_sorts() {
         let tmp = tempfile::tempdir().unwrap();
         let dirs = make_dirs(tmp.path());
 
+        #[cfg(unix)]
         let v83 = dirs.data.join("php").join("php-8.3").join("sbin");
+        #[cfg(windows)]
+        let v83 = dirs.data.join("php").join("php-8.3");
         std::fs::create_dir_all(&v83).unwrap();
+        #[cfg(unix)]
         std::fs::write(v83.join("php-fpm"), b"#!/bin/sh\n").unwrap();
+        #[cfg(windows)]
+        std::fs::write(v83.join("php-cgi.exe"), b"fixture").unwrap();
 
+        #[cfg(unix)]
         let v74 = dirs.data.join("php").join("php-7.4").join("sbin");
+        #[cfg(windows)]
+        let v74 = dirs.data.join("php").join("php-7.4");
         std::fs::create_dir_all(&v74).unwrap();
+        #[cfg(unix)]
         std::fs::write(v74.join("php-fpm"), b"#!/bin/sh\n").unwrap();
+        #[cfg(windows)]
+        std::fs::write(v74.join("php-cgi.exe"), b"fixture").unwrap();
 
         let bogus = dirs.data.join("php").join("php-bogus");
         std::fs::create_dir_all(bogus).unwrap();

--- a/crates/yerd-php/tests/fpm_conf_golden.rs
+++ b/crates/yerd-php/tests/fpm_conf_golden.rs
@@ -1,6 +1,7 @@
 //! Byte-exact golden test for the rendered FPM config. Pins the
 //! template format - future edits flip this test deliberately.
 
+#![cfg(unix)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/crates/yerd-php/tests/supervisor_states.rs
+++ b/crates/yerd-php/tests/supervisor_states.rs
@@ -195,12 +195,15 @@ impl HealthProbe for FakeProbe {
 }
 
 fn make_dirs() -> PlatformDirs {
+    static NEXT_DIR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let id = NEXT_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!("yerd-php-test-{}-{id}", std::process::id()));
     PlatformDirs {
-        config: PathBuf::from("/tmp/yerd-test/cfg"),
-        data: PathBuf::from("/tmp/yerd-test/data"),
-        state: PathBuf::from("/tmp/yerd-test/state"),
-        cache: PathBuf::from("/tmp/yerd-test/cache"),
-        runtime: PathBuf::from("/tmp/yerd-test/run"),
+        config: root.join("cfg"),
+        data: root.join("data"),
+        state: root.join("state"),
+        cache: root.join("cache"),
+        runtime: root.join("run"),
     }
 }
 
@@ -284,22 +287,19 @@ async fn set_ca_bundle_is_rendered_into_pool_config() {
 
     let cfg_path = dirs.config.join("php-fpm-8.3-5150.conf");
     let on_disk = std::fs::read_to_string(&cfg_path).unwrap();
-    assert!(
-        on_disk.contains(&format!(
-            "php_admin_value[openssl.cafile] = {}\n",
-            bundle.display()
-        )),
-        "got: {on_disk}"
-    );
-    assert!(
-        on_disk.contains(&format!(
-            "php_admin_value[curl.cainfo] = {}\n",
-            bundle.display()
-        )),
-        "got: {on_disk}"
-    );
+    #[cfg(unix)]
+    let expected = format!("php_admin_value[openssl.cafile] = {}\n", bundle.display());
+    #[cfg(windows)]
+    let expected = format!("openssl.cafile={}\n", bundle.display());
+    assert!(on_disk.contains(&expected), "got: {on_disk}");
+    #[cfg(unix)]
+    let expected = format!("php_admin_value[curl.cainfo] = {}\n", bundle.display());
+    #[cfg(windows)]
+    let expected = format!("curl.cainfo={}\n", bundle.display());
+    assert!(on_disk.contains(&expected), "got: {on_disk}");
 }
 
+#[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn set_pool_overrides_is_rendered_into_pool_config() {
     let v = PhpVersion::new(8, 3);
@@ -343,6 +343,7 @@ async fn set_pool_overrides_is_rendered_into_pool_config() {
 /// rather than breaking the pool: `override_max_children` returns `None` and
 /// `ensure` never touches `cfg.max_children`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[cfg(unix)]
 async fn invalid_pool_override_falls_back_to_the_default() {
     let v = PhpVersion::new(8, 3);
     let spawner = FakeSpawner::new(vec![SpawnPlan {

--- a/crates/yerd-platform/src/error.rs
+++ b/crates/yerd-platform/src/error.rs
@@ -149,6 +149,10 @@ pub enum ResolverErrorReason {
     #[error("tld empty")]
     TldEmpty,
 
+    /// System resolver API or command failed.
+    #[error("system resolver API failed: {0}")]
+    SystemApi(String),
+
     /// `systemd-resolved` was expected but is not active.
     #[error("systemd-resolved not active")]
     ResolvedNotActive,

--- a/crates/yerd-platform/src/lib.rs
+++ b/crates/yerd-platform/src/lib.rs
@@ -3,9 +3,8 @@
 //! The core traits live here - [`Paths`], [`TrustStore`], [`ResolverInstaller`],
 //! [`PortBinder`], [`PortRedirector`], and [`TerminalLauncher`] - each with a single thin
 //! implementation per OS selected by `#[cfg(target_os = ...)]`. macOS and Linux
-//! ship in Phase 1;
-//! Windows compiles against the [`os::unsupported`] stub that returns
-//! [`PlatformError::Unsupported`] for every method.
+//! ship the complete surface. Windows currently supports paths, terminal launch,
+//! and port binding; privileged integration remains unsupported.
 //!
 //! ## Privilege boundary
 //!

--- a/crates/yerd-platform/src/nss_exec.rs
+++ b/crates/yerd-platform/src/nss_exec.rs
@@ -225,6 +225,7 @@ pub fn browser_trust(
 /// service manager hands the daemon a stripped `PATH` that hides the tool. The
 /// existence probe is injected so the walk is unit-tested against the real
 /// candidate lists on any host, without touching the filesystem.
+#[cfg(any(unix, test))]
 fn resolve_certutil(
     candidates: &[PathBuf],
     path_dirs: &[PathBuf],

--- a/crates/yerd-platform/src/os/mod.rs
+++ b/crates/yerd-platform/src/os/mod.rs
@@ -1,14 +1,16 @@
 //! Per-OS implementations selected by `#[cfg(target_os = ...)]`.
 //!
-//! Exactly one of `linux`, `macos`, or `unsupported` is active per build.
+//! Exactly one of `linux`, `macos`, `windows`, or `unsupported` is active per build.
 //! The `active` re-export below is the entry point used by `lib.rs`.
 
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 mod unsupported;
+#[cfg(target_os = "windows")]
+mod windows;
 
 pub(crate) mod active {
     //! Type aliases for the currently-active OS implementation.
@@ -31,7 +33,16 @@ pub(crate) mod active {
         MacosTrustStore as ActiveTrustStore,
     };
 
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(target_os = "windows")]
+    pub use super::windows::{
+        WindowsPaths as ActivePaths, WindowsPortBinder as ActivePortBinder,
+        WindowsPortRedirector as ActivePortRedirector,
+        WindowsResolverInstaller as ActiveResolverInstaller,
+        WindowsSystemMetrics as ActiveSystemMetrics,
+        WindowsTerminalLauncher as ActiveTerminalLauncher, WindowsTrustStore as ActiveTrustStore,
+    };
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     pub use super::unsupported::{
         UnsupportedPaths as ActivePaths, UnsupportedPortBinder as ActivePortBinder,
         UnsupportedPortRedirector as ActivePortRedirector,

--- a/crates/yerd-platform/src/os/windows.rs
+++ b/crates/yerd-platform/src/os/windows.rs
@@ -1,0 +1,360 @@
+//! Windows implementations of the platform traits.
+//!
+//! Paths, terminal launch, and TCP binding are available without elevation.
+//! Trust-store and resolver integration remain explicit unsupported operations.
+
+#![allow(clippy::similar_names)]
+
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+use std::path::Path;
+use std::process::Command;
+
+use directories::ProjectDirs;
+
+use crate::error::ops;
+use crate::metrics::SystemMetrics;
+use crate::paths::{Paths, PlatformDirs};
+use crate::port_binder::{BoundPort, PortBinder, PortPair};
+use crate::port_redirect::PortRedirector;
+use crate::pure::port_plan;
+use crate::resolver::ResolverInstaller;
+use crate::terminal::TerminalLauncher;
+use crate::trust_store::{CaFingerprint, NssOutcome, TrustStore};
+use crate::{BindPairErrorReason, PlatformError, TerminalErrorReason};
+
+/// Windows terminal launcher.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsTerminalLauncher;
+
+impl WindowsTerminalLauncher {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl TerminalLauncher for WindowsTerminalLauncher {
+    fn open_terminal(&self, path: &Path) -> Result<(), PlatformError> {
+        if Command::new("wt.exe").arg("-d").arg(path).spawn().is_ok() {
+            return Ok(());
+        }
+        Command::new("cmd.exe")
+            .arg("/K")
+            .current_dir(path)
+            .spawn()
+            .map(|_| ())
+            .map_err(|_| PlatformError::Terminal {
+                reason: TerminalErrorReason::NoSupportedTerminal,
+            })
+    }
+}
+
+/// Windows path implementation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsPaths;
+
+impl WindowsPaths {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Paths for WindowsPaths {
+    fn resolve(&self) -> Result<PlatformDirs, PlatformError> {
+        let pd = ProjectDirs::from("io", "yerd", "Yerd").ok_or(PlatformError::MissingHomeDir)?;
+        let data = pd.data_dir().to_path_buf();
+        let local = pd.data_local_dir().to_path_buf();
+        Ok(PlatformDirs {
+            config: pd.config_dir().to_path_buf(),
+            data,
+            state: local.clone(),
+            cache: pd.cache_dir().to_path_buf(),
+            runtime: local.join("run"),
+        })
+    }
+}
+
+/// Windows trust-store stub until privileged certificate integration is available.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsTrustStore;
+
+impl WindowsTrustStore {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl TrustStore for WindowsTrustStore {
+    fn install_system(&self, _: &str, _: &CaFingerprint) -> Result<(), PlatformError> {
+        Err(PlatformError::NeedsHelper {
+            operation: ops::INSTALL_CA,
+        })
+    }
+
+    fn uninstall_system(&self, _: &CaFingerprint) -> Result<(), PlatformError> {
+        Err(PlatformError::NeedsHelper {
+            operation: ops::UNINSTALL_CA,
+        })
+    }
+
+    fn is_present_system(&self, _: &CaFingerprint) -> Result<bool, PlatformError> {
+        Err(PlatformError::Unsupported {
+            operation: ops::IS_PRESENT_SYSTEM,
+        })
+    }
+
+    fn is_trusted(&self, ca_path: &Path, _: &CaFingerprint) -> Result<bool, PlatformError> {
+        let status = Command::new(r"C:\Windows\System32\certutil.exe")
+            .args(["-verify"])
+            .arg(ca_path)
+            .status()
+            .map_err(|source| PlatformError::Io {
+                path: ca_path.to_path_buf(),
+                source,
+            })?;
+        Ok(status.success())
+    }
+
+    fn install_firefox_nss(&self, _: &Path) -> Result<NssOutcome, PlatformError> {
+        Err(PlatformError::Unsupported {
+            operation: ops::INSTALL_FIREFOX_NSS,
+        })
+    }
+
+    fn uninstall_firefox_nss(&self) -> Result<NssOutcome, PlatformError> {
+        Err(PlatformError::Unsupported {
+            operation: ops::UNINSTALL_FIREFOX_NSS,
+        })
+    }
+
+    fn system_root_bundle(&self) -> Result<Option<String>, PlatformError> {
+        Ok(None)
+    }
+}
+
+/// Windows resolver stub until NRPT or DNS policy integration is available.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsResolverInstaller;
+
+impl WindowsResolverInstaller {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl ResolverInstaller for WindowsResolverInstaller {
+    fn install(&self, _: &str, _: SocketAddr) -> Result<(), PlatformError> {
+        Err(PlatformError::NeedsHelper {
+            operation: ops::INSTALL_RESOLVER,
+        })
+    }
+
+    fn uninstall(&self, _: &str) -> Result<(), PlatformError> {
+        Err(PlatformError::NeedsHelper {
+            operation: ops::UNINSTALL_RESOLVER,
+        })
+    }
+
+    fn is_installed(&self, tld: &str, addr: SocketAddr) -> Result<bool, PlatformError> {
+        if tld.is_empty() {
+            return Err(PlatformError::Resolver {
+                reason: crate::ResolverErrorReason::TldEmpty,
+            });
+        }
+        if addr != SocketAddr::from((Ipv4Addr::LOCALHOST, 53)) {
+            return Ok(false);
+        }
+        let command = format!(
+            "if (Get-DnsClientNrptRule | Where-Object {{ $_.Namespace -contains '.{tld}' -and $_.NameServers -contains '127.0.0.1' -and $_.Comment -eq 'Yerd managed' }}) {{ exit 0 }} else {{ exit 1 }}"
+        );
+        let status = Command::new(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &command])
+            .status()
+            .map_err(|source| PlatformError::Resolver {
+                reason: crate::ResolverErrorReason::SystemApi(source.to_string()),
+            })?;
+        Ok(status.success())
+    }
+}
+
+/// Windows TCP port binder.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsPortBinder;
+
+impl WindowsPortBinder {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+fn bind_at(ip: Ipv4Addr, port: u16) -> std::io::Result<TcpListener> {
+    TcpListener::bind(SocketAddr::from((ip, port)))
+}
+
+impl PortBinder for WindowsPortBinder {
+    fn bind(&self, port: u16) -> Result<BoundPort, PlatformError> {
+        bind_at(Ipv4Addr::LOCALHOST, port)
+            .map(|listener| BoundPort { listener })
+            .map_err(|source| PlatformError::Bind { port, source })
+    }
+
+    fn bind_pair(
+        &self,
+        lan: bool,
+        desired: (u16, u16),
+        fallback: (u16, u16),
+    ) -> Result<PortPair, PlatformError> {
+        bind_pair_impl(lan, desired, fallback)
+    }
+}
+
+fn bind_pair_impl(
+    lan: bool,
+    desired: (u16, u16),
+    fallback: (u16, u16),
+) -> Result<PortPair, PlatformError> {
+    let ip = if lan {
+        Ipv4Addr::UNSPECIFIED
+    } else {
+        Ipv4Addr::LOCALHOST
+    };
+    let http_attempt = bind_at(ip, desired.0);
+    let https_attempt = bind_at(ip, desired.1);
+    let http_outcome = http_attempt
+        .as_ref()
+        .map(|_| ())
+        .map_err(std::io::Error::kind);
+    let https_outcome = https_attempt
+        .as_ref()
+        .map(|_| ())
+        .map_err(std::io::Error::kind);
+
+    match port_plan::classify_desired(http_outcome, https_outcome) {
+        port_plan::DesiredPairAction::KeepDesired => Ok(PortPair {
+            http: BoundPort {
+                listener: http_attempt.map_err(|source| PlatformError::Bind {
+                    port: desired.0,
+                    source,
+                })?,
+            },
+            https: BoundPort {
+                listener: https_attempt.map_err(|source| PlatformError::Bind {
+                    port: desired.1,
+                    source,
+                })?,
+            },
+        }),
+        port_plan::DesiredPairAction::HardFail(_) => {
+            if let Err(source) = http_attempt {
+                return Err(PlatformError::Bind {
+                    port: desired.0,
+                    source,
+                });
+            }
+            if let Err(source) = https_attempt {
+                return Err(PlatformError::Bind {
+                    port: desired.1,
+                    source,
+                });
+            }
+            Err(PlatformError::Bind {
+                port: desired.0,
+                source: std::io::Error::from(std::io::ErrorKind::Other),
+            })
+        }
+        port_plan::DesiredPairAction::UseFallback => {
+            let desired_http_kind = http_outcome.err().unwrap_or(std::io::ErrorKind::Other);
+            let desired_https_kind = https_outcome.err().unwrap_or(std::io::ErrorKind::Other);
+            drop(http_attempt);
+            drop(https_attempt);
+            let fallback_http = bind_at(ip, fallback.0);
+            let fallback_https = bind_at(ip, fallback.1);
+            let fallback_http_outcome = fallback_http
+                .as_ref()
+                .map(|_| ())
+                .map_err(std::io::Error::kind);
+            let fallback_https_outcome = fallback_https
+                .as_ref()
+                .map(|_| ())
+                .map_err(std::io::Error::kind);
+
+            match port_plan::classify_fallback(fallback_http_outcome, fallback_https_outcome) {
+                port_plan::FallbackPairAction::KeepFallback => Ok(PortPair {
+                    http: BoundPort {
+                        listener: fallback_http.map_err(|source| PlatformError::Bind {
+                            port: fallback.0,
+                            source,
+                        })?,
+                    },
+                    https: BoundPort {
+                        listener: fallback_https.map_err(|source| PlatformError::Bind {
+                            port: fallback.1,
+                            source,
+                        })?,
+                    },
+                }),
+                port_plan::FallbackPairAction::BothFailed => Err(PlatformError::BindPair {
+                    reason: BindPairErrorReason::BothPairsFailed {
+                        desired_http: desired_http_kind,
+                        desired_https: desired_https_kind,
+                        fallback_http: fallback_http_outcome
+                            .err()
+                            .unwrap_or(std::io::ErrorKind::Other),
+                        fallback_https: fallback_https_outcome
+                            .err()
+                            .unwrap_or(std::io::ErrorKind::Other),
+                    },
+                }),
+            }
+        }
+    }
+}
+
+/// Best-effort Windows metrics placeholder.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsSystemMetrics;
+
+impl WindowsSystemMetrics {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl SystemMetrics for WindowsSystemMetrics {
+    fn rss_bytes(&self, _: u32) -> Option<u64> {
+        None
+    }
+
+    fn load_average(&self) -> Option<[f64; 3]> {
+        None
+    }
+}
+
+/// Windows port redirect probe placeholder.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsPortRedirector;
+
+impl WindowsPortRedirector {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl PortRedirector for WindowsPortRedirector {
+    fn is_active(&self) -> Option<bool> {
+        None
+    }
+}

--- a/crates/yerd-platform/src/os/windows.rs
+++ b/crates/yerd-platform/src/os/windows.rs
@@ -108,16 +108,23 @@ impl TrustStore for WindowsTrustStore {
         })
     }
 
-    fn is_trusted(&self, ca_path: &Path, _: &CaFingerprint) -> Result<bool, PlatformError> {
-        let status = Command::new(r"C:\Windows\System32\certutil.exe")
+    fn is_trusted(&self, ca_path: &Path, fp: &CaFingerprint) -> Result<bool, PlatformError> {
+        let pem = std::fs::read_to_string(ca_path).map_err(|source| PlatformError::Io {
+            path: ca_path.to_path_buf(),
+            source,
+        })?;
+        if CaFingerprint::from_pem(&pem).as_ref() != Some(fp) {
+            return Ok(false);
+        }
+        let output = Command::new(r"C:\Windows\System32\certutil.exe")
             .args(["-verify"])
             .arg(ca_path)
-            .status()
+            .output()
             .map_err(|source| PlatformError::Io {
                 path: ca_path.to_path_buf(),
                 source,
             })?;
-        Ok(status.success())
+        Ok(output.status.success())
     }
 
     fn install_firefox_nss(&self, _: &Path) -> Result<NssOutcome, PlatformError> {
@@ -171,8 +178,12 @@ impl ResolverInstaller for WindowsResolverInstaller {
         if addr != SocketAddr::from((Ipv4Addr::LOCALHOST, 53)) {
             return Ok(false);
         }
+        let tld = yerd_core::Tld::new(tld).map_err(|error| PlatformError::Resolver {
+            reason: crate::ResolverErrorReason::SystemApi(error.to_string()),
+        })?;
         let command = format!(
-            "if (Get-DnsClientNrptRule | Where-Object {{ $_.Namespace -contains '.{tld}' -and $_.NameServers -contains '127.0.0.1' -and $_.Comment -eq 'Yerd managed' }}) {{ exit 0 }} else {{ exit 1 }}"
+            "if (Get-DnsClientNrptRule | Where-Object {{ $_.Namespace -contains '.{}' -and $_.NameServers -contains '127.0.0.1' -and $_.Comment -eq 'Yerd managed' }}) {{ exit 0 }} else {{ exit 1 }}",
+            tld.as_str()
         );
         let status = Command::new(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")
             .args(["-NoProfile", "-NonInteractive", "-Command", &command])

--- a/crates/yerd-platform/src/paths.rs
+++ b/crates/yerd-platform/src/paths.rs
@@ -2,6 +2,9 @@
 
 use std::path::PathBuf;
 
+#[cfg(windows)]
+use sha2::{Digest, Sha256};
+
 use crate::PlatformError;
 
 /// The five directories Yerd cares about. Returned by [`Paths::resolve`].
@@ -28,6 +31,7 @@ pub struct PlatformDirs {
     /// Linux: `XDG_RUNTIME_DIR/yerd` or, when `XDG_RUNTIME_DIR` is unset,
     /// `/tmp/yerd-$UID` (see struct-level docs for the caller contract).
     /// macOS: a deterministic `/tmp/yerd-$UID`, not `$TMPDIR`/`temp_dir()`.
+    /// Windows: `%LOCALAPPDATA%\yerd\Yerd\data\run`.
     /// `os::macos::resolve` explains why the uid-derived path is load-bearing
     /// for socket reconstruction.
     pub runtime: PathBuf,
@@ -43,14 +47,16 @@ impl PlatformDirs {
     /// reproduces exactly what `directories` produces in `resolve` (a
     /// drift-guard test asserts the two agree for the current home).
     ///
-    /// `runtime` is the deterministic uid fallback (`/tmp/yerd-$uid`); a caller
+    /// On Unix, `runtime` is the deterministic uid fallback
+    /// (`/tmp/yerd-$uid`); a caller
     /// that also wants the `XDG_RUNTIME_DIR` location (`/run/user/$uid/yerd`,
     /// which `resolve` prefers when the env var is set) must add it itself,
     /// since the real value can't be recovered from a stripped sudo environment.
     #[must_use]
-    pub fn for_user(home: &std::path::Path, _uid: u32) -> Self {
+    /// Windows ignores `uid` and derives the runtime directory from `home`.
+    pub fn for_user(home: &std::path::Path, uid: u32) -> Self {
         #[cfg(not(target_os = "windows"))]
-        let runtime = PathBuf::from(format!("/tmp/yerd-{_uid}"));
+        let runtime = PathBuf::from(format!("/tmp/yerd-{uid}"));
         #[cfg(target_os = "macos")]
         {
             let app = home
@@ -78,6 +84,7 @@ impl PlatformDirs {
         }
         #[cfg(target_os = "windows")]
         {
+            let _ = uid;
             let roaming = home
                 .join("AppData")
                 .join("Roaming")
@@ -104,6 +111,21 @@ impl PlatformDirs {
             }
         }
     }
+}
+
+/// Derive the per-user Windows daemon pipe name from the runtime directory.
+#[cfg(windows)]
+#[must_use]
+pub fn daemon_pipe_name(dirs: &PlatformDirs) -> String {
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut hasher = Sha256::new();
+    for unit in dirs.runtime.as_os_str().encode_wide() {
+        hasher.update(unit.to_le_bytes());
+    }
+    let digest = hasher.finalize();
+    let scope = digest.get(..8).unwrap_or(&digest);
+    format!("yerd-daemon-{}", hex::encode(scope))
 }
 
 /// OS path-discovery abstraction.
@@ -149,5 +171,36 @@ mod for_user_tests {
         assert_eq!(f.data, r.data, "data dir");
         assert_eq!(f.cache, r.cache, "cache dir");
         assert_eq!(f.state, r.state, "state dir");
+    }
+}
+
+#[cfg(all(test, windows))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod windows_pipe_tests {
+    use super::{daemon_pipe_name, PlatformDirs};
+    use std::path::PathBuf;
+
+    fn dirs(runtime: &str) -> PlatformDirs {
+        PlatformDirs {
+            config: PathBuf::new(),
+            data: PathBuf::new(),
+            state: PathBuf::new(),
+            cache: PathBuf::new(),
+            runtime: PathBuf::from(runtime),
+        }
+    }
+
+    #[test]
+    fn pipe_name_is_stable_and_user_scoped() {
+        let first = daemon_pipe_name(&dirs(r"C:\Users\Alice\AppData\Local\yerd\run"));
+        assert_eq!(
+            first,
+            daemon_pipe_name(&dirs(r"C:\Users\Alice\AppData\Local\yerd\run"))
+        );
+        assert_ne!(
+            first,
+            daemon_pipe_name(&dirs(r"C:\Users\Bob\AppData\Local\yerd\run"))
+        );
+        assert!(first.starts_with("yerd-daemon-"));
     }
 }

--- a/crates/yerd-platform/src/paths.rs
+++ b/crates/yerd-platform/src/paths.rs
@@ -48,8 +48,9 @@ impl PlatformDirs {
     /// which `resolve` prefers when the env var is set) must add it itself,
     /// since the real value can't be recovered from a stripped sudo environment.
     #[must_use]
-    pub fn for_user(home: &std::path::Path, uid: u32) -> Self {
-        let runtime = PathBuf::from(format!("/tmp/yerd-{uid}"));
+    pub fn for_user(home: &std::path::Path, _uid: u32) -> Self {
+        #[cfg(not(target_os = "windows"))]
+        let runtime = PathBuf::from(format!("/tmp/yerd-{_uid}"));
         #[cfg(target_os = "macos")]
         {
             let app = home
@@ -75,7 +76,24 @@ impl PlatformDirs {
                 runtime,
             }
         }
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[cfg(target_os = "windows")]
+        {
+            let roaming = home
+                .join("AppData")
+                .join("Roaming")
+                .join("yerd")
+                .join("Yerd");
+            let local = home.join("AppData").join("Local").join("yerd").join("Yerd");
+            let state = local.join("data");
+            Self {
+                config: roaming.join("config"),
+                data: roaming.join("data"),
+                state: state.clone(),
+                cache: local.join("cache"),
+                runtime: state.join("run"),
+            }
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
         {
             Self {
                 config: home.join(".config").join("yerd"),

--- a/crates/yerd-platform/src/pure/shell_profile.rs
+++ b/crates/yerd-platform/src/pure/shell_profile.rs
@@ -282,6 +282,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn body_is_guarded_and_quotes_the_space() {
         let posix = render_body(Shell::Zsh, &bin());
         assert!(posix.contains("Application Support"));
@@ -306,6 +307,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn body_escapes_shell_metacharacters_in_the_path() {
         let dir = PathBuf::from(r#"/home/b$x/a`b/c\d/e"f/bin"#);
 

--- a/crates/yerd-platform/src/pure/system_roots.rs
+++ b/crates/yerd-platform/src/pure/system_roots.rs
@@ -45,6 +45,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
+    #[cfg(unix)]
     fn linux_candidates_are_absolute_and_ordered() {
         let c = linux_root_candidates();
         assert_eq!(

--- a/crates/yerd-platform/tests/unsupported.rs
+++ b/crates/yerd-platform/tests/unsupported.rs
@@ -1,7 +1,7 @@
 //! Stub-only test: every trait method returns `Unsupported` on
-//! non-Linux, non-macOS targets (Phase 1: Windows).
+//! targets without a dedicated adapter.
 
-#![cfg(not(any(target_os = "linux", target_os = "macos")))]
+#![cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/crates/yerd-platform/tests/windows_smoke.rs
+++ b/crates/yerd-platform/tests/windows_smoke.rs
@@ -1,0 +1,72 @@
+//! Per-OS smoke tests gated to Windows.
+
+#![cfg(target_os = "windows")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+mod common;
+
+use common::random_fingerprint;
+use yerd_platform::{
+    ActivePaths, ActivePortBinder, ActiveResolverInstaller, ActiveTrustStore, Paths, PlatformDirs,
+    PlatformError, PortBinder, ResolverInstaller, TrustStore,
+};
+
+#[test]
+fn paths_resolve_returns_windows_directories() {
+    let dirs = ActivePaths.resolve().expect("Windows paths should resolve");
+    assert!(!dirs.config.as_os_str().is_empty());
+    assert!(!dirs.data.as_os_str().is_empty());
+    assert!(!dirs.state.as_os_str().is_empty());
+    assert!(!dirs.cache.as_os_str().is_empty());
+    assert!(dirs.runtime.ends_with("run"));
+}
+
+#[test]
+fn for_user_layout_matches_resolve_for_current_home() {
+    let home = std::env::var_os("USERPROFILE").expect("USERPROFILE should exist");
+    let resolved = ActivePaths.resolve().expect("Windows paths should resolve");
+    let explicit = PlatformDirs::for_user(std::path::Path::new(&home), 0);
+    assert_eq!(explicit, resolved);
+}
+
+#[test]
+fn privileged_integrations_require_the_helper() {
+    let fp = random_fingerprint(0xAA);
+    assert!(matches!(
+        ActiveTrustStore.install_system("pem", &fp),
+        Err(PlatformError::NeedsHelper {
+            operation: "install-ca"
+        })
+    ));
+    assert!(matches!(
+        ActiveResolverInstaller.install("test", "127.0.0.1:53".parse().unwrap()),
+        Err(PlatformError::NeedsHelper {
+            operation: "install-resolver"
+        })
+    ));
+}
+
+#[test]
+fn port_binder_binds_single_and_pair() {
+    let single = ActivePortBinder.bind(0).expect("bind ephemeral port");
+    assert_ne!(single.port().unwrap(), 0);
+    let pair = ActivePortBinder
+        .bind_pair(false, (0, 0), (0, 0))
+        .expect("bind ephemeral pair");
+    assert_ne!(pair.http.port().unwrap(), pair.https.port().unwrap());
+}
+
+#[test]
+fn port_binder_falls_back_from_occupied_port() {
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let pair = ActivePortBinder
+        .bind_pair(false, (occupied_port, 0), (0, 0))
+        .expect("occupied desired port should use fallback");
+    assert_ne!(pair.http.port().unwrap(), occupied_port);
+}

--- a/crates/yerd-proxy/src/pure/cgi_params.rs
+++ b/crates/yerd-proxy/src/pure/cgi_params.rs
@@ -84,6 +84,8 @@ pub fn build_params(
         ),
         None => (document_root.join("index.php"), "/index.php".to_owned()),
     };
+    let script_filename = cgi_path(&script_filename);
+    let document_root = cgi_path(document_root);
 
     push(&mut out, b"GATEWAY_INTERFACE", b"CGI/1.1");
     push(&mut out, b"SERVER_PROTOCOL", b"HTTP/1.1");
@@ -91,16 +93,8 @@ pub fn build_params(
     push(&mut out, b"REQUEST_URI", path_and_query.as_bytes());
     push(&mut out, b"QUERY_STRING", query.as_bytes());
     push(&mut out, b"SCRIPT_NAME", script_name.as_bytes());
-    push(
-        &mut out,
-        b"SCRIPT_FILENAME",
-        script_filename.to_string_lossy().as_bytes(),
-    );
-    push(
-        &mut out,
-        b"DOCUMENT_ROOT",
-        document_root.to_string_lossy().as_bytes(),
-    );
+    push(&mut out, b"SCRIPT_FILENAME", script_filename.as_bytes());
+    push(&mut out, b"DOCUMENT_ROOT", document_root.as_bytes());
     push(&mut out, b"PATH_INFO", path.as_bytes());
     push(
         &mut out,
@@ -174,6 +168,17 @@ pub fn build_params(
     }
 
     out
+}
+
+fn cgi_path(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    #[cfg(windows)]
+    return path
+        .strip_prefix(r"\\?\")
+        .unwrap_or(&path)
+        .replace('\\', "/");
+    #[cfg(unix)]
+    path.into_owned()
 }
 
 fn push(out: &mut Vec<(Vec<u8>, Vec<u8>)>, name: &[u8], value: &[u8]) {
@@ -492,4 +497,12 @@ mod tests {
             Some("/srv/www/blog/wp-login.php".as_bytes())
         );
     }
+}
+#[cfg(windows)]
+#[test]
+fn cgi_path_removes_windows_verbatim_prefix() {
+    assert_eq!(
+        cgi_path(Path::new(r"\\?\C:\Sites\app\index.php")),
+        "C:/Sites/app/index.php"
+    );
 }

--- a/crates/yerd-proxy/src/pure/cgi_params.rs
+++ b/crates/yerd-proxy/src/pure/cgi_params.rs
@@ -173,11 +173,15 @@ pub fn build_params(
 fn cgi_path(path: &Path) -> String {
     let path = path.to_string_lossy();
     #[cfg(windows)]
-    return path
-        .strip_prefix(r"\\?\")
-        .unwrap_or(&path)
-        .replace('\\', "/");
-    #[cfg(unix)]
+    {
+        if let Some(path) = path.strip_prefix(r"\\?\UNC\") {
+            return format!("//{}", path.replace('\\', "/"));
+        }
+        path.strip_prefix(r"\\?\")
+            .unwrap_or(&path)
+            .replace('\\', "/")
+    }
+    #[cfg(not(windows))]
     path.into_owned()
 }
 
@@ -504,5 +508,9 @@ fn cgi_path_removes_windows_verbatim_prefix() {
     assert_eq!(
         cgi_path(Path::new(r"\\?\C:\Sites\app\index.php")),
         "C:/Sites/app/index.php"
+    );
+    assert_eq!(
+        cgi_path(Path::new(r"\\?\UNC\server\share\app\index.php")),
+        "//server/share/app/index.php"
     );
 }

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -846,7 +846,15 @@ async fn subdirectory_index_php_wins_over_root_index_php() {
     );
     assert_eq!(
         params.get("SCRIPT_FILENAME").map(String::as_str),
-        Some(docroot.path().join("wp-admin/index.php").to_str().unwrap())
+        Some(
+            docroot
+                .path()
+                .join("wp-admin/index.php")
+                .to_str()
+                .unwrap()
+                .replace('\\', "/")
+                .as_str()
+        )
     );
 
     let _ = tx_shutdown.send(());
@@ -1286,7 +1294,15 @@ async fn direct_script_execution_gated_to_wordpress_sites() {
     );
     assert_eq!(
         params.get("SCRIPT_FILENAME").map(String::as_str),
-        Some(docroot.path().join("index.php").to_str().unwrap())
+        Some(
+            docroot
+                .path()
+                .join("index.php")
+                .to_str()
+                .unwrap()
+                .replace('\\', "/")
+                .as_str()
+        )
     );
 
     let _ = tx_shutdown.send(());

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -850,8 +850,7 @@ async fn subdirectory_index_php_wins_over_root_index_php() {
             docroot
                 .path()
                 .join("wp-admin/index.php")
-                .to_str()
-                .unwrap()
+                .to_string_lossy()
                 .replace('\\', "/")
                 .as_str()
         )
@@ -1298,8 +1297,7 @@ async fn direct_script_execution_gated_to_wordpress_sites() {
             docroot
                 .path()
                 .join("index.php")
-                .to_str()
-                .unwrap()
+                .to_string_lossy()
                 .replace('\\', "/")
                 .as_str()
         )

--- a/crates/yerd-service-ctl/src/lib.rs
+++ b/crates/yerd-service-ctl/src/lib.rs
@@ -30,6 +30,7 @@ const DAEMON_LABEL: &str = "dev.yerd.daemon";
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const SYSTEMD_UNIT: &str = "yerd";
 /// The exact process name to match when falling back to signalling by pid.
+#[cfg(unix)]
 const DAEMON_PROCESS: &str = "yerdd";
 
 /// A daemon service-control failure.
@@ -219,6 +220,7 @@ fn running_pids() -> Vec<i32> {
 }
 
 /// Parse `pgrep` stdout (one pid per line) into pids, skipping junk.
+#[cfg(any(unix, test))]
 fn parse_pids(stdout: &str) -> Vec<i32> {
     stdout
         .lines()

--- a/crates/yerd-services/src/config_render.rs
+++ b/crates/yerd-services/src/config_render.rs
@@ -41,9 +41,13 @@ pub fn render_redis_conf(port: u16, datadir: &Path, logfile: &Path) -> String {
 /// (the only metacharacters its double-quoted-string parser honours). The same
 /// double-quoted-value form is accepted by `MySQL`/`MariaDB` option files.
 fn quote_conf_path(p: &Path) -> String {
-    let s = p.display().to_string();
-    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    let s = config_path(p);
+    let escaped = s.replace('"', "\\\"");
     format!("\"{escaped}\"")
+}
+
+fn config_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 /// Render a `MySQL` / `MariaDB` option file: loopback-only, no password.
@@ -148,8 +152,8 @@ pub fn render_my_bootstrap_sql() -> &'static str {
 /// so the line never duplicates or accumulates.
 #[must_use]
 pub fn render_postgresql_conf(port: u16, datadir: &Path, preload_libraries: &[&str]) -> String {
-    let hba = quote_pg_string(&datadir.join("pg_hba.conf").display().to_string());
-    let ident = quote_pg_string(&datadir.join("pg_ident.conf").display().to_string());
+    let hba = quote_pg_string(&config_path(&datadir.join("pg_hba.conf")));
+    let ident = quote_pg_string(&config_path(&datadir.join("pg_ident.conf")));
     let preload = render_preload_line(preload_libraries);
     format!(
         "# Managed by Yerd — do not edit by hand.\n\
@@ -197,9 +201,9 @@ fn quote_pg_string(s: &str) -> String {
 #[must_use]
 pub fn render_include_lines(dialect: OverrideDialect, confd_dir: &Path) -> String {
     match dialect {
-        OverrideDialect::MyCnf => format!("!includedir {}\n", confd_dir.display()),
+        OverrideDialect::MyCnf => format!("!includedir {}\n", config_path(confd_dir)),
         OverrideDialect::PostgresConf => {
-            let dir = quote_pg_string(&confd_dir.display().to_string());
+            let dir = quote_pg_string(&config_path(confd_dir));
             format!("include_dir {dir}\n")
         }
         OverrideDialect::RedisConf => {

--- a/crates/yerd-services/src/config_render.rs
+++ b/crates/yerd-services/src/config_render.rs
@@ -47,7 +47,11 @@ fn quote_conf_path(p: &Path) -> String {
 }
 
 fn config_path(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    let path = path.to_string_lossy();
+    #[cfg(windows)]
+    return path.replace('\\', "/");
+    #[cfg(not(windows))]
+    path.into_owned()
 }
 
 /// Render a `MySQL` / `MariaDB` option file: loopback-only, no password.

--- a/crates/yerd-services/src/manager.rs
+++ b/crates/yerd-services/src/manager.rs
@@ -1548,8 +1548,9 @@ mod tests {
         let confd = version::confd_dir(&dirs, "mysql");
         let main = std::fs::read_to_string(&config_path).unwrap();
         assert!(main.starts_with("[mysqld]\nport = 3306\n"));
+        let confd = confd.to_string_lossy().replace('\\', "/");
         assert!(
-            main.ends_with(&format!("!includedir {}\n", confd.display())),
+            main.ends_with(&format!("!includedir {confd}\n")),
             "got: {main}"
         );
         assert!(std::fs::read_to_string(&managed)

--- a/crates/yerd-services/src/service.rs
+++ b/crates/yerd-services/src/service.rs
@@ -740,9 +740,9 @@ impl ServiceDefinition for Meilisearch {
             .arg("--db-path")
             .arg(ctx.datadir)
             .arg("--dump-dir")
-            .arg(ctx.datadir.join("dumps"))
+            .arg(command_path(&ctx.datadir.join("dumps")))
             .arg("--snapshot-dir")
-            .arg(ctx.datadir.join("snapshots"))
+            .arg(command_path(&ctx.datadir.join("snapshots")))
             .arg("--env")
             .arg("development")
             .arg("--no-analytics");
@@ -751,6 +751,10 @@ impl ServiceDefinition for Meilisearch {
             capture_output_to_log: true,
         })
     }
+}
+
+fn command_path(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 /// Laravel Reverb: a per-site WebSocket app server, supervised as

--- a/crates/yerd-services/src/service.rs
+++ b/crates/yerd-services/src/service.rs
@@ -754,7 +754,11 @@ impl ServiceDefinition for Meilisearch {
 }
 
 fn command_path(path: &std::path::Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    let path = path.to_string_lossy();
+    #[cfg(windows)]
+    return path.replace('\\', "/");
+    #[cfg(not(windows))]
+    path.into_owned()
 }
 
 /// Laravel Reverb: a per-site WebSocket app server, supervised as


### PR DESCRIPTION
## What does this PR do?

Adds native Windows support across the platform adapter, named-pipe IPC, UAC helper, CA/NRPT integration, PHP CGI runtime, managed tooling, GUI lifecycle, Task Scheduler autostart, and NSIS packaging.

Review follow-up `87b5c2d` hardens elevated process launching, scopes IPC per user, validates trust and resolver inputs, moves blocking diagnostics off Tokio workers, fixes Windows tool reconciliation, and preserves platform-specific path semantics.

## Related issues

None.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / internal change
- [x] Documentation
- [x] Build / CI / tooling

## Platforms tested

- [ ] macOS
- [ ] Linux
- [x] Windows

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` is clean
- [x] `cargo test --workspace --exclude yerd-dns` passes
- [x] `npm run test` passes (353 tests)
- [x] `npm run build` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed

## Known limitations

- `cargo test --workspace` reaches one host-environment failure: `yerd-dns --test server_smoke` cannot open its Hickory UDP client on this Windows host (`WSAEACCES 10013`); server binding succeeds.
- Linux and macOS runtime verification was unavailable locally. CI should validate preserved Unix paths.
- The NSIS installer is not code-signed.
- Windows service archives, Bun, cloudflared installation, CA uninstall, and Node version switching remain unsupported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support for the desktop app, daemon, bundled NSIS installer, background startup, local communication, and certificate/resolver management.
  * Added Windows support for PHP, Node.js, Composer, Laravel, and WP-CLI installation and execution.
  * Added CLI options to configure fallback HTTP/HTTPS ports and the embedded DNS port.
  * Added Windows-specific diagnostics for port conflicts and service issues.
  * Composer is now installed automatically when required for Laravel or WP-CLI tools.
  * Updated tool actions to clearly distinguish installation from reinstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->