### PR TITLE
[Feat] Stream PHP-FPM responses as they are flushed

### DIFF
--- a/crates/yerd-proxy/src/forward/fcgi.rs
+++ b/crates/yerd-proxy/src/forward/fcgi.rs
@@ -170,8 +170,9 @@ pub async fn forward(
     };
 
     if !can_have_body(&parts.method, head.status) {
-        if let Some(discarded) = drain_to_end_request(&mut read_half, &backend_label).await? {
-            writer.wind_down();
+        let drained = drain_to_end_request(&mut read_half, &backend_label).await?;
+        writer.wind_down();
+        if let Some(discarded) = drained {
             let seen = u64::try_from(head.body_remainder.len()).unwrap_or(u64::MAX);
             restore_head_content_length(&mut head, &parts.method, seen.saturating_add(discarded));
         }
@@ -238,8 +239,9 @@ fn restore_head_content_length(head: &mut Head, method: &http::Method, body_len:
 /// a clean 5xx.
 ///
 /// Returns how many STDOUT bytes were discarded, or `None` once past
-/// [`MAX_DISCARDED_BYTES`] - the caller then drops the socket, which frees the
-/// worker, and answers without a `Content-Length` it can no longer total.
+/// [`MAX_DISCARDED_BYTES`] - the caller then answers without a `Content-Length`
+/// it can no longer total. Either way it winds the writer down and drops the
+/// read half, which closes the connection and frees the worker.
 async fn drain_to_end_request(
     read_half: &mut ReadHalf<BackendStream>,
     backend_label: &str,
@@ -502,11 +504,16 @@ impl WriterHandle {
     /// Stop sending to FPM, but leave the task alive to drain what is left of
     /// the client's request body.
     ///
-    /// Used once the backend has said `END_REQUEST`. Nothing more may be sent -
-    /// a backend that answered without reading STDIN would never drain the
+    /// Used once the response is settled, whether the backend said
+    /// `END_REQUEST` or overran the drain limit. Nothing more may be sent - a
+    /// backend that answered without reading STDIN would never drain the
     /// socket, and the writer would block against a full kernel buffer for
     /// good - but abandoning a part-read request body makes hyper close the
     /// client's read side, which a client still uploading sees as a reset.
+    ///
+    /// Cancelling the write also releases the write half, so together with the
+    /// caller dropping the read half the FPM connection closes and the worker
+    /// is freed, all without taking the drain down with it.
     fn wind_down(&mut self) {
         if let Some(stop) = self.stop_writing.take() {
             let _ = stop.send(());

--- a/crates/yerd-proxy/src/forward/fcgi.rs
+++ b/crates/yerd-proxy/src/forward/fcgi.rs
@@ -1,20 +1,39 @@
-//! FastCGI forwarder: connect → BEGIN_REQUEST → PARAMS → STDIN → drain
-//! STDOUT + STDERR → END_REQUEST.
+//! FastCGI forwarder: connect, split the socket, and write the request on one
+//! half while reading the response on the other.
+//!
+//! The response head goes out as soon as the CGI header block completes;
+//! STDOUT records after it are relayed to the client one at a time, so a
+//! streamed PHP response (SSE, Livewire `wire:stream`) reaches the browser as
+//! PHP flushes it. Two consequences worth knowing:
+//!
+//! * A failure *after* the head is on the wire cannot change the status, so it
+//!   aborts the connection instead. Failures before it still return a
+//!   `ProxyError` and get the usual clean 5xx.
+//! * A response hyper cannot give a body to (HEAD, 1xx, 204, 304) is drained
+//!   here rather than streamed. Hyper drops such a body the instant the head is
+//!   encoded, which would otherwise read as a client disconnect and kill the
+//!   PHP script mid-run.
 
 use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use bytes::Bytes;
+use http_body::{Body, Frame};
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use hyper::{Request, Response};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::backend::Backend;
 use crate::error::ProxyError;
 use crate::forward::{empty_body, BoxBody};
+use crate::pure::cgi_head::{Head, HeadAccumulator, HeadFeed};
 use crate::pure::cgi_params::{build_params, AutoLoginParams};
 use crate::pure::fcgi_codec::{
     encode_begin_request_body, encode_name_value, FcgiError, Header, RecordType, FCGI_MAX_PAYLOAD,
@@ -23,7 +42,22 @@ use crate::pure::fcgi_codec::{
 
 const REQUEST_ID: u16 = 1;
 
-/// Forward `req` to a FastCGI `backend`. Returns the response, or a `ProxyError`.
+/// STDOUT records that may sit between the backend reader and the client.
+///
+/// This bound *is* the backpressure onto FPM: when the client stops consuming,
+/// the channel fills, the reader stops reading the socket, the kernel buffer
+/// fills, and FPM's own writes block. Unbounded would reintroduce whole-body
+/// buffering for slow clients.
+const STDOUT_CHANNEL_RECORDS: usize = 8;
+
+/// Response header nginx consumes rather than forwarding, so neither do we.
+const X_ACCEL_BUFFERING: &str = "x-accel-buffering";
+
+/// Forward `req` to a FastCGI `backend`, streaming the response.
+///
+/// Returns once the CGI header block is parsed - the body keeps arriving
+/// afterwards through a background reader task - or a `ProxyError` if the
+/// backend fails before that point.
 ///
 /// `script_rel`, if given, is a real, on-disk `.php` file (relative to
 /// `served_root`) that [`crate::forward::script_file::resolve_script`]
@@ -45,16 +79,17 @@ pub async fn forward(
     let backend_label = backend.to_string();
     let (parts, body) = req.into_parts();
 
-    let mut stream = open_backend(&backend)
+    let stream = open_backend(&backend)
         .await
         .map_err(|source| ProxyError::BackendConnect {
             backend: backend_label.clone(),
             source,
         })?;
+    let (mut read_half, write_half) = tokio::io::split(stream);
 
-    let mut framed: Vec<u8> = Vec::with_capacity(64);
+    let mut prelude: Vec<u8> = Vec::with_capacity(64);
     write_record(
-        &mut framed,
+        &mut prelude,
         RecordType::BeginRequest,
         &encode_begin_request_body(FCGI_RESPONDER, false),
     );
@@ -75,50 +110,172 @@ pub async fn forward(
         encode_name_value(name, value, &mut param_buf)?;
     }
     for chunk in param_buf.chunks(FCGI_MAX_PAYLOAD) {
-        write_record(&mut framed, RecordType::Params, chunk);
+        write_record(&mut prelude, RecordType::Params, chunk);
     }
-    write_record(&mut framed, RecordType::Params, &[]);
+    write_record(&mut prelude, RecordType::Params, &[]);
 
-    stream
-        .write_all(&framed)
-        .await
-        .map_err(|source| ProxyError::BackendProtocol { source })?;
+    let writer_label = backend_label.clone();
+    let writer = AbortOnDrop(tokio::spawn(async move {
+        if let Err(e) = write_request(write_half, prelude, body, &writer_label).await {
+            tracing::debug!(
+                target: "yerd_proxy::fcgi",
+                backend = %writer_label,
+                error = %e,
+                "FPM request write ended"
+            );
+        }
+    }));
 
-    write_stdin(&mut stream, body, &backend_label).await?;
+    let mut accumulator = HeadAccumulator::new();
+    let parsed = loop {
+        let (header, content) = read_record(&mut read_half).await?;
+        match header.record_type {
+            RecordType::Stdout => match accumulator.feed(&content) {
+                HeadFeed::Pending => {}
+                HeadFeed::Complete(head) => break Some(head),
+                HeadFeed::TooLarge => {
+                    return Err(ProxyError::BackendProtocol {
+                        source: io::Error::other("FPM response head exceeded the size limit"),
+                    })
+                }
+            },
+            RecordType::Stderr => log_stderr(&backend_label, &content),
+            RecordType::EndRequest => break None,
+            _ => {}
+        }
+    };
+    let Some(mut head) = parsed else {
+        return synthesise_response(accumulator.finish(), empty_body());
+    };
 
-    let (stdout, stderr) = read_fcgi_response(&mut stream).await?;
-
-    if !stderr.is_empty() {
-        tracing::warn!(
-            target: "yerd_proxy::fcgi",
-            backend = %backend_label,
-            stderr = %String::from_utf8_lossy(&stderr),
-            "FPM stderr"
-        );
+    if !can_have_body(&parts.method, head.status) {
+        drain_to_end_request(&mut read_half, &backend_label).await?;
+        return synthesise_response(head, empty_body());
     }
 
-    let (status, headers, body_bytes) = parse_cgi_response(&stdout);
-    synthesise_response(status, headers, body_bytes)
+    let (tx, rx) = mpsc::channel(STDOUT_CHANNEL_RECORDS);
+    let remainder = std::mem::take(&mut head.body_remainder);
+    tokio::spawn(read_response(
+        read_half,
+        tx,
+        remainder,
+        writer,
+        backend_label,
+    ));
+    synthesise_response(head, ChannelBody { rx }.boxed())
 }
 
-/// Stream the request `body` to the backend as FCGI STDIN records (each chunked
-/// at `FCGI_MAX_PAYLOAD`), then write the zero-length STDIN terminator. HTTP
-/// trailers are dropped - FastCGI cannot represent them.
-async fn write_stdin(
-    stream: &mut BackendStream,
-    mut body: Incoming,
+/// Whether hyper will let this response carry a body. Mirrors hyper's own rule
+/// (`proto::h1::role::Server::can_have_body`): it drops the body of anything
+/// else the moment the head is encoded, and on the streaming path that drop is
+/// indistinguishable from the client hanging up.
+fn can_have_body(method: &http::Method, status: http::StatusCode) -> bool {
+    if *method == http::Method::HEAD {
+        return false;
+    }
+    if *method == http::Method::CONNECT && status.is_success() {
+        return false;
+    }
+    !(status.is_informational()
+        || status == http::StatusCode::NO_CONTENT
+        || status == http::StatusCode::NOT_MODIFIED)
+}
+
+/// Read records to `END_REQUEST`, discarding STDOUT and logging STDERR.
+///
+/// Used for responses that cannot carry a body: the client gets the head, and
+/// PHP still runs to completion exactly as it did before the forwarder
+/// streamed. Nothing has reached the client yet, so an error here still maps to
+/// a clean 5xx.
+async fn drain_to_end_request(
+    read_half: &mut ReadHalf<BackendStream>,
     backend_label: &str,
 ) -> Result<(), ProxyError> {
     loop {
+        let (header, content) = read_record(read_half).await?;
+        match header.record_type {
+            RecordType::Stderr => log_stderr(backend_label, &content),
+            RecordType::EndRequest => return Ok(()),
+            _ => {}
+        }
+    }
+}
+
+/// Relay STDOUT records to the client until `END_REQUEST` or the client leaves.
+///
+/// Owns the writer guard, so finishing here also tears down the request writer,
+/// drops both socket halves, and lets FPM abort the request and free its
+/// worker.
+async fn read_response(
+    mut read_half: ReadHalf<BackendStream>,
+    tx: mpsc::Sender<Result<Frame<Bytes>, io::Error>>,
+    body_remainder: Vec<u8>,
+    _writer: AbortOnDrop,
+    backend_label: String,
+) {
+    if !body_remainder.is_empty()
+        && tx
+            .send(Ok(Frame::data(Bytes::from(body_remainder))))
+            .await
+            .is_err()
+    {
+        return;
+    }
+    loop {
+        let record = tokio::select! {
+            record = read_record(&mut read_half) => record,
+            () = tx.closed() => break,
+        };
+        let (header, content) = match record {
+            Ok(record) => record,
+            Err(e) => {
+                let _ = tx.send(Err(io::Error::other(e.to_string()))).await;
+                break;
+            }
+        };
+        match header.record_type {
+            RecordType::Stdout => {
+                if content.is_empty() {
+                    continue;
+                }
+                if tx
+                    .send(Ok(Frame::data(Bytes::from(content))))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            RecordType::Stderr => log_stderr(&backend_label, &content),
+            RecordType::EndRequest => break,
+            _ => {}
+        }
+    }
+}
+
+/// Write the prelude, then stream the request `body` as STDIN records (each
+/// chunked at `FCGI_MAX_PAYLOAD`), then the zero-length STDIN terminator.
+///
+/// Runs concurrently with the response read, so a large request body can no
+/// longer deadlock against a backend that answers before draining STDIN. HTTP
+/// trailers are dropped - FastCGI cannot represent them.
+async fn write_request(
+    mut write_half: WriteHalf<BackendStream>,
+    prelude: Vec<u8>,
+    mut body: Incoming,
+    backend_label: &str,
+) -> io::Result<()> {
+    write_half.write_all(&prelude).await?;
+    loop {
         match body.frame().await {
             None => break,
-            Some(Err(source)) => return Err(ProxyError::Hyper { source }),
+            Some(Err(source)) => return Err(io::Error::other(source.to_string())),
             Some(Ok(frame)) => {
                 if frame.is_trailers() {
                     tracing::debug!(
                         target: "yerd_proxy::fcgi",
                         backend = %backend_label,
-                        "dropping HTTP trailers — FCGI cannot represent them"
+                        "dropping HTTP trailers - FCGI cannot represent them"
                     );
                     continue;
                 }
@@ -128,72 +285,74 @@ async fn write_stdin(
                 for chunk in data.chunks(FCGI_MAX_PAYLOAD) {
                     let mut buf = Vec::with_capacity(8 + chunk.len());
                     write_record(&mut buf, RecordType::Stdin, chunk);
-                    stream
-                        .write_all(&buf)
-                        .await
-                        .map_err(|source| ProxyError::BackendProtocol { source })?;
+                    write_half.write_all(&buf).await?;
                 }
             }
         }
     }
     let mut term = Vec::with_capacity(8);
     write_record(&mut term, RecordType::Stdin, &[]);
-    stream
-        .write_all(&term)
+    write_half.write_all(&term).await
+}
+
+/// Read one whole FCGI record: header, content, and any padding.
+///
+/// Not cancel-safe - a record can be lost part-read. The only place it is
+/// raced is the reader loop's teardown branch, where the connection is being
+/// dropped anyway.
+async fn read_record(
+    read_half: &mut ReadHalf<BackendStream>,
+) -> Result<(Header, Vec<u8>), ProxyError> {
+    let mut header_buf = [0u8; 8];
+    read_half
+        .read_exact(&mut header_buf)
         .await
-        .map_err(|source| ProxyError::BackendProtocol { source })
-}
-
-/// Drain STDOUT/STDERR records from the backend until END_REQUEST, returning the
-/// concatenated `(stdout, stderr)` byte streams. Unknown record types are
-/// ignored defensively.
-async fn read_fcgi_response(stream: &mut BackendStream) -> Result<(Vec<u8>, Vec<u8>), ProxyError> {
-    let mut stdout = Vec::<u8>::new();
-    let mut stderr = Vec::<u8>::new();
-    loop {
-        let mut header_buf = [0u8; 8];
-        stream
-            .read_exact(&mut header_buf)
-            .await
-            .map_err(|source| ProxyError::BackendProtocol { source })?;
-        let header = Header::decode(&header_buf)?;
-        if header.request_id != REQUEST_ID {
-            return Err(ProxyError::Fcgi {
-                source: FcgiError::UnexpectedRequestId(header.request_id),
-            });
-        }
-        let mut content = vec![0u8; header.content_length as usize];
-        stream
-            .read_exact(&mut content)
-            .await
-            .map_err(|source| ProxyError::BackendProtocol { source })?;
-        if header.padding_length > 0 {
-            let mut pad = vec![0u8; header.padding_length as usize];
-            stream
-                .read_exact(&mut pad)
-                .await
-                .map_err(|source| ProxyError::BackendProtocol { source })?;
-        }
-        match header.record_type {
-            RecordType::Stdout => stdout.extend_from_slice(&content),
-            RecordType::Stderr => stderr.extend_from_slice(&content),
-            RecordType::EndRequest => break,
-            _ => {}
-        }
+        .map_err(|source| ProxyError::BackendProtocol { source })?;
+    let header = Header::decode(&header_buf)?;
+    if header.request_id != REQUEST_ID {
+        return Err(ProxyError::Fcgi {
+            source: FcgiError::UnexpectedRequestId(header.request_id),
+        });
     }
-    Ok((stdout, stderr))
+    let mut content = vec![0u8; header.content_length as usize];
+    read_half
+        .read_exact(&mut content)
+        .await
+        .map_err(|source| ProxyError::BackendProtocol { source })?;
+    if header.padding_length > 0 {
+        let mut pad = vec![0u8; header.padding_length as usize];
+        read_half
+            .read_exact(&mut pad)
+            .await
+            .map_err(|source| ProxyError::BackendProtocol { source })?;
+    }
+    Ok((header, content))
 }
 
-/// Build the HTTP response from the parsed CGI status, headers, and body.
-/// Header names/values that aren't valid HTTP are skipped.
-fn synthesise_response(
-    status: http::StatusCode,
-    headers: Vec<(String, String)>,
-    body_bytes: &[u8],
-) -> Result<Response<BoxBody>, ProxyError> {
-    let mut resp = Response::builder().status(status);
+fn log_stderr(backend_label: &str, content: &[u8]) {
+    if content.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        target: "yerd_proxy::fcgi",
+        backend = %backend_label,
+        stderr = %String::from_utf8_lossy(content),
+        "FPM stderr"
+    );
+}
+
+/// Build the HTTP response from the parsed CGI head and a body.
+///
+/// Header names/values that aren't valid HTTP are skipped, as is
+/// `X-Accel-Buffering`. A PHP-supplied `Content-Length` passes through
+/// verbatim; without one, hyper frames the streaming body as chunked.
+fn synthesise_response(head: Head, body: BoxBody) -> Result<Response<BoxBody>, ProxyError> {
+    let mut resp = Response::builder().status(head.status);
     if let Some(resp_headers) = resp.headers_mut() {
-        for (name, value) in headers {
+        for (name, value) in head.headers {
+            if name.eq_ignore_ascii_case(X_ACCEL_BUFFERING) {
+                continue;
+            }
             if let (Ok(n), Ok(v)) = (
                 http::HeaderName::from_bytes(name.as_bytes()),
                 http::HeaderValue::from_bytes(value.as_bytes()),
@@ -202,16 +361,41 @@ fn synthesise_response(
             }
         }
     }
-    let body: BoxBody = if body_bytes.is_empty() {
-        empty_body()
-    } else {
-        http_body_util::Full::new(Bytes::copy_from_slice(body_bytes))
-            .map_err(|never| match never {})
-            .boxed()
-    };
     resp.body(body).map_err(|_| ProxyError::BackendProtocol {
         source: io::Error::other("failed to build response"),
     })
+}
+
+/// Streaming response body fed by [`read_response`] over a bounded channel.
+struct ChannelBody {
+    rx: mpsc::Receiver<Result<Frame<Bytes>, io::Error>>,
+}
+
+impl Body for ChannelBody {
+    type Data = Bytes;
+    type Error = io::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, io::Error>>> {
+        self.get_mut().rx.poll_recv(cx)
+    }
+}
+
+/// Aborts the request-writing task when dropped.
+///
+/// `tokio::io::split` keeps the socket alive until *both* halves drop, and
+/// dropping a `JoinHandle` detaches rather than cancels. Holding the handle in
+/// this guard makes teardown unconditional: the headers-only fallback, a
+/// pre-head error return, the reader task finishing, and cancellation of the
+/// `forward` future itself all release the write half.
+struct AbortOnDrop(JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 /// Forward an upgrade request - FastCGI cannot model duplex byte streams,
@@ -320,61 +504,6 @@ fn path_and_query_of(uri: &http::Uri) -> &str {
     uri.path_and_query().map_or("/", |pq| pq.as_str())
 }
 
-/// Parse a CGI-style header block from FCGI STDOUT. The block ends at the
-/// first `\r\n\r\n` or `\n\n`; everything after is the response body.
-/// `Status: NNN Reason` is translated into the HTTP status code; absent →
-/// 200 OK.
-fn parse_cgi_response(stdout: &[u8]) -> (http::StatusCode, Vec<(String, String)>, &[u8]) {
-    let split = find_header_terminator(stdout);
-    let (head, body) = stdout.split_at(split.0);
-    let body = body.get(split.1..).unwrap_or(&[]);
-    let head_str = std::str::from_utf8(head).unwrap_or("");
-
-    let mut status = http::StatusCode::OK;
-    let mut headers: Vec<(String, String)> = Vec::new();
-    for line in head_str.split('\n') {
-        let line = line.trim_end_matches('\r');
-        if line.is_empty() {
-            continue;
-        }
-        let Some((name, value)) = line.split_once(':') else {
-            continue;
-        };
-        let name = name.trim();
-        let value = value.trim();
-        if name.eq_ignore_ascii_case("Status") {
-            if let Some(sc) = parse_cgi_status(value) {
-                status = sc;
-            }
-        } else {
-            headers.push((name.to_owned(), value.to_owned()));
-        }
-    }
-    (status, headers, body)
-}
-
-/// Parse a CGI `Status:` header value - `"200 OK"` or a bare `"200"` - into an
-/// HTTP status code. Returns `None` when it isn't a valid code (caller keeps the
-/// default 200).
-fn parse_cgi_status(value: &str) -> Option<http::StatusCode> {
-    let code = value.split_once(' ').map_or(value, |(code, _)| code);
-    http::StatusCode::from_u16(code.parse::<u16>().ok()?).ok()
-}
-
-/// Return `(offset_of_terminator, terminator_length)`. If no terminator is
-/// found, returns `(stdout.len(), 0)` - body is then empty.
-fn find_header_terminator(stdout: &[u8]) -> (usize, usize) {
-    for i in 0..stdout.len() {
-        if i + 4 <= stdout.len() && stdout.get(i..i + 4) == Some(b"\r\n\r\n") {
-            return (i, 4);
-        }
-        if i + 2 <= stdout.len() && stdout.get(i..i + 2) == Some(b"\n\n") {
-            return (i, 2);
-        }
-    }
-    (stdout.len(), 0)
-}
-
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -385,86 +514,22 @@ fn find_header_terminator(stdout: &[u8]) -> (usize, usize) {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parse_cgi_status_and_headers() {
-        let stdout = b"Status: 404 Not Found\r\nContent-Type: text/plain\r\n\r\nnope";
-        let (status, headers, body) = parse_cgi_response(stdout);
-        assert_eq!(status, http::StatusCode::NOT_FOUND);
-        assert!(headers
-            .iter()
-            .any(|(k, v)| k == "Content-Type" && v == "text/plain"));
-        assert_eq!(body, b"nope");
+    fn head(status: http::StatusCode, headers: &[(&str, &str)]) -> Head {
+        Head {
+            status,
+            headers: headers
+                .iter()
+                .map(|(n, v)| ((*n).to_owned(), (*v).to_owned()))
+                .collect(),
+            body_remainder: Vec::new(),
+        }
     }
 
     #[test]
-    fn parse_cgi_default_status_is_200() {
-        let stdout = b"Content-Type: text/plain\n\nhello";
-        let (status, _, body) = parse_cgi_response(stdout);
-        assert_eq!(status, http::StatusCode::OK);
-        assert_eq!(body, b"hello");
-    }
-
-    #[test]
-    fn parse_cgi_no_headers_no_body() {
-        let (status, headers, body) = parse_cgi_response(b"");
-        assert_eq!(status, http::StatusCode::OK);
-        assert!(headers.is_empty());
-        assert_eq!(body, b"");
-    }
-
-    #[test]
-    fn find_header_terminator_prefers_crlf() {
-        let s = b"A: B\r\n\r\nbody";
-        assert_eq!(find_header_terminator(s), (4, 4));
-    }
-
-    #[test]
-    fn find_header_terminator_falls_back_to_lf() {
-        let s = b"A: B\n\nbody";
-        assert_eq!(find_header_terminator(s), (4, 2));
-    }
-
-    #[test]
-    fn parse_cgi_status_with_reason_phrase() {
-        assert_eq!(parse_cgi_status("200 OK"), Some(http::StatusCode::OK));
-        assert_eq!(
-            parse_cgi_status("301 Moved Permanently"),
-            Some(http::StatusCode::MOVED_PERMANENTLY)
-        );
-    }
-
-    #[test]
-    fn parse_cgi_status_bare_code() {
-        assert_eq!(parse_cgi_status("404"), Some(http::StatusCode::NOT_FOUND));
-    }
-
-    #[test]
-    fn parse_cgi_status_invalid_is_none() {
-        assert!(parse_cgi_status("").is_none());
-        assert!(parse_cgi_status("abc").is_none());
-        assert!(parse_cgi_status("999999").is_none());
-        assert!(parse_cgi_status("99").is_none());
-    }
-
-    /// The Status line drives the response code; it is not echoed as a header.
-    #[test]
-    fn parse_cgi_response_status_header_not_surfaced() {
-        let stdout = b"Status: 301 Moved\r\nLocation: /x\r\n\r\n";
-        let (status, headers, body) = parse_cgi_response(stdout);
-        assert_eq!(status, http::StatusCode::MOVED_PERMANENTLY);
-        assert!(headers.iter().any(|(k, v)| k == "Location" && v == "/x"));
-        assert!(!headers
-            .iter()
-            .any(|(k, _)| k.eq_ignore_ascii_case("Status")));
-        assert_eq!(body, b"");
-    }
-
-    #[test]
-    fn synthesise_response_carries_status_headers_and_body() {
+    fn synthesise_response_carries_status_and_headers() {
         let resp = synthesise_response(
-            http::StatusCode::CREATED,
-            vec![("X-Test".to_owned(), "1".to_owned())],
-            b"hello",
+            head(http::StatusCode::CREATED, &[("X-Test", "1")]),
+            empty_body(),
         )
         .unwrap();
         assert_eq!(resp.status(), http::StatusCode::CREATED);
@@ -475,12 +540,8 @@ mod tests {
     #[test]
     fn synthesise_response_skips_invalid_header_name() {
         let resp = synthesise_response(
-            http::StatusCode::OK,
-            vec![
-                ("Bad Name".to_owned(), "v".to_owned()),
-                ("Good".to_owned(), "y".to_owned()),
-            ],
-            b"",
+            head(http::StatusCode::OK, &[("Bad Name", "v"), ("Good", "y")]),
+            empty_body(),
         )
         .unwrap();
         assert!(resp.headers().get("Good").is_some());
@@ -488,10 +549,46 @@ mod tests {
     }
 
     #[test]
-    fn synthesise_response_empty_body_builds() {
-        let resp = synthesise_response(http::StatusCode::NO_CONTENT, vec![], b"").unwrap();
+    fn synthesise_response_strips_x_accel_buffering() {
+        let resp = synthesise_response(
+            head(
+                http::StatusCode::OK,
+                &[("X-Accel-Buffering", "no"), ("Content-Type", "text/plain")],
+            ),
+            empty_body(),
+        )
+        .unwrap();
+        assert!(resp.headers().get("x-accel-buffering").is_none());
+        assert_eq!(resp.headers().get("Content-Type").unwrap(), "text/plain");
+    }
+
+    #[test]
+    fn synthesise_response_empty_head_builds() {
+        let resp =
+            synthesise_response(head(http::StatusCode::NO_CONTENT, &[]), empty_body()).unwrap();
         assert_eq!(resp.status(), http::StatusCode::NO_CONTENT);
         assert!(resp.headers().is_empty());
+    }
+
+    #[test]
+    fn can_have_body_matches_hypers_rule() {
+        let cases = [
+            (http::Method::GET, http::StatusCode::OK, true),
+            (http::Method::HEAD, http::StatusCode::OK, false),
+            (http::Method::GET, http::StatusCode::NO_CONTENT, false),
+            (http::Method::GET, http::StatusCode::NOT_MODIFIED, false),
+            (http::Method::GET, http::StatusCode::CONTINUE, false),
+            (http::Method::CONNECT, http::StatusCode::OK, false),
+            (http::Method::CONNECT, http::StatusCode::BAD_GATEWAY, true),
+            (http::Method::POST, http::StatusCode::CREATED, true),
+        ];
+        for (method, status, expected) in cases {
+            assert_eq!(
+                can_have_body(&method, status),
+                expected,
+                "{method} {status}"
+            );
+        }
     }
 
     #[test]

--- a/crates/yerd-proxy/src/forward/fcgi.rs
+++ b/crates/yerd-proxy/src/forward/fcgi.rs
@@ -13,6 +13,9 @@
 //!   here rather than streamed. Hyper drops such a body the instant the head is
 //!   encoded, which would otherwise read as a client disconnect and kill the
 //!   PHP script mid-run.
+//! * The request write outliving the response read is deliberate: PHP may
+//!   answer before it has read STDIN, and abandoning a part-read request body
+//!   makes hyper close the client's read side under an upload still in flight.
 
 use std::io;
 use std::net::SocketAddr;
@@ -27,7 +30,7 @@ use hyper::body::Incoming;
 use hyper::{Request, Response};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::backend::Backend;
@@ -52,6 +55,12 @@ const STDOUT_CHANNEL_RECORDS: usize = 8;
 
 /// Response header nginx consumes rather than forwarding, so neither do we.
 const X_ACCEL_BUFFERING: &str = "x-accel-buffering";
+
+/// Cap on the response body discarded for a request that cannot receive one.
+/// `HEAD /events` against an endpoint that streams forever would otherwise hold
+/// an FPM worker for as long as the script runs, against a default pool of 16.
+/// Past the cap the backend socket is dropped instead.
+const MAX_DISCARDED_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Forward `req` to a FastCGI `backend`, streaming the response.
 ///
@@ -115,8 +124,14 @@ pub async fn forward(
     write_record(&mut prelude, RecordType::Params, &[]);
 
     let writer_label = backend_label.clone();
-    let writer = AbortOnDrop(tokio::spawn(async move {
-        if let Err(e) = write_request(write_half, prelude, body, &writer_label).await {
+    let (stop_writing, stop_signal) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let mut body = body;
+        let wrote = tokio::select! {
+            result = write_request(write_half, prelude, &mut body, &writer_label) => result,
+            _ = stop_signal => Ok(()),
+        };
+        if let Err(e) = wrote {
             tracing::debug!(
                 target: "yerd_proxy::fcgi",
                 backend = %writer_label,
@@ -124,7 +139,12 @@ pub async fn forward(
                 "FPM request write ended"
             );
         }
-    }));
+        drain_client_body(&mut body).await;
+    });
+    let mut writer = WriterHandle {
+        task: Some(task),
+        stop_writing: Some(stop_writing),
+    };
 
     let mut accumulator = HeadAccumulator::new();
     let parsed = loop {
@@ -145,11 +165,16 @@ pub async fn forward(
         }
     };
     let Some(mut head) = parsed else {
+        writer.wind_down();
         return synthesise_response(accumulator.finish(), empty_body());
     };
 
     if !can_have_body(&parts.method, head.status) {
-        drain_to_end_request(&mut read_half, &backend_label).await?;
+        if let Some(discarded) = drain_to_end_request(&mut read_half, &backend_label).await? {
+            writer.wind_down();
+            let seen = u64::try_from(head.body_remainder.len()).unwrap_or(u64::MAX);
+            restore_head_content_length(&mut head, &parts.method, seen.saturating_add(discarded));
+        }
         return synthesise_response(head, empty_body());
     }
 
@@ -166,19 +191,43 @@ pub async fn forward(
 }
 
 /// Whether hyper will let this response carry a body. Mirrors hyper's own rule
-/// (`proto::h1::role::Server::can_have_body`): it drops the body of anything
-/// else the moment the head is encoded, and on the streaming path that drop is
+/// (`proto::h1::role::Server::can_chunked`, which is exactly
+/// `can_have_content_length` minus HEAD): it drops the body of anything else
+/// the moment the head is encoded, and on the streaming path that drop is
 /// indistinguishable from the client hanging up.
 fn can_have_body(method: &http::Method, status: http::StatusCode) -> bool {
-    if *method == http::Method::HEAD {
+    *method != http::Method::HEAD && can_have_content_length(method, status)
+}
+
+/// Whether a `Content-Length` is meaningful here. Mirrors hyper's
+/// `proto::h1::role::Server::can_have_content_length`.
+fn can_have_content_length(method: &http::Method, status: http::StatusCode) -> bool {
+    if status.is_informational() || (*method == http::Method::CONNECT && status.is_success()) {
         return false;
     }
-    if *method == http::Method::CONNECT && status.is_success() {
-        return false;
+    !(status == http::StatusCode::NO_CONTENT || status == http::StatusCode::NOT_MODIFIED)
+}
+
+/// Give a HEAD response the `Content-Length` the same GET would have carried.
+///
+/// The bodyless path hands hyper an exact zero-length body, and hyper refuses
+/// to write an implicit `content-length: 0` for HEAD
+/// (`can_have_implicit_zero_content_length`), so without this a HEAD on a page
+/// that sets no length of its own answers with no length at all - RFC 9110
+/// 9.3.2 wants the field a GET would have sent. A length PHP set itself wins.
+fn restore_head_content_length(head: &mut Head, method: &http::Method, body_len: u64) {
+    if *method != http::Method::HEAD || !can_have_content_length(method, head.status) {
+        return;
     }
-    !(status.is_informational()
-        || status == http::StatusCode::NO_CONTENT
-        || status == http::StatusCode::NOT_MODIFIED)
+    if head
+        .headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+    {
+        return;
+    }
+    head.headers
+        .push(("Content-Length".to_owned(), body_len.to_string()));
 }
 
 /// Read records to `END_REQUEST`, discarding STDOUT and logging STDERR.
@@ -187,15 +236,32 @@ fn can_have_body(method: &http::Method, status: http::StatusCode) -> bool {
 /// PHP still runs to completion exactly as it did before the forwarder
 /// streamed. Nothing has reached the client yet, so an error here still maps to
 /// a clean 5xx.
+///
+/// Returns how many STDOUT bytes were discarded, or `None` once past
+/// [`MAX_DISCARDED_BYTES`] - the caller then drops the socket, which frees the
+/// worker, and answers without a `Content-Length` it can no longer total.
 async fn drain_to_end_request(
     read_half: &mut ReadHalf<BackendStream>,
     backend_label: &str,
-) -> Result<(), ProxyError> {
+) -> Result<Option<u64>, ProxyError> {
+    let mut discarded: u64 = 0;
     loop {
         let (header, content) = read_record(read_half).await?;
         match header.record_type {
+            RecordType::Stdout => {
+                discarded =
+                    discarded.saturating_add(u64::try_from(content.len()).unwrap_or(u64::MAX));
+                if discarded > MAX_DISCARDED_BYTES {
+                    tracing::debug!(
+                        target: "yerd_proxy::fcgi",
+                        backend = %backend_label,
+                        "bodyless response passed the drain limit; closing the FPM connection"
+                    );
+                    return Ok(None);
+                }
+            }
             RecordType::Stderr => log_stderr(backend_label, &content),
-            RecordType::EndRequest => return Ok(()),
+            RecordType::EndRequest => return Ok(Some(discarded)),
             _ => {}
         }
     }
@@ -203,14 +269,15 @@ async fn drain_to_end_request(
 
 /// Relay STDOUT records to the client until `END_REQUEST` or the client leaves.
 ///
-/// Owns the writer guard, so finishing here also tears down the request writer,
+/// Owns the writer guard, so giving up here also tears down the request writer,
 /// drops both socket halves, and lets FPM abort the request and free its
-/// worker.
+/// worker. A clean `END_REQUEST` winds the writer down first, leaving it to
+/// finish draining the client's request body.
 async fn read_response(
     mut read_half: ReadHalf<BackendStream>,
     tx: mpsc::Sender<Result<Frame<Bytes>, io::Error>>,
     body_remainder: Vec<u8>,
-    _writer: AbortOnDrop,
+    mut writer: WriterHandle,
     backend_label: String,
 ) {
     if !body_remainder.is_empty()
@@ -247,7 +314,10 @@ async fn read_response(
                 }
             }
             RecordType::Stderr => log_stderr(&backend_label, &content),
-            RecordType::EndRequest => break,
+            RecordType::EndRequest => {
+                writer.wind_down();
+                break;
+            }
             _ => {}
         }
     }
@@ -259,17 +329,29 @@ async fn read_response(
 /// Runs concurrently with the response read, so a large request body can no
 /// longer deadlock against a backend that answers before draining STDIN. HTTP
 /// trailers are dropped - FastCGI cannot represent them.
+///
+/// Takes the write half by value so it is released as soon as the request is
+/// on the wire; the socket itself stays open until the read half goes too.
+///
+/// A `body` that errors part-way gets a `shutdown` rather than the terminator:
+/// dropping the half alone sends nothing, and writing the terminator would tell
+/// PHP a truncated body was the whole of it. The half-close is a protocol
+/// error FPM answers by abandoning the request, which is what the pre-streaming
+/// forwarder achieved by dropping the socket outright.
 async fn write_request(
     mut write_half: WriteHalf<BackendStream>,
     prelude: Vec<u8>,
-    mut body: Incoming,
+    body: &mut Incoming,
     backend_label: &str,
 ) -> io::Result<()> {
     write_half.write_all(&prelude).await?;
     loop {
         match body.frame().await {
             None => break,
-            Some(Err(source)) => return Err(io::Error::other(source.to_string())),
+            Some(Err(source)) => {
+                let _ = write_half.shutdown().await;
+                return Err(io::Error::other(source.to_string()));
+            }
             Some(Ok(frame)) => {
                 if frame.is_trailers() {
                     tracing::debug!(
@@ -293,6 +375,21 @@ async fn write_request(
     let mut term = Vec::with_capacity(8);
     write_record(&mut term, RecordType::Stdin, &[]);
     write_half.write_all(&term).await
+}
+
+/// Read whatever is left of the client's request body and throw it away.
+///
+/// PHP is free to answer before it has read STDIN - a 419 or a 401 on a large
+/// upload - and hyper closes a connection's read side when a request body is
+/// dropped part-read, which a client still uploading sees as a reset instead of
+/// the response it was about to be handed. Consuming the rest costs one frame
+/// of memory and no FPM worker.
+///
+/// Deliberately uncapped: the upload that most needs the courtesy is the big
+/// one, and a cap would abandon exactly those. The client's own `Content-Length`
+/// bounds it, as does the connection going away.
+async fn drain_client_body(body: &mut Incoming) {
+    while let Some(Ok(_)) = body.frame().await {}
 }
 
 /// Read one whole FCGI record: header, content, and any padding.
@@ -346,6 +443,11 @@ fn log_stderr(backend_label: &str, content: &[u8]) {
 /// Header names/values that aren't valid HTTP are skipped, as is
 /// `X-Accel-Buffering`. A PHP-supplied `Content-Length` passes through
 /// verbatim; without one, hyper frames the streaming body as chunked.
+///
+/// Hop-by-hop headers are stripped for the same reason the plain reverse-proxy
+/// path strips them: the canonical PHP SSE snippet emits `Connection:
+/// keep-alive` beside `X-Accel-Buffering: no`, and a PHP-set `Transfer-Encoding`
+/// would pre-empt hyper's own framing of the stream.
 fn synthesise_response(head: Head, body: BoxBody) -> Result<Response<BoxBody>, ProxyError> {
     let mut resp = Response::builder().status(head.status);
     if let Some(resp_headers) = resp.headers_mut() {
@@ -360,6 +462,7 @@ fn synthesise_response(head: Head, body: BoxBody) -> Result<Response<BoxBody>, P
                 resp_headers.append(n, v);
             }
         }
+        crate::forward::upgrade::strip_hop_by_hop_only(resp_headers);
     }
     resp.body(body).map_err(|_| ProxyError::BackendProtocol {
         source: io::Error::other("failed to build response"),
@@ -383,18 +486,40 @@ impl Body for ChannelBody {
     }
 }
 
-/// Aborts the request-writing task when dropped.
+/// Handle on the request-writing task, which aborts it when dropped.
 ///
 /// `tokio::io::split` keeps the socket alive until *both* halves drop, and
-/// dropping a `JoinHandle` detaches rather than cancels. Holding the handle in
-/// this guard makes teardown unconditional: the headers-only fallback, a
-/// pre-head error return, the reader task finishing, and cancellation of the
+/// dropping a `JoinHandle` detaches rather than cancels, so holding the handle
+/// here is what makes teardown unconditional: the headers-only fallback, a
+/// pre-head error return, the reader task giving up, and cancellation of the
 /// `forward` future itself all release the write half.
-struct AbortOnDrop(JoinHandle<()>);
+struct WriterHandle {
+    task: Option<JoinHandle<()>>,
+    stop_writing: Option<oneshot::Sender<()>>,
+}
 
-impl Drop for AbortOnDrop {
+impl WriterHandle {
+    /// Stop sending to FPM, but leave the task alive to drain what is left of
+    /// the client's request body.
+    ///
+    /// Used once the backend has said `END_REQUEST`. Nothing more may be sent -
+    /// a backend that answered without reading STDIN would never drain the
+    /// socket, and the writer would block against a full kernel buffer for
+    /// good - but abandoning a part-read request body makes hyper close the
+    /// client's read side, which a client still uploading sees as a reset.
+    fn wind_down(&mut self) {
+        if let Some(stop) = self.stop_writing.take() {
+            let _ = stop.send(());
+        }
+        self.task = None;
+    }
+}
+
+impl Drop for WriterHandle {
     fn drop(&mut self) {
-        self.0.abort();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
     }
 }
 
@@ -562,6 +687,36 @@ mod tests {
         assert_eq!(resp.headers().get("Content-Type").unwrap(), "text/plain");
     }
 
+    /// The canonical PHP SSE snippet sets `Connection: keep-alive` next to
+    /// `X-Accel-Buffering: no`; neither belongs on the wire to the client.
+    #[test]
+    fn synthesise_response_strips_hop_by_hop_headers() {
+        let resp = synthesise_response(
+            head(
+                http::StatusCode::OK,
+                &[
+                    ("Connection", "keep-alive, X-Vendor"),
+                    ("Keep-Alive", "timeout=5"),
+                    ("Transfer-Encoding", "identity"),
+                    ("X-Vendor", "dropped by the Connection token"),
+                    ("Content-Type", "text/event-stream"),
+                ],
+            ),
+            empty_body(),
+        )
+        .unwrap();
+        for stripped in ["connection", "keep-alive", "transfer-encoding", "x-vendor"] {
+            assert!(
+                resp.headers().get(stripped).is_none(),
+                "{stripped} must not reach the client"
+            );
+        }
+        assert_eq!(
+            resp.headers().get("Content-Type").unwrap(),
+            "text/event-stream"
+        );
+    }
+
     #[test]
     fn synthesise_response_empty_head_builds() {
         let resp =
@@ -588,6 +743,64 @@ mod tests {
                 expected,
                 "{method} {status}"
             );
+        }
+    }
+
+    #[test]
+    fn can_have_content_length_matches_hypers_rule() {
+        let cases = [
+            (http::Method::GET, http::StatusCode::OK, true),
+            (http::Method::HEAD, http::StatusCode::OK, true),
+            (http::Method::GET, http::StatusCode::NO_CONTENT, false),
+            (http::Method::GET, http::StatusCode::NOT_MODIFIED, false),
+            (http::Method::GET, http::StatusCode::CONTINUE, false),
+            (http::Method::CONNECT, http::StatusCode::OK, false),
+            (http::Method::CONNECT, http::StatusCode::BAD_GATEWAY, true),
+        ];
+        for (method, status, expected) in cases {
+            assert_eq!(
+                can_have_content_length(&method, status),
+                expected,
+                "{method} {status}"
+            );
+        }
+    }
+
+    #[test]
+    fn restore_head_content_length_fills_in_the_length_for_head() {
+        let mut h = head(http::StatusCode::OK, &[("Content-Type", "text/plain")]);
+        restore_head_content_length(&mut h, &http::Method::HEAD, 42);
+        assert_eq!(
+            h.headers,
+            vec![
+                ("Content-Type".to_owned(), "text/plain".to_owned()),
+                ("Content-Length".to_owned(), "42".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn restore_head_content_length_leaves_a_php_supplied_length_alone() {
+        let mut h = head(http::StatusCode::OK, &[("content-length", "7")]);
+        restore_head_content_length(&mut h, &http::Method::HEAD, 42);
+        assert_eq!(
+            h.headers,
+            vec![("content-length".to_owned(), "7".to_owned())]
+        );
+    }
+
+    /// GET never needs it (hyper frames the real body) and 204/304 must not
+    /// carry one at all.
+    #[test]
+    fn restore_head_content_length_skips_everything_else() {
+        for (method, status) in [
+            (http::Method::GET, http::StatusCode::OK),
+            (http::Method::HEAD, http::StatusCode::NO_CONTENT),
+            (http::Method::HEAD, http::StatusCode::NOT_MODIFIED),
+        ] {
+            let mut h = head(status, &[]);
+            restore_head_content_length(&mut h, &method, 42);
+            assert!(h.headers.is_empty(), "{method} {status}");
         }
     }
 

--- a/crates/yerd-proxy/src/pure/cgi_head.rs
+++ b/crates/yerd-proxy/src/pure/cgi_head.rs
@@ -6,8 +6,8 @@
 //! [`HeadFeed::Complete`] comes back, so nothing waits for `END_REQUEST`.
 //!
 //! Buffering until the terminator is found is what makes a record boundary
-//! falling inside a `\r\n\r\n` harmless: each feed rescans the whole buffer,
-//! so the split point never matters.
+//! falling inside a `\r\n\r\n` harmless: a feed resumes its scan three bytes
+//! back into what was already there, so the split point never matters.
 
 use http::StatusCode;
 
@@ -15,6 +15,10 @@ use http::StatusCode;
 /// `fastcgi_buffer_size` of 4-8 KiB: a head past this is a runaway backend,
 /// not a real response.
 const MAX_HEAD_BYTES: usize = 64 * 1024;
+
+/// Bytes of the previous buffer a rescan has to revisit so a terminator split
+/// across two feeds is still found: one less than the longest terminator.
+const TERMINATOR_OVERLAP: usize = 3;
 
 /// A parsed CGI response head, plus any body bytes that arrived with it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,8 +57,9 @@ impl HeadAccumulator {
 
     /// Add `chunk` and rescan for the header terminator.
     pub fn feed(&mut self, chunk: &[u8]) -> HeadFeed {
+        let scan_from = self.buf.len().saturating_sub(TERMINATOR_OVERLAP);
         self.buf.extend_from_slice(chunk);
-        match find_header_terminator(&self.buf) {
+        match find_header_terminator(&self.buf, scan_from) {
             Some((offset, terminator_len)) => {
                 let (head, rest) = self.buf.split_at(offset);
                 let body_remainder = rest.get(terminator_len..).unwrap_or_default().to_vec();
@@ -86,13 +91,19 @@ impl HeadAccumulator {
 
 /// Parse a CGI header block: `Status: NNN Reason` drives the status code and is
 /// not surfaced as a header; everything else is passed through trimmed. Lines
-/// without a colon are skipped, as is a block that isn't UTF-8.
+/// without a colon are skipped.
+///
+/// Decoding is lossy and per line, so a header carrying bytes that aren't UTF-8
+/// (a `setrawcookie` payload, a latin-1 filename in `Content-Disposition`) costs
+/// only that one value. Decoding the block as a whole would instead drop every
+/// header and the `Status:` line with them, turning a 302 into a bare 200 with
+/// no `Location`.
 fn parse_head(head: &[u8]) -> (StatusCode, Vec<(String, String)>) {
-    let head_str = std::str::from_utf8(head).unwrap_or("");
     let mut status = StatusCode::OK;
     let mut headers: Vec<(String, String)> = Vec::new();
-    for line in head_str.split('\n') {
-        let line = line.trim_end_matches('\r');
+    for raw_line in head.split(|byte| *byte == b'\n') {
+        let decoded = String::from_utf8_lossy(raw_line);
+        let line = decoded.trim_end_matches('\r');
         if line.is_empty() {
             continue;
         }
@@ -121,8 +132,11 @@ fn parse_cgi_status(value: &str) -> Option<StatusCode> {
 
 /// Locate the blank line ending the header block, returning
 /// `(offset, terminator_len)`. `None` when the buffer holds no terminator yet.
-fn find_header_terminator(buf: &[u8]) -> Option<(usize, usize)> {
-    for i in 0..buf.len() {
+///
+/// Scanning starts at `from`, which lets a repeated feed skip the bytes it has
+/// already rejected instead of rescanning the whole buffer each time.
+fn find_header_terminator(buf: &[u8], from: usize) -> Option<(usize, usize)> {
+    for i in from..buf.len() {
         if buf.get(i..i + 4) == Some(b"\r\n\r\n".as_slice()) {
             return Some((i, 4));
         }
@@ -304,9 +318,37 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_head_yields_no_headers() {
-        let head = complete(feed_all(&[b"A: \xff\xfe\r\n\r\nbody"]));
-        assert!(head.headers.is_empty());
+    fn non_utf8_value_is_lossy_and_costs_only_its_own_line() {
+        let head = complete(feed_all(&[
+            b"Status: 302 Found\r\nSet-Cookie: \xff\xfe\r\nLocation: /next\r\n\r\nbody",
+        ]));
+        assert_eq!(head.status, StatusCode::FOUND);
+        assert_eq!(
+            head.headers,
+            vec![
+                ("Set-Cookie".to_owned(), "\u{fffd}\u{fffd}".to_owned()),
+                ("Location".to_owned(), "/next".to_owned()),
+            ]
+        );
         assert_eq!(head.body_remainder, b"body");
+    }
+
+    #[test]
+    fn many_tiny_feeds_still_find_a_terminator_the_scan_resumes_past() {
+        let mut acc = HeadAccumulator::new();
+        let whole: &[u8] = b"Content-Type: text/plain\r\n\r\ntail";
+        let mut outcome = HeadFeed::Pending;
+        for byte in whole {
+            outcome = acc.feed(std::slice::from_ref(byte));
+            if matches!(outcome, HeadFeed::Complete(_)) {
+                break;
+            }
+        }
+        let head = complete(outcome);
+        assert_eq!(
+            head.headers,
+            vec![("Content-Type".to_owned(), "text/plain".to_owned())]
+        );
+        assert!(head.body_remainder.is_empty());
     }
 }

--- a/crates/yerd-proxy/src/pure/cgi_head.rs
+++ b/crates/yerd-proxy/src/pure/cgi_head.rs
@@ -1,0 +1,312 @@
+//! Incremental CGI response-head parsing.
+//!
+//! PHP-FPM delivers a response as a stream of STDOUT records whose leading
+//! bytes are a CGI header block ending at a blank line. The forwarder feeds
+//! those records here as they arrive and starts streaming the body the moment
+//! [`HeadFeed::Complete`] comes back, so nothing waits for `END_REQUEST`.
+//!
+//! Buffering until the terminator is found is what makes a record boundary
+//! falling inside a `\r\n\r\n` harmless: each feed rescans the whole buffer,
+//! so the split point never matters.
+
+use http::StatusCode;
+
+/// Cap on the buffered header block. Generous next to nginx's default
+/// `fastcgi_buffer_size` of 4-8 KiB: a head past this is a runaway backend,
+/// not a real response.
+const MAX_HEAD_BYTES: usize = 64 * 1024;
+
+/// A parsed CGI response head, plus any body bytes that arrived with it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Head {
+    /// Code from the CGI `Status:` line, or 200 when there wasn't one.
+    pub status: StatusCode,
+    /// Header lines in wire order, with `Status:` removed.
+    pub headers: Vec<(String, String)>,
+    /// Body bytes that followed the terminator in the same feed.
+    pub body_remainder: Vec<u8>,
+}
+
+/// What feeding a STDOUT chunk to a [`HeadAccumulator`] produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeadFeed {
+    /// No terminator yet; keep feeding.
+    Pending,
+    /// The header block is complete.
+    Complete(Head),
+    /// The block passed the size cap with no terminator in sight.
+    TooLarge,
+}
+
+/// Buffers STDOUT bytes until the CGI header block terminates.
+#[derive(Debug, Default)]
+pub struct HeadAccumulator {
+    buf: Vec<u8>,
+}
+
+impl HeadAccumulator {
+    /// A new, empty accumulator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    /// Add `chunk` and rescan for the header terminator.
+    pub fn feed(&mut self, chunk: &[u8]) -> HeadFeed {
+        self.buf.extend_from_slice(chunk);
+        match find_header_terminator(&self.buf) {
+            Some((offset, terminator_len)) => {
+                let (head, rest) = self.buf.split_at(offset);
+                let body_remainder = rest.get(terminator_len..).unwrap_or_default().to_vec();
+                let (status, headers) = parse_head(head);
+                HeadFeed::Complete(Head {
+                    status,
+                    headers,
+                    body_remainder,
+                })
+            }
+            None if self.buf.len() > MAX_HEAD_BYTES => HeadFeed::TooLarge,
+            None => HeadFeed::Pending,
+        }
+    }
+
+    /// The backend finished the response without ever terminating the header
+    /// block. Everything buffered is the head and the body is empty, which is
+    /// what the pre-streaming forwarder did with the same input.
+    #[must_use]
+    pub fn finish(self) -> Head {
+        let (status, headers) = parse_head(&self.buf);
+        Head {
+            status,
+            headers,
+            body_remainder: Vec::new(),
+        }
+    }
+}
+
+/// Parse a CGI header block: `Status: NNN Reason` drives the status code and is
+/// not surfaced as a header; everything else is passed through trimmed. Lines
+/// without a colon are skipped, as is a block that isn't UTF-8.
+fn parse_head(head: &[u8]) -> (StatusCode, Vec<(String, String)>) {
+    let head_str = std::str::from_utf8(head).unwrap_or("");
+    let mut status = StatusCode::OK;
+    let mut headers: Vec<(String, String)> = Vec::new();
+    for line in head_str.split('\n') {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            continue;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim();
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("Status") {
+            if let Some(code) = parse_cgi_status(value) {
+                status = code;
+            }
+        } else {
+            headers.push((name.to_owned(), value.to_owned()));
+        }
+    }
+    (status, headers)
+}
+
+/// Parse a CGI `Status:` value - `"200 OK"` or a bare `"200"` - into a status
+/// code. `None` when it isn't a valid code, leaving the caller's default.
+fn parse_cgi_status(value: &str) -> Option<StatusCode> {
+    let code = value.split_once(' ').map_or(value, |(code, _)| code);
+    StatusCode::from_u16(code.parse::<u16>().ok()?).ok()
+}
+
+/// Locate the blank line ending the header block, returning
+/// `(offset, terminator_len)`. `None` when the buffer holds no terminator yet.
+fn find_header_terminator(buf: &[u8]) -> Option<(usize, usize)> {
+    for i in 0..buf.len() {
+        if buf.get(i..i + 4) == Some(b"\r\n\r\n".as_slice()) {
+            return Some((i, 4));
+        }
+        if buf.get(i..i + 2) == Some(b"\n\n".as_slice()) {
+            return Some((i, 2));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    fn complete(feed: HeadFeed) -> Head {
+        match feed {
+            HeadFeed::Complete(head) => head,
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    fn feed_all(chunks: &[&[u8]]) -> HeadFeed {
+        let mut acc = HeadAccumulator::new();
+        let mut last = HeadFeed::Pending;
+        for chunk in chunks {
+            last = acc.feed(chunk);
+            if matches!(last, HeadFeed::Complete(_) | HeadFeed::TooLarge) {
+                break;
+            }
+        }
+        last
+    }
+
+    #[test]
+    fn whole_head_and_body_in_one_feed() {
+        let cases: [(&[u8], &str); 2] = [
+            (b"Content-Type: text/plain\r\n\r\nhello", "text/plain"),
+            (b"Content-Type: text/html\n\nhello", "text/html"),
+        ];
+        for (input, content_type) in cases {
+            let head = complete(feed_all(&[input]));
+            assert_eq!(head.status, StatusCode::OK);
+            assert_eq!(
+                head.headers,
+                vec![("Content-Type".to_owned(), content_type.to_owned())]
+            );
+            assert_eq!(head.body_remainder, b"hello");
+        }
+    }
+
+    #[test]
+    fn head_split_across_feeds_completes_on_the_later_chunk() {
+        let mut acc = HeadAccumulator::new();
+        assert_eq!(acc.feed(b"Content-Type: text/plain\r\n"), HeadFeed::Pending);
+        assert_eq!(acc.feed(b"X-Extra: 1\r\n"), HeadFeed::Pending);
+        let head = complete(acc.feed(b"\r\nbody bytes"));
+        assert_eq!(
+            head.headers,
+            vec![
+                ("Content-Type".to_owned(), "text/plain".to_owned()),
+                ("X-Extra".to_owned(), "1".to_owned()),
+            ]
+        );
+        assert_eq!(head.body_remainder, b"body bytes");
+    }
+
+    #[test]
+    fn terminator_straddling_a_feed_boundary_at_every_split_point() {
+        let whole: &[u8] = b"Content-Type: text/plain\r\n\r\nchunk";
+        let terminator_start = 24;
+        for split in 1..4 {
+            let at = terminator_start + split;
+            let head = complete(feed_all(&[&whole[..at], &whole[at..]]));
+            assert_eq!(head.status, StatusCode::OK);
+            assert_eq!(
+                head.headers,
+                vec![("Content-Type".to_owned(), "text/plain".to_owned())],
+                "split at {at}"
+            );
+            assert_eq!(head.body_remainder, b"chunk", "split at {at}");
+        }
+    }
+
+    #[test]
+    fn status_line_drives_the_code_and_is_not_surfaced() {
+        let cases: [(&[u8], StatusCode); 4] = [
+            (b"Status: 404 Not Found\r\n\r\n", StatusCode::NOT_FOUND),
+            (b"Status: 301\r\n\r\n", StatusCode::MOVED_PERMANENTLY),
+            (b"Status: abc\r\n\r\n", StatusCode::OK),
+            (b"Status: 99\r\n\r\n", StatusCode::OK),
+        ];
+        for (input, expected) in cases {
+            let head = complete(feed_all(&[input]));
+            assert_eq!(head.status, expected);
+            assert!(head
+                .headers
+                .iter()
+                .all(|(name, _)| !name.eq_ignore_ascii_case("Status")));
+        }
+    }
+
+    #[test]
+    fn status_alongside_other_headers_keeps_them() {
+        let head = complete(feed_all(&[b"Status: 301 Moved\r\nLocation: /x\r\n\r\n"]));
+        assert_eq!(head.status, StatusCode::MOVED_PERMANENTLY);
+        assert_eq!(head.headers, vec![("Location".to_owned(), "/x".to_owned())]);
+        assert!(head.body_remainder.is_empty());
+    }
+
+    #[test]
+    fn oversize_head_without_a_terminator_is_too_large() {
+        let mut acc = HeadAccumulator::new();
+        let filler = vec![b'x'; 8 * 1024];
+        let mut outcome = HeadFeed::Pending;
+        for _ in 0..9 {
+            outcome = acc.feed(&filler);
+        }
+        assert_eq!(outcome, HeadFeed::TooLarge);
+    }
+
+    #[test]
+    fn head_at_the_cap_still_completes_when_terminated() {
+        let mut acc = HeadAccumulator::new();
+        let mut line = b"X-Pad: ".to_vec();
+        line.extend(std::iter::repeat_n(b'y', 1_000));
+        line.extend_from_slice(b"\r\n");
+        for _ in 0..8 {
+            assert_eq!(acc.feed(&line), HeadFeed::Pending);
+        }
+        let head = complete(acc.feed(b"\r\ntail"));
+        assert_eq!(head.headers.len(), 8);
+        assert_eq!(head.body_remainder, b"tail");
+    }
+
+    #[test]
+    fn finish_treats_an_unterminated_block_as_the_whole_head() {
+        let mut acc = HeadAccumulator::new();
+        assert_eq!(acc.feed(b"Content-Type: text/plain"), HeadFeed::Pending);
+        let head = acc.finish();
+        assert_eq!(head.status, StatusCode::OK);
+        assert_eq!(
+            head.headers,
+            vec![("Content-Type".to_owned(), "text/plain".to_owned())]
+        );
+        assert!(head.body_remainder.is_empty());
+    }
+
+    #[test]
+    fn finish_on_an_empty_accumulator_is_a_bare_200() {
+        let head = HeadAccumulator::new().finish();
+        assert_eq!(head.status, StatusCode::OK);
+        assert!(head.headers.is_empty());
+        assert!(head.body_remainder.is_empty());
+    }
+
+    #[test]
+    fn body_remainder_is_empty_when_nothing_trails_the_terminator() {
+        let head = complete(feed_all(&[b"Content-Type: text/plain\r\n\r\n"]));
+        assert!(head.body_remainder.is_empty());
+    }
+
+    #[test]
+    fn crlf_terminator_wins_over_a_later_bare_lf_pair() {
+        let head = complete(feed_all(&[b"A: b\r\n\r\nbody\n\nmore"]));
+        assert_eq!(head.headers, vec![("A".to_owned(), "b".to_owned())]);
+        assert_eq!(head.body_remainder, b"body\n\nmore");
+    }
+
+    #[test]
+    fn lines_without_a_colon_are_skipped() {
+        let head = complete(feed_all(&[b"garbage line\r\nA: b\r\n\r\n"]));
+        assert_eq!(head.headers, vec![("A".to_owned(), "b".to_owned())]);
+    }
+
+    #[test]
+    fn non_utf8_head_yields_no_headers() {
+        let head = complete(feed_all(&[b"A: \xff\xfe\r\n\r\nbody"]));
+        assert!(head.headers.is_empty());
+        assert_eq!(head.body_remainder, b"body");
+    }
+}

--- a/crates/yerd-proxy/src/pure/mod.rs
+++ b/crates/yerd-proxy/src/pure/mod.rs
@@ -1,5 +1,6 @@
 //! Pure (synchronous, runtime-free, I/O-free) helpers.
 
+pub mod cgi_head;
 pub mod cgi_params;
 pub mod fcgi_codec;
 pub mod query;

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -2423,3 +2423,489 @@ async fn client_post(addr: SocketAddr, host: &str, path: &str) -> (u16, Vec<u8>)
         .to_vec();
     (status, body)
 }
+
+/// Frame-level client: returns the response un-collected so a caller can pull
+/// body frames as they arrive. Every other helper here `collect`s, which cannot
+/// observe incremental delivery. The `method` parameter lets the HEAD test
+/// share it rather than adding a seventh near-identical helper.
+async fn client_request_streaming(
+    addr: SocketAddr,
+    host: &str,
+    method: &str,
+    path: &str,
+) -> hyper::Response<hyper::body::Incoming> {
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = Request::builder()
+        .method(method)
+        .uri(path)
+        .header("Host", host)
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+    sender.send_request(req).await.unwrap()
+}
+
+/// Pull the next data frame, skipping trailers. `None` at end of body.
+async fn next_data_frame(body: &mut hyper::body::Incoming) -> Option<Vec<u8>> {
+    while let Some(frame) = body.frame().await {
+        if let Ok(data) = frame.unwrap().into_data() {
+            return Some(data.to_vec());
+        }
+    }
+    None
+}
+
+// ─── Streaming pass-through (issue #212) ────────────────────────────
+
+const RECORD_END_REQUEST: u8 = 3;
+const RECORD_PARAMS: u8 = 4;
+const RECORD_STDIN: u8 = 5;
+const RECORD_STDOUT: u8 = 6;
+const RECORD_STDERR: u8 = 7;
+
+const END_REQUEST_BODY: [u8; 8] = [0; 8];
+
+/// How long the HEAD test waits to prove the backend socket stays open. This is
+/// an absence assertion, so CI load can only make it safer: without the
+/// bodyless carve-out the proxy closes the socket immediately after the head.
+const NO_EOF_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Generous backstop so a regression fails the test instead of hanging it.
+const HARNESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// A fake FastCGI backend that emits records on cue instead of all at once.
+///
+/// The first record goes out as soon as the request has been read; each one
+/// after it waits for a permit on `gate`, which is what makes delivery-ordering
+/// assertions deterministic without calibrated sleeps.
+///
+/// While waiting for a permit the backend also reads its socket, so a peer
+/// close is noticed promptly and the task ends - that is how the disconnect and
+/// HEAD tests observe what the proxy did to the connection. The one exception
+/// is `respond_before_stdin`, where reading would defeat the point: that mode
+/// exists to leave STDIN unread so the proxy's request write wedges against a
+/// full kernel buffer, so its gate wait awaits the permit alone and closure is
+/// detected by the terminal read phase instead.
+///
+/// Once the sequence is exhausted every mode reads to EOF and returns, so the
+/// `JoinHandle` completing always means the proxy let go of the socket.
+async fn run_fake_fcgi_staged(
+    listener: TcpListener,
+    records: Vec<(u8, Vec<u8>)>,
+    mut gate: tokio::sync::mpsc::Receiver<()>,
+    respond_before_stdin: bool,
+) {
+    let (mut conn, _) = listener.accept().await.unwrap();
+    let stop_at = if respond_before_stdin {
+        RECORD_PARAMS
+    } else {
+        RECORD_STDIN
+    };
+    read_records_until_empty(&mut conn, stop_at).await;
+
+    let mut records = records.into_iter();
+    if let Some((record_type, payload)) = records.next() {
+        write_record(&mut conn, record_type, &payload).await;
+    }
+    for (record_type, payload) in records {
+        if respond_before_stdin {
+            if gate.recv().await.is_none() {
+                return;
+            }
+            read_records_until_empty(&mut conn, RECORD_STDIN).await;
+        } else if !wait_for_permit_or_close(&mut conn, &mut gate).await {
+            return;
+        }
+        write_record(&mut conn, record_type, &payload).await;
+    }
+    read_to_eof(&mut conn).await;
+}
+
+/// Read and discard FCGI records until an empty record of `stop_type` (the
+/// PARAMS or STDIN terminator), or the peer goes away.
+async fn read_records_until_empty(conn: &mut TcpStream, stop_type: u8) {
+    loop {
+        let mut header = [0u8; 8];
+        if conn.read_exact(&mut header).await.is_err() {
+            return;
+        }
+        let record_type = header[1];
+        let content_len = u16::from_be_bytes([header[4], header[5]]) as usize;
+        let padding = header[6] as usize;
+        if content_len > 0 {
+            let mut content = vec![0u8; content_len];
+            if conn.read_exact(&mut content).await.is_err() {
+                return;
+            }
+        }
+        if padding > 0 {
+            let mut pad = vec![0u8; padding];
+            if conn.read_exact(&mut pad).await.is_err() {
+                return;
+            }
+        }
+        if record_type == stop_type && content_len == 0 {
+            return;
+        }
+    }
+}
+
+/// Wait for the next permit while watching for the peer closing. `true` when a
+/// permit arrived, `false` when the socket closed or the gate was dropped.
+async fn wait_for_permit_or_close(
+    conn: &mut TcpStream,
+    gate: &mut tokio::sync::mpsc::Receiver<()>,
+) -> bool {
+    let mut sink = [0u8; 1024];
+    loop {
+        tokio::select! {
+            permit = gate.recv() => return permit.is_some(),
+            read = conn.read(&mut sink) => match read {
+                Ok(0) | Err(_) => return false,
+                Ok(_) => {}
+            },
+        }
+    }
+}
+
+async fn read_to_eof(conn: &mut TcpStream) {
+    let mut sink = [0u8; 8192];
+    loop {
+        match conn.read(&mut sink).await {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+    }
+}
+
+/// A router holding one linked site named `app`, rooted anywhere - these tests
+/// never touch the filesystem, every request falls through to FastCGI.
+fn streaming_router() -> SiteRouter {
+    let cfg = RouterConfig::with_tld(Tld::new("test").unwrap());
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("app", PathBuf::from("/srv/www/app"), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    router
+}
+
+/// Issue #212: the head and body frames must reach the client while the backend
+/// is still holding the final record, which the store-and-forward forwarder
+/// could never do. Doubles as the record-demultiplexing proof: a STDERR record
+/// before the head must not reach the head accumulator, and one mid-stream must
+/// not become a body frame.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcgi_response_streams_before_end_request() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let (gate_tx, gate_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let records = vec![
+        (RECORD_STDERR, b"PHP Notice: boot".to_vec()),
+        (
+            RECORD_STDOUT,
+            b"Content-Type: text/event-stream\r\nX-Accel-Buffering: no\r\n\r\nchunk-one".to_vec(),
+        ),
+        (RECORD_STDERR, b"PHP Notice: midway".to_vec()),
+        (RECORD_STDOUT, b"chunk-two".to_vec()),
+        (RECORD_END_REQUEST, END_REQUEST_BODY.to_vec()),
+    ];
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, false));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        streaming_router(),
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    for _ in 0..3 {
+        gate_tx.send(()).await.unwrap();
+    }
+
+    let resp = tokio::time::timeout(
+        HARNESS_TIMEOUT,
+        client_request_streaming(proxy_addr, "app.test", "GET", "/stream"),
+    )
+    .await
+    .expect("response head must arrive before END_REQUEST");
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "text/event-stream"
+    );
+    assert!(
+        resp.headers().get("content-length").is_none(),
+        "a streamed response with no PHP Content-Length must be chunked"
+    );
+    assert!(
+        resp.headers().get("x-accel-buffering").is_none(),
+        "X-Accel-Buffering is consumed by the proxy, not forwarded"
+    );
+
+    let mut body = resp.into_body();
+    let first = tokio::time::timeout(HARNESS_TIMEOUT, next_data_frame(&mut body))
+        .await
+        .expect("first body frame must arrive before END_REQUEST")
+        .unwrap();
+    assert_eq!(first, b"chunk-one");
+    let second = tokio::time::timeout(HARNESS_TIMEOUT, next_data_frame(&mut body))
+        .await
+        .expect("second body frame must arrive before END_REQUEST")
+        .unwrap();
+    assert_eq!(second, b"chunk-two");
+
+    gate_tx.send(()).await.unwrap();
+    let tail = tokio::time::timeout(HARNESS_TIMEOUT, body.collect())
+        .await
+        .unwrap()
+        .unwrap()
+        .to_bytes();
+    assert!(tail.is_empty());
+
+    let delivered = [first, second].concat();
+    assert!(
+        !delivered.windows(4).any(|w| w == b"PHP "),
+        "STDERR records must never appear in the response body"
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, fake_task).await;
+}
+
+/// A `Content-Length` PHP set itself passes through untouched (hyper frames the
+/// body by it instead of chunking), and `X-Accel-Buffering` is stripped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn php_content_length_passes_through_and_x_accel_is_stripped() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let payload =
+        b"Content-Type: text/plain\r\nContent-Length: 5\r\nX-Accel-Buffering: no\r\n\r\nhello"
+            .to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(fcgi_listener, payload, captured));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        streaming_router(),
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    let (status, headers) = client_get_headers(proxy_addr, "app.test", "/sized").await;
+    assert_eq!(status, 200);
+    assert_eq!(headers.get("content-length").unwrap(), "5");
+    assert!(headers.get("transfer-encoding").is_none());
+    assert!(headers.get("x-accel-buffering").is_none());
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, fake_task).await;
+}
+
+/// Hyper drops the body of a response it cannot encode one for the moment the
+/// head goes out. On the streaming path that drop would read as a client
+/// disconnect and close the FCGI socket, killing the PHP script mid-run, so
+/// bodyless responses are drained to END_REQUEST instead. The discriminator is
+/// a read: the backend must not see EOF while it is still holding END_REQUEST.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn head_request_drains_backend_instead_of_killing_the_script() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let (gate_tx, gate_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let records = vec![
+        (
+            RECORD_STDOUT,
+            b"Content-Type: text/plain\r\n\r\nhello".to_vec(),
+        ),
+        (RECORD_END_REQUEST, END_REQUEST_BODY.to_vec()),
+    ];
+    let mut fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, false));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        streaming_router(),
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    let request = tokio::spawn(async move {
+        let resp = client_request_streaming(proxy_addr, "app.test", "HEAD", "/").await;
+        let status = resp.status().as_u16();
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let mut body = resp.into_body();
+        let frame = next_data_frame(&mut body).await;
+        (status, content_type, frame)
+    });
+
+    assert!(
+        tokio::time::timeout(NO_EOF_WINDOW, &mut fake_task)
+            .await
+            .is_err(),
+        "the backend saw EOF while holding END_REQUEST: the proxy closed the FCGI \
+         socket after the head and would have killed the PHP script"
+    );
+
+    gate_tx.send(()).await.unwrap();
+    let (status, content_type, frame) = tokio::time::timeout(HARNESS_TIMEOUT, request)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(status, 200);
+    assert_eq!(content_type.as_deref(), Some("text/plain"));
+    assert!(frame.is_none(), "a HEAD response carries no body");
+
+    let joined = tokio::time::timeout(HARNESS_TIMEOUT, fake_task)
+        .await
+        .unwrap();
+    assert!(joined.is_ok(), "the fake backend must not panic");
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+}
+
+/// A client that vanishes mid-stream must close the FCGI socket even when the
+/// backend has gone quiet - the SSE case, where the next record may be minutes
+/// away. Without waking the reader on the dropped body, the proxy would sit in
+/// its socket read and hold an FPM worker indefinitely.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_disconnect_mid_stream_closes_backend_socket() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let (_gate_tx, gate_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let records = vec![(
+        RECORD_STDOUT,
+        b"Content-Type: text/event-stream\r\n\r\nfirst".to_vec(),
+    )];
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, false));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        streaming_router(),
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    let stream = TcpStream::connect(proxy_addr).await.unwrap();
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io)
+        .await
+        .unwrap();
+    let conn_task = tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = Request::builder()
+        .method("GET")
+        .uri("/events")
+        .header("Host", "app.test")
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+    let resp = tokio::time::timeout(HARNESS_TIMEOUT, sender.send_request(req))
+        .await
+        .expect("the response head must arrive before END_REQUEST")
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let mut body = resp.into_body();
+    let first = tokio::time::timeout(HARNESS_TIMEOUT, next_data_frame(&mut body))
+        .await
+        .expect("the first flush must arrive before the backend goes idle")
+        .unwrap();
+    assert_eq!(first, b"first");
+
+    drop(body);
+    drop(sender);
+    conn_task.abort();
+
+    let joined = tokio::time::timeout(HARNESS_TIMEOUT, fake_task)
+        .await
+        .expect("the backend socket must close once the client is gone");
+    assert!(joined.is_ok(), "the fake backend must not panic");
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+}
+
+/// The read and write halves run concurrently, so a backend that answers before
+/// draining STDIN no longer deadlocks the forwarder. The body is sized well past
+/// what an unread loopback link absorbs (measured at 727-814 KiB on macOS with
+/// 4 MiB autotuning maxima), so the pre-split code wedges in its request write
+/// and the head never arrives.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn large_post_does_not_deadlock_when_backend_responds_first() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let (gate_tx, gate_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let records = vec![
+        (
+            RECORD_STDOUT,
+            b"Content-Type: text/plain\r\n\r\naccepted".to_vec(),
+        ),
+        (RECORD_END_REQUEST, END_REQUEST_BODY.to_vec()),
+    ];
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, true));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        streaming_router(),
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    let upload = Bytes::from(vec![b'z'; 4 * 1024 * 1024]);
+    let exchange = async move {
+        let stream = TcpStream::connect(proxy_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) =
+            hyper::client::conn::http1::handshake::<_, http_body_util::Full<Bytes>>(io)
+                .await
+                .unwrap();
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/upload")
+            .header("Host", "app.test")
+            .body(http_body_util::Full::new(upload))
+            .unwrap();
+        let resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let mut body = resp.into_body();
+        assert_eq!(next_data_frame(&mut body).await.unwrap(), b"accepted");
+        gate_tx.send(()).await.unwrap();
+        body.collect().await.unwrap().to_bytes()
+    };
+
+    let rest = tokio::time::timeout(std::time::Duration::from_secs(30), exchange)
+        .await
+        .expect("the response must arrive while the request body is still being written");
+    assert!(rest.is_empty());
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, fake_task).await;
+}

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -2471,13 +2471,34 @@ const RECORD_STDERR: u8 = 7;
 
 const END_REQUEST_BODY: [u8; 8] = [0; 8];
 
-/// How long the HEAD test waits to prove the backend socket stays open. This is
-/// an absence assertion, so CI load can only make it safer: without the
-/// bodyless carve-out the proxy closes the socket immediately after the head.
+/// How long the HEAD test waits to prove the backend socket stays open, once
+/// the backend has signalled that it wrote its first record. Waiting on that
+/// signal is what stops the assertion passing vacuously while the proxy has yet
+/// to connect; past it the wait is a pure absence assertion, so CI load can only
+/// make it safer.
 const NO_EOF_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
 
 /// Generous backstop so a regression fails the test instead of hanging it.
 const HARNESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Knobs on [`run_fake_fcgi_staged`] beyond its record sequence.
+#[derive(Default)]
+struct StagedOptions {
+    /// Stop reading at the PARAMS terminator and leave STDIN untouched until a
+    /// permit arrives, so the proxy's request write has nothing draining it.
+    respond_before_stdin: bool,
+    /// With `respond_before_stdin`, never drain STDIN at all - the backend
+    /// answers and finishes with the upload still wedged in the socket, which
+    /// is the shape a 419 on a large POST takes. The connection is then parked
+    /// until the gate is dropped rather than closed, because closing a socket
+    /// with unread data in its receive buffer sends an RST that would discard
+    /// the records just written.
+    never_read_stdin: bool,
+    /// Fired once the first record is on the wire. Tests that assert the
+    /// backend socket is *still open* wait on this first, so the assertion
+    /// cannot pass merely because the proxy has yet to connect.
+    first_record: Option<oneshot::Sender<()>>,
+}
 
 /// A fake FastCGI backend that emits records on cue instead of all at once.
 ///
@@ -2494,13 +2515,20 @@ const HARNESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// detected by the terminal read phase instead.
 ///
 /// Once the sequence is exhausted every mode reads to EOF and returns, so the
-/// `JoinHandle` completing always means the proxy let go of the socket.
+/// `JoinHandle` completing always means the proxy let go of the socket. Dropping
+/// the gate before the sequence runs out instead makes the backend vanish
+/// mid-response, which is how the truncation test cuts a stream short.
 async fn run_fake_fcgi_staged(
     listener: TcpListener,
     records: Vec<(u8, Vec<u8>)>,
     mut gate: tokio::sync::mpsc::Receiver<()>,
-    respond_before_stdin: bool,
+    options: StagedOptions,
 ) {
+    let StagedOptions {
+        respond_before_stdin,
+        never_read_stdin,
+        first_record,
+    } = options;
     let (mut conn, _) = listener.accept().await.unwrap();
     let stop_at = if respond_before_stdin {
         RECORD_PARAMS
@@ -2513,16 +2541,25 @@ async fn run_fake_fcgi_staged(
     if let Some((record_type, payload)) = records.next() {
         write_record(&mut conn, record_type, &payload).await;
     }
+    if let Some(signal) = first_record {
+        let _ = signal.send(());
+    }
     for (record_type, payload) in records {
         if respond_before_stdin {
             if gate.recv().await.is_none() {
                 return;
             }
-            read_records_until_empty(&mut conn, RECORD_STDIN).await;
+            if !never_read_stdin {
+                read_records_until_empty(&mut conn, RECORD_STDIN).await;
+            }
         } else if !wait_for_permit_or_close(&mut conn, &mut gate).await {
             return;
         }
         write_record(&mut conn, record_type, &payload).await;
+    }
+    if never_read_stdin {
+        while gate.recv().await.is_some() {}
+        return;
     }
     read_to_eof(&mut conn).await;
 }
@@ -2584,14 +2621,16 @@ async fn read_to_eof(conn: &mut TcpStream) {
     }
 }
 
-/// A router holding one linked site named `app`, rooted anywhere - these tests
-/// never touch the filesystem, every request falls through to FastCGI.
-fn streaming_router() -> SiteRouter {
+/// A router holding one linked site named `app`, rooted at an empty temp dir so
+/// nothing on disk can satisfy a request and every one falls through to
+/// FastCGI. The caller keeps the `TempDir` alive for the length of the test.
+fn streaming_router() -> (SiteRouter, tempfile::TempDir) {
+    let docroot = tempfile::tempdir().unwrap();
     let cfg = RouterConfig::with_tld(Tld::new("test").unwrap());
     let mut router = SiteRouter::new(cfg);
-    let site = Site::linked("app", PathBuf::from("/srv/www/app"), PhpVersion::new(8, 3)).unwrap();
+    let site = Site::linked("app", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
     router.insert(site).unwrap();
-    router
+    (router, docroot)
 }
 
 /// Issue #212: the head and body frames must reach the client while the backend
@@ -2614,13 +2653,19 @@ async fn fcgi_response_streams_before_end_request() {
         (RECORD_STDOUT, b"chunk-two".to_vec()),
         (RECORD_END_REQUEST, END_REQUEST_BODY.to_vec()),
     ];
-    let fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, false));
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(
+        fcgi_listener,
+        records,
+        gate_rx,
+        StagedOptions::default(),
+    ));
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
     let (tx_shutdown, proxy_task) = spawn_route_proxy(
         proxy_listener,
-        streaming_router(),
+        router,
         Arc::new(StaticResolver {
             backend: Backend::PhpFpmTcp { addr: fcgi_addr },
         }),
@@ -2695,9 +2740,10 @@ async fn php_content_length_passes_through_and_x_accel_is_stripped() {
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
     let (tx_shutdown, proxy_task) = spawn_route_proxy(
         proxy_listener,
-        streaming_router(),
+        router,
         Arc::new(StaticResolver {
             backend: Backend::PhpFpmTcp { addr: fcgi_addr },
         }),
@@ -2719,6 +2765,10 @@ async fn php_content_length_passes_through_and_x_accel_is_stripped() {
 /// disconnect and close the FCGI socket, killing the PHP script mid-run, so
 /// bodyless responses are drained to END_REQUEST instead. The discriminator is
 /// a read: the backend must not see EOF while it is still holding END_REQUEST.
+///
+/// Draining is also where the `Content-Length` comes from. Hyper will not write
+/// an implicit one for HEAD, so without totting up the discarded bytes a HEAD
+/// on a page that sets no length of its own answers with no length at all.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn head_request_drains_backend_instead_of_killing_the_script() {
     let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2731,13 +2781,23 @@ async fn head_request_drains_backend_instead_of_killing_the_script() {
         ),
         (RECORD_END_REQUEST, END_REQUEST_BODY.to_vec()),
     ];
-    let mut fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, false));
+    let (responded_tx, responded_rx) = oneshot::channel();
+    let mut fake_task = tokio::spawn(run_fake_fcgi_staged(
+        fcgi_listener,
+        records,
+        gate_rx,
+        StagedOptions {
+            first_record: Some(responded_tx),
+            ..StagedOptions::default()
+        },
+    ));
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
     let (tx_shutdown, proxy_task) = spawn_route_proxy(
         proxy_listener,
-        streaming_router(),
+        router,
         Arc::new(StaticResolver {
             backend: Backend::PhpFpmTcp { addr: fcgi_addr },
         }),
@@ -2746,16 +2806,16 @@ async fn head_request_drains_backend_instead_of_killing_the_script() {
     let request = tokio::spawn(async move {
         let resp = client_request_streaming(proxy_addr, "app.test", "HEAD", "/").await;
         let status = resp.status().as_u16();
-        let content_type = resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_owned);
+        let headers = resp.headers().clone();
         let mut body = resp.into_body();
         let frame = next_data_frame(&mut body).await;
-        (status, content_type, frame)
+        (status, headers, frame)
     });
 
+    tokio::time::timeout(HARNESS_TIMEOUT, responded_rx)
+        .await
+        .expect("the backend must get as far as writing its head record")
+        .unwrap();
     assert!(
         tokio::time::timeout(NO_EOF_WINDOW, &mut fake_task)
             .await
@@ -2765,12 +2825,18 @@ async fn head_request_drains_backend_instead_of_killing_the_script() {
     );
 
     gate_tx.send(()).await.unwrap();
-    let (status, content_type, frame) = tokio::time::timeout(HARNESS_TIMEOUT, request)
+    let (status, headers, frame) = tokio::time::timeout(HARNESS_TIMEOUT, request)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(status, 200);
-    assert_eq!(content_type.as_deref(), Some("text/plain"));
+    assert_eq!(headers.get("content-type").unwrap(), "text/plain");
+    assert_eq!(
+        headers.get("content-length").unwrap(),
+        "5",
+        "HEAD must report the length the same GET would have sent; hyper writes \
+         no implicit one for HEAD, so the drained byte count has to supply it"
+    );
     assert!(frame.is_none(), "a HEAD response carries no body");
 
     let joined = tokio::time::timeout(HARNESS_TIMEOUT, fake_task)
@@ -2795,13 +2861,19 @@ async fn client_disconnect_mid_stream_closes_backend_socket() {
         RECORD_STDOUT,
         b"Content-Type: text/event-stream\r\n\r\nfirst".to_vec(),
     )];
-    let fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, false));
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(
+        fcgi_listener,
+        records,
+        gate_rx,
+        StagedOptions::default(),
+    ));
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
     let (tx_shutdown, proxy_task) = spawn_route_proxy(
         proxy_listener,
-        streaming_router(),
+        router,
         Arc::new(StaticResolver {
             backend: Backend::PhpFpmTcp { addr: fcgi_addr },
         }),
@@ -2848,9 +2920,14 @@ async fn client_disconnect_mid_stream_closes_backend_socket() {
 
 /// The read and write halves run concurrently, so a backend that answers before
 /// draining STDIN no longer deadlocks the forwarder. The body is sized well past
-/// what an unread loopback link absorbs (measured at 727-814 KiB on macOS with
-/// 4 MiB autotuning maxima), so the pre-split code wedges in its request write
-/// and the head never arrives.
+/// what an unread loopback link absorbs, so the pre-split code wedges in its
+/// request write and the head never arrives.
+///
+/// Sizing has to clear the *largest* plausible pair of socket buffers, not the
+/// one this developer measured: macOS wedges by around 800 KiB, but Linux
+/// autotuning defaults (`tcp_wmem` to 4 MiB plus `tcp_rmem` to 6 MiB) can
+/// swallow well over 10 MiB, and a body under that would let the old code pass
+/// too - a green test guarding nothing.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn large_post_does_not_deadlock_when_backend_responds_first() {
     let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2863,19 +2940,28 @@ async fn large_post_does_not_deadlock_when_backend_responds_first() {
         ),
         (RECORD_END_REQUEST, END_REQUEST_BODY.to_vec()),
     ];
-    let fake_task = tokio::spawn(run_fake_fcgi_staged(fcgi_listener, records, gate_rx, true));
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(
+        fcgi_listener,
+        records,
+        gate_rx,
+        StagedOptions {
+            respond_before_stdin: true,
+            ..StagedOptions::default()
+        },
+    ));
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
     let (tx_shutdown, proxy_task) = spawn_route_proxy(
         proxy_listener,
-        streaming_router(),
+        router,
         Arc::new(StaticResolver {
             backend: Backend::PhpFpmTcp { addr: fcgi_addr },
         }),
     );
 
-    let upload = Bytes::from(vec![b'z'; 4 * 1024 * 1024]);
+    let upload = Bytes::from(vec![b'z'; 32 * 1024 * 1024]);
     let exchange = async move {
         let stream = TcpStream::connect(proxy_addr).await.unwrap();
         let io = TokioIo::new(stream);
@@ -2904,6 +2990,192 @@ async fn large_post_does_not_deadlock_when_backend_responds_first() {
         .await
         .expect("the response must arrive while the request body is still being written");
     assert!(rest.is_empty());
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, fake_task).await;
+}
+
+/// A backend that vanishes mid-body cannot retract a head already on the wire,
+/// so the truncation has to surface as a body error rather than a short but
+/// apparently complete response. Hyper turns that into an aborted connection,
+/// which the client sees as a failed frame.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backend_dying_mid_stream_fails_the_body_rather_than_truncating_it() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let (gate_tx, gate_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let records = vec![
+        (
+            RECORD_STDOUT,
+            b"Content-Type: text/event-stream\r\n\r\nfirst".to_vec(),
+        ),
+        (RECORD_STDOUT, b"never sent".to_vec()),
+    ];
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(
+        fcgi_listener,
+        records,
+        gate_rx,
+        StagedOptions::default(),
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        router,
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    let resp = tokio::time::timeout(
+        HARNESS_TIMEOUT,
+        client_request_streaming(proxy_addr, "app.test", "GET", "/events"),
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let mut body = resp.into_body();
+    assert_eq!(
+        tokio::time::timeout(HARNESS_TIMEOUT, next_data_frame(&mut body))
+            .await
+            .unwrap()
+            .unwrap(),
+        b"first"
+    );
+
+    drop(gate_tx);
+    let outcome = tokio::time::timeout(HARNESS_TIMEOUT, body.collect())
+        .await
+        .expect("the truncated body must resolve, not hang");
+    assert!(
+        outcome.is_err(),
+        "a backend that disappeared mid-stream must not look like a clean end of body"
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, fake_task).await;
+}
+
+/// 204 takes the same bodyless carve-out as HEAD, and unlike HEAD it must come
+/// out with no `Content-Length` at all - hyper refuses one for 204, and adding
+/// one anyway would put a length on a response defined to have no body.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn no_content_response_is_drained_and_carries_no_length() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let payload = b"Status: 204 No Content\r\nX-Marker: seen\r\n\r\n".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(fcgi_listener, payload, captured));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        router,
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    let (status, headers) = client_get_headers(proxy_addr, "app.test", "/ping").await;
+    assert_eq!(status, 204);
+    assert_eq!(headers.get("x-marker").unwrap(), "seen");
+    assert!(headers.get("content-length").is_none());
+    assert!(headers.get("transfer-encoding").is_none());
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;
+    let _ = tokio::time::timeout(HARNESS_TIMEOUT, fake_task).await;
+}
+
+/// PHP is free to answer before it has read STDIN - a 419 or a 401 on a large
+/// upload. Cutting the request writer off at END_REQUEST would leave hyper with
+/// a part-read request body, and hyper responds to that by closing the client's
+/// read side, which the browser reports as a reset instead of showing the
+/// response. The writer therefore keeps draining after END_REQUEST, and the
+/// discriminator is that the client can still read its body to completion.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn upload_rejected_before_stdin_is_read_still_reaches_the_client() {
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let (gate_tx, gate_rx) = tokio::sync::mpsc::channel::<()>(8);
+    let records = vec![
+        (
+            RECORD_STDOUT,
+            b"Status: 419 Page Expired\r\nContent-Type: text/plain\r\n\r\ntoken expired".to_vec(),
+        ),
+        (RECORD_END_REQUEST, END_REQUEST_BODY.to_vec()),
+    ];
+    let fake_task = tokio::spawn(run_fake_fcgi_staged(
+        fcgi_listener,
+        records,
+        gate_rx,
+        StagedOptions {
+            respond_before_stdin: true,
+            never_read_stdin: true,
+            ..StagedOptions::default()
+        },
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let (router, _docroot) = streaming_router();
+    let (tx_shutdown, proxy_task) = spawn_route_proxy(
+        proxy_listener,
+        router,
+        Arc::new(StaticResolver {
+            backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+        }),
+    );
+
+    let upload = Bytes::from(vec![b'u'; 32 * 1024 * 1024]);
+    let exchange = async move {
+        let stream = TcpStream::connect(proxy_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) =
+            hyper::client::conn::http1::handshake::<_, http_body_util::Full<Bytes>>(io)
+                .await
+                .unwrap();
+        let conn_task = tokio::spawn(async move { conn.await.is_ok() });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/upload")
+            .header("Host", "app.test")
+            .body(http_body_util::Full::new(upload))
+            .unwrap();
+        let resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status().as_u16(), 419);
+        gate_tx.send(()).await.unwrap();
+        let body = resp
+            .into_body()
+            .collect()
+            .await
+            .map(http_body_util::Collected::to_bytes);
+        let alive = tokio::time::timeout(std::time::Duration::from_millis(400), conn_task)
+            .await
+            .is_err();
+        drop(sender);
+        (body, alive)
+    };
+
+    let (body, reusable) = tokio::time::timeout(std::time::Duration::from_secs(30), exchange)
+        .await
+        .expect("the exchange must not stall");
+    assert_eq!(
+        body.expect("the client must be able to read the whole response"),
+        Bytes::from_static(b"token expired")
+    );
+    assert!(
+        reusable,
+        "the client connection was closed under an upload still in flight: the \
+         request writer was cut off at END_REQUEST, leaving hyper with a part-read \
+         request body, and hyper answers that by closing the read side"
+    );
 
     let _ = tx_shutdown.send(());
     let _ = tokio::time::timeout(HARNESS_TIMEOUT, proxy_task).await;

--- a/docs/guide/sites.md
+++ b/docs/guide/sites.md
@@ -399,6 +399,21 @@ A rule only applies when the request matched no real file, so assets and real di
 
 See [Routing rules](../reference/cli/routes) for the full semantics, and note this is different from a [reverse proxy path rule](./proxies), which forwards to a separate running service rather than to a file inside the site.
 
+## Streaming responses (SSE / Livewire `wire:stream`)
+
+Streamed responses pass straight through as PHP flushes them - server-sent events, `response()->stream()`, Livewire's `wire:stream`, and token-by-token AI output all reach the browser incrementally. There is no setting to turn on and no header to send: `X-Accel-Buffering: no` is unnecessary (Yerd consumes it rather than forwarding it), and a response that sets no `Content-Length` is sent chunked.
+
+Each open stream occupies one PHP-FPM worker for as long as it stays open, so a page holding several event streams, or a few tabs left open on one, can reach the per-version ceiling of 16 workers and leave later requests queueing. Raise it with [`yerd php pool`](./php-versions#pool-size) if you work with streaming regularly.
+
+If a stream still arrives in one burst, the buffering is on the application side. Check `output_buffering` and any `ob_*` handlers your framework installs, and `zlib.output_compression`, which buffers to compress:
+
+```php
+while (ob_get_level() > 0) {
+    ob_end_flush();
+}
+flush();
+```
+
 ## Related
 
 - [PHP Versions](./php-versions) - set the global default and pin a site to a version.


### PR DESCRIPTION
<!-- Thanks for contributing to Yerd! Please fill in the sections below. -->

## What does this PR do?

Rewrites the FastCGI forwarder to split the backend socket and relay STDOUT records to the client as PHP flushes them — so SSE, response()->stream(), Livewire wire:stream and token-by-token AI output arrive incrementally instead of being buffered until END_REQUEST — while running the request write concurrently so a large upload can no longer deadlock against a backend that answers early.

## Related issues

Closes #212 

## Type of change

- [x] New feature
- [x] Documentation

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FastCGI responses now stream to clients incrementally, improving responsiveness for large or long-running responses.
  * Streaming support enables server-sent events and application-driven flushes.
* **Bug Fixes**
  * Improved handling of HEAD, 204, early-response, truncated, and disconnected requests.
  * CGI headers are processed more reliably, with improved filtering of internal and hop-by-hop headers.
  * Large uploads and concurrent request/response activity are handled more reliably.
* **Documentation**
  * Added guidance for streamed responses, PHP buffering, chunked delivery, and worker pool sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->