### PR TITLE
[Fix] Site details sidebar polish, WordPress auto-login guardrails, and tray/filter corrections

### DIFF
--- a/apps/yerd-gui/src-tauri/src/tray.rs
+++ b/apps/yerd-gui/src-tauri/src/tray.rs
@@ -30,7 +30,7 @@ use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Emitter, Wry};
 
 use yerd_core::PhpVersion;
-use yerd_ipc::{Request, Response};
+use yerd_ipc::{PhpPoolStatus, Request, Response};
 
 use crate::ipc::{exchange, exchange_timeout};
 
@@ -224,6 +224,17 @@ pub(crate) fn spawn_tray_poller(app: AppHandle) {
     });
 }
 
+/// The installed versions the "Default PHP:" block may offer, newest-last in
+/// daemon order. Legacy (< 8.2) versions are dropped: the daemon refuses them as
+/// the global default (`LegacyRestricted`), so listing one would only ever
+/// produce an error toast on click. They stay installable and usable per-site.
+fn default_php_choices(php: &[PhpPoolStatus]) -> Vec<String> {
+    php.iter()
+        .filter(|p| !p.version.is_legacy())
+        .map(|p| p.version.to_string())
+        .collect()
+}
+
 /// Fetch daemon status into a snapshot, plus the cached (network-free) update
 /// target. An unreachable daemon yields the "stopped" snapshot.
 async fn fetch_state() -> TrayState {
@@ -242,7 +253,7 @@ async fn fetch_state() -> TrayState {
     TrayState {
         running: true,
         default_php: Some(report.default_php.to_string()),
-        installed: report.php.iter().map(|p| p.version.to_string()).collect(),
+        installed: default_php_choices(&report.php),
         http: Some(report.http.bound),
         https: Some(report.https.bound),
         update_target,
@@ -959,7 +970,32 @@ async fn wait_until_restarted(prev: Option<u64>) {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{icons, menu_icon, recolor_opaque, y_glyph_rgba, TrayIconVariant};
+    use super::{default_php_choices, icons, menu_icon, recolor_opaque, y_glyph_rgba};
+    use super::{PhpPoolStatus, PhpVersion, TrayIconVariant};
+    use yerd_ipc::PoolRunState;
+
+    fn pool(major: u8, minor: u8) -> PhpPoolStatus {
+        PhpPoolStatus {
+            version: PhpVersion::new(major, minor),
+            installed_patch: None,
+            state: PoolRunState::Stopped,
+            pid: None,
+            listen: None,
+            rss_bytes: None,
+            update_available: None,
+        }
+    }
+
+    #[test]
+    fn default_php_choices_drops_legacy_versions() {
+        let pools = [pool(7, 4), pool(8, 1), pool(8, 2), pool(8, 4)];
+        assert_eq!(default_php_choices(&pools), vec!["8.2", "8.4"]);
+    }
+
+    #[test]
+    fn default_php_choices_is_empty_when_only_legacy_is_installed() {
+        assert!(default_php_choices(&[pool(7, 4), pool(8, 0)]).is_empty());
+    }
 
     #[test]
     fn menu_icon_light_leaves_pixels_unchanged() {

--- a/apps/yerd-gui/src/assets/mdbin-mark.svg
+++ b/apps/yerd-gui/src/assets/mdbin-mark.svg
@@ -1,0 +1,20 @@
+<!--
+  The mdbin brand mark, as published at https://mdbin.app/favicon.svg.
+  The "md" is traced to outlines rather than set in JetBrains Mono, so it
+  renders identically here without shipping the webfont. Same mark in light
+  and dark, by their design - don't recolour it to match our theme.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="36" height="36" role="img" aria-label="mdbin">
+  <defs>
+    <linearGradient id="mdbin-tile" x1="0.90957602" y1="0.21321178" x2="0.09042398" y2="0.78678822">
+      <stop offset="0" stop-color="#E8455C"/>
+      <stop offset="1" stop-color="#9E1628"/>
+    </linearGradient>
+  </defs>
+  <rect width="36" height="36" rx="8" fill="url(#mdbin-tile)"/>
+  <g fill="#FFFFFF">
+    <path transform="translate(2.02 24.0) scale(0.022 -0.022)" d="M38 0V550H161V465H163Q166 507 191.0 533.5Q216 560 255 560Q291 560 317.5 534.5Q344 509 352 468Q355 510 381.0 535.0Q407 560 446 560Q495 560 528.5 521.0Q562 482 562 420V0H433V403Q433 451 395 451Q359 451 359 403V0H241V403Q241 451 205 451Q167 451 167 403V0Z"/>
+    <path transform="translate(14.01 24.0) scale(0.022 -0.022)" d="M238 -10Q159 -10 109.5 48.5Q60 107 60 205V345Q60 443 109.5 501.5Q159 560 238 560Q293 560 331.5 532.5Q370 505 388 454L384 580V730H534V0H389V99Q371 47 332.0 18.5Q293 -10 238 -10ZM296 120Q339 120 361.5 144.5Q384 169 384 215V335Q384 381 361.5 405.5Q339 430 296 430Q255 430 232.5 407.0Q210 384 210 340V210Q210 167 232.5 143.5Q255 120 296 120Z"/>
+  </g>
+  <rect x="28.35" y="7.2" width="5.7" height="19" fill="#6E0B18"/>
+</svg>

--- a/apps/yerd-gui/src/components/SiteDetailsSidebar.spec.ts
+++ b/apps/yerd-gui/src/components/SiteDetailsSidebar.spec.ts
@@ -209,7 +209,7 @@ describe("SiteDetailsSidebar", () => {
     expect(openInIde).not.toHaveBeenCalled();
     expect(
       wrapper.get('[aria-label="Site IDE"]').findAll("option").map((option) => option.text()),
-    ).toEqual(["Use default (Open folder)", "System default (open folder)"]);
+    ).toEqual(["Use default (Open folder)", "Open folder"]);
   });
 
   it("opens the site folder with the selected detected IDE and stores the override", async () => {
@@ -222,7 +222,7 @@ describe("SiteDetailsSidebar", () => {
 
     expect(
       wrapper.get('[aria-label="Site IDE"]').findAll("option").map((option) => option.text()),
-    ).toEqual(["Use default (VS Code)", "VS Code", "Zed", "System default (open folder)"]);
+    ).toEqual(["Use default (VS Code)", "VS Code", "Zed", "Open folder"]);
     await wrapper.get('[aria-label="Site IDE"]').setValue("zed");
     await flushPromises();
     expect(setSiteIdeOverride).toHaveBeenCalledWith("blog", "zed");
@@ -623,6 +623,23 @@ describe("SiteDetailsSidebar WordPress controls", () => {
     expect(wrapper.find('[aria-label="Sign in as"]').exists()).toBe(false);
   });
 
+  it("ignores an admin-user failure that lands after the sidebar closes", async () => {
+    let fail!: (e: Error) => void;
+    wordpressAdminUsers.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        fail = reject;
+      }),
+    );
+    const wrapper = mountSidebar(wpSite({ wp_auto_login: true }));
+
+    await wrapper.setProps({ open: false });
+    fail(new Error("wp-cli exploded"));
+    await flushPromises();
+
+    expect(toastError).not.toHaveBeenCalled();
+    expect(wrapper.emitted("changeWpAutoLogin")).toBeUndefined();
+  });
+
   it("reads no admin users at all while auto-login is off", async () => {
     wordpressAdminUsers.mockRejectedValue(new Error("wp-cli exploded"));
     const wrapper = mountSidebar(wpSite({ wp_auto_login: false }));
@@ -641,7 +658,6 @@ describe("SiteDetailsSidebar WordPress controls", () => {
     await wrapper.get('[aria-label="WordPress Auto Admin Login"]').trigger("click");
     await flushPromises();
 
-    // One click, one toast: no "enabled" write to undo, so no success toasts.
     expect(wordpressAdminUsers).toHaveBeenCalledOnce();
     expect(toastError).toHaveBeenCalledOnce();
     expect(wrapper.emitted("changeWpAutoLogin")).toBeUndefined();

--- a/apps/yerd-gui/src/components/SiteDetailsSidebar.spec.ts
+++ b/apps/yerd-gui/src/components/SiteDetailsSidebar.spec.ts
@@ -47,6 +47,11 @@ vi.mock("@/ipc/client", () => ({
   IpcError: class IpcError extends Error {},
 }));
 
+const toastError = vi.fn();
+vi.mock("@/composables/useToast", () => ({
+  useToast: () => ({ success: vi.fn(), error: toastError }),
+}));
+
 const hostPlatform = ref("linux");
 vi.mock("@/composables/usePlatform", () => ({
   loadPlatform: () => Promise.resolve(),
@@ -475,9 +480,7 @@ describe("SiteDetailsSidebar", () => {
     await saveWebRoot.trigger("click");
     expect(wrapper.emitted("changeWebRoot")).toEqual([[site(), "public"]]);
 
-    const frontController = wrapper.get('[aria-label="Route through front controller"]');
-    await frontController.trigger("click");
-    expect(wrapper.emitted("toggleFrontController")).toEqual([[site(), false]]);
+    expect(wrapper.find('[aria-label="Route through front controller"]').exists()).toBe(false);
 
     const https = wrapper.get('[aria-label="HTTPS"]');
     await https.trigger("click");
@@ -519,6 +522,25 @@ describe("SiteDetailsSidebar", () => {
     await wrapper.get('[aria-label="Remove route /api"]').trigger("click");
     await flushPromises();
     expect(removeRouteRule).toHaveBeenCalledWith("blog", "/api");
+  });
+
+  it("toggles the front controller from the Routing tab", async () => {
+    const wrapper = mountSidebar();
+
+    await openTab(wrapper, "Routing");
+    await flushPromises();
+
+    await wrapper.get('[aria-label="Route through front controller"]').trigger("click");
+    expect(wrapper.emitted("toggleFrontController")).toEqual([[site(), false]]);
+  });
+
+  it("hides the front-controller switch for a WordPress site", async () => {
+    const wrapper = mountSidebar(wpSite({ uses_front_controller: true }));
+
+    await openTab(wrapper, "Routing");
+    await flushPromises();
+
+    expect(wrapper.find('[aria-label="Route through front controller"]').exists()).toBe(false);
   });
 
   it("returns to the General tab when reopened", async () => {
@@ -583,7 +605,78 @@ describe("SiteDetailsSidebar WordPress controls", () => {
   beforeEach(() => {
     openInBrowser.mockReset();
     mintWordPressLoginToken.mockReset();
+    toastError.mockReset();
     wordpressAdminUsers.mockReset().mockResolvedValue([]);
+  });
+
+  it("turns auto-login back off and toasts when the admin users can't be read", async () => {
+    wordpressAdminUsers.mockRejectedValue(new Error("wp-cli exploded"));
+    const on = wpSite({ wp_auto_login: true });
+    const wrapper = mountSidebar(on);
+    await flushPromises();
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Couldn't load WordPress admin users",
+      "wp-cli exploded",
+    );
+    expect(wrapper.emitted("changeWpAutoLogin")).toEqual([[on, false, null, { silent: true }]]);
+    expect(wrapper.find('[aria-label="Sign in as"]').exists()).toBe(false);
+  });
+
+  it("reads no admin users at all while auto-login is off", async () => {
+    wordpressAdminUsers.mockRejectedValue(new Error("wp-cli exploded"));
+    const wrapper = mountSidebar(wpSite({ wp_auto_login: false }));
+    await flushPromises();
+
+    expect(wordpressAdminUsers).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+    expect(wrapper.emitted("changeWpAutoLogin")).toBeUndefined();
+  });
+
+  it("writes nothing when the fetch the switch triggers fails", async () => {
+    wordpressAdminUsers.mockRejectedValue(new Error("still broken"));
+    const wrapper = mountSidebar(wpSite({ wp_auto_login: false }));
+    await flushPromises();
+
+    await wrapper.get('[aria-label="WordPress Auto Admin Login"]').trigger("click");
+    await flushPromises();
+
+    // One click, one toast: no "enabled" write to undo, so no success toasts.
+    expect(wordpressAdminUsers).toHaveBeenCalledOnce();
+    expect(toastError).toHaveBeenCalledOnce();
+    expect(wrapper.emitted("changeWpAutoLogin")).toBeUndefined();
+  });
+
+  it("writes the change once a retried fetch succeeds", async () => {
+    wordpressAdminUsers.mockRejectedValueOnce(new Error("transient"));
+    const off = wpSite({ wp_auto_login: false });
+    const wrapper = mountSidebar(off);
+    await flushPromises();
+
+    await wrapper.get('[aria-label="WordPress Auto Admin Login"]').trigger("click");
+    await flushPromises();
+    expect(wrapper.emitted("changeWpAutoLogin")).toBeUndefined();
+
+    wordpressAdminUsers.mockResolvedValue([{ login: "editor", display_name: "Editor" }]);
+    await wrapper.get('[aria-label="WordPress Auto Admin Login"]').trigger("click");
+    await flushPromises();
+
+    expect(wrapper.emitted("changeWpAutoLogin")).toEqual([[off, true, null]]);
+  });
+
+  it("shows the user picker only once the admin list has loaded", async () => {
+    const wrapper = mountSidebar(wpSite({ wp_auto_login: true }));
+    expect(wrapper.find('[aria-label="Sign in as"]').exists()).toBe(false);
+
+    await flushPromises();
+    expect(wrapper.find('[aria-label="Sign in as"]').exists()).toBe(true);
+  });
+
+  it("hides the controls that don't apply to WordPress", async () => {
+    const wrapper = mountSidebar(wpSite());
+
+    expect(wrapper.findAll("button").some((b) => b.text().includes("Dumps"))).toBe(false);
+    expect(wrapper.find('[aria-label="Site web root"]').exists()).toBe(false);
   });
 
   it("opens the plain WP Admin link when auto-login is off", async () => {

--- a/apps/yerd-gui/src/components/SiteDetailsSidebar.vue
+++ b/apps/yerd-gui/src/components/SiteDetailsSidebar.vue
@@ -37,7 +37,7 @@ import {
   wordpressAdminUsers,
 } from "@/ipc/client";
 import type { SiteEntry, StatusReport } from "@/ipc/types";
-import { resolveIde } from "@/lib/ideChoice";
+import { resolveIde, SYSTEM_LABEL } from "@/lib/ideChoice";
 import { siteUrl } from "@/lib/siteUrl";
 import { openWpAdmin } from "@/lib/wpAdmin";
 import { loadIdes, useIdes } from "@/composables/useIdes";
@@ -116,7 +116,7 @@ const ideOptions = computed(() => [
     label: `Use default (${resolveIde(null, globalIde.value, installedIdes.value).label})`,
   },
   ...installedIdes.value.map((ide) => ({ value: ide.id, label: ide.label })),
-  { value: "system", label: "System default (open folder)" },
+  { value: "system", label: SYSTEM_LABEL },
 ]);
 
 // A native <select> renders blank when its value matches no option, so an
@@ -144,7 +144,12 @@ const wpAutoLoginChecking = ref(false);
 let wpAdminUsersRequestId = 0;
 
 /** Fetch `name`'s admin list, reporting whether it is now loaded. A stale
- *  response (the user moved on) counts as a failure: it must not be acted on. */
+ *  response (the user moved on) counts as a failure: it must not be acted on.
+ *
+ *  On failure a site already set to auto-login is switched back off, since
+ *  auto-login can't work without an admin to mint the token for. That write is
+ *  silent - the error toast is the only message worth showing for one failure -
+ *  and only happens for the site still in view. */
 async function loadWpAdminUsers(name: string): Promise<boolean> {
   const requestId = ++wpAdminUsersRequestId;
   wpAdminUsersStatus.value = "loading";
@@ -164,11 +169,6 @@ async function loadWpAdminUsers(name: string): Promise<boolean> {
       "Couldn't load WordPress admin users",
       (e as IpcError).message || "couldn't load admin users",
     );
-    // Auto-login can't work without an admin to mint the token for, so a site
-    // already set to use it is switched back off - silently, because the toast
-    // above is the only message worth showing for one failure. Guarded on the
-    // site still being the one in view: a failure for a site the user has
-    // navigated away from must not write to it.
     if (props.site?.name === name && props.site.wp_auto_login) {
       emit("changeWpAutoLogin", props.site, false, null, { silent: true });
     }
@@ -378,10 +378,12 @@ watch(
 // list is needed for. Opening a site that isn't using it must not reach for the
 // database (nor report that it couldn't); switching the toggle on fetches then.
 //
-// The editor preference is invalidated (request id bumped) and cleared in the
-// same tick, before any await: leaving the previous site's values in place would
-// let the Editor button open the new site's folder in the old site's editor for
-// as long as the two host calls take to resolve.
+// Both request ids are invalidated and their state cleared in the same tick,
+// ahead of every early return: leaving the previous site's editor preference in
+// place would let the Editor button open the new site's folder in the old site's
+// editor until the host calls resolve, and an admin-user fetch left live across
+// a close would land on a panel that is no longer showing - toasting, and
+// writing auto-login off, behind the user's back.
 watch(
   [() => props.open, () => props.site?.name],
   () => {
@@ -389,14 +391,13 @@ watch(
     editorPreferenceRequestId += 1;
     globalIde.value = null;
     siteIdeOverride.value = null;
-    if (!props.open || !props.site) return;
-    void loadIdes();
-    void loadEditorPreferences(props.site.name);
-    if (!props.open || !props.site?.is_wordpress) return;
     wpAdminUsersRequestId += 1;
     wpAdminUsersStatus.value = "idle";
     wpAdminUsersOptions.value = [DEFAULT_ADMIN_OPTION];
-    if (!props.site.wp_auto_login) return;
+    if (!props.open || !props.site) return;
+    void loadIdes();
+    void loadEditorPreferences(props.site.name);
+    if (!props.site.is_wordpress || !props.site.wp_auto_login) return;
     void loadWpAdminUsers(props.site.name);
   },
   { immediate: true },

--- a/apps/yerd-gui/src/components/SiteDetailsSidebar.vue
+++ b/apps/yerd-gui/src/components/SiteDetailsSidebar.vue
@@ -17,6 +17,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import SiteDomainsPanel from "@/components/SiteDomainsPanel.vue";
 import SiteRoutesPanel from "@/components/SiteRoutesPanel.vue";
 import Button from "@/components/ui/Button.vue";
+import InfoBanner from "@/components/ui/InfoBanner.vue";
 import Input from "@/components/ui/Input.vue";
 import Select from "@/components/ui/Select.vue";
 import Spinner from "@/components/ui/Spinner.vue";
@@ -66,7 +67,14 @@ const emit = defineEmits<{
   toggleSecure: [site: SiteEntry];
   toggleFrontController: [site: SiteEntry, enabled: boolean];
   changeGroup: [site: SiteEntry, group: string];
-  changeWpAutoLogin: [site: SiteEntry, enabled: boolean, user: string | null];
+  /** `options.silent` suppresses the parent's success toast, for a change the
+   *  user didn't ask for and that another toast already explains. */
+  changeWpAutoLogin: [
+    site: SiteEntry,
+    enabled: boolean,
+    user: string | null,
+    options?: { silent?: boolean },
+  ];
   share: [site: SiteEntry];
   unlink: [site: SiteEntry];
   domainsChanged: [];
@@ -124,41 +132,47 @@ const hasGroups = computed(() => (props.groupOptions?.length ?? 0) > 0);
 const DEFAULT_ADMIN_OPTION = { value: "", label: "Earliest admin (default)" };
 type WpAdminUsersStatus = "idle" | "loading" | "ready" | "error";
 const wpAdminUsersStatus = ref<WpAdminUsersStatus>("idle");
-const wpAdminUsersError = ref("");
 const wpAdminUsersOptions = ref<{ value: string; label: string }[]>([DEFAULT_ADMIN_OPTION]);
 
-/** The picker's real `:options` while loaded; a single synthetic "Loading…"/
- *  "Error: …" entry otherwise, paired with the Select's own `disabled` state
- *  (also gated on `wpAdminUsersStatus`) so an in-flight or failed fetch is
- *  never mistaken for "no other admins exist". */
-const wpAdminUserSelectOptions = computed(() =>
-  wpAdminUsersStatus.value === "loading"
-    ? [{ value: "", label: "Loading users…" }]
-    : wpAdminUsersStatus.value === "error"
-      ? [{ value: "", label: `Error: ${wpAdminUsersError.value}` }]
-      : wpAdminUsersOptions.value,
-);
+/** True while a "switch auto-login on" click is waiting on the admin list, so
+ *  the switch can't be clicked again mid-check. */
+const wpAutoLoginChecking = ref(false);
 
 /** Bumped on every `loadWpAdminUsers` call so a response for a site the user
  *  has since navigated away from (closed the sidebar, opened another site's)
  *  can recognize it's stale and skip applying its result. */
 let wpAdminUsersRequestId = 0;
 
-async function loadWpAdminUsers(name: string): Promise<void> {
+/** Fetch `name`'s admin list, reporting whether it is now loaded. A stale
+ *  response (the user moved on) counts as a failure: it must not be acted on. */
+async function loadWpAdminUsers(name: string): Promise<boolean> {
   const requestId = ++wpAdminUsersRequestId;
   wpAdminUsersStatus.value = "loading";
   try {
     const users = await wordpressAdminUsers(name);
-    if (requestId !== wpAdminUsersRequestId) return;
+    if (requestId !== wpAdminUsersRequestId) return false;
     wpAdminUsersOptions.value = [
       DEFAULT_ADMIN_OPTION,
       ...users.map((u) => ({ value: u.login, label: u.display_name || u.login })),
     ];
     wpAdminUsersStatus.value = "ready";
+    return true;
   } catch (e) {
-    if (requestId !== wpAdminUsersRequestId) return;
-    wpAdminUsersError.value = (e as IpcError).message || "couldn't load admin users";
+    if (requestId !== wpAdminUsersRequestId) return false;
     wpAdminUsersStatus.value = "error";
+    toast.error(
+      "Couldn't load WordPress admin users",
+      (e as IpcError).message || "couldn't load admin users",
+    );
+    // Auto-login can't work without an admin to mint the token for, so a site
+    // already set to use it is switched back off - silently, because the toast
+    // above is the only message worth showing for one failure. Guarded on the
+    // site still being the one in view: a failure for a site the user has
+    // navigated away from must not write to it.
+    if (props.site?.name === name && props.site.wp_auto_login) {
+      emit("changeWpAutoLogin", props.site, false, null, { silent: true });
+    }
+    return false;
   }
 }
 
@@ -262,8 +276,25 @@ function changeGroup(site: SiteEntry | null, group: string): void {
   if (site) emit("changeGroup", site, group);
 }
 
-function toggleWpAutoLogin(site: SiteEntry, enabled: boolean): void {
-  emit("changeWpAutoLogin", site, enabled, site.wp_auto_login_user || null);
+/** Switching auto-login on is gated on the admin list, retrying a fetch that
+ *  failed earlier: the daemon needs a user to mint the token for, so the write
+ *  only happens once the list is in hand. A failure toasts once and leaves the
+ *  switch off, rather than writing "on" and immediately writing "off" again -
+ *  which is three toasts for one click. Switching off needs no such check. */
+async function toggleWpAutoLogin(site: SiteEntry, enabled: boolean): Promise<void> {
+  const user = site.wp_auto_login_user || null;
+  if (!enabled) {
+    emit("changeWpAutoLogin", site, false, user);
+    return;
+  }
+  wpAutoLoginChecking.value = true;
+  try {
+    if (wpAdminUsersStatus.value !== "ready" && !(await loadWpAdminUsers(site.name))) return;
+  } finally {
+    wpAutoLoginChecking.value = false;
+  }
+  if (props.site?.name !== site.name) return;
+  emit("changeWpAutoLogin", site, true, user);
 }
 
 function changeWpAutoLoginUser(site: SiteEntry, user: string): void {
@@ -342,9 +373,10 @@ watch(
 );
 
 // Reopening (or retargeting) starts on General rather than whichever tab was
-// left showing, and refetches the WordPress admin list for the site now in view.
-// The fetch isn't gated on `wp_auto_login` being on: the picker has to be
-// populated by the time the toggle is switched on, not after.
+// left showing, and refetches the WordPress admin list for the site now in view
+// - but only where auto-login is actually on, since that's the only state the
+// list is needed for. Opening a site that isn't using it must not reach for the
+// database (nor report that it couldn't); switching the toggle on fetches then.
 //
 // The editor preference is invalidated (request id bumped) and cleared in the
 // same tick, before any await: leaving the previous site's values in place would
@@ -361,8 +393,10 @@ watch(
     void loadIdes();
     void loadEditorPreferences(props.site.name);
     if (!props.open || !props.site?.is_wordpress) return;
+    wpAdminUsersRequestId += 1;
     wpAdminUsersStatus.value = "idle";
     wpAdminUsersOptions.value = [DEFAULT_ADMIN_OPTION];
+    if (!props.site.wp_auto_login) return;
     void loadWpAdminUsers(props.site.name);
   },
   { immediate: true },
@@ -382,404 +416,430 @@ onUnmounted(() => {
     <Transition name="site-sidebar-backdrop">
       <div
         v-if="open && site"
-        class="site-sidebar-backdrop fixed inset-0 z-40 bg-black/40"
+        class="site-sidebar-backdrop fixed inset-x-0 bottom-0 top-8 z-40 rounded-b-[10px] bg-black/40 [html.window-maximized_&]:rounded-none"
         aria-hidden="true"
         @click="emit('close')"
       />
     </Transition>
 
-    <Transition name="site-sidebar-panel">
-      <aside
-        v-if="open && site"
-        ref="panel"
-        class="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l bg-background shadow-2xl"
-        aria-label="Site details"
-        role="dialog"
-        aria-modal="true"
-        @click.stop
-      >
-        <div class="flex items-start justify-between gap-4 border-b px-5 py-4">
-          <div class="min-w-0">
-            <div class="mb-2 flex items-center gap-2 text-muted-foreground">
-              <Pencil class="size-4" />
-              <span class="text-xs font-medium uppercase tracking-wider">Site details</span>
-            </div>
-            <h2 class="truncate font-mono text-lg font-medium">{{ displayHost(site) }}</h2>
-            <p class="mt-1 text-xs text-muted-foreground">{{ applicationLabel(site) }}</p>
-          </div>
-          <Button variant="ghost" size="icon" aria-label="Close site details" @click="emit('close')">
-            <X class="size-5" />
-          </Button>
-        </div>
-
-        <div class="flex border-b px-5" role="tablist" aria-label="Site details sections">
-          <button
-            id="site-details-tab-general"
-            type="button"
-            class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'general' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
-            :aria-selected="activeTab === 'general'"
-            aria-controls="site-details-panel-general"
-            role="tab"
-            @click="activeTab = 'general'"
-          >
-            General
-          </button>
-          <button
-            id="site-details-tab-domains"
-            type="button"
-            class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'domains' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
-            :aria-selected="activeTab === 'domains'"
-            aria-controls="site-details-panel-domains"
-            role="tab"
-            @click="activeTab = 'domains'"
-          >
-            Domains
-          </button>
-          <button
-            id="site-details-tab-routing"
-            type="button"
-            class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'routing' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
-            :aria-selected="activeTab === 'routing'"
-            aria-controls="site-details-panel-routing"
-            role="tab"
-            @click="activeTab = 'routing'"
-          >
-            Routing
-          </button>
-          <button
-            id="site-details-tab-information"
-            type="button"
-            class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
-            :class="activeTab === 'information' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
-            :aria-selected="activeTab === 'information'"
-            aria-controls="site-details-panel-information"
-            role="tab"
-            @click="activeTab = 'information'"
-          >
-            Information
-          </button>
-        </div>
-
-        <div
-          :id="`site-details-panel-${activeTab}`"
-          class="min-h-0 flex-1 overflow-y-auto px-5 py-5"
-          role="tabpanel"
-          :aria-labelledby="`site-details-tab-${activeTab}`"
+    <!-- A teleported overlay is a sibling of `#app`, so it escapes the rounded
+         `overflow-hidden` clip that gives the window its corners. This wrapper
+         restores that clip for the panel: rounding the panel itself isn't
+         enough, because its drop shadow spills past the corner and fills the
+         notch back in. `top-8` clears the titlebar (its `h-8`) so the window
+         controls and the drag region stay live while the panel is open. It's
+         mounted unconditionally - `pointer-events-none` and paint-free while
+         empty - so the panel keeps its leave transition on close. -->
+    <div
+      class="pointer-events-none fixed inset-x-0 bottom-0 top-8 z-50 overflow-hidden rounded-b-[10px] [html.window-maximized_&]:rounded-none"
+    >
+      <Transition name="site-sidebar-panel">
+        <aside
+          v-if="open && site"
+          ref="panel"
+          class="pointer-events-auto absolute inset-y-0 right-0 flex w-full max-w-md flex-col border-l bg-background shadow-2xl"
+          aria-label="Site details"
+          role="dialog"
+          aria-modal="true"
+          @click.stop
         >
-          <template v-if="activeTab === 'general'">
-            <Button class="w-full" @click="openSite(site, report)">
-              Open site
-              <ArrowUpRight />
-            </Button>
-
-            <div class="mt-4 grid grid-cols-2 gap-2">
-              <Button class="min-w-0 px-2" variant="outline" size="sm" @click="openTerminal(site)">
-                <Terminal /> <span class="truncate">Terminal</span>
-              </Button>
-              <!-- Same macOS-or-Linux predicate as the PATH install: host editor
-                   launching has no Windows adapter either. -->
-              <Button
-                v-if="supportsPathInstall"
-                class="min-w-0 px-2"
-                variant="outline"
-                size="sm"
-                :title="editorTooltip"
-                @click="openEditor(site)"
-              >
-                <Code2 /> <span class="truncate">{{ editorLabel }}</span>
-              </Button>
-              <Button
-                class="min-w-0 px-2"
-                variant="outline"
-                size="sm"
-                title="Open the Dumps viewer (captured dump/query telemetry, all sites)"
-                @click="openDumps"
-              >
-                <FileText /> <span class="truncate">Dumps</span>
-              </Button>
-              <Button
-                v-if="site.is_wordpress"
-                class="min-w-0 px-2"
-                variant="outline"
-                size="sm"
-                title="Signs you in automatically when auto-login is enabled"
-                @click="openWpAdmin(site, report)"
-              >
-                <UserRound /> <span class="truncate">WP Admin</span>
-              </Button>
-              <Button
-                class="min-w-0 px-2"
-                variant="outline"
-                size="sm"
-                :disabled="sharing"
-                title="Publish this site over a Cloudflare Quick Tunnel"
-                @click="emit('share', site)"
-              >
-                <Spinner v-if="sharing" class="size-4" />
-                <Globe v-else />
-                <span class="truncate">Share publicly…</span>
-              </Button>
+          <div class="flex items-start justify-between gap-4 border-b px-5 py-4">
+            <div class="min-w-0">
+              <div class="mb-2 flex items-center gap-2 text-muted-foreground">
+                <Pencil class="size-4" />
+                <span class="text-xs font-medium uppercase tracking-wider">Site details</span>
+              </div>
+              <h2 class="truncate font-mono text-lg font-medium">{{ displayHost(site) }}</h2>
+              <p class="mt-1 text-xs text-muted-foreground">{{ applicationLabel(site) }}</p>
             </div>
+            <Button variant="ghost" size="icon" aria-label="Close site details" @click="emit('close')">
+              <X class="size-5" />
+            </Button>
+          </div>
 
-            <dl class="mt-5 divide-y rounded-lg border">
-              <div class="flex items-center justify-between gap-4 px-3 py-3">
-                <dt class="shrink-0 text-xs text-muted-foreground">PHP version</dt>
-                <dd class="min-w-0">
-                  <Select
-                    :model-value="site.php"
-                    :options="phpOptions"
-                    aria-label="Site PHP version"
-                    :disabled="busy || phpOptions.length === 0"
-                    @update:model-value="changePhp(site, $event)"
-                  />
-                </dd>
+          <div class="flex border-b px-5" role="tablist" aria-label="Site details sections">
+            <button
+              id="site-details-tab-general"
+              type="button"
+              class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
+              :class="activeTab === 'general' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
+              :aria-selected="activeTab === 'general'"
+              aria-controls="site-details-panel-general"
+              role="tab"
+              @click="activeTab = 'general'"
+            >
+              General
+            </button>
+            <button
+              id="site-details-tab-domains"
+              type="button"
+              class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
+              :class="activeTab === 'domains' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
+              :aria-selected="activeTab === 'domains'"
+              aria-controls="site-details-panel-domains"
+              role="tab"
+              @click="activeTab = 'domains'"
+            >
+              Domains
+            </button>
+            <button
+              id="site-details-tab-routing"
+              type="button"
+              class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
+              :class="activeTab === 'routing' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
+              :aria-selected="activeTab === 'routing'"
+              aria-controls="site-details-panel-routing"
+              role="tab"
+              @click="activeTab = 'routing'"
+            >
+              Routing
+            </button>
+            <button
+              id="site-details-tab-information"
+              type="button"
+              class="border-b-2 px-3 py-2.5 text-xs font-medium transition-colors"
+              :class="activeTab === 'information' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
+              :aria-selected="activeTab === 'information'"
+              aria-controls="site-details-panel-information"
+              role="tab"
+              @click="activeTab = 'information'"
+            >
+              Information
+            </button>
+          </div>
+
+          <div
+            :id="`site-details-panel-${activeTab}`"
+            class="min-h-0 flex-1 overflow-y-auto px-5 py-5"
+            role="tabpanel"
+            :aria-labelledby="`site-details-tab-${activeTab}`"
+          >
+            <template v-if="activeTab === 'general'">
+              <Button class="w-full" @click="openSite(site, report)">
+                Open site
+                <ArrowUpRight />
+              </Button>
+
+              <div class="mt-4 grid grid-cols-2 gap-2">
+                <Button class="min-w-0 px-2" variant="outline" size="sm" @click="openTerminal(site)">
+                  <Terminal /> <span class="truncate">Terminal</span>
+                </Button>
+                <!-- Same macOS-or-Linux predicate as the PATH install: host editor
+                     launching has no Windows adapter either. -->
+                <Button
+                  v-if="supportsPathInstall"
+                  class="min-w-0 px-2"
+                  variant="outline"
+                  size="sm"
+                  :title="editorTooltip"
+                  @click="openEditor(site)"
+                >
+                  <Code2 /> <span class="truncate">{{ editorLabel }}</span>
+                </Button>
+                <!-- Dump capture is a Laravel/Symfony affair; WordPress emits
+                     nothing the viewer would ever show for this site. -->
+                <Button
+                  v-if="!site.is_wordpress"
+                  class="min-w-0 px-2"
+                  variant="outline"
+                  size="sm"
+                  title="Open the Dumps viewer (captured dump/query telemetry, all sites)"
+                  @click="openDumps"
+                >
+                  <FileText /> <span class="truncate">Dumps</span>
+                </Button>
+                <Button
+                  v-if="site.is_wordpress"
+                  class="min-w-0 px-2"
+                  variant="outline"
+                  size="sm"
+                  title="Signs you in automatically when auto-login is enabled"
+                  @click="openWpAdmin(site, report)"
+                >
+                  <UserRound /> <span class="truncate">WP Admin</span>
+                </Button>
+                <Button
+                  class="min-w-0 px-2"
+                  variant="outline"
+                  size="sm"
+                  :disabled="sharing"
+                  title="Publish this site over a Cloudflare Quick Tunnel"
+                  @click="emit('share', site)"
+                >
+                  <Spinner v-if="sharing" class="size-4" />
+                  <Globe v-else />
+                  <span class="truncate">Share publicly…</span>
+                </Button>
               </div>
-              <!-- Same macOS-or-Linux predicate as the PATH install: host editor
-                   launching has no Windows adapter either. -->
-              <div
-                v-if="supportsPathInstall"
-                class="flex items-center justify-between gap-4 px-3 py-3"
-              >
-                <dt class="shrink-0 text-xs text-muted-foreground">Editor</dt>
-                <dd class="min-w-0">
-                  <Select
-                    :model-value="selectedIde"
-                    :options="ideOptions"
-                    aria-label="Site IDE"
-                    :disabled="busy"
-                    @update:model-value="changeIde(site, $event)"
-                  />
-                </dd>
-              </div>
-              <div class="px-3 py-3">
-                <dt class="text-xs text-muted-foreground">Path</dt>
-                <dd class="mt-1 flex items-start gap-2 text-sm">
-                  <FolderOpen class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                  <button
-                    class="min-w-0 break-all text-left font-mono hover:text-brand"
-                    :title="`Reveal ${site.document_root}`"
-                    @click="revealSitePath(site)"
-                  >
-                    {{ site.document_root }}
-                  </button>
-                </dd>
-              </div>
-              <div class="px-3 py-3">
-                <label class="block text-xs text-muted-foreground" for="site-web-root">Web root</label>
-                <div class="mt-1.5 flex gap-2">
-                  <Input
-                    id="site-web-root"
-                    v-model="webRoot"
-                    class="h-8 min-w-0"
-                    :disabled="busy"
-                    placeholder="public"
-                    aria-label="Site web root"
-                    @keydown.enter="changeWebRoot(site)"
-                  />
-                  <Button
-                    variant="outline"
-                    :disabled="busy"
-                    aria-label="Choose web root directory"
-                    @click="chooseWebRoot(site)"
-                  >
-                    <FolderOpen class="size-4" />
-                  </Button>
-                  <Button
-                    variant="outline"
-                    :disabled="busy"
-                    aria-label="Copy web root"
-                    title="Copy web root"
-                    @click="copyWebRoot"
-                  >
-                    <Copy class="size-4" />
-                  </Button>
-                </div>
-                <p class="mt-1 text-xs text-muted-foreground">
-                  Directory served as the document root, relative to the site folder (e.g.
-                  <code class="font-mono">public</code>). Leave blank to auto-detect.
-                </p>
-                <div v-if="webRoot.trim() !== (site.web_subpath ?? '')" class="mt-2 flex justify-end">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    :disabled="busy"
-                    @click="changeWebRoot(site)"
-                  >
-                    Save
-                  </Button>
-                </div>
-              </div>
-              <div class="px-3 py-3">
-                <dt class="text-xs text-muted-foreground">URL</dt>
-                <dd class="mt-1 break-all font-mono text-sm">{{ siteUrl(site, report) }}</dd>
-              </div>
-              <div class="px-3 py-3">
-                <div class="flex items-center justify-between gap-4">
-                  <div>
-                    <dt class="text-sm font-medium">HTTPS</dt>
-                    <dd class="mt-1 text-xs text-muted-foreground">Serve this site over TLS.</dd>
-                  </div>
-                  <Switch
-                    :model-value="site.secure"
-                    :disabled="busy"
-                    aria-label="HTTPS"
-                    @update:model-value="emit('toggleSecure', site)"
-                  />
-                </div>
-              </div>
-              <div v-if="!site.is_wordpress && site.uses_front_controller !== undefined" class="px-3 py-3">
-                <div class="flex items-center justify-between gap-4">
-                  <div>
-                    <dt class="text-sm font-medium">Route through front controller</dt>
-                    <dd class="mt-1 text-xs text-muted-foreground">
-                      On: every request funnels through the site's <code class="font-mono">index.php</code>
-                      (Laravel, Symfony). Off: named <code class="font-mono">.php</code> files are executed directly
-                      (plain PHP).
-                    </dd>
-                  </div>
-                  <Switch
-                    :model-value="site.uses_front_controller"
-                    :disabled="busy"
-                    aria-label="Route through front controller"
-                    @update:model-value="emit('toggleFrontController', site, $event)"
-                  />
-                </div>
-              </div>
-              <div v-if="site.is_wordpress" class="px-3 py-3">
-                <div class="flex items-center justify-between gap-4">
-                  <div>
-                    <dt class="text-sm font-medium">WordPress Auto Admin Login</dt>
-                    <dd class="mt-1 text-xs text-muted-foreground">
-                      Sign in automatically when opening WP Admin.
-                    </dd>
-                  </div>
-                  <Switch
-                    :model-value="site.wp_auto_login ?? false"
-                    :disabled="busy"
-                    aria-label="WordPress Auto Admin Login"
-                    @update:model-value="toggleWpAutoLogin(site, $event)"
-                  />
-                </div>
-                <div v-if="site.wp_auto_login" class="mt-3">
-                  <label class="block text-xs text-muted-foreground" for="site-wp-admin-user">
-                    Sign in as
-                  </label>
-                  <div class="mt-1.5">
-                    <Select
-                      id="site-wp-admin-user"
-                      :model-value="wpAdminUsersStatus === 'ready' ? (site.wp_auto_login_user ?? '') : ''"
-                      :options="wpAdminUserSelectOptions"
-                      :disabled="busy || wpAdminUsersStatus !== 'ready'"
-                      class="w-full"
-                      aria-label="Sign in as"
-                      @update:model-value="changeWpAutoLoginUser(site, $event)"
-                    />
-                  </div>
-                </div>
-              </div>
-              <div v-if="hasGroups" class="px-3 py-3">
-                <div class="flex items-center justify-between gap-4">
-                  <dt class="shrink-0 text-xs text-muted-foreground">Group</dt>
+
+              <dl class="mt-5 divide-y rounded-lg border">
+                <div class="flex items-center justify-between gap-4 px-3 py-3">
+                  <dt class="shrink-0 text-sm font-medium">PHP version</dt>
                   <dd class="min-w-0">
                     <Select
-                      :model-value="currentGroup ?? ''"
-                      :options="groupOptions ?? []"
-                      :disabled="busy"
-                      aria-label="Site group"
-                      @update:model-value="changeGroup(site, $event)"
+                      :model-value="site.php"
+                      :options="phpOptions"
+                      aria-label="Site PHP version"
+                      :disabled="busy || phpOptions.length === 0"
+                      @update:model-value="changePhp(site, $event)"
                     />
                   </dd>
                 </div>
-              </div>
-            </dl>
-
-            <!-- Only linked sites are removable here (by name). A parked site is
-                 removed by un-parking its folder. -->
-            <div v-if="site.kind === 'linked'" class="mt-5 rounded-lg border border-destructive/40 p-3">
-              <div class="flex items-center justify-between gap-4">
-                <div class="min-w-0">
-                  <p class="text-sm font-medium">Unlink this site</p>
-                  <p class="mt-1 text-xs text-muted-foreground">
-                    Stops serving {{ displayHost(site) }}. The project folder is left untouched.
-                  </p>
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  class="shrink-0 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  :disabled="busy"
-                  @click="emit('unlink', site)"
+                <!-- Same macOS-or-Linux predicate as the PATH install: host editor
+                     launching has no Windows adapter either. -->
+                <div
+                  v-if="supportsPathInstall"
+                  class="flex items-center justify-between gap-4 px-3 py-3"
                 >
-                  <Trash2 class="size-4" /> Unlink
-                </Button>
-              </div>
-            </div>
-          </template>
-
-          <template v-else-if="activeTab === 'domains'">
-            <SiteDomainsPanel :site="site" :tld="tld" @changed="emit('domainsChanged')" />
-          </template>
-
-          <template v-else-if="activeTab === 'routing'">
-            <SiteRoutesPanel :site="site" />
-          </template>
-
-          <template v-else>
-            <dl class="divide-y rounded-lg border">
-              <div class="px-3 py-3">
-                <dt class="text-xs text-muted-foreground">Application</dt>
-                <dd class="mt-1 text-sm">{{ applicationLabel(site) }}</dd>
-              </div>
-              <div class="px-3 py-3">
-                <dt class="text-xs text-muted-foreground">Domains</dt>
-                <dd class="mt-1 space-y-1 font-mono text-sm">
-                  <div v-for="domain in site.domains ?? [displayHost(site)]" :key="domain">
-                    {{ domain }}
+                  <dt class="shrink-0 text-sm font-medium">Editor</dt>
+                  <dd class="min-w-0">
+                    <Select
+                      :model-value="selectedIde"
+                      :options="ideOptions"
+                      aria-label="Site IDE"
+                      :disabled="busy"
+                      @update:model-value="changeIde(site, $event)"
+                    />
+                  </dd>
+                </div>
+                <div class="flex items-start justify-between gap-4 px-3 py-3">
+                  <dt class="shrink-0 text-sm font-medium">Path</dt>
+                  <dd class="flex min-w-0 items-start gap-2 text-sm">
+                    <FolderOpen class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                    <button
+                      class="min-w-0 break-all text-right font-mono hover:text-brand"
+                      :title="`Reveal ${site.document_root}`"
+                      @click="revealSitePath(site)"
+                    >
+                      {{ site.document_root }}
+                    </button>
+                  </dd>
+                </div>
+                <!-- WordPress always serves from the site folder itself, so a
+                     web-root override has nothing useful to point at. -->
+                <div v-if="!site.is_wordpress" class="px-3 py-3">
+                  <label class="block text-sm font-medium" for="site-web-root">Web root</label>
+                  <div class="mt-1.5 flex gap-2">
+                    <Input
+                      id="site-web-root"
+                      v-model="webRoot"
+                      class="h-8 min-w-0"
+                      :disabled="busy"
+                      placeholder="public"
+                      aria-label="Site web root"
+                      @keydown.enter="changeWebRoot(site)"
+                    />
+                    <Button
+                      variant="outline"
+                      :disabled="busy"
+                      aria-label="Choose web root directory"
+                      @click="chooseWebRoot(site)"
+                    >
+                      <FolderOpen class="size-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      :disabled="busy"
+                      aria-label="Copy web root"
+                      title="Copy web root"
+                      @click="copyWebRoot"
+                    >
+                      <Copy class="size-4" />
+                    </Button>
                   </div>
-                </dd>
-              </div>
-              <div class="grid grid-cols-2 divide-x border-t">
+                  <InfoBanner class="mt-3">
+                    Directory served as the document root, relative to the site folder (e.g.
+                    <code class="font-mono">public</code>). Leave blank to auto-detect.
+                  </InfoBanner>
+                  <div v-if="webRoot.trim() !== (site.web_subpath ?? '')" class="mt-2 flex justify-end">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      :disabled="busy"
+                      @click="changeWebRoot(site)"
+                    >
+                      Save
+                    </Button>
+                  </div>
+                </div>
+                <div class="flex items-center justify-between gap-4 px-3 py-3">
+                  <dt class="shrink-0 text-sm font-medium">URL</dt>
+                  <dd class="min-w-0 break-all text-right font-mono text-sm">
+                    {{ siteUrl(site, report) }}
+                  </dd>
+                </div>
                 <div class="px-3 py-3">
-                  <dt class="text-xs text-muted-foreground">Web root</dt>
-                  <dd class="mt-1 font-mono text-sm">{{ servedLabel(site) }}</dd>
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <dt class="text-sm font-medium">HTTPS</dt>
+                      <dd class="mt-1 text-xs text-muted-foreground">Serve this site over TLS.</dd>
+                    </div>
+                    <Switch
+                      :model-value="site.secure"
+                      :disabled="busy"
+                      aria-label="HTTPS"
+                      @update:model-value="emit('toggleSecure', site)"
+                    />
+                  </div>
                 </div>
-                <div class="px-3 py-3 pl-4">
-                  <dt class="text-xs text-muted-foreground">Type</dt>
-                  <dd class="mt-1 capitalize text-sm">{{ site.kind }}</dd>
+                <div v-if="site.is_wordpress" class="px-3 py-3">
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <dt class="text-sm font-medium">WordPress Auto Admin Login</dt>
+                      <dd class="mt-1 text-xs text-muted-foreground">
+                        Sign in automatically when opening WP Admin.
+                      </dd>
+                    </div>
+                    <Switch
+                      :model-value="site.wp_auto_login ?? false"
+                      :disabled="busy || wpAutoLoginChecking"
+                      aria-label="WordPress Auto Admin Login"
+                      @update:model-value="toggleWpAutoLogin(site, $event)"
+                    />
+                  </div>
+                  <div v-if="site.wp_auto_login && wpAdminUsersStatus === 'ready'" class="mt-3">
+                    <label class="block text-xs text-muted-foreground" for="site-wp-admin-user">
+                      Sign in as
+                    </label>
+                    <div class="mt-1.5">
+                      <Select
+                        id="site-wp-admin-user"
+                        :model-value="site.wp_auto_login_user ?? ''"
+                        :options="wpAdminUsersOptions"
+                        :disabled="busy"
+                        class="w-full"
+                        aria-label="Sign in as"
+                        @update:model-value="changeWpAutoLoginUser(site, $event)"
+                      />
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <div class="grid grid-cols-2 divide-x border-t">
-                <div class="px-3 py-3">
-                  <dt class="text-xs text-muted-foreground">PHP</dt>
-                  <dd class="mt-1 font-mono text-sm">{{ site.php }}</dd>
+                <div v-if="hasGroups" class="px-3 py-3">
+                  <div class="flex items-center justify-between gap-4">
+                    <dt class="shrink-0 text-sm font-medium">Group</dt>
+                    <dd class="min-w-0">
+                      <Select
+                        :model-value="currentGroup ?? ''"
+                        :options="groupOptions ?? []"
+                        :disabled="busy"
+                        aria-label="Site group"
+                        @update:model-value="changeGroup(site, $event)"
+                      />
+                    </dd>
+                  </div>
                 </div>
-                <div class="px-3 py-3 pl-4">
-                  <dt class="text-xs text-muted-foreground">Protocol</dt>
-                  <dd class="mt-1 text-sm">{{ site.secure ? "HTTPS" : "HTTP" }}</dd>
-                </div>
-              </div>
-              <div v-if="site.uses_front_controller !== undefined" class="px-3 py-3">
-                <dt class="text-xs text-muted-foreground">Front controller</dt>
-                <dd class="mt-1 text-sm">{{ site.uses_front_controller ? "Enabled" : "Disabled" }}</dd>
-              </div>
-              <div v-if="site.is_wordpress" class="px-3 py-3">
-                <dt class="text-xs text-muted-foreground">WordPress auto-login</dt>
-                <dd class="mt-1 text-sm">
-                  {{ site.wp_auto_login ? `Enabled${site.wp_auto_login_user ? ` as ${site.wp_auto_login_user}` : ""}` : "Disabled" }}
-                </dd>
-              </div>
-            </dl>
+              </dl>
 
-            <p v-if="site.apex_shadowed_by" class="mt-4 rounded-md border border-warning/40 bg-warning/10 p-3 text-xs text-warning">
-              {{ site.name }}.{{ tld }} is served by “{{ site.apex_shadowed_by }}”.
-            </p>
-          </template>
-        </div>
-      </aside>
-    </Transition>
+              <!-- Only linked sites are removable here (by name). A parked site is
+                   removed by un-parking its folder. -->
+              <div v-if="site.kind === 'linked'" class="mt-5 rounded-lg border border-destructive/40 p-3">
+                <div class="flex items-center justify-between gap-4">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium">Unlink this site</p>
+                    <p class="mt-1 text-xs text-muted-foreground">
+                      Stops serving {{ displayHost(site) }}. The project folder is left untouched.
+                    </p>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    class="shrink-0 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    :disabled="busy"
+                    @click="emit('unlink', site)"
+                  >
+                    <Trash2 class="size-4" /> Unlink
+                  </Button>
+                </div>
+              </div>
+            </template>
+
+            <template v-else-if="activeTab === 'domains'">
+              <SiteDomainsPanel :site="site" :tld="tld" @changed="emit('domainsChanged')" />
+            </template>
+
+            <template v-else-if="activeTab === 'routing'">
+              <!-- The site-wide "everything through index.php" switch belongs with
+                   the per-prefix rules it governs, and comes first because it sets
+                   the default those rules carve exceptions out of. -->
+              <template v-if="!site.is_wordpress && site.uses_front_controller !== undefined">
+                <div class="rounded-lg border px-3 py-3">
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="text-sm font-medium">Route through front controller</p>
+                      <p class="mt-1 text-xs text-muted-foreground">
+                        On: every request funnels through the site's <code class="font-mono">index.php</code>
+                        (Laravel, Symfony). Off: named <code class="font-mono">.php</code> files are executed directly
+                        (plain PHP).
+                      </p>
+                    </div>
+                    <Switch
+                      :model-value="site.uses_front_controller"
+                      :disabled="busy"
+                      aria-label="Route through front controller"
+                      @update:model-value="emit('toggleFrontController', site, $event)"
+                    />
+                  </div>
+                </div>
+                <hr class="my-4" />
+              </template>
+
+              <SiteRoutesPanel :site="site" />
+            </template>
+
+            <template v-else>
+              <dl class="divide-y rounded-lg border">
+                <div class="px-3 py-3">
+                  <dt class="text-xs text-muted-foreground">Application</dt>
+                  <dd class="mt-1 text-sm">{{ applicationLabel(site) }}</dd>
+                </div>
+                <div class="px-3 py-3">
+                  <dt class="text-xs text-muted-foreground">Domains</dt>
+                  <dd class="mt-1 space-y-1 font-mono text-sm">
+                    <div v-for="domain in site.domains ?? [displayHost(site)]" :key="domain">
+                      {{ domain }}
+                    </div>
+                  </dd>
+                </div>
+                <div class="grid grid-cols-2 divide-x border-t">
+                  <div class="px-3 py-3">
+                    <dt class="text-xs text-muted-foreground">Web root</dt>
+                    <dd class="mt-1 font-mono text-sm">{{ servedLabel(site) }}</dd>
+                  </div>
+                  <div class="px-3 py-3 pl-4">
+                    <dt class="text-xs text-muted-foreground">Type</dt>
+                    <dd class="mt-1 capitalize text-sm">{{ site.kind }}</dd>
+                  </div>
+                </div>
+                <div class="grid grid-cols-2 divide-x border-t">
+                  <div class="px-3 py-3">
+                    <dt class="text-xs text-muted-foreground">PHP</dt>
+                    <dd class="mt-1 font-mono text-sm">{{ site.php }}</dd>
+                  </div>
+                  <div class="px-3 py-3 pl-4">
+                    <dt class="text-xs text-muted-foreground">Protocol</dt>
+                    <dd class="mt-1 text-sm">{{ site.secure ? "HTTPS" : "HTTP" }}</dd>
+                  </div>
+                </div>
+                <div v-if="site.uses_front_controller !== undefined" class="px-3 py-3">
+                  <dt class="text-xs text-muted-foreground">Front controller</dt>
+                  <dd class="mt-1 text-sm">{{ site.uses_front_controller ? "Enabled" : "Disabled" }}</dd>
+                </div>
+                <div v-if="site.is_wordpress" class="px-3 py-3">
+                  <dt class="text-xs text-muted-foreground">WordPress auto-login</dt>
+                  <dd class="mt-1 text-sm">
+                    {{ site.wp_auto_login ? `Enabled${site.wp_auto_login_user ? ` as ${site.wp_auto_login_user}` : ""}` : "Disabled" }}
+                  </dd>
+                </div>
+              </dl>
+
+              <p v-if="site.apex_shadowed_by" class="mt-4 rounded-md border border-warning/40 bg-warning/10 p-3 text-xs text-warning">
+                {{ site.name }}.{{ tld }} is served by “{{ site.apex_shadowed_by }}”.
+              </p>
+            </template>
+          </div>
+        </aside>
+      </Transition>
+    </div>
   </Teleport>
 </template>
 

--- a/apps/yerd-gui/src/components/SiteDomainsPanel.vue
+++ b/apps/yerd-gui/src/components/SiteDomainsPanel.vue
@@ -4,6 +4,7 @@ import { computed, ref, watch } from "vue";
 
 import Badge from "@/components/ui/Badge.vue";
 import Button from "@/components/ui/Button.vue";
+import InfoBanner from "@/components/ui/InfoBanner.vue";
 import Input from "@/components/ui/Input.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { useToast } from "@/composables/useToast";
@@ -128,13 +129,10 @@ function removeDisabled(d: string): boolean {
 
 <template>
   <div class="space-y-4">
-    <p
-      v-if="site.apex_shadowed_by"
-      class="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400"
-    >
+    <InfoBanner v-if="site.apex_shadowed_by" variant="warning">
       {{ site.name }}.{{ tld }} is currently served by "{{ site.apex_shadowed_by }}". Give this
       site a different primary domain to route it separately.
-    </p>
+    </InfoBanner>
 
     <ul class="space-y-1.5">
       <li
@@ -190,19 +188,21 @@ function removeDisabled(d: string): boolean {
           <Plus v-else class="size-4" /> Add
         </Button>
       </div>
-      <p v-if="shapeError" class="mt-1 text-xs text-destructive">{{ shapeError }}</p>
-      <p v-else-if="tldHint" class="mt-1 text-xs text-amber-600 dark:text-amber-500">
+      <InfoBanner v-if="shapeError" variant="destructive" class="mt-4">
+        {{ shapeError }}
+      </InfoBanner>
+      <InfoBanner v-else-if="tldHint" variant="warning" class="mt-4">
         {{ tldHint }}
-      </p>
-      <p v-else class="mt-1 text-xs text-muted-foreground">
+      </InfoBanner>
+      <InfoBanner v-else class="mt-4">
         An exact domain (<code class="font-mono">api.{{ site.name }}.{{ tld }}</code>) or a
         single-label wildcard (<code class="font-mono">*.{{ site.name }}.{{ tld }}</code>).
-      </p>
+      </InfoBanner>
     </div>
 
-    <p v-if="site.is_wordpress" class="text-xs text-muted-foreground">
+    <InfoBanner v-if="site.is_wordpress">
       This is a WordPress site — changing the primary also updates its site URL.
-    </p>
+    </InfoBanner>
 
     <div class="flex justify-end border-t pt-4">
       <Button

--- a/apps/yerd-gui/src/components/SiteRoutesPanel.spec.ts
+++ b/apps/yerd-gui/src/components/SiteRoutesPanel.spec.ts
@@ -68,7 +68,7 @@ describe("SiteRoutesPanel", () => {
 
   it("shows an empty state when the site has no rules", async () => {
     const wrapper = await mountPanel();
-    expect(wrapper.text()).toContain("No routing rules for this site.");
+    expect(wrapper.text()).toContain("No custom routing rules for this site.");
   });
 
   it("adds a rule, clears the inputs, and refetches", async () => {

--- a/apps/yerd-gui/src/components/SiteRoutesPanel.vue
+++ b/apps/yerd-gui/src/components/SiteRoutesPanel.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { Plus, Trash2 } from "lucide-vue-next";
+import { Plus, Route, Trash2 } from "lucide-vue-next";
 import { computed, ref, watch } from "vue";
 
 import Button from "@/components/ui/Button.vue";
+import EmptyState from "@/components/ui/EmptyState.vue";
+import InfoBanner from "@/components/ui/InfoBanner.vue";
 import Input from "@/components/ui/Input.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { useToast } from "@/composables/useToast";
@@ -148,10 +150,10 @@ function remove(prefix: string): void {
       </li>
     </ul>
 
-    <p v-else class="text-sm text-muted-foreground">No routing rules for this site.</p>
+    <EmptyState v-else :icon="Route" title="No custom routing rules for this site." />
 
     <div>
-      <label for="add-route-prefix" class="text-sm font-medium">Add a rule</label>
+      <label for="add-route-prefix" class="text-sm font-medium">Add a custom rule</label>
       <div class="mt-2 flex gap-2">
         <Input
           id="add-route-prefix"
@@ -174,18 +176,20 @@ function remove(prefix: string): void {
           <Plus v-else class="size-4" /> Add
         </Button>
       </div>
-      <p v-if="prefixError" class="mt-1 text-xs text-destructive">{{ prefixError }}</p>
-      <p v-else class="mt-1 text-xs text-muted-foreground">
+      <InfoBanner v-if="prefixError" variant="destructive" class="mt-4">
+        {{ prefixError }}
+      </InfoBanner>
+      <InfoBanner v-else class="mt-4">
         Requests under the prefix that match no real file are handled by the target, a path
         relative to this site's web root. A <code class="font-mono">.php</code> target runs as a
         nested front controller; anything else is served as a static file.
-      </p>
+      </InfoBanner>
     </div>
 
-    <p class="border-t pt-4 text-xs text-muted-foreground">
+    <InfoBanner>
       A site whose web root holds an <code class="font-mono">index.html</code> and no
       <code class="font-mono">index.php</code> already routes deep links to it automatically, with
       no rule needed.
-    </p>
+    </InfoBanner>
   </div>
 </template>

--- a/apps/yerd-gui/src/components/ui/InfoBanner.vue
+++ b/apps/yerd-gui/src/components/ui/InfoBanner.vue
@@ -1,0 +1,56 @@
+<script lang="ts">
+import { cva, type VariantProps } from "class-variance-authority";
+
+export const infoBannerVariants = cva(
+  "flex items-start gap-2 rounded-md border px-3 py-2 text-xs leading-relaxed",
+  {
+    variants: {
+      variant: {
+        info: "border-border bg-muted/50 text-muted-foreground",
+        warning: "border-warning/40 bg-warning/10 text-warning",
+        destructive: "border-destructive/40 bg-destructive/10 text-destructive",
+      },
+    },
+    defaultVariants: { variant: "info" },
+  },
+);
+
+export type InfoBannerVariants = VariantProps<typeof infoBannerVariants>;
+</script>
+
+<script setup lang="ts">
+import { CircleAlert, Info, TriangleAlert } from "lucide-vue-next";
+import { computed, type Component } from "vue";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * A short note attached to a control: what a field accepts, a soft warning, or
+ * why an entry was rejected. One surface for all three so a panel doesn't drift
+ * into a mix of bare muted paragraphs and hand-rolled coloured boxes, and so a
+ * note that changes severity keeps its footprint instead of reflowing the form.
+ *
+ * Content goes in the default slot, which may carry markup (`<code>` and the
+ * like). `icon` overrides the per-variant glyph where a more specific one
+ * carries meaning.
+ */
+const props = defineProps<{
+  variant?: InfoBannerVariants["variant"];
+  icon?: Component;
+}>();
+
+const VARIANT_ICONS = {
+  info: Info,
+  warning: TriangleAlert,
+  destructive: CircleAlert,
+} as const;
+
+const glyph = computed(() => props.icon ?? VARIANT_ICONS[props.variant ?? "info"]);
+</script>
+
+<template>
+  <div :class="cn(infoBannerVariants({ variant }))">
+    <component :is="glyph" class="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+    <div class="min-w-0"><slot /></div>
+  </div>
+</template>

--- a/apps/yerd-gui/src/components/ui/InfoBanner.vue
+++ b/apps/yerd-gui/src/components/ui/InfoBanner.vue
@@ -46,10 +46,15 @@ const VARIANT_ICONS = {
 } as const;
 
 const glyph = computed(() => props.icon ?? VARIANT_ICONS[props.variant ?? "info"]);
+
+/** A destructive banner reports a failure the user needs told about now (a
+ *  rejected entry), so it announces itself; the calmer variants are static
+ *  guidance a screen reader should reach in document order. */
+const role = computed(() => (props.variant === "destructive" ? "alert" : undefined));
 </script>
 
 <template>
-  <div :class="cn(infoBannerVariants({ variant }))">
+  <div :class="cn(infoBannerVariants({ variant }))" :role="role">
     <component :is="glyph" class="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
     <div class="min-w-0"><slot /></div>
   </div>

--- a/apps/yerd-gui/src/composables/useIdes.test.ts
+++ b/apps/yerd-gui/src/composables/useIdes.test.ts
@@ -31,6 +31,39 @@ describe("rescanIdes", () => {
     await expect(rescanIdes()).resolves.toBe(0);
   });
 
+  it("waits for the newer scan when the superseded one resolves first", async () => {
+    getInstalledIdes.mockResolvedValueOnce([ide("vscode"), ide("phpstorm")]);
+    let releaseSecond!: (v: IdeOption[]) => void;
+    getInstalledIdes.mockReturnValueOnce(
+      new Promise<IdeOption[]>((resolve) => {
+        releaseSecond = resolve;
+      }),
+    );
+
+    const first = rescanIdes();
+    const second = rescanIdes();
+
+    releaseSecond([ide("zed")]);
+    await expect(first).resolves.toBe(1);
+    await expect(second).resolves.toBe(1);
+    expect(useIdes().installedIdes.value.map((i) => i.id)).toEqual(["zed"]);
+  });
+
+  it("falls back to the cache when a reset supersedes an in-flight scan", async () => {
+    let release!: (v: IdeOption[]) => void;
+    getInstalledIdes.mockReturnValueOnce(
+      new Promise<IdeOption[]>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const scan = rescanIdes();
+
+    resetIdes();
+    release([ide("vscode")]);
+
+    await expect(scan).resolves.toBe(0);
+  });
+
   it("reports the newer result when a later scan supersedes it", async () => {
     let releaseFirst!: (v: IdeOption[]) => void;
     getInstalledIdes.mockReturnValueOnce(

--- a/apps/yerd-gui/src/composables/useIdes.test.ts
+++ b/apps/yerd-gui/src/composables/useIdes.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getInstalledIdes = vi.fn();
+vi.mock("@/ipc/client", () => ({
+  getInstalledIdes: (...args: unknown[]) => getInstalledIdes(...args),
+}));
+
+import { rescanIdes, resetIdes, useIdes } from "./useIdes";
+import type { IdeOption } from "@/ipc/types";
+
+function ide(id: string): IdeOption {
+  return { id, label: id } as IdeOption;
+}
+
+afterEach(() => {
+  resetIdes();
+  getInstalledIdes.mockReset();
+});
+
+describe("rescanIdes", () => {
+  it("caches the detected editors and reports how many were found", async () => {
+    getInstalledIdes.mockResolvedValue([ide("vscode"), ide("phpstorm")]);
+
+    await expect(rescanIdes()).resolves.toBe(2);
+    expect(useIdes().installedIdes.value.map((i) => i.id)).toEqual(["vscode", "phpstorm"]);
+  });
+
+  it("reports zero when the host has no editors", async () => {
+    getInstalledIdes.mockResolvedValue([]);
+
+    await expect(rescanIdes()).resolves.toBe(0);
+  });
+
+  it("reports the newer result when a later scan supersedes it", async () => {
+    let releaseFirst!: (v: IdeOption[]) => void;
+    getInstalledIdes.mockReturnValueOnce(
+      new Promise<IdeOption[]>((resolve) => {
+        releaseFirst = resolve;
+      }),
+    );
+    const first = rescanIdes();
+
+    getInstalledIdes.mockResolvedValue([ide("zed")]);
+    await expect(rescanIdes()).resolves.toBe(1);
+
+    releaseFirst([ide("vscode"), ide("phpstorm")]);
+    await expect(first).resolves.toBe(1);
+    expect(useIdes().installedIdes.value.map((i) => i.id)).toEqual(["zed"]);
+  });
+});

--- a/apps/yerd-gui/src/composables/useIdes.ts
+++ b/apps/yerd-gui/src/composables/useIdes.ts
@@ -14,18 +14,44 @@ let loadPromise: Promise<void> | null = null;
 // overwrite a rescan the user triggered after it (or write into reset state).
 let generation = 0;
 
+/** The newest detection, resolving to the count it leaves cached. A superseded
+ *  scan chains onto this rather than reading `installedIdes` directly: when the
+ *  older scan is the one that resolves first, the cache still holds the
+ *  pre-scan list, and reporting that would be a count of neither scan. */
+let newest: Promise<number> = Promise.resolve(0);
+
+/**
+ * Run one detection under a fresh generation token, publishing its result only
+ * while it is still the newest, and resolving to the count that ends up cached
+ * - the winner's, for a scan that lost the race.
+ *
+ * `resetIdes` bumps the generation without starting a scan, so a superseded run
+ * can still be `newest` itself; that case reads the cache (which the reset just
+ * emptied) instead of awaiting itself forever. A newer run that fails is
+ * likewise no reason to fail this one, so its rejection falls back the same way.
+ */
+function detect(): Promise<number> {
+  const mine = ++generation;
+  const run: Promise<number> = getInstalledIdes().then((ides) => {
+    if (mine === generation) {
+      installedIdes.value = ides;
+      return ides.length;
+    }
+    return newest === run
+      ? installedIdes.value.length
+      : newest.catch(() => installedIdes.value.length);
+  });
+  newest = run;
+  return run;
+}
+
 /** Detect the host's editors once; safe to call from multiple components. A
  *  failed call clears the cache so a later call can retry, rather than leaving
  *  `installedIdes` permanently empty. */
 export function loadIdes(): Promise<void> {
   if (!loadPromise) {
-    const mine = ++generation;
-    loadPromise = getInstalledIdes()
-      .then((ides) => {
-        if (mine === generation) {
-          installedIdes.value = ides;
-        }
-      })
+    loadPromise = detect()
+      .then(() => undefined)
       .catch(() => {
         loadPromise = null;
       });
@@ -36,16 +62,12 @@ export function loadIdes(): Promise<void> {
 /** Re-run host detection and replace the cached list. Backs the Settings
  *  "Rescan" button, and refreshes the host-side launch-target cache with it.
  *  Returns how many editors are now cached, so the button can report the result
- *  back; a superseded scan reports the newer list rather than its own stale one,
- *  since that is what the user is looking at. */
+ *  back; a superseded scan reports the newer list rather than its own, since
+ *  that is what the user is looking at. */
 export async function rescanIdes(): Promise<number> {
-  const mine = ++generation;
-  const ides = await getInstalledIdes();
-  if (mine === generation) {
-    installedIdes.value = ides;
-  }
+  const count = await detect();
   loadPromise = Promise.resolve();
-  return installedIdes.value.length;
+  return count;
 }
 
 /** Test-only: drop the singleton so each spec starts from a clean detection. */

--- a/apps/yerd-gui/src/composables/useIdes.ts
+++ b/apps/yerd-gui/src/composables/useIdes.ts
@@ -34,14 +34,18 @@ export function loadIdes(): Promise<void> {
 }
 
 /** Re-run host detection and replace the cached list. Backs the Settings
- *  "Rescan" button, and refreshes the host-side launch-target cache with it. */
-export async function rescanIdes(): Promise<void> {
+ *  "Rescan" button, and refreshes the host-side launch-target cache with it.
+ *  Returns how many editors are now cached, so the button can report the result
+ *  back; a superseded scan reports the newer list rather than its own stale one,
+ *  since that is what the user is looking at. */
+export async function rescanIdes(): Promise<number> {
   const mine = ++generation;
   const ides = await getInstalledIdes();
   if (mine === generation) {
     installedIdes.value = ides;
   }
   loadPromise = Promise.resolve();
+  return installedIdes.value.length;
 }
 
 /** Test-only: drop the singleton so each spec starts from a clean detection. */

--- a/apps/yerd-gui/src/composables/useToast.test.ts
+++ b/apps/yerd-gui/src/composables/useToast.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useToast } from "./useToast";
+
+// The store is a module-level singleton; drain it between cases so one test's
+// toasts can't be seen by the next.
+afterEach(() => {
+  const { toasts, dismiss } = useToast();
+  [...toasts.value].forEach((t) => dismiss(t.id));
+  vi.useRealTimers();
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+describe("useToast auto-dismiss", () => {
+  const cases = [
+    { kind: "success", ttl: 4000 },
+    { kind: "info", ttl: 4000 },
+    { kind: "error", ttl: 8000 },
+  ] as const;
+
+  for (const { kind, ttl } of cases) {
+    it(`dismisses a ${kind} toast after ${ttl}ms by default`, () => {
+      const toast = useToast();
+      toast[kind]("hello");
+      expect(toast.toasts.value).toHaveLength(1);
+
+      vi.advanceTimersByTime(ttl - 1);
+      expect(toast.toasts.value).toHaveLength(1);
+
+      vi.advanceTimersByTime(1);
+      expect(toast.toasts.value).toHaveLength(0);
+    });
+
+    it(`honours an explicit ttl on a ${kind} toast`, () => {
+      const toast = useToast();
+      toast[kind]("hello", undefined, 1500);
+
+      vi.advanceTimersByTime(1499);
+      expect(toast.toasts.value).toHaveLength(1);
+
+      vi.advanceTimersByTime(1);
+      expect(toast.toasts.value).toHaveLength(0);
+    });
+  }
+});

--- a/apps/yerd-gui/src/composables/useToast.ts
+++ b/apps/yerd-gui/src/composables/useToast.ts
@@ -14,12 +14,12 @@ export interface Toast {
 const toasts = ref<Toast[]>([]);
 let nextId = 1;
 
-/** `ttlMs` overrides the per-kind default, for a confirmation that shouldn't
+/** Raise a toast that auto-dismisses: errors linger, success and info clear
+ *  sooner. `ttlMs` overrides that default, for a confirmation that shouldn't
  *  outstay its welcome (an idempotent action the user may repeat). */
 function push(kind: ToastKind, title: string, detail?: string, ttlMs?: number): number {
   const id = nextId++;
   toasts.value = [...toasts.value, { id, kind, title, detail }];
-  // Errors linger; success/info auto-dismiss.
   const ttl = ttlMs ?? (kind === "error" ? 8000 : 4000);
   setTimeout(() => dismiss(id), ttl);
   return id;

--- a/apps/yerd-gui/src/composables/useToast.ts
+++ b/apps/yerd-gui/src/composables/useToast.ts
@@ -14,11 +14,13 @@ export interface Toast {
 const toasts = ref<Toast[]>([]);
 let nextId = 1;
 
-function push(kind: ToastKind, title: string, detail?: string): number {
+/** `ttlMs` overrides the per-kind default, for a confirmation that shouldn't
+ *  outstay its welcome (an idempotent action the user may repeat). */
+function push(kind: ToastKind, title: string, detail?: string, ttlMs?: number): number {
   const id = nextId++;
   toasts.value = [...toasts.value, { id, kind, title, detail }];
   // Errors linger; success/info auto-dismiss.
-  const ttl = kind === "error" ? 8000 : 4000;
+  const ttl = ttlMs ?? (kind === "error" ? 8000 : 4000);
   setTimeout(() => dismiss(id), ttl);
   return id;
 }
@@ -30,9 +32,10 @@ function dismiss(id: number): void {
 export function useToast() {
   return {
     toasts: readonly(toasts),
-    success: (title: string, detail?: string) => push("success", title, detail),
-    error: (title: string, detail?: string) => push("error", title, detail),
-    info: (title: string, detail?: string) => push("info", title, detail),
+    success: (title: string, detail?: string, ttlMs?: number) =>
+      push("success", title, detail, ttlMs),
+    error: (title: string, detail?: string, ttlMs?: number) => push("error", title, detail, ttlMs),
+    info: (title: string, detail?: string, ttlMs?: number) => push("info", title, detail, ttlMs),
     dismiss,
   };
 }

--- a/apps/yerd-gui/src/lib/ideChoice.ts
+++ b/apps/yerd-gui/src/lib/ideChoice.ts
@@ -10,8 +10,9 @@ export type IdeChoice =
 const SYSTEM = "system";
 
 /** Button/tooltip wording for the system arm; also the name shown by the
- *  sidebar's `Use default (…)` option when nothing is detected. */
-const SYSTEM_LABEL = "Open folder";
+ *  sidebar's `Use default (…)` option when nothing is detected, and by the
+ *  system entry in both editor pickers - one wording, one place. */
+export const SYSTEM_LABEL = "Open folder";
 
 /**
  * Resolve the preference chain: per-site override, then the global preference,

--- a/apps/yerd-gui/src/lib/siteFilter.test.ts
+++ b/apps/yerd-gui/src/lib/siteFilter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesSiteFilter } from "./siteFilter";
+import type { SiteEntry } from "@/ipc/types";
+
+function site(overrides: Partial<SiteEntry> = {}): SiteEntry {
+  return {
+    name: "codestash",
+    document_root: "/srv/codestash",
+    php: "8.3",
+    secure: false,
+    kind: "linked",
+    ...overrides,
+  } as SiteEntry;
+}
+
+describe("matchesSiteFilter", () => {
+  const cases: { query: string; expected: boolean; why: string }[] = [
+    { query: "", expected: true, why: "an empty query matches everything" },
+    { query: "   ", expected: true, why: "a whitespace-only query is empty" },
+    { query: "codestash", expected: true, why: "the apex label" },
+    { query: "CODESTASH.TEST", expected: true, why: "matching is case-insensitive" },
+    { query: "admin.", expected: true, why: "an added subdomain" },
+    { query: "shop.example.test", expected: true, why: "a whole added domain" },
+    { query: "*.staging", expected: true, why: "a wildcard domain" },
+    { query: "blog", expected: false, why: "no domain contains it" },
+  ];
+
+  const configured = site({
+    primary_domain: "codestash.test",
+    domains: ["codestash.test", "admin.codestash.test", "shop.example.test", "*.staging.test"],
+  });
+
+  for (const { query, expected, why } of cases) {
+    it(`${expected ? "matches" : "rejects"} ${JSON.stringify(query)} - ${why}`, () => {
+      expect(matchesSiteFilter(configured, "test", query)).toBe(expected);
+    });
+  }
+
+  it("falls back to the default apex for a site with no configured domains", () => {
+    expect(matchesSiteFilter(site(), "test", "codestash.test")).toBe(true);
+    expect(matchesSiteFilter(site(), "test", "admin.")).toBe(false);
+  });
+
+  it("keeps the default apex findable even when domains omit it", () => {
+    const moved = site({ primary_domain: "example.test", domains: ["example.test"] });
+    expect(matchesSiteFilter(moved, "test", "codestash.test")).toBe(true);
+    expect(matchesSiteFilter(moved, "test", "example")).toBe(true);
+  });
+});

--- a/apps/yerd-gui/src/lib/siteFilter.ts
+++ b/apps/yerd-gui/src/lib/siteFilter.ts
@@ -1,0 +1,24 @@
+import type { SiteEntry } from "@/ipc/types";
+
+/** Every domain a site answers on: the default `<name>.<tld>` apex plus any
+ *  extra domains, subdomains or wildcards configured for it. `domains` is
+ *  omitted for an uncustomised site and is authoritative when present, but the
+ *  apex is kept regardless so a site is always findable by its own name.
+ */
+function siteDomains(site: SiteEntry, tld: string): string[] {
+  const domains = new Set([`${site.name}.${tld}`]);
+  if (site.primary_domain) domains.add(site.primary_domain);
+  for (const domain of site.domains ?? []) domains.add(domain);
+  return [...domains];
+}
+
+/**
+ * Whether `query` matches any domain the site serves, case-insensitively and as
+ * a substring - so "admin." finds `codestash.test` when its only match is an
+ * added domain like `admin.codestash.test`. An empty query matches everything.
+ */
+export function matchesSiteFilter(site: SiteEntry, tld: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === "") return true;
+  return siteDomains(site, tld).some((domain) => domain.toLowerCase().includes(q));
+}

--- a/apps/yerd-gui/src/views/AboutView.vue
+++ b/apps/yerd-gui/src/views/AboutView.vue
@@ -4,6 +4,7 @@ import { ArrowUpRight, Download, FileText, RefreshCw, Stethoscope } from "lucide
 import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import logoUrl from "@/assets/logo.svg";
+import mdbinMarkUrl from "@/assets/mdbin-mark.svg";
 import PageHeader from "@/components/PageHeader.vue";
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
@@ -38,6 +39,16 @@ const running = computed(() => connected.value === true);
 const appVersion = ref("");
 const protocol = ref<number | null>(null);
 const daemonVersion = ref("");
+
+/** The mdbin capabilities worth naming in the cross-promo, in their own
+ *  wording. Short enough to read as tags rather than a second paragraph. */
+const mdbinFeatures = [
+  "Highlighted code",
+  "Mermaid + FreeDraw",
+  "Line comments",
+  "Forkable edits",
+  "MCP server",
+] as const;
 
 // ── self-update ──
 const channelOptions = [
@@ -329,22 +340,58 @@ async function copyDiagnostics(): Promise<void> {
           </Button>
         </div>
 
-        <div
-          class="flex flex-col gap-3 border-t border-brand/20 pt-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
-        >
-          <p class="text-sm text-muted-foreground">
-            Why not check out other free tools by Forjed, such as
-            <span class="font-medium text-foreground">MDBIN</span> - share Markdown
-            with a link, no account needed.
+        <!-- Cross-promo for mdbin, the studio's other free tool. Its own brand
+             mark and wordmark (lowercase, mono) rather than ours, so it reads as
+             a product being recommended and not another Yerd feature. -->
+        <div class="border-t border-brand/20 pt-5">
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Also from Forjed
           </p>
-          <Button
-            variant="outline"
-            class="shrink-0"
-            @click="openInBrowser('https://mdbin.app/?utm=yerdapp')"
-          >
-            Try MDBIN
-            <ArrowUpRight class="opacity-80" />
-          </Button>
+
+          <div class="mt-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-4">
+            <img
+              :src="mdbinMarkUrl"
+              alt=""
+              aria-hidden="true"
+              class="size-9 shrink-0 rounded-lg"
+            />
+
+            <div class="min-w-0 flex-1">
+              <p class="font-mono text-lg font-extrabold leading-none tracking-tight">mdbin</p>
+              <p class="mt-1.5 text-sm font-medium">Share Markdown with a link.</p>
+              <p class="mt-1 text-sm text-muted-foreground">
+                Paste a README, a deploy note, an RFC - publish it and send the URL. Code is
+                highlighted, Mermaid diagrams render themselves, and anyone can comment on a
+                line or fork the doc to suggest an edit. No account needed.
+              </p>
+
+              <ul class="mt-3 flex flex-wrap gap-1.5">
+                <li
+                  v-for="feature in mdbinFeatures"
+                  :key="feature"
+                  class="rounded-full border border-brand/20 bg-background/60 px-2.5 py-0.5 text-[11px] text-muted-foreground"
+                >
+                  {{ feature }}
+                </li>
+              </ul>
+
+              <div class="mt-4 flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  @click="openInBrowser('https://mdbin.app/new?utm=yerdapp')"
+                >
+                  Create a document
+                  <ArrowUpRight class="opacity-80" />
+                </Button>
+                <button
+                  class="rounded-md px-2 py-1 text-sm text-muted-foreground hover:text-foreground"
+                  @click="openInBrowser('https://mdbin.app/?utm=yerdapp')"
+                >
+                  mdbin.app
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       </Card>
 

--- a/apps/yerd-gui/src/views/GeneralView.vue
+++ b/apps/yerd-gui/src/views/GeneralView.vue
@@ -38,6 +38,7 @@ import {
   setTrayIconVariant,
 } from "@/ipc/client";
 import type { AutostartState, CliPathStatus, TitleBarStyle, TrayIconVariant } from "@/ipc/types";
+import { SYSTEM_LABEL } from "@/lib/ideChoice";
 import { useTheme, type ThemePref } from "@/lib/theme";
 import { useTitleBarStyle } from "@/lib/titleBarStyle";
 
@@ -123,7 +124,7 @@ const preferredIde = ref("auto");
 const preferredIdeOptions = computed(() => [
   { value: "auto", label: "Auto-detect" },
   ...installedIdes.value.map((ide) => ({ value: ide.id, label: ide.label })),
-  { value: "system", label: "System default (open folder)" },
+  { value: "system", label: SYSTEM_LABEL },
 ]);
 
 // A native <select> renders blank when its value matches no option, so an
@@ -153,10 +154,21 @@ async function setPreferredIdePref(next: string): Promise<void> {
   }
 }
 
+/** A rescan usually changes nothing visible (the picker already lists what was
+ *  found), so it confirms itself with a count. Kept brief: it's an idempotent
+ *  action the user may click a few times while installing an editor, and a
+ *  stack of identical toasts would be worse than none. */
+const RESCAN_TOAST_MS = 1500;
+
 async function rescanEditors(): Promise<void> {
   busy.value = "ide:rescan";
   try {
-    await rescanIdes();
+    const found = await rescanIdes();
+    toast.success(
+      found === 0 ? "No editors found" : `Found ${found} editor${found === 1 ? "" : "s"}`,
+      undefined,
+      RESCAN_TOAST_MS,
+    );
   } catch (e) {
     toast.error("Couldn't detect installed editors", (e as IpcError).message);
   } finally {

--- a/apps/yerd-gui/src/views/SitesView.spec.ts
+++ b/apps/yerd-gui/src/views/SitesView.spec.ts
@@ -132,8 +132,6 @@ describe("SitesView WordPress auto-login controls", () => {
     const wrapper = await mountSites();
     await openEditFor(wrapper, alpha);
 
-    // Rendering the picker against an unloaded list would show the site's
-    // configured "editor" with no matching <option> - a blank control.
     expect(wrapper.find("#site-wp-admin-user").exists()).toBe(false);
 
     pending.resolve(usersEnvelope(["editor"]));

--- a/apps/yerd-gui/src/views/SitesView.spec.ts
+++ b/apps/yerd-gui/src/views/SitesView.spec.ts
@@ -117,7 +117,7 @@ describe("SitesView WordPress auto-login controls", () => {
     expect(labels).toEqual(["Earliest admin (default)", "beta-editor"]);
   });
 
-  it("shows the loading placeholder as selected instead of a blank control, even when a prior admin was already configured", async () => {
+  it("withholds the picker until the admin list arrives, then selects the configured admin", async () => {
     const alpha = wpSite("alpha", { wp_auto_login_user: "editor" });
     const pending = deferred<unknown>();
     invokeMock.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
@@ -132,13 +132,9 @@ describe("SitesView WordPress auto-login controls", () => {
     const wrapper = await mountSites();
     await openEditFor(wrapper, alpha);
 
-    const select = wrapper.find<HTMLSelectElement>("#site-wp-admin-user");
-    // The select's bound value must match the "Loading users…" placeholder's
-    // value (""), not the site's already-configured "editor" - a bound value
-    // with no matching <option> renders as a blank control, not the intended
-    // loading text.
-    expect(select.element.value).toBe("");
-    expect(select.element.selectedOptions[0]?.textContent).toBe("Loading users…");
+    // Rendering the picker against an unloaded list would show the site's
+    // configured "editor" with no matching <option> - a blank control.
+    expect(wrapper.find("#site-wp-admin-user").exists()).toBe(false);
 
     pending.resolve(usersEnvelope(["editor"]));
     await flushPromises();
@@ -146,7 +142,7 @@ describe("SitesView WordPress auto-login controls", () => {
     expect(settled.element.value).toBe("editor");
   });
 
-  it("shows an error state without touching the picker options when the fetch fails", async () => {
+  it("locks auto-login and hides the picker when the fetch fails", async () => {
     const alpha = wpSite("alpha");
     invokeMock.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
       if (cmd === "list_sites") return Promise.resolve({ type: "sites", sites: [alpha] });
@@ -156,15 +152,19 @@ describe("SitesView WordPress auto-login controls", () => {
       if (cmd === "wordpress_admin_users" && args?.site === "alpha") {
         return Promise.reject(new Error("boom"));
       }
+      if (cmd === "set_wordpress_auto_login") return Promise.resolve({ type: "ok" });
       return Promise.reject(new Error(`unexpected invoke ${cmd}`));
     });
 
     const wrapper = await mountSites();
     await openEditFor(wrapper, alpha);
+    await flushPromises();
 
-    const select = wrapper.find("#site-wp-admin-user");
-    expect(select.attributes("disabled")).toBeDefined();
-    const labels = select.findAll("option").map((o) => o.text());
-    expect(labels).toEqual(["Error: boom"]);
+    expect(wrapper.find("#site-wp-admin-user").exists()).toBe(false);
+    expect(invokeMock).toHaveBeenCalledWith("set_wordpress_auto_login", {
+      name: "alpha",
+      enabled: false,
+      user: null,
+    });
   });
 });

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -16,6 +16,7 @@ import {
   Plus,
   Rocket,
   Search,
+  SearchX,
   ShieldAlert,
 } from "lucide-vue-next";
 
@@ -426,6 +427,10 @@ const visibleSections = computed(() =>
 // match" copy as the flat view instead of a blank pane.
 const groupedNoMatch = computed(() => searching.value && visibleSections.value.length === 0);
 
+/** Shared by the flat and grouped listings, which each render their own
+ *  filter-miss state but must word it identically. */
+const filterMissTitle = computed(() => `No sites match “${siteFilter.value}”`);
+
 /** A section renders expanded when searching (to reveal matches) or when not
  *  remembered-collapsed. */
 function sectionExpanded(sec: GroupSection): boolean {
@@ -759,15 +764,18 @@ async function shareSitePublicly(s: Site): Promise<void> {
               @toggle-secure="toggleSecure"
             />
           </div>
-          <p
+          <EmptyState
             v-else-if="siteFilter"
-            class="py-12 text-center text-sm text-muted-foreground"
-          >
-            No sites match “{{ siteFilter }}”.
-          </p>
-          <p v-else class="py-12 text-center text-sm text-muted-foreground">
-            Your parked folders have no child directories yet.
-          </p>
+            :icon="SearchX"
+            :title="filterMissTitle"
+            description="Every domain a site serves is searched, including added domains and wildcards. Try a shorter fragment, or clear the filter."
+          />
+          <EmptyState
+            v-else
+            :icon="FolderOpen"
+            title="No sites yet"
+            description="Your parked folders have no child directories. Add a project inside one, or link a single project directory."
+          />
         </template>
 
         <!-- Grouped listing: collapsible sections + trailing Unallocated. -->
@@ -858,12 +866,12 @@ async function shareSitePublicly(s: Site): Promise<void> {
               </div>
             </section>
           </div>
-          <p
+          <EmptyState
             v-if="groupedNoMatch"
-            class="py-12 text-center text-sm text-muted-foreground"
-          >
-            No sites match “{{ siteFilter }}”.
-          </p>
+            :icon="SearchX"
+            :title="filterMissTitle"
+            description="Every domain a site serves is searched, including added domains and wildcards. Try a shorter fragment, or clear the filter."
+          />
         </template>
 
         <!-- Parked folders (demoted: the management surface, below the sites) -->

--- a/apps/yerd-gui/src/views/SitesView.vue
+++ b/apps/yerd-gui/src/views/SitesView.vue
@@ -40,6 +40,7 @@ import Modal from "@/components/ui/Modal.vue";
 import Spinner from "@/components/ui/Spinner.vue";
 import { registerViewActions } from "@/lib/shortcuts/useViewActions";
 import { sitesIntent } from "@/lib/shortcuts/sitesIntent";
+import { matchesSiteFilter } from "@/lib/siteFilter";
 import { slugifySiteName } from "@/lib/siteName";
 import { useSitesGroupState } from "@/lib/sitesGroupState";
 import { useDaemon } from "@/composables/useDaemon";
@@ -374,12 +375,13 @@ const folderRows = computed(() =>
   })),
 );
 
-// Live, case-insensitive filter on the full `<name>.<tld>` domain, sorted
-// alphabetically by name so the list is stable and scannable.
+// Live, case-insensitive filter across every domain a site serves - its apex
+// plus any added domains, subdomains and wildcards - sorted alphabetically by
+// name so the list is stable and scannable.
 const filteredSites = computed(() => {
-  const q = siteFilter.value.trim().toLowerCase();
+  const q = siteFilter.value.trim();
   const list = q
-    ? sites.value.filter((s) => `${s.name}.${tld.value}`.toLowerCase().includes(q))
+    ? sites.value.filter((s) => matchesSiteFilter(s, tld.value, q))
     : [...sites.value];
   return list.sort((a, b) => a.name.localeCompare(b.name));
 });
@@ -450,6 +452,7 @@ async function changeWpAutoLogin(
   site: SiteEntry,
   enabled: boolean,
   user: string | null,
+  options?: { silent?: boolean },
 ): Promise<void> {
   if (enabled === (site.wp_auto_login ?? false) && (user ?? "") === (site.wp_auto_login_user ?? "")) {
     return;
@@ -457,11 +460,13 @@ async function changeWpAutoLogin(
   rowBusy.value = `edit:${site.name}`;
   try {
     await setWordpressAutoLogin(site.name, enabled, user);
-    toast.success(
-      enabled
-        ? `Auto-login enabled for ${site.name}`
-        : `Auto-login disabled for ${site.name}`,
-    );
+    if (!options?.silent) {
+      toast.success(
+        enabled
+          ? `Auto-login enabled for ${site.name}`
+          : `Auto-login disabled for ${site.name}`,
+      );
+    }
     await load({ force: true });
   } catch (e) {
     toast.error("Couldn't change auto-login", (e as IpcError).message);

--- a/crates/yerd-platform/src/error.rs
+++ b/crates/yerd-platform/src/error.rs
@@ -180,17 +180,9 @@ pub enum ResolverErrorReason {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum TerminalErrorReason {
-    /// The temporary macOS launcher could not be created.
-    #[error("could not create launcher: {0}")]
-    CreateLauncher(#[source] std::io::Error),
-
-    /// The temporary macOS launcher could not be written or configured.
-    #[error("could not prepare launcher: {0}")]
-    PrepareLauncher(#[source] std::io::Error),
-
-    /// The temporary macOS launcher could not be opened.
-    #[error("could not open launcher: {0}")]
-    OpenLauncher(#[source] std::io::Error),
+    /// The macOS terminal application could not be launched.
+    #[error("could not open terminal: {0}")]
+    OpenTerminal(#[source] std::io::Error),
 
     /// No supported terminal emulator could be launched.
     #[error("no supported terminal emulator was found")]
@@ -503,9 +495,7 @@ mod tests {
             install_hint: Some("y"),
         };
         for reason in [
-            TerminalErrorReason::CreateLauncher(std::io::Error::from(std::io::ErrorKind::Other)),
-            TerminalErrorReason::PrepareLauncher(std::io::Error::from(std::io::ErrorKind::Other)),
-            TerminalErrorReason::OpenLauncher(std::io::Error::from(std::io::ErrorKind::Other)),
+            TerminalErrorReason::OpenTerminal(std::io::Error::from(std::io::ErrorKind::Other)),
             TerminalErrorReason::NoSupportedTerminal,
         ] {
             let _ = PlatformError::Terminal { reason };

--- a/crates/yerd-platform/src/os/macos.rs
+++ b/crates/yerd-platform/src/os/macos.rs
@@ -15,11 +15,10 @@
 #![allow(clippy::similar_names)]
 
 use std::fs;
-use std::io::{self, Write};
+use std::io;
 use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use directories::ProjectDirs;
 
@@ -59,77 +58,21 @@ impl MacosTerminalLauncher {
 }
 
 impl TerminalLauncher for MacosTerminalLauncher {
+    /// Hand the directory straight to Terminal.app, which opens a new window
+    /// with the folder as the login shell's working directory.
+    ///
+    /// The obvious alternative - writing a throwaway `.command` script and
+    /// `open`ing it - is what a shipped build used to do, and it leaks: Terminal
+    /// echoes the script's full temp path into the fresh window and stamps the
+    /// launcher's filename into the window title. Passing the directory leaves
+    /// the window as clean as one opened by hand.
     fn open_terminal(&self, path: &Path) -> Result<(), PlatformError> {
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| PlatformError::Terminal {
-                reason: TerminalErrorReason::PrepareLauncher(std::io::Error::other(e)),
-            })?
-            .as_millis();
-        let quoted_path = shell_quote(&path.to_string_lossy());
-        let script = format!(
-            "#!/bin/sh\nrm -f -- \"$0\"\ncd -- {quoted_path}\nexec \"${{SHELL:-/bin/zsh}}\" -l\n"
-        );
-
-        let mut created = None;
-        for attempt in 0u32..100 {
-            let script_path = std::env::temp_dir().join(format!(
-                "yerd-terminal-{}-{stamp}-{attempt}.command",
-                std::process::id()
-            ));
-            match fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o700)
-                .open(&script_path)
-            {
-                Ok(file) => {
-                    created = Some((script_path, file));
-                    break;
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-                Err(e) => {
-                    return Err(PlatformError::Terminal {
-                        reason: TerminalErrorReason::CreateLauncher(e),
-                    });
-                }
-            }
-        }
-        let Some((script_path, mut file)) = created else {
-            return Err(PlatformError::Terminal {
-                reason: TerminalErrorReason::CreateLauncher(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    "could not create a unique terminal launcher",
-                )),
-            });
-        };
-        if let Err(e) = file
-            .write_all(script.as_bytes())
-            .and_then(|()| fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700)))
-        {
-            let _ = fs::remove_file(&script_path);
-            return Err(PlatformError::Terminal {
-                reason: TerminalErrorReason::PrepareLauncher(e),
-            });
-        }
-        drop(file);
-
-        match Command::new("open").arg(&script_path).spawn() {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let _ = fs::remove_file(&script_path);
-                Err(PlatformError::Terminal {
-                    reason: TerminalErrorReason::OpenLauncher(e),
-                })
-            }
-        }
+        let mut command = Command::new("/usr/bin/open");
+        command.arg("-a").arg("Terminal").arg(path);
+        wait_and_check(&mut command, "/usr/bin/open").map_err(|source| PlatformError::Terminal {
+            reason: TerminalErrorReason::OpenTerminal(source),
+        })
     }
-}
-
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// macOS IDE launcher using a CLI launcher when available and the standard


### PR DESCRIPTION
## What does this PR do?

Fixes a batch of UI and behaviour issues across the site details sidebar, the WordPress auto-login flow, the macOS terminal launcher, the site filter, and the tray's default-PHP menu.

### Fixes applied

- Terminal launch (macOS) — hand the site folder straight to Terminal.app instead of writing a throwaway .command script, which leaked its temp path into the window and its filename into the title. Removes the now-unused CreateLauncher/PrepareLauncher error variants.
- Sidebar overlay — the panel and backdrop start below the titlebar (window controls and drag region stay live) and are clipped to the shell's rounded corners, so the drop shadow no longer squares off the window's bottom-right.
- Routing tab — "Route through front controller" moved here from General, above the rules and separated by a rule; copy is now "No custom routing rules for this site." / "Add a custom rule", with the empty list rendered as a shared EmptyState.
- General tab — Path and URL values right-aligned like the other rows, and all row labels restyled to match the HTTPS label.
- WordPress sites — Dumps button and the Web root override are hidden (neither applies).
- WordPress auto-login — the admin-user list is only fetched when auto-login is actually on; a failed fetch produces exactly one error toast (no enable-then-undo toast storm), leaves the toggle off, and silently turns off a site that was already on; "Sign in as" only renders once the list has loaded; switching the toggle back on retries the fetch.
- Site filter — "Filter by domain…" now matches every domain a site serves (extra domains, subdomains, wildcards), not just its apex.
- New InfoBanner component — one surface for field notes, soft warnings, and validation errors, replacing the loose muted paragraphs and hand-rolled coloured boxes on the Routing, Domains, and General panels.
- Tray menu — legacy (< 8.2) PHP versions removed from "Default PHP:", since the daemon rejects them as the global default.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS
- [x] Linux

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search sites across apex domains, subdomains, wildcards, and configured domains with case-insensitive matching.
  - Added consistent informational, warning, and error banners throughout site panels.
  - Improved WordPress auto-login setup with administrator loading feedback and safer recovery.
  - Added clearer routing guidance and empty-state messaging.
  - Open requested directories directly in Terminal on macOS.
  - Editor rescans now report the number of editors found.
  - Added an updated MDBIN product card with feature highlights and links.

- **Bug Fixes**
  - Prevented legacy PHP versions from appearing among selectable default choices.
  - Improved WordPress-specific control visibility and failed administrator lookup handling.
  - Refined sidebar layout, overlays, and site configuration controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->