### PR TITLE
[Meta] Bring docs up to date with everything shipped since v2.0.4

### DIFF
--- a/docs/developer/binaries/yerd.md
+++ b/docs/developer/binaries/yerd.md
@@ -42,8 +42,15 @@ the `tests/cli_e2e.rs` integration test can drive the same code paths.
 | `src/cover_shim.rs` | Multi-call dispatch: when `argv[0]` is a `phpcover`/`php<ver>cover` alias, exec PHP with pcov enabled (Unix-only). Runs before clap. |
 | `src/composer_shim.rs` | Multi-call dispatch: when `argv[0]` is `composer`, exec the default PHP against `{data}/tools/composer/composer.phar` (Unix-only). Runs before clap. See [Dev-tool installers](../dev-tools). |
 | `src/wp_shim.rs` | Multi-call dispatch: when `argv[0]` is `wp`, exec WP-CLI - site-aware if cwd is inside a registered site (pins that site's PHP, scopes via `--path=`) (Unix-only). Runs before clap. |
-| `src/shim.rs` | Shared PHP-resolution helpers for the cover, composer, and `wp` multi-call shims (default-version resolution, highest-installed fallback). |
+| `src/laravel_shim.rs` | Multi-call dispatch: when `argv[0]` is `laravel`, exec the Laravel installer under the resolved PHP (Unix-only). Runs before clap. |
+| `src/shim.rs` | Shared PHP-resolution helpers for the cover, composer, `wp`, and `laravel` multi-call shims (default-version resolution, highest-installed fallback). |
+| `src/cli_shim.rs` | Multi-call dispatch: when `argv[0]` is `php` or `php<major>.<minor>`, exec that version's PHP CLI with `PHPRC` pointed at its generated ini (Unix-only). Runs before clap. |
+| `src/site_scope.rs` | Resolve the site owning a directory (or a `--site` name) to its pinned PHP version - the shared lookup behind `exec`, `which`, and the site-aware `wp` shim. |
+| `src/exec_cmd.rs` | `yerd exec` / `yerd which`: run a tool under a site's pinned PHP, or print the binary that would be used (local exec, no IPC beyond the site lookup; Unix-only). |
 | `src/path_cmd.rs` | `yerd path install`/`uninstall`/`print`: edit the user's shell startup file to add `{data}/bin` to `PATH` (local, no IPC; Unix-only). |
+| `src/mcp_cmd.rs` | `yerd mcp`: serve Yerd's tools to AI agents over MCP on stdin/stdout. |
+| `src/apply.rs` | Self-update applier: install a staged, verified artifact, in-process for `yerd update --yes` or detached (gated by `YERD_APPLY_UPDATE`) when the GUI drives it. |
+| `src/uninstall.rs` | `yerd uninstall`: the full self-uninstall flow. |
 | `src/error.rs` | `ClientError` - the client's error type. |
 
 ```mermaid

--- a/docs/developer/binaries/yerdd.md
+++ b/docs/developer/binaries/yerdd.md
@@ -103,8 +103,8 @@ The daemon's modules (`src/lib.rs` re-exports each as `pub mod`):
 | `backend_resolver` | `DaemonBackendResolver` - routes a `Site` to a live FPM pool. |
 | `detect_cache` | `DetectCache` - memoises web-root detection per project, keyed on a freshness stamp. |
 | `fs_watch` | Debounced filesystem watcher that re-scans parked roots as projects appear/change. |
-| `mutate` | Pure, I/O-free config-mutation logic (`Park`/`Link`/`SetPhp`/… plus the four domain mutations). |
-| `site_domains` | Infallible, collision-resolving router builder (`build`) plus `collisions`, which reports the losing side of each domain clash (surfaced as `StatusReport.shadows`). |
+| `mutate` | Pure, I/O-free config-mutation logic (`Park`/`Link`/`SetPhp`/… plus the four domain mutations, the proxy and routing rules, and the per-version PHP pool settings). |
+| `site_domains` | Infallible, collision-resolving router builder (`build`) plus `collisions`, which reports the losing side of each domain clash (surfaced as `StatusReport.shadows`). Resolves domains for whole-host proxies as well as sites - every site is considered before any proxy. |
 | `php_install` | Download + unpack prebuilt PHP builds; `reqwest` downloader. |
 | `php_updates` | PHP update poller + cache (notify-only). |
 | `self_update` | Yerd self-update poller: fetches the GitHub Releases API, decides via the pure `yerd-update` crate, and persists a snapshot (`checked_at` + decision) both to disk and in `DaemonState` (notify-only). |
@@ -117,6 +117,13 @@ The daemon's modules (`src/lib.rs` re-exports each as `pub mod`):
 | `wordpress_url_sync` | Keeps a `WordPress` site's own `siteurl`/`home` options in sync with its HTTP/HTTPS toggle. |
 | `wordpress_users` | Lists a `WordPress` site's administrator accounts (`wp user list`) for the login-as-user picker. |
 | `wordpress_versions` | Cached `WordPress` core-version list for the create-site wizard's version dropdown. |
+| `services` | Service-instance lifecycle over IPC: add/remove/start/stop/restart, port and autostart changes, and the free-form [configuration overrides](../crates/yerd-services#configuration-overrides) (`SetServiceOverrides` / `ServiceOverrides`). |
+| `service_install` | Download + unpack prebuilt service builds per engine and version. |
+| `db_admin` | SQL database administration (`ListDatabases`, `CreateDatabase`, `DropDatabase`, backup/restore). |
+| `jobs` | The background-job registry behind `JobStarted` / `JobStatus` (site creation, streamed installs). |
+| `lan_setup` | The one-time LAN remote-device bootstrap endpoint (serves the public CA + installer script). |
+| `laravel_detect` | Narrow marker-file check for whether a site is a Laravel app (`artisan`), gating per-site Reverb instances. |
+| `ansi` | ANSI stripping for captured subprocess output. |
 | `secure_fs` | Filesystem hardening (`0o700` dirs, `0o600` secrets). |
 | `signals` | Unified shutdown future (SIGTERM + Ctrl-C). |
 | `single_instance` | `InstanceLock` - exclusive `flock` so only one daemon runs. |

--- a/docs/developer/crates/yerd-config.md
+++ b/docs/developer/crates/yerd-config.md
@@ -75,7 +75,7 @@ pub use schema::{
     DEFAULT_DNS_PORT, DEFAULT_DUMP_PORT, DEFAULT_MAIL_PORT, RESERVED_GROUP_NAME,
 };
 
-pub const CURRENT_VERSION: u32 = 11;
+pub const CURRENT_VERSION: u32 = 23;
 ```
 
 `Config` exposes exactly four pure methods and two I/O methods:
@@ -117,7 +117,10 @@ pub struct Config {
     pub mail: MailSection,
     pub dumps: DumpsSection,
     pub domains: DomainsSection,
-    // ... plus the optional tunnel / groups / update_channel state.
+    pub proxies: Vec<ProxySite>,
+    pub proxy_rules: ProxyRulesSection,
+    pub route_rules: RouteRulesSection,
+    // ... plus the optional tunnel / groups / update_channel / LAN state.
 }
 ```
 
@@ -332,7 +335,7 @@ version is the single trigger for forward migrations.
 
 ```rust
 /// The on-disk schema version this crate writes.
-pub const CURRENT_VERSION: u32 = 11;
+pub const CURRENT_VERSION: u32 = 23;
 ```
 
 `CURRENT_VERSION` is **decoupled** from `yerd_ipc::PROTOCOL_VERSION`: the on-disk
@@ -341,8 +344,14 @@ with a new entry in `migrate::STEPS`.
 
 `migrate.rs` holds the steps, indexed so that **`STEPS[N]` walks `vN → v(N+1)`**
 - matching `migrate::up`, which indexes `STEPS[current]` (the version being
-migrated *from*). At v11 there are eleven (`STEPS.len() == CURRENT_VERSION`, pinned
-by `steps_cover_every_version_below_current`):
+migrated *from*). At v23 there are twenty-three (`STEPS.len() == CURRENT_VERSION`,
+pinned by `steps_cover_every_version_below_current`). Most entries are **bare
+version bumps** - the version added an optional table or scalar that defaults
+when absent, so the step only rewrites the `version` line. `v14 → v15` (the
+multi-instance services rework) is the recent exception: it rewrites the
+`[services]` table so previously-installed engines keep starting across the
+upgrade. See [Config Schema History](../config-schema-history) for what each
+version added and how to hand-downgrade a file:
 
 ```rust
 pub(crate) type MigrationStep = fn(&mut Value) -> Result<(), ConfigError>;

--- a/docs/developer/crates/yerd-core.md
+++ b/docs/developer/crates/yerd-core.md
@@ -51,38 +51,59 @@ from `lib.rs`:
 
 ```rust
 pub mod detect;
+mod domain;
 mod error;
 mod host;
+mod net;
 mod php;
+pub mod php_directives;
+pub mod php_extensions;
+pub mod php_pool;
 pub mod php_settings;
+mod proxy;
+mod route_rule;
 mod router;
+pub mod service_directives;
 mod site;
 mod tld;
 
 pub use detect::{detect, Detection, ProjectSignals};
-pub use domain::{choose_primary, effective_domains, Domain, DomainErrorReason};
-pub use error::{CoreError, PhpVersionErrorReason, SiteNameErrorReason, TldErrorReason};
-pub use php::PhpVersion;
+pub use domain::{choose_primary, effective_domains, Domain};
+pub use error::{CoreError, PhpVersionErrorReason, SiteNameErrorReason, TldErrorReason, /* … */};
+pub use net::is_lan_source;
+pub use php::{PhpVersion, FIRST_SUPPORTED_MINOR};
+pub use php_directives::{DirectiveError, DirectiveNameErrorReason};
+pub use php_extensions::{ExtError, NameErrorReason, PathErrorReason};
+pub use php_pool::{PoolNameErrorReason, PoolSettingError, PoolValueErrorReason};
 pub use php_settings::{PhpSettingError, ValueErrorReason};
-pub use router::{RouterConfig, SiteRouter};
-pub use site::{Site, SiteKind};
+pub use proxy::{match_rule, validate_proxy_name, ProxyRule, ProxySite, UpstreamTarget};
+pub use route_rule::RouteRule;
+pub use router::{Route, RouterConfig, SiteRouter};
+pub use site::{normalize_site_name, slugify_site_name, Site, SiteKind};
 pub use tld::Tld;
 ```
 
-| Module          | Visibility    | Responsibility                                            |
-| --------------- | ------------- | --------------------------------------------------------- |
-| `error`         | re-exported   | `CoreError` + the typed `*Reason` sub-enums               |
-| `php`           | re-exported   | `PhpVersion` `(major, minor)` value type                  |
-| `site`          | re-exported   | `Site` / `SiteKind`                                       |
-| `tld`           | re-exported   | `Tld` validated DNS-suffix newtype                        |
-| `domain`        | re-exported   | `Domain` sub-part + `effective_domains` / `choose_primary` algebra |
-| `router`        | re-exported   | `RouterConfig` + `SiteRouter` (the resolve algorithm)     |
-| `php_settings`  | `pub mod`     | managed PHP ini directives + value validation             |
-| `detect`        | `pub mod`     | pure web-root detection (`ProjectSignals` → `Detection`)  |
-| `host`          | `pub(crate)`  | `Host:` header normalisation, consumed only by `resolve`  |
+| Module               | Visibility    | Responsibility                                            |
+| -------------------- | ------------- | --------------------------------------------------------- |
+| `error`              | re-exported   | `CoreError` + the typed `*Reason` sub-enums               |
+| `php`                | re-exported   | `PhpVersion` `(major, minor)` value type                  |
+| `site`               | re-exported   | `Site` / `SiteKind` + name normalisation/slugification    |
+| `tld`                | re-exported   | `Tld` validated DNS-suffix newtype                        |
+| `domain`             | re-exported   | `Domain` sub-part + `effective_domains` / `choose_primary` algebra |
+| `proxy`              | re-exported   | whole-host proxies + path-prefix rules (`match_rule`)     |
+| `route_rule`         | re-exported   | `RouteRule` - a path prefix resolved to a file inside the site |
+| `router`             | re-exported   | `RouterConfig` + `SiteRouter` (the resolve algorithm)     |
+| `net`                | re-exported   | `is_lan_source` - whether a peer address is LAN, not loopback |
+| `php_settings`       | `pub mod`     | managed PHP ini directives + value validation             |
+| `php_directives`     | `pub mod`     | free-form per-version ini directives (shape checks + reserved names) |
+| `php_extensions`     | `pub mod`     | custom `.so` extension registry validation                |
+| `php_pool`           | `pub mod`     | FPM pool-block settings (`max_children`) + the built-in default |
+| `service_directives` | `pub mod`     | free-form service config overrides: dialects, rendering, `scan_local` |
+| `detect`             | `pub mod`     | pure web-root detection (`ProjectSignals` → `Detection`)  |
+| `host`               | `pub(crate)`  | `Host:` header normalisation, consumed only by `resolve`  |
 
-`php_settings` is a `pub mod` (callers reach functions as
-`yerd_core::php_settings::validate_value(...)`); `host` is deliberately
+The `pub mod`s are reached through their path (`yerd_core::php_settings::validate_value(...)`)
+with only their error types re-exported at the root; `host` is deliberately
 crate-private - only `SiteRouter::resolve` consumes it.
 
 ## `PhpVersion`
@@ -325,6 +346,129 @@ Injection attempts - embedded newlines, `;`, `#`, `]`, `=`, or over-length
 input - are all rejected here. Downstream renderers re-validate, but this is the
 first and primary gate.
 :::
+
+## `php_pool` - FPM pool-block settings
+
+FPM's pool knobs (`pm`, `pm.max_children`, …) are **not** ini directives: they
+sit in the pool block of the generated config, not behind `php_value[…]`.
+Setting one through the free-form directives path would render
+`php_value[pm.max_children]`, which FPM refuses with `ERROR: Unable to set
+php_value` on every worker spawn - so `php_directives::reserved` denies the whole
+`pm.` prefix and points here.
+
+```rust
+pub const DEFAULT_MAX_CHILDREN: u32 = 16;
+
+pub fn validate_name(name: &str) -> Result<(), PoolSettingError>;   // allowlist of one
+pub fn validate_value(value: &str) -> Result<u32, PoolSettingError>; // 1..=1024
+pub fn override_max_children(settings: Option<&BTreeMap<String, String>>) -> Option<u32>;
+```
+
+Yerd exposes exactly one knob, `max_children`, so `validate_name` is an
+allowlist of one rather than a shape check - pool settings are a typed surface,
+not free-form ini. `validate_value` accepts a plain run of ASCII digits
+(surrounding whitespace trimmed) inside `1..=1024`; a leading sign or a decimal
+point is rejected rather than coerced.
+
+`DEFAULT_MAX_CHILDREN` is the single source of truth for the default:
+[`yerd-php`](./yerd-php)'s `PoolConfig::dev_defaults` renders it and the CLI
+prints it as `(default)`, so the two cannot drift. `override_max_children`
+returns `None` both when a version has no override *and* when its stored value
+no longer validates, which is what makes a bad hand-edit of `[php.pool]` degrade
+to the default instead of breaking the pool.
+
+## `route_rule` - path prefix to a local file {#route-rule}
+
+A `RouteRule` maps a URI path prefix to a target **under the site's served
+root**: `api/index.php` for a nested front controller, `index.html` for SPA
+history-API routing. It is the local-file sibling of `ProxyRule`, which forwards
+to an HTTP upstream instead.
+
+```rust
+pub struct RouteRule { /* private: prefix + target */ }
+
+impl RouteRule {
+    pub fn new(prefix: &str, target: &str) -> Result<Self, CoreError>;
+    #[must_use] pub fn prefix(&self) -> &str;
+    #[must_use] pub fn target(&self) -> &str;
+    #[must_use] pub fn matches_path(&self, path: &str) -> bool;
+}
+```
+
+`new` validates the prefix as absolute, free of control characters, spaces, `?`
+and `#` (none of which can appear in a `uri.path()`) and of any `..` component,
+then normalises a trailing slash away (`/api/` → `/api`; root stays `/`). The
+target is validated as a **safe relative path** - non-empty, no control
+characters, and no root, drive prefix, or `..` component - so it can only ever
+resolve to a descendant of the served root. Containment is re-checked against
+the real filesystem at request time; this is the first line of defence, not the
+only one.
+
+Matching is boundary-correct (`/api` matches `/api` and `/api/user` but never
+`/apix`), and longest-prefix-wins is applied by the caller -
+[`yerd-proxy`](./yerd-proxy)'s `pure::route_rules::match_route`, the mirror of
+this crate's `match_rule` for proxy rules.
+
+::: info Why the prefix checks are duplicated
+`RouteRule::new` deliberately repeats `ProxyRule::new`'s prefix validation
+rather than sharing a helper: both are shipped types, and a shared helper would
+mean either one's rules could not move without the other's. Each keeps its own
+table tests, which is what catches drift.
+:::
+
+## `service_directives` - free-form service config overrides {#service-directives}
+
+Yerd regenerates a config-backed service's own config file on every start, so a
+hand edit there is clobbered. Instead, overrides are rendered into a sidecar
+(`conf.d/10-yerd.<ext>`) that the generated config includes *after* its own
+settings. Those overrides are not typed - Yerd cannot know every directive of
+every engine - so what this module guarantees is narrower and more important:
+**an override can never corrupt a generated config file**.
+
+```rust
+pub enum OverrideDialect { MyCnf, PostgresConf, RedisConf }
+
+pub fn dialect_for(type_id: &str) -> Option<OverrideDialect>;   // None = accepts no overrides
+pub const fn file_ext(dialect: OverrideDialect) -> &'static str;
+pub fn reserved(dialect: OverrideDialect, name: &str) -> Option<&'static str>;  // hint if denied
+pub fn validate_name(name: &str) -> Result<(), OverrideError>;
+pub fn validate_value(dialect: OverrideDialect, value: &str) -> Result<(), OverrideError>;
+pub fn render_managed(dialect: OverrideDialect, overrides: &BTreeMap<String, String>) -> String;
+pub fn render_local_stub(dialect: OverrideDialect) -> String;
+pub fn scan_local(dialect: OverrideDialect, content: &str) -> Vec<LocalOverrideIssue>;
+```
+
+`OverrideDialect` is the **whole capability descriptor**: the line form, the
+sidecar file extension, and the engine's native include directive (rendered by
+[`yerd-services`](./yerd-services)'s `config_render::render_include_lines`) are
+all total functions of it, so they cannot disagree. `dialect_for` is therefore
+the single source of truth for "does this service accept overrides at all" - it
+backs `Service::override_capability`, the CLI's client-side check, and
+`yerd-ipc`'s `ServiceStatus::supports_overrides`. Meilisearch and Reverb are
+argv/env driven and map to `None`.
+
+Validation is the **injection boundary**, and it runs four times: when an
+override is set (CLI and daemon), when the config is loaded from disk
+(`yerd-config`, leniently - a bad entry is dropped rather than failing the
+load), and defensively again at render time. Names are ≤ 128 bytes and start
+with a letter or `_`; values are ≤ 512 bytes (twice `php_directives`' cap, since
+a real `sql_mode` list runs long) with no control characters, `;`, or `#`, and -
+outside PostgreSQL, whose values are quoted - no quote characters either, since
+an unbalanced quote aborts the whole config load.
+
+`reserved` is the per-dialect denylist for directives Yerd manages through typed
+paths (the port, data directory, socket, pid file, logging, the MySQL/MariaDB
+bootstrap `init-file`, the loopback binding, and the engines' own `include`
+directives). It returns the *hint* naming the right command, not just a bool.
+Matching folds case in every dialect and additionally folds `-`/`_` for the
+MySQL family, so `Bind_Address` is refused just as `bind-address` is.
+
+`scan_local` is the read-only counterpart: it parses the hand-edit file
+(`conf.d/50-local.<ext>`, which Yerd creates once via `render_local_stub` and
+never rewrites) and returns one `LocalOverrideIssue` per line that names a
+reserved directive or parses as no directive at all. [`yerd-doctor`](./yerd-doctor)
+turns each into a `ServiceOverrideInvalid` warning; the remedy is the user's own
+editor, since rewriting the file would undo their work.
 
 ## `detect`
 

--- a/docs/developer/crates/yerd-doctor.md
+++ b/docs/developer/crates/yerd-doctor.md
@@ -29,17 +29,35 @@ Source: [`crates/yerd-doctor/src/lib.rs`](https://github.com/forjedio/yerd/blob/
 
 ## Public API
 
-### `diagnose(&StatusReport, Option<bool>) -> Vec<Diagnosis>`
+### `diagnose(&StatusReport, Option<bool>, &[(String, String, String)]) -> Vec<Diagnosis>`
 
 Runs every check against the report and returns the findings in a stable order.
-The second argument, `path_needs_setup`, lets the caller surface a
-`BinDirNotOnPath` warning when the yerd bin dir isn't on `PATH` (`None` = unknown,
-skip that check).
+Everything past the report is daemon-supplied input that can't be read from it,
+because this crate does no I/O:
+
+- `path_needs_setup` surfaces a `BinDirNotOnPath` warning when the yerd bin dir
+  isn't on `PATH` (`None` = unknown, skip that check).
+- `local_override_files` carries one `(service_id, path, content)` tuple per
+  override-capable service whose hand-edited
+  [`conf.d/50-local.<ext>`](./yerd-services#configuration-overrides) exists. Each
+  is scanned with `yerd_core::service_directives::scan_local`, and every issue
+  becomes a `ServiceOverrideInvalid` warning. A service id with no dialect is
+  skipped, so an argv-driven or unknown service is never scanned.
 
 ```rust
 #[must_use]
-pub fn diagnose(report: &StatusReport, path_needs_setup: Option<bool>) -> Vec<Diagnosis>;
+pub fn diagnose(
+    report: &StatusReport,
+    path_needs_setup: Option<bool>,
+    local_override_files: &[(String, String, String)],
+) -> Vec<Diagnosis>;
 ```
+
+::: info The remedy is the user's editor, not a command
+Yerd never rewrites `50-local.<ext>` - that is the entire point of the file - so
+`ServiceOverrideInvalid` is **not** auto-fixable and its remedy names the file
+and a restart rather than a command that would undo the user's work.
+:::
 
 Two cross-cutting invariants hold for the output:
 
@@ -161,6 +179,7 @@ The plain `yerd doctor` path is even simpler - it just renders `diagnose(&build_
 | 5 | `DefaultPhpNotInstalled` | `Fail` | `default_php` not among installed `php` | `yerd install php <default>` |
 | 6 | `FpmPoolFailed` | `Fail` | one per pool with `state == Failed` | auto-fixed by `yerd doctor fix`, or `yerd use <ver>` |
 | 7 | `ServiceFailed` | `Fail` | one per DB/cache service with `state == Failed` | `yerd service restart <svc>` |
+| 7a | `ServiceOverrideInvalid` | `Warn` | one per bad line of a hand-edited `conf.d/50-local.<ext>` file; **not** auto-fixable | edit the file yourself, then `yerd service restart <svc>` |
 | 8 | `PhpUpdateAvailable` | `Ok` | a pool has `update_available = Some(latest)` | `yerd update php <ver>` |
 | 9 | `ResolverBackupSaved` | `Ok` | `resolver_backup == Some(path)` | informational, **no** remedy |
 | 10 | `NoSites` | `Ok` | `sites.parked == 0 && sites.linked == 0` | `yerd park <dir>` / `yerd link <name> <dir>` |

--- a/docs/developer/crates/yerd-platform.md
+++ b/docs/developer/crates/yerd-platform.md
@@ -122,6 +122,10 @@ pub struct NssOutcome {
 pub enum NssFailure { CertutilMissing, CertutilExit(i32), DbMissing }
 ```
 
+On **macOS** the same path runs for Firefox, which keeps its own NSS store there too; Chromium-family browsers on macOS read the system keychain instead, so they need nothing extra.
+
+`certutil` itself is resolved to an **absolute path**, once, by `resolve_certutil`: the per-OS candidate list (`pure::nss::certutil_candidates_linux` / `_macos`) is probed first, and only then `certutil` under each `$PATH` directory. The candidate list wins because a service manager hands the daemon a stripped `PATH` - a launchd `LaunchAgent` gets `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, which never contains the Homebrew or MacPorts prefixes where macOS's `certutil` actually lives, so a `$PATH`-only lookup silently reported the tool as missing. (`/usr/bin` is deliberately absent from the macOS list: macOS ships `certtool` there, never `certutil`.) It mirrors the `/usr/bin/id` / `/bin/ps` precedent elsewhere in this crate. The existence probe is injected, so the walk is unit-tested against the real candidate lists on any host without touching the filesystem.
+
 The caller decides whether to surface the degraded outcome. See [HTTPS & Certificates](../../guide/https) for the user-facing story.
 
 ### `ResolverInstaller`
@@ -216,6 +220,23 @@ pub trait SystemOpener {
 Opens a directory with the desktop's default handler - the fallback when no editor is detected or the user picks "System default". Candidate ordering per desktop lives in the table-tested `pure/opener_spec.rs`.
 
 Both traits ship public fakes (`FakeIdeLauncher`, `FakeSystemOpener`), following `FakeLanIpProvider`: each records its calls and takes an optional forced error, so callers can test the seam without touching the host.
+
+### `TerminalLauncher`
+
+```rust
+pub trait TerminalLauncher {
+    fn open_terminal(&self, path: &Path) -> Result<(), PlatformError>;
+}
+```
+
+Opens a terminal with `path` as its working directory - what the site details sidebar's **Terminal** button drives. macOS is one line (`/usr/bin/open -a Terminal <path>`); Linux is where the work is, and its decision half lives in the table-tested `pure/terminal_spec.rs`.
+
+`TERMINAL_SPECS` pairs each terminal we know how to launch with the flags that set its working directory (`gnome-terminal --working-directory`, `konsole --workdir`, `kitty --directory`, `wezterm start --cwd`, …). Two matching rules matter:
+
+- **Lookups match the program's file name, not the whole string.** KDE stores `TerminalApplication` in `kdeglobals` as either a bare name (`konsole`) or an absolute path (`/usr/bin/konsole`), and both must resolve to the same flags or the terminal opens in the wrong directory.
+- **A trailing `.wrapper` is stripped first.** Debian's `x-terminal-emulator` alternative points at `gnome-terminal.wrapper`, which forwards its arguments to `gnome-terminal` and so takes the same flags.
+
+`x-terminal-emulator` itself is deliberately absent from the table: it is an alternatives symlink rather than a terminal, so it carries no flags of its own. The Linux impl probes it separately and resolves the link before looking flags up. An unrecognised program returns `None`, and the caller falls back to the spawned child inheriting the current directory.
 
 ## OS implementations and the `Active*` aliases
 

--- a/docs/developer/crates/yerd-proxy.md
+++ b/docs/developer/crates/yerd-proxy.md
@@ -25,9 +25,13 @@ crates/yerd-proxy/src/
 ├── pure/            # synchronous, runtime-free, I/O-free helpers
 │   ├── mod.rs
 │   ├── cgi_params.rs   # build the CGI/1.1 param list for FastCGI
+│   ├── cgi_head.rs     # incremental CGI response-head parsing (streaming)
 │   ├── fcgi_codec.rs   # FastCGI record framing (encode/decode)
+│   ├── query.rs        # login-token query-string helpers (one-click WP admin)
+│   ├── route_rules.rs  # longest-prefix match of a site's routing rules
 │   ├── try_files.rs    # static-file/directory-index candidate resolution + MIME map
-│   └── redirect.rs     # HTTP → HTTPS redirect URI builder
+│   ├── unbound.rs      # resolver-off localhost access (header / switch URL / cookie / picker)
+│   └── redirect.rs     # HTTP → HTTPS upgrade + trailing-slash directory Location
 └── forward/         # async per-backend forwarding I/O
     ├── mod.rs          # BoxBody + body helpers
     ├── static_file.rs  # serve a real static file, or a directory's index.html/.htm
@@ -103,7 +107,7 @@ The `document_root` parameter is the directory actually served, which is the sit
 
 Beyond the script vars, `build_params` emits the standard CGI/1.1 set (`GATEWAY_INTERFACE`, `SERVER_PROTOCOL`, `REQUEST_METHOD`, `QUERY_STRING`, `DOCUMENT_ROOT`, `REMOTE_ADDR`/`REMOTE_PORT`, `SERVER_ADDR`/`SERVER_PORT`, `SERVER_SOFTWARE = yerd`). `HTTPS=on` is added only when the request arrived on the TLS listener. `Host` is surfaced as both `SERVER_NAME` and `HTTP_HOST`; `Content-Type` and `Content-Length` are emitted un-prefixed (FPM expects them that way). Every other header is translated to the generic `HTTP_*` form (uppercased, `-` → `_`), with `Host`/`Content-Type`/`Content-Length` explicitly skipped so they are not double-emitted.
 
-### `redirect` - HTTP → HTTPS upgrade URI
+### `redirect` - HTTP → HTTPS upgrade URI {#redirect}
 
 `build_redirect_uri(host, path_and_query, https_port)` constructs the `Location` for the permanent redirect used when a secure site is hit on the plain-HTTP listener:
 
@@ -113,6 +117,14 @@ pub fn build_redirect_uri(host: &str, path_and_query: &str, https_port: u16) -> 
 
 It strips any inbound port from `host` (handling both `host:80` and bracketed IPv6 `[::1]:80`), lowercases the host, defaults an empty path to `/`, and appends `:port` only when the HTTPS port is not 443. The `strip_port` helper is careful about IPv6: a bracketed literal keeps everything up to and including the `]`, and a plain host is only split when it contains exactly one colon (so an unbracketed IPv6 address is left intact). All of this is exercised by a table test (`build_table`) covering `app.test:80`, `[::1]:80`, `[2001:db8::1]:80`, and the 443-vs-8443 port cases.
 
+The module also builds the **trailing-slash directory** `Location`:
+
+```rust
+pub fn directory_redirect_location(path_and_query: &str) -> String  // "/sub?x=1" -> "/sub/?x=1"
+```
+
+This one is deliberately **path-relative**, so it is scheme- and host-agnostic and works behind either listener. An empty input degrades to `/`, and a path that already ends in `/` is returned unchanged, so the caller can never build a redirect loop. See [the directory redirect](#the-trailing-slash-directory-redirect) for when it fires.
+
 ### `try_files` - static-file resolution {#try_files-static-file-resolution}
 
 `try_files` decides, purely, whether a request *could* be a static file and what its safe relative path and MIME type would be. It does no I/O - the [`static_file`](#static_file-serving-real-files) forwarder does the actual stat/read.
@@ -121,6 +133,32 @@ It strips any inbound port from `host` (handling both `host:80` and bracketed IP
 - **`directory_candidate(path)`** is `static_candidate`'s counterpart for directory-index resolution: it maps a *directory-style* URL path (trailing slash, or the bare root `/`) to a safe relative directory `PathBuf`, or `None` for anything else. Same percent-decoding and traversal rules as `static_candidate` - the two intentionally partition every URL shape between them (a path never satisfies both).
 - **`is_php_source(path)`** flags PHP source extensions (`php`, `phtml`, `php3`/`php4`/`php5`/`php7`, `phps`, `pht`) so they are *never* served as static bytes - they fall through to FastCGI.
 - **`content_type_for(path)`** maps a file extension to a `Content-Type` for the response (a small MIME table, defaulting to `application/octet-stream`).
+
+### `route_rules` - matching a site's routing rules
+
+The mirror of `yerd_core::match_rule` for [`RouteRule`](./yerd-core#route-rule), which resolves to a local file rather than an HTTP upstream:
+
+```rust
+pub fn match_route<'a>(rules: &'a [RouteRule], path: &str) -> Option<&'a RouteRule>
+```
+
+Longest-prefix wins, and ties cannot occur because duplicate prefixes per site are rejected when the rule is added. Callers pass the raw, case-sensitive, percent-encoded `uri.path()` with **no** normalization, exactly as `match_rule` does: an under-match (an encoded path failing to match) is acceptable for a dev tool, and the matcher never over-matches.
+
+Matching is the whole of the pure half. Whether the matched target is a PHP script or a static document is derived at the dispatch site from `try_files::is_php_source`, so this module needs to know neither.
+
+### `cgi_head` - incremental response-head parsing {#cgi_head-incremental-response-head-parsing}
+
+PHP-FPM delivers a response as a stream of STDOUT records whose leading bytes are a CGI header block ending at a blank line. `cgi_head` is what lets the forwarder start the body **before** the request finishes:
+
+```rust
+pub struct HeadAccumulator { /* private buffer */ }
+pub enum HeadFeed { Pending, Complete(Head), TooLarge }
+pub struct Head { pub status: StatusCode, pub headers: Vec<(String, String)>, pub body_remainder: Vec<u8> }
+```
+
+The forwarder feeds STDOUT records in as they arrive and starts streaming the moment `HeadFeed::Complete` comes back, so nothing waits for `END_REQUEST`. Buffering until the terminator is found is what makes a record boundary falling *inside* a `\r\n\r\n` harmless: each feed resumes its scan three bytes back into what was already buffered, so the split point never matters. `Status:` is parsed out of the header list into `Head::status` (defaulting to 200 when absent), and any body bytes that arrived in the same feed come back as `body_remainder`.
+
+`HeadFeed::TooLarge` fires past a 64 KiB cap - generous next to nginx's default `fastcgi_buffer_size` of 4-8 KiB, so a head that long is a runaway backend rather than a real response.
 
 ## The `Backend` enum
 
@@ -330,29 +368,56 @@ A `NotFound` result here means no index file exists (or `index.php` won) and the
 `script_file::resolve_script` extends `cgi_params`'s "everything to `index.php`" front-controller policy with the `try_files $uri $uri/index.php` half of the classic WordPress/nginx policy: a real, more specific script wins over the site root's `index.php` when one exists.
 
 ```rust
+pub enum ScriptResolution {
+    Script(PathBuf),      // a real, on-disk script to execute, relative to served_root
+    DirectoryRedirect,    // a real directory requested without its trailing slash
+    Fallback,             // nothing matched - the site root's index.php
+}
+
 pub async fn resolve_script(
     uri_path: &str,
     served_root: &Path,
     allowed_root: &Path,
-) -> Option<PathBuf>
+    symlink_protection: bool,
+) -> ScriptResolution
 ```
 
 - Only called at all when `BackendResolver::allows_direct_script_execution(site)` returns `true` (see [`resolve_script_if_allowed`](#per-request-dispatch), which skips the filesystem check entirely otherwise) - a Laravel or plain-PHP site never reaches this function.
-- Checks, in order: an exact non-directory match (`/wp-login.php` → `wp-login.php`), then - for a directory-style request - that directory's own index (`/wp-admin/` → `wp-admin/index.php`).
+- Checks, in order: an exact non-directory match (`/wp-login.php` → `wp-login.php`), then that same path as a **directory missing its trailing slash** (`/sub` → `DirectoryRedirect`), then - for a directory-style request - that directory's own index (`/wp-admin/` → `wp-admin/index.php`).
 - Unlike `static_file`, this applies to **every HTTP method**, not just GET/HEAD - a real script like `wp-login.php` handles POST too. It never reads or serves file *content*, only decides which path FastCGI should be told to execute.
-- Same canonicalise-and-check-containment discipline as `static_file`: a symlinked script that resolves outside `allowed_root` (`document_root`) is treated as not found (falls back to the root `index.php` policy) rather than handed to FastCGI.
-- `None` (fall back to the site root's `index.php`, today's behavior for every framework with only one front controller) whenever there's no real, on-disk, non-directory `.php` file at the resolved path.
+- Same canonicalise-and-check-containment discipline as `static_file`: a symlinked script that resolves outside `allowed_root` (`document_root`) is treated as not found (falls back to the root `index.php` policy) rather than handed to FastCGI. `is_existing_directory` mirrors that containment match, so the two share symlink semantics exactly.
+- `Fallback` (the site root's `index.php`, the behaviour for every framework with only one front controller) whenever there's no real, on-disk, non-directory `.php` file and no real directory at the resolved path.
+
+#### The trailing-slash directory redirect {#the-trailing-slash-directory-redirect}
+
+`DirectoryRedirect` answers `301` to the slashed form, built by [`redirect::directory_redirect_location`](#redirect) and sent with `Cache-Control: no-store`. This matches Apache's `DirectorySlash` and nginx's `try_files $uri $uri/`.
+
+Two scoping rules make it safe:
+
+- **Direct mode only.** It rides the existing `allows_direct_script_execution` gate. A front-controller site treats `/foo` as a framework route, so redirecting there would break it.
+- **GET/HEAD only**, to avoid surprising POST semantics.
+
+The redirect fires whether or not the directory holds an `index.php`, so a static-only `/assets` redirects to `/assets/`, where `try_serve_index` serves its `index.html`. Without it, `GET /sub` on a legacy multi-directory PHP app fell through to the *root* `index.php`; if that script redirects into the subdirectory, the browser looped until it gave up. The one-click WordPress login token is consumed only once a request is definitely forwarded to FastCGI, so it survives this 301 and still works on the slashed follow-up.
 
 ### `fcgi` - the PHP-FPM forwarder
 
-`fcgi::forward` drives the full FastCGI exchange against PHP-FPM:
+`fcgi::forward` drives the full FastCGI exchange against PHP-FPM. The socket is **split**, so the request is written on one half while the response is read on the other:
 
 1. **Connect.** `open_backend` opens a `UnixStream` for `PhpFpm { socket }` (Unix only - non-Unix returns `ErrorKind::Unsupported`) or a `TcpStream` for `PhpFpmTcp { addr }`. The two are unified behind a `BackendStream` enum that implements `AsyncRead`/`AsyncWrite`. (`FrankenPhp` reaching this path is a `#[cold]` "dispatch bug" error.)
 2. **BEGIN_REQUEST** with `FCGI_RESPONDER`, `keep_conn = false`, `request_id = 1`.
 3. **PARAMS** from `build_params`, chunked at `FCGI_MAX_PAYLOAD`, followed by a zero-length PARAMS terminator. The prelude is flushed before the body is drained.
-4. **STDIN.** The request body is streamed frame-by-frame, chunked at `FCGI_MAX_PAYLOAD`, then a zero-length STDIN terminator. HTTP trailers are dropped (FastCGI cannot represent them).
-5. **Read STDOUT/STDERR** until `END_REQUEST`. Each record's content and padding are read with `read_exact`; a `request_id != 1` yields `FcgiError::UnexpectedRequestId`. Any non-empty STDERR is logged at warn ("FPM stderr").
-6. **Synthesise the response.** `parse_cgi_response` splits the CGI header block at the first `\r\n\r\n` or `\n\n`, translates `Status: NNN [Reason]` into the HTTP status (defaulting to `200 OK`), and copies the rest as the body. Headers that fail `HeaderName`/`HeaderValue` validation are silently skipped.
+4. **STDIN.** The request body is streamed frame-by-frame, chunked at `FCGI_MAX_PAYLOAD`, then a zero-length STDIN terminator. HTTP trailers are dropped (FastCGI cannot represent them). The write task deliberately outlives the response read: PHP may answer before it has read STDIN, and abandoning a part-read request body makes hyper close the client's read side under an upload still in flight.
+5. **Head.** STDOUT records are fed to [`cgi_head::HeadAccumulator`](#cgi_head-incremental-response-head-parsing) until it reports `Complete`. A `request_id != 1` yields `FcgiError::UnexpectedRequestId`; any non-empty STDERR is logged at warn ("FPM stderr").
+6. **Stream the body.** The head goes out immediately and every subsequent STDOUT record is relayed to the client one at a time over a channel body, so an SSE stream or a Livewire `wire:stream` reaches the browser as PHP flushes it. A `Content-Length` PHP set itself passes through verbatim; without one, hyper frames the body as chunked.
+
+::: warning Streaming moves the error boundary
+A failure *before* the head is on the wire still returns a `ProxyError` and gets the usual clean 5xx. A failure *after* it cannot change the status any more, so the forwarder aborts the connection instead.
+:::
+
+Two details fall out of streaming:
+
+- **Bodyless responses are drained, not streamed.** For a HEAD, or a `1xx`/`204`/`304`, hyper drops the body the instant the head is encoded - which on the streaming path is indistinguishable from the client hanging up, and would kill the PHP script mid-run. `drain_to_end_request` reads to `END_REQUEST` discarding STDOUT instead, so PHP still runs to completion. `restore_head_content_length` then gives a HEAD the `Content-Length` the same GET would have carried (RFC 9110 §9.3.2), unless the drain passed `MAX_DISCARDED_BYTES` and the total is no longer known.
+- **`X-Accel-Buffering` is consumed, not forwarded.** It is an nginx directive with no meaning to a client, and Yerd never buffers a stream in the first place. A PHP-set `Transfer-Encoding` is dropped for the same reason: it would pre-empt hyper's own framing.
 
 `upgrade_not_supported()` is the `501` response for upgrade attempts on a FastCGI backend.
 

--- a/docs/developer/crates/yerd-services.md
+++ b/docs/developer/crates/yerd-services.md
@@ -7,14 +7,20 @@ backup / restore). It is the services counterpart to [`yerd-php`](./yerd-php) an
 is structured the same way - every *decision* is pure and unit-testable; every
 byte of I/O sits behind the [`yerd-supervise`](./yerd-supervise) trait seams.
 
-The four engines it models:
+The config-backed engines it models:
 
-| Service | `id` | Display name | Kind | Default port | Server binary |
-|---|---|---|---|---|---|
-| Redis | `redis` | `Redis (Valkey)` | Cache | 6379 | `valkey-server` |
-| MySQL | `mysql` | `MySQL` | Database | 3306 | `mysqld` |
-| MariaDB | `mariadb` | `MariaDB` | Database | 3306 | `mariadbd` |
-| PostgreSQL | `postgres` | `PostgreSQL` | Database | 5432 | `postgres` |
+| Service | `id` | Display name | Kind | Default port | Server binary | Overrides |
+|---|---|---|---|---|---|---|
+| Redis | `redis` | `Redis (Valkey)` | Cache | 6379 | `valkey-server` | `RedisConf` |
+| MySQL | `mysql` | `MySQL` | Database | 3306 | `mysqld` | `MyCnf` |
+| MariaDB | `mariadb` | `MariaDB` | Database | 3306 | `mariadbd` | `MyCnf` |
+| PostgreSQL | `postgres` | `PostgreSQL` | Database | 5432 | `postgres` | `PostgresConf` |
+
+Two further types are supervised the same way but have **no config file**:
+Meilisearch (`meilisearch`, `Search`) and Laravel Reverb (`reverb:<site>`,
+`AppServer` - one instance per linked Laravel site, running against that site's
+PHP rather than a downloaded binary). Both are argv/env driven, so both accept
+no [configuration overrides](#configuration-overrides).
 
 ::: info Redis is served by Valkey
 The "Redis" slot is filled by **Valkey** - the BSD-licensed fork - because Redis
@@ -44,6 +50,7 @@ src/
 ├── config_render.rs  # pure config rendering (redis.conf / my.cnf / postgresql.conf)
 ├── release.rs        # pure artifact resolution from the hosted listing
 ├── version.rs        # version labels + on-disk path layout; discover_installed
+├── port.rs           # candidate_ports - free-port selection for a new instance
 ├── health.rs         # readiness probes (Redis PING, MySQL/Postgres handshake)
 ├── manager.rs        # ServiceManager - the I/O driver that runs the state machine
 └── error.rs          # ServiceError
@@ -119,6 +126,50 @@ here):
 - **`render_postgresql_conf`** - `listen_addresses = '127.0.0.1'` and
   **`unix_socket_directories = ''`** (Postgres uses TCP loopback only; the macOS
   `sun_path` limit rules out a socket here), with hba/ident pinned to the datadir.
+
+`render_include_lines(dialect, confd_dir)` renders the include line(s) the
+manager appends to each rendered config so the engine reads the
+[override sidecars](#configuration-overrides) *after* Yerd's own settings. Each
+dialect gets its native form: `!includedir` for `MyCnf` and `include_dir` for
+`PostgresConf` (both read a directory in name order), while `RedisConf` has no
+directory form at all, so both files are named explicitly with `50-local` last -
+the order is what carries the precedence.
+
+::: warning `!includedir` has no quoting syntax
+Unlike an option *value*, MySQL's `!includedir` directive cannot be quoted, so
+the path is emitted raw. A real `mysqld` parses a spaced macOS state path
+(`~/Library/Application Support/yerd/...`) that way, which is what makes this
+safe; the other two dialects quote exactly as their values do. There are table
+tests pinning all three against a spaced path.
+:::
+
+## Configuration overrides
+
+An override-capable engine gets a `conf.d/` directory beside its rendered
+config, holding two files:
+
+| File | Written by | Rewritten? |
+|---|---|---|
+| `10-yerd.<ext>` | Yerd, from `[services.<id>.overrides]` | every start |
+| `50-local.<ext>` | the user | **never** - created once from a stub |
+
+`Service::override_capability() -> Option<OverrideDialect>` is the capability
+descriptor, and its one body delegates to
+[`yerd_core::service_directives::dialect_for`](./yerd-core#service-directives),
+which the CLI and `yerd-config` also call - so no service type can declare a
+capability that disagrees with theirs. `Some` reads as "accepts overrides", and
+the dialect determines the line form, the file extension, and the include
+directive alike. It surfaces on the wire as
+[`ServiceStatus::supports_overrides`](../ipc-protocol#status-doctor-payloads).
+
+Every override-capable engine sets `capture_output_to_log: true` in its launch
+plan, including the ones that log to their own file via rendered config. An
+invalid directive is reported while the option file is *still being parsed* -
+before `mysqld` opens its configured `log-error`, or Valkey its `logfile` - so
+without capture that complaint would land on the daemon's inherited stderr and
+reach no file at all. The manager and the engine then both append to the same
+path, so neither truncates the other's lines. A test asserts the invariant
+directly: `override_capable_engines_capture_output_to_the_instance_log`.
 
 ## `release.rs` - artifact resolution (pure)
 

--- a/docs/developer/cross-platform.md
+++ b/docs/developer/cross-platform.md
@@ -236,12 +236,15 @@ The macOS probe is deliberately strict about the port: a bare `nameserver 127.0.
 | Anchor dirs scanned | `/usr/local/share/ca-certificates`, `/etc/pki/ca-trust/source/anchors`, `/etc/ca-certificates/trust-source/anchors` | n/a | - |
 | `install` / `uninstall` | `NeedsHelper` (`install-ca` / `uninstall-ca`) | `NeedsHelper` (same tags) | `Unsupported` |
 | `is_present_system` probe | hash each anchor `.crt` DER, match fingerprint (`pem_match`) | enumerate Keychain certs via `security-framework`, SHA-256 the DER | `Unsupported` |
-| Firefox/NSS install | degraded `NssOutcome` (`certutil_missing: false`) - wiring planned | degraded `NssOutcome` (`certutil_missing: true`) - wiring planned | `Unsupported` |
+| Browser/NSS install | `nss_exec::real_install` - `~/.pki/nssdb` (Chromium-family) + every Firefox profile, incl. Snap/Flatpak | `nss_exec::real_install` - Firefox profiles only (Chromium-family reads the keychain) | `Unsupported` |
+| `certutil` lookup | `/usr/bin/certutil`, then `$PATH` | Homebrew (linked + keg-only `nss`) and MacPorts prefixes, then `$PATH` | n/a |
 
 The fingerprint is a `CaFingerprint` newtype wrapping a 32-byte SHA-256 digest, with a strict lowercase-hex wire form (`to_hex` / `from_hex`). The presence probe is a *presence* check, not a trust-policy check.
 
-::: info Firefox/NSS is partially landed
-Both OS impls currently return a degraded `NssOutcome` reporting zero profiles attempted; the actual `certutil` invocation is a planned follow-up that lands when the daemon and helper drive it end to end. The `pure::firefox` `profiles.ini` parser already exists.
+::: info Both OS impls drive `certutil` for real
+`install_firefox_nss` / `uninstall_firefox_nss` / `browser_ca_trust` all delegate to `nss_exec`, which discovers the per-user NSS databases, runs `certutil` against each, and aggregates the results into an `NssOutcome`. Path derivation and the argv are pure (`pure::nss`, `pure::firefox`'s `profiles.ini` parser); only the discover→run→aggregate orchestration touches the host, and it does so behind injected seams so it is unit-tested in-memory.
+
+`certutil` is resolved to an absolute path from a per-OS candidate list **before** `$PATH`, because a service manager hands the daemon a stripped environment. A missing tool stays a first-class degraded outcome (`certutil_missing` / `BrowserCaTrust::ToolMissing`), never an error.
 :::
 
 ### Autostart

--- a/docs/developer/gui.md
+++ b/docs/developer/gui.md
@@ -43,15 +43,20 @@ apps/yerd-gui/
 └── src/                    Vue FRONTEND
     ├── main.ts             createApp + router; initTheme(); initDesktopChrome()
     ├── App.vue             AppShell + Toaster; shared daemon poller; first-run daemon start
-    ├── router.ts           hash router: /overview (default) /general /php /sites /tooling /services /dumps /mail /doctor /about (+ /dumps-window, /mails-viewer standalone routes)
+    ├── router.ts           hash router: /overview (default) /general /php /sites /tooling /services /proxies /dumps /integrations /mail /doctor /about (+ /dumps-window, /mails-viewer standalone routes)
     ├── ipc/
     │   ├── types.ts        TypeScript mirror of the yerd-ipc wire JSON
     │   ├── client.ts       typed wrappers around invoke() + IpcError
     │   └── client.test.ts  command-mapping + error-categorisation tests
-    ├── composables/        useDaemon (singleton poller), usePoll, useToast
-    ├── components/         AppShell, SideNav, NavLink, TitleBar, StatusPill, ComingSoon, EnvironmentCard, ManageDomainsModal, ui/ (incl. AsyncState, EmptyState)
-    ├── views/              OverviewView, GeneralView, PhpView, SitesView, ToolingView, ServicesView, LaravelDumpsView, DumpsWindowView, MailView, MailsViewerView, DoctorView, AboutView
-    └── lib/                utils (cn, humanisers), theme, desktop chrome, domainValidation (client-side domain-shape checks)
+    ├── composables/        useDaemon (singleton poller), usePoll, useToast, useIdes
+    ├── components/         AppShell, SideNav, NavLink, TitleBar, StatusPill, ComingSoon, EnvironmentCard,
+    │                       SiteCard, SiteDetailsSidebar (+ SiteDomainsPanel / SiteRoutesPanel),
+    │                       PhpVersionPanel, ServiceOverridesModal, ui/ (incl. AsyncState, EmptyState, InfoBanner)
+    ├── views/              OverviewView, GeneralView, PhpView, SitesView, ProxiesView, ToolingView, ServicesView, LaravelDumpsView, DumpsWindowView, MailView, MailsViewerView, DoctorView, AboutView
+    └── lib/                utils (cn, humanisers), theme, desktop chrome, domainValidation,
+                            siteFilter (match a query against every domain a site answers),
+                            ideChoice (resolve "auto"/"system"/an id to a label), wpAdmin,
+                            phpSettings (client-side pool/setting shape checks), windowState
 ```
 
 ## The Rust bridge (`src-tauri`)
@@ -426,7 +431,10 @@ export type Response =
 `ipc/client.ts` wraps each Tauri command in a typed function and narrows the
 `Response` for callers - including the domain mutators
 `addDomain` / `removeDomain` / `setPrimaryDomain` / `resetDomains` that back
-`ManageDomainsModal.vue`. A low-level `call` normalises every rejection into an
+`SiteDomainsPanel.vue`, the routing mutators `addRouteRule` / `removeRouteRule` /
+`listRoutes` behind `SiteRoutesPanel.vue`, `setPhpPoolSettings` behind
+`PhpVersionPanel.vue`, and `serviceOverrides` / `setServiceOverride` behind
+`ServiceOverridesModal.vue`. A low-level `call` normalises every rejection into an
 `IpcError`, and `ensureOk` defensively throws if a `type:"error"` ever slips
 through:
 
@@ -452,6 +460,29 @@ The client also exposes host helpers that are **Tauri plugins, not daemon IPC**:
 and `elevate` (the `elevate` command above), typed to the
 `ElevateTarget = "trust" | "resolver" | "ports"` union.
 
+A second group of host-only commands backs the **editor and terminal** launchers
+in the site details sidebar, implemented over
+[`yerd-platform`](./crates/yerd-platform)'s `IdeLauncher` / `SystemOpener` /
+`TerminalLauncher` seams rather than any daemon request:
+
+| Wrapper | Command | Purpose |
+| --- | --- | --- |
+| `getInstalledIdes` | `get_installed_ides` | rank-sorted detected editors (id + display label) |
+| `openInIde` | `open_in_ide` | open a site's folder in the editor with this id |
+| `openInSystemDefault` | `open_in_default` | open it with the desktop's default handler |
+| `openInTerminal` | `open_terminal` | open a terminal with that directory as its cwd |
+| `getPreferredIde` / `setPreferredIde` | `get_preferred_ide` / `set_preferred_ide` | the app-wide preference (`null` = auto-detect) |
+| `getSiteIdeOverrides` / `setSiteIdeOverride` | `get_site_ide_overrides` / `set_site_ide_override` | per-site overrides of that preference |
+
+`open_in_ide` / `open_in_default` take a **site name**, not a path: the host
+resolves the directory from the daemon's site list, so no absolute path is
+handed back and forth across the webview boundary. The editor preference and the
+per-site overrides persist host-side in `gui-settings.json`, alongside the tray
+icon variant and title-bar style. Preferences are stored as **raw ids**, so an id
+this host can't currently see (an uninstalled editor, or one set on another
+machine) survives untouched and simply renders as auto-detect - `lib/ideChoice.ts`
+does that resolution.
+
 ### Composables
 
 | Composable | Role |
@@ -460,6 +491,7 @@ and `elevate` (the `elevate` command above), typed to the
 | `useDaemonStart` | **Singleton** "start the daemon, wait for it to connect, diagnose on failure" flow shared by onboarding step 1, `DaemonDownHero`, and Doctor. `phase` (click-driven, fed by the Rust `daemon-start-phase` event) and `backgroundBusy` (fed by macOS's launch-time self-repair thread's `daemon-self-repair` event, see above) both OR into `starting`/`activeLabel` so every consumer's button reflects either kind of in-flight work - but `start()`'s own re-entrancy guard reads `phase` alone, so a same-tick self-repair no-op can never suppress `App.vue`'s automatic start. |
 | `usePoll` | Generic mount-scoped poller. Never overlaps in-flight calls, **pauses while the document is hidden** (background tab / tray), refreshes on becoming visible, and clears its timer on unmount. Default cadence 4s; callers should not go below ~3s for `status`. |
 | `useToast` | Module-level toast store rendered by the single `<Toaster>` in `App.vue`. Errors linger (8s), success/info auto-dismiss (4s). |
+| `useIdes` | **Singleton** cache of the host's detected editors, in rank order. Detection is a filesystem scan, so it runs once per session (`loadIdes`) and every editor picker reads the same list rather than re-probing on open; `rescanIdes` backs the Settings **Rescan** button. Each run carries a monotonic generation token and publishes only while it is still the newest, so a slow initial load can never overwrite a rescan the user triggered after it. |
 
 Both pollers gate on `document.visibilityState === "hidden"` to avoid hammering
 the daemon when the window is hidden to the tray - a real cost, since each

--- a/docs/developer/ipc-protocol.md
+++ b/docs/developer/ipc-protocol.md
@@ -182,6 +182,9 @@ The variant set is the daemon's whole RPC surface - liveness, site management, P
 | `SetServicePort { service, port }` | `{"type":"set_service_port","service":"redis","port":6380}` |
 | `SetServiceOverrides { service, overrides }` | `{"type":"set_service_overrides","service":"mysql","overrides":{"max_connections":"500","sql_mode":""}}` (free-form engine config directives, merged into the instance; `""` removes a key; takes effect on the next start/restart, nothing is restarted implicitly) |
 | `ServiceOverrides { service }` | `{"type":"service_overrides","service":"mysql"}` (replies `ServiceOverrides { overrides }`) |
+| `AddRouteRule { site, prefix, target }` | `{"type":"add_route_rule","site":"portal","prefix":"/api","target":"api/index.php"}` (target is relative to the served root; never absolute, never containing `..`) |
+| `RemoveRouteRule { site, prefix }` | `{"type":"remove_route_rule","site":"portal","prefix":"/api"}` |
+| `ListRoutes` | `{"type":"list_routes"}` (replies `Routes { rules }`) |
 | `ServiceLogs { service, lines }` | `{"type":"service_logs","service":"redis","lines":100}` |
 | `ListDatabases { service }` | `{"type":"list_databases","service":"mysql"}` |
 | `CreateDatabase` / `DropDatabase` | `{"type":"create_database","service":"mysql","name":"app"}` (and `drop_database`) |
@@ -249,7 +252,7 @@ pub enum Response {
     Error { code: ErrorCode, message: String },
     Parked { paths: Vec<String> },
     Info { dns_addr, tld, ca_path, ca_fingerprint, http_port, https_port },
-    PhpVersions { installed, default, updates, settings },
+    PhpVersions { installed, default, updates, settings, version_settings, directives, pool },
     AvailablePhp { available, installed, legacy },
     PhpExtensions { by_version },                  // version → [PhpExtInfo{name,path,zend,present}]
     Status { report: Box<StatusReport> },         // boxed: large payload
@@ -258,6 +261,7 @@ pub enum Response {
     Services { services: Vec<ServiceStatus> },
     AvailableServices { services: Vec<ServiceAvailability> },
     ServiceOverrides { overrides: BTreeMap<String, String> },  // name → value, in name order
+    Routes { rules: Vec<RouteRuleEntry> },        // every site's path-prefix routing rules
     ServiceLogs { lines: Vec<String> },
     Databases { databases: Vec<DatabaseSummary> },
     Mails { mails: Vec<MailSummary> },
@@ -320,6 +324,14 @@ no-`PROTOCOL_VERSION`-bump pattern as `web_subpath`.
 The proxy feature adds four mutators - `AddProxy { name, url }`, `RemoveProxy { name }`, `AddProxyRule { site, prefix, url }`, `RemoveProxyRule { site, prefix }` (all reply with the generic `Ok`) - and one query, `ListProxies`. Because a whole-host proxy is **not** a `Site`, it can't ride `Response::Sites`/`SiteEntry`; `ListProxies` gets a dedicated `Response::Proxies { proxies: Vec<ProxyEntry>, rules: Vec<ProxyRuleEntry> }` instead, where `ProxyEntry { name, target, secure, primary_domain, domains }` and `ProxyRuleEntry { site, prefix, target }` are built from plain `String`/`bool`/`Option<String>`/`Vec<String>`, so they satisfy the `PartialEq` that `Response` derives (see above: `Response` is `PartialEq` only, never `Eq`). New variants are additive by serde tag, so existing pins are byte-identical and no `PROTOCOL_VERSION` bump is needed. `url` stays a `String` on the wire; the daemon parses and validates it (returning a typed error) rather than the client.
 
 `ProxyEntry` later gained `primary_domain: Option<String>` and `domains: Vec<String>` (FQDNs) so a proxy can carry the extra domains, subdomains and wildcards [`yerd domain`](../reference/cli/domains) now gives it. Both use `#[serde(default, skip_serializing_if = ...)]` and are populated only for a **customised** proxy, so an uncustomised one serialises to the original three-field byte shape and an older client decodes it unchanged - the same additive, no-`PROTOCOL_VERSION`-bump pattern as `web_subpath` and `supports_overrides`. A proxy the router never inserted (one name-shadowed by a site) reports both as empty rather than the shadowing site's domains.
+:::
+
+::: info Routing rules are a separate surface from proxy rules
+Per-site [routing rules](../reference/cli/routes) add three variants - `AddRouteRule { site, prefix, target }` and `RemoveRouteRule { site, prefix }` (both reply with the generic `Ok`) plus the `ListRoutes` query, which gets its own `Response::Routes { rules: Vec<RouteRuleEntry> }`.
+
+`RouteRuleEntry { site, prefix, target }` is field-identical to `ProxyRuleEntry` and is deliberately **not** the same struct: `yerd-ipc` is a byte-pinned contract, so coupling two features' wire evolution to one type would make either one hard to change. The semantic difference is what the `target` is - a proxy rule's target is an HTTP upstream URL, a routing rule's target is a path relative to the site's *served root* (a nested `api/index.php`, or `index.html` for an SPA). The daemon validates it as a safe relative path; an absolute path or one containing `..` is refused.
+
+All three variants are additive by serde tag, so existing pins are byte-identical and no `PROTOCOL_VERSION` bump was needed.
 :::
 
 ### ErrorCode

--- a/docs/guide/desktop-app.md
+++ b/docs/guide/desktop-app.md
@@ -16,11 +16,11 @@ The sidebar opens on **Overview** and groups the rest:
 
 | Group | Pages |
 | --- | --- |
-| (top) | **Overview** - a live dashboard of what's running |
-| Environment | **PHP** · **Sites** |
-| Developer | **Tooling** · **Services** · **Mail** · **Dumps** |
+| General | **Overview** - a live dashboard of what's running · **About** |
+| Environment | **Sites** · **PHP** · **Services** |
+| Developer | **Tooling** · **Proxies** · **Mail** · **Dumps** |
 | Integrations | **Share** - publish a site over a public URL ([guide](./sharing)) |
-| System | **Settings** · **Doctor** · **About** |
+| System | **Settings** · **Doctor** |
 
 ### Overview
 
@@ -51,8 +51,9 @@ Manages your installed [PHP versions](./php-versions):
 - Refresh re-checks for updates. Update all updates every version with a pending update. Updates are notify-only.
 - Each row's `⋯` menu offers Restart (only when the pool is running or failed), Update (only when available), Set default (marks it with a star), and Uninstall. Restart all restarts every running pool.
 - A Default settings card edits the global ini defaults applied to every version: `memory_limit`, `max_execution_time`, `max_input_time`, `max_file_uploads`, `upload_max_filesize`, `post_max_size`, `error_reporting`, and `display_errors`. Leave a field blank to use PHP's built-in default. Saving restarts running pools to apply.
-- A Per-version configuration card lists your versions down the side, newest first. Picking one scopes everything to that version: a settings form overriding the defaults above (empty fields inherit), its custom extensions, and free-form ini directives. See [Per-version configuration](./php-versions#per-version-configuration).
+- A Per-version configuration card lists your versions down the side, newest first. Picking one scopes everything to that version: a settings form overriding the defaults above (empty fields inherit), its custom extensions, free-form ini directives, and its FPM pool size. See [Per-version configuration](./php-versions#per-version-configuration).
 - The Extensions section of that card registers extra `.so` extensions for the selected version (loaded into both FPM and the CLI): Add… browses for the file, optionally names it and toggles Zend extension. Each is load-probed before saving, and any whose file has gone missing is flagged. See [Custom extensions](./php-versions#custom-extensions).
+- **FPM pool size** sets how many PHP workers that version may run at once (`pm.max_children`, 1-1024, default 16). It applies to the web pool only, never the CLI. The pool is on-demand, so a higher ceiling costs nothing while idle - raise it when requests queue behind queue workers, parallel test runs, or long-lived streams. Saving restarts that version's pool. See [Pool size](./php-versions#pool-size).
 
 ### Sites
 
@@ -62,13 +63,24 @@ The home base for [managing sites](./sites). Polls the daemon every 5 seconds wh
 
 Parked folders. Each parked directory shows a count of the `.test` sites it produces (one per child directory). Park folder opens a native directory picker; each row's menu offers Reveal folder or Un-park (with confirmation).
 
-Sites. Every parked and linked site is a card: the `name.test` URL (click to open in your browser), the document root, and badges for kind (`parked`/`linked`), PHP version, HTTPS/HTTP, and the [served web root](./sites#web-root-the-served-directory) when it isn't the project root. A `+N` badge appears when the site answers extra domains beyond its apex, and an amber warning shows when another site claims this site's apex.
+Sites. Every parked and linked site is a card: the `name.test` URL (click to open in your browser), the document root, and badges for kind (`parked`/`linked`), PHP version, HTTPS/HTTP, and the [served web root](./sites#web-root-the-served-directory) when it isn't the project root. A `+N` badge appears when the site answers extra domains beyond its apex, and an amber warning shows when another site claims this site's apex. A WordPress site with one-click login enabled also gets a small chip that signs you straight into `wp-admin`.
 
-Each card's `⋯` menu offers **Edit…**, **Manage domains…** (set the primary domain, add or remove aliases and wildcards), Open in browser, Reveal folder, **Share publicly…** (jumps to the [Share page](#share)), and (linked sites only) Unlink. **Edit…** opens one dialog covering everything about the site: PHP version, web root (blank means auto-detect), the HTTPS toggle, and its [group](./sites#site-groups). Parked sites have no destructive action here; remove them by un-parking their folder, or they'd reappear.
+The card itself keeps only the inline shortcuts - open, the HTTPS lock, and that WordPress chip. **Everything else about a site lives in its details sidebar**, which the card's pencil button slides in from the right.
 
-Selecting a site opens its details sidebar, which includes an **Editor** row (macOS and Linux). It defaults to the Preferred editor set in [Settings](#settings), shown as `Use default (…)`; pick a specific editor there to override it for that one site, and the choice is remembered.
+The filter box above the list matches **any** domain a site answers, not just its name - typing `admin.` finds `codestash.test` when its only match is an added `admin.codestash.test`.
 
-Sites can also be organized into named, reorderable groups shown as collapsible sections on this page; see [Sites](./sites) for the full walkthrough.
+Sites can also be organized into named, reorderable groups shown as collapsible sections on this page; see [Sites](./sites) for the full walkthrough. The **Create** menu at the top of the page offers New Laravel site…, New WordPress site…, Link existing site, Park folder, and New group….
+
+#### The site details sidebar
+
+Four tabs, covering everything Yerd knows about one site:
+
+- **General.** An **Open site** button, then a row of actions - **Terminal** (opens your terminal in the project directory), the **editor** button (macOS and Linux), **Dumps** or **WP Admin** depending on the site, and **Share publicly…** (a [Cloudflare Quick Tunnel](#share)). Below them: PHP version, the **Editor** used for this site, the path (with reveal), the served web root (blank means auto-detect), the URL, the **HTTPS** toggle, **WordPress Auto Admin Login** with an admin picker on WordPress sites, its [group](./sites#site-groups), and - for a linked site only - **Unlink**. Parked sites have no destructive action here; remove them by un-parking their folder, or they'd reappear.
+- **Domains.** Set the primary domain and add or remove aliases, subdomains, and wildcards. See [Domains](../reference/cli/domains).
+- **Routing.** The **Route through front controller** switch (on: everything funnels through `index.php`, as Laravel and Symfony want; off: named `.php` files execute directly), and beneath it the per-prefix [routing rules](../reference/cli/routes) that carve exceptions out of that default - a nested `api/index.php`, or `index.html` for an SPA.
+- **Information.** A read-only summary: detected application, every domain the site answers, web root, kind, protocol, front-controller mode, and WordPress auto-login state.
+
+The **Editor** row defaults to the Preferred editor set in [Settings](#settings), shown as `Use default (…)`; pick a specific editor to override it for that one site, and the choice is remembered.
 
 ::: tip Untrusted CA banner
 If your local CA isn't trusted in the system store, the Sites view shows a banner (browsers will warn on HTTPS sites until fixed). It links to the **Doctor** page's Environment panel, where one click runs the fix. See [HTTPS & Certificates](./https).
@@ -80,11 +92,22 @@ If your local CA isn't trusted in the system store, the Sites view shows a banne
 
 Installs self-contained developer tools - Composer, Node, and Bun - onto your PATH alongside PHP, each managed by Yerd (install / update / uninstall) so they don't collide with system installs. See [Tooling](./tooling).
 
+### Proxies
+
+Puts a `.test` address in front of a service Yerd doesn't run itself. Two cards, matching the two shapes of [reverse proxy](./proxies):
+
+- **Whole-host proxies** - `reverb.test` → an upstream URL. Each row opens in the browser, toggles HTTPS, and has a **Manage domains** button giving the proxy extra domains, subdomains, and wildcards exactly as a site gets them; a customised proxy shows a `N domains · primary …` hint. Proxy names may be **dotted**, so a proxy's own address can be a subdomain (`api.account.test`).
+- **Path rules** - one path on an existing site forwarded to a service (`myapp.test/app` → Reverb), keeping everything same-origin.
+
+The **Add** menu creates either shape. See [Reverse Proxies](./proxies).
+
 ### Services
 
 <ThemedImage light="/images/services-light.png" dark="/images/services-dark.png" alt="Services page" />
 
-The database and cache engines Yerd supervises - Redis (Valkey), MySQL, MariaDB, and PostgreSQL. Install a version, then Start / Stop / Restart it. Each installed engine's `⋯` menu also offers **Configuration** (copy the Laravel `.env` for that engine - with a database picker that pre-fills `DB_DATABASE` for SQL engines), Edit port, View logs, **Manage databases** (create / drop / back up / restore, SQL engines only), Change version, and Uninstall. The daemon **auto-starts every installed engine** on boot. See [Services & Databases](./services).
+The database and cache engines Yerd supervises - Redis (Valkey), MySQL, MariaDB, and PostgreSQL. Install a version, then Start / Stop / Restart it. Each installed engine's `⋯` menu also offers **Configuration** (copy the Laravel `.env` for that engine - with a database picker that pre-fills `DB_DATABASE` for SQL engines), Edit port, **Override settings**, View logs, **Manage databases** (create / drop / back up / restore, SQL engines only), Change version, and Uninstall. The daemon **auto-starts every installed engine** on boot. See [Services & Databases](./services).
+
+**Override settings** opens a dialog listing the engine's stored [configuration overrides](./services#service-configuration-overrides) - free-form directives for its own config file, such as `max_allowed_packet` or `maxmemory-policy` - with an add form and a remove button per entry. Like Edit port, an override takes effect on the **next start or restart**, not immediately. The item only appears for the engines that have a config file to override; Meilisearch and Reverb are argv-driven, so they don't get it.
 
 ### Mail
 
@@ -159,7 +182,7 @@ The command palette also lists your sites at the bottom (grouped by domain): **O
 | Close window | `⌘W` | `Ctrl+W` | Hide the window to the tray |
 | Close dialog | `Esc` | `Esc` | Dismiss the open modal |
 
-`⌘1`…`⌘9` follow the sidebar order: **1** Overview, **2** PHP, **3** Sites, **4** Tooling, **5** Services, **6** Mail, **7** Dumps, **8** Settings, **9** Doctor.
+`⌘1`…`⌘9` are: **1** Overview, **2** PHP, **3** Sites, **4** Tooling, **5** Services, **6** Mail, **7** Dumps, **8** Settings, **9** Doctor. Proxies and About have no digit - reach them from the sidebar or the command palette.
 
 ::: info Quitting the app
 There's no Quit shortcut: closing the window (`⌘W` / `Ctrl+W`) hides it to the tray and leaves the daemon running, by design. Quit from the tray menu, or on macOS with the standard `⌘Q`.

--- a/docs/guide/diagnostics.md
+++ b/docs/guide/diagnostics.md
@@ -133,6 +133,7 @@ When nothing is wrong:
 | `ResolverBackupSaved` | `Ok` | Installing the resolver replaced a pre-existing `/etc/resolver/<tld>` (e.g. a Valet/Herd leftover); a timestamped backup was saved. `sudo yerd unelevate resolver` restores it automatically. | _(none)_ |
 | `NoSites` | `Ok` | No sites configured yet. | `yerd park <dir>` or `yerd link <name> <dir>` |
 | `DomainShadowed` | `Warn` | Two sites claim the same domain, so one was dropped from routing. Which site wins can depend on directory scan order, so it may change on restart (usually the result of a hand-edited config). | Make each site's domains unique with `yerd domain remove` or `yerd domain primary` |
+| `ServiceOverrideInvalid` | `Warn` | A line in a service's hand-edited `conf.d/50-local.<ext>` file names a directive Yerd manages itself, or reads as no directive at all. One finding per bad line, naming the file and line number. | Edit the file (Yerd never rewrites it), then `yerd service restart <SVC>` |
 | `AllGood` | `Ok` | Nothing else is wrong. | _(none)_ |
 
 ::: tip No false alarms

--- a/docs/guide/proxies.md
+++ b/docs/guide/proxies.md
@@ -37,6 +37,36 @@ yerd secure reverb
 
 Remove it with `yerd proxy remove reverb`.
 
+### Names and extra domains
+
+A proxy's name may be **dotted**, so its own address can be a subdomain:
+
+```sh
+yerd proxy add api.account http://127.0.0.1:9011
+# http://api.account.test/
+```
+
+Beyond that address, a whole-host proxy carries extra domains, subdomains, and
+wildcards exactly as a site does - through the same [`yerd domain`](../reference/cli/domains)
+commands, with the proxy name where a site name would go:
+
+```sh
+yerd proxy add account-dev http://127.0.0.1:48087
+yerd domain add account-dev custom-domain.test
+yerd domain add account-dev '*.account-dev.test'
+yerd domain primary account-dev custom-domain.test
+```
+
+`yerd proxy list` shows a customised proxy's domains beneath it and marks the
+primary; `yerd domain list` stays site-only. In the desktop app the same controls
+are the **Manage domains** button on the Proxies page.
+
+A domain can only be claimed by one site or proxy. If two claim the same one,
+every **site** is considered before any proxy, and a domain added explicitly
+beats a claim on a default apex - a proxy that loses one domain keeps its
+others, and [`yerd doctor`](../reference/cli/diagnostics) reports each contested
+domain with its winner.
+
 ## Path rules (the Reverb case)
 
 Attach a path to an existing site. Say `myapp` is a Laravel app and Reverb is

--- a/docs/guide/sites.md
+++ b/docs/guide/sites.md
@@ -360,6 +360,12 @@ The served path shows up in `yerd sites` (the `SERVED` column, `/` meaning the p
 A request that resolves to a real file under the served root (a stylesheet, image, `favicon.ico`, compiled JS, …) is returned straight from disk by the proxy, with a guessed `Content-Type` - it never touches PHP. A directory request (including the site root) falls back to `index.html` or `index.htm` from that directory when there's no `index.php` there, so a plain static site (no PHP at all) works with no extra configuration. Everything else is handed to the framework's front controller (`index.php`). PHP source files are never served as static bytes. A symlink is allowed to point anywhere inside the site's project directory - so Laravel's `public/storage -> ../storage/app/public` link works with no extra setup - but a symlink that escapes the project directory entirely is refused with an explicit `403 Forbidden` naming the requested path, rather than being silently handed to PHP.
 :::
 
+::: info Directory requests get a trailing-slash redirect
+On a site running in **direct** mode - front controller off, where named `.php` files are executable by URL - a `GET /sub` naming a real directory answers `301` to `/sub/`, exactly as Apache's `DirectorySlash` and nginx's `try_files $uri $uri/` do. The slashed form is then resolved normally: `sub/index.php` if it has one, otherwise `sub/index.html`. This is what makes a legacy multi-directory PHP app work - without it, `/sub` fell through to the *root* `index.php`, and an app whose root script redirects into the subdirectory looped until the browser gave up.
+
+Front-controller sites are deliberately unaffected: there, `/sub` is a framework route, not a directory. The redirect is also limited to `GET` and `HEAD`, so a `POST` is never redirected.
+:::
+
 ### Overriding the served path
 
 When detection guesses wrong, or you have an unconventional layout, set the served directory explicitly:

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -37,11 +37,12 @@ The exceptions are the two passthrough commands. Anything after [`coverage`](./c
 | [Sites](./sites) | `sites`, `park`, `unpark`, `link`, `unlink`, `root` |
 | [Domains](./domains) | `domain list`, `domain add`, `domain remove`, `domain primary`, `domain reset` |
 | [Proxies](./proxies) | `proxy add`, `proxy remove`, `proxy list` |
+| [Routing rules](./routes) | `route add`, `route remove`, `route list` |
 | [HTTPS](./https) | `secure`, `unsecure` |
-| [PHP](./php) | `use`, `install php`, `uninstall php`, `update php`, `restart php`, `list php`, `list parked`, `set php`, `unset php`, `php ext add`/`remove`/`list`, [`coverage`](./coverage) |
+| [PHP](./php) | `use`, `install php`, `uninstall php`, `update php`, `restart php`, `list php`, `list parked`, `set php`, `unset php`, `php ext add`/`remove`/`list`, `php ini set`/`unset`/`list`, `php pool set`/`unset`/`list`, [`coverage`](./coverage) |
 | [Exec and Which](./exec) | `exec php`, `exec composer`, `which php` |
 | [Tooling](./tooling) | `tools`, `install tool`, `uninstall tool`, `path install`, `path uninstall`, `path print` |
-| [Services](./services) | `services`, `service available`, `service install`, `service change-version`, `service uninstall`, `service start`, `service stop`, `service restart`, `service set-port`, `service logs` |
+| [Services](./services) | `services`, `service available`, `service install`, `service change-version`, `service uninstall`, `service start`, `service stop`, `service restart`, `service set-port`, `service set`, `service unset`, `service overrides`, `service logs`, `service add`, `service remove`, `service set-autostart`, `service set-site` |
 | [Databases](./db) | `db list`, `db create`, `db drop`, `db backup`, `db restore` |
 | [Mail](./mail) | `mail list`, `mail show`, `mail clear` |
 | [LAN sharing](./lan) | `lan enable`, `lan disable`, `lan status`, `remote-setup` |

--- a/docs/reference/cli/services.md
+++ b/docs/reference/cli/services.md
@@ -1,8 +1,9 @@
 # Services
 
 Yerd installs and supervises local database, cache, and search engines as native,
-per-user processes - no Docker. Each engine is identified by a short `id`:
-`redis`, `mysql`, `mariadb`, `postgres`, or `meilisearch`. The [Services & Databases
+per-user processes - no Docker. Each service is identified by a short `id`:
+`redis`, `mysql`, `mariadb`, `postgres`, `meilisearch`, or - per site -
+`reverb:<site>` (see [Instances](#instances)). The [Services & Databases
 guide](../../guide/services) covers the model in depth; this page is the command
 reference. For creating and managing the databases *inside* a SQL engine, see
 [Databases](./db).
@@ -133,6 +134,42 @@ and warns about reserved or malformed lines. See
 [Service configuration overrides](../../guide/services#service-configuration-overrides)
 for the two-file model, and the [Configuration
 Reference](../configuration#services-id) for how overrides are stored.
+
+## Instances
+
+The commands above address a service by its **wire id**. For an engine that only
+ever has one instance, the id is just the type (`mysql`, `redis`). Per-site types
+- Laravel Reverb today - can have one instance per site, and their ids carry the
+site: `reverb:blog`.
+
+| Command | Description | Example |
+| --- | --- | --- |
+| `yerd service add --type <TYPE> [--site <SITE>] [--port <PORT>] [--version <VERSION>] [--autostart on\|off]` | Add a new instance of a service type. | `yerd service add --type reverb --site blog` |
+| `yerd service remove <SVC> [--purge]` | Remove a per-site instance. Add `--purge` to delete its stored state too. | `yerd service remove reverb:blog` |
+| `yerd service set-autostart <SVC> on\|off` | Set whether the instance starts with Yerd. | `yerd service set-autostart redis off` |
+| `yerd service set-site <SVC> <SITE>` | Re-link a per-site instance to a different site. | `yerd service set-site reverb:blog shop` |
+
+```sh
+yerd service add --type reverb --site blog     # reverb:blog, on the next free port
+yerd service add --type postgres --version 17  # an engine instance, explicit version
+yerd service set-autostart reverb:blog on
+yerd service set-site reverb:blog shop         # becomes reverb:shop
+yerd service remove reverb:blog --purge
+```
+
+- `--type` is a type id (`redis`, `mysql`, `mariadb`, `postgres`, `meilisearch`,
+  `reverb`), not a wire id.
+- `--site` is **required** for a per-site type, and must name a **linked Laravel**
+  site (one with an `artisan` file). The instance runs against that site's PHP and
+  document root, which is why `--version` doesn't apply to it.
+- `--version` is required for a versioned type - `add` installs that version as
+  part of the call.
+- `--port` defaults to the next free loopback port at or above the type's default.
+  An explicit port already reserved by another instance is refused.
+- `--autostart` defaults per type: engines start with Yerd, per-site app servers
+  do not.
+- `remove` is for per-site instances. Removing an engine's *installed version* is
+  [`yerd service uninstall`](#installing-versioning).
 
 ## See also
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,30 +29,38 @@ Every field below maps one-to-one to a field in `schema.rs`. The on-disk shape a
 
 | Key         | TOML type            | Meaning                                                            | Default        |
 | ----------- | -------------------- | ----------------------------------------------------------------- | -------------- |
-| `version`   | integer              | On-disk schema version. **Mandatory**; written as `18` by this release. | `n/a (required)` |
+| `version`   | integer              | On-disk schema version. **Mandatory**; written as `23` by this release. | `n/a (required)` |
 | `tld`       | string               | TLD served by Yerd's resolver.                                    | `"test"`       |
 | `dns_port`  | integer (u16)        | Loopback port for the embedded `.test` DNS responder.             | `1053`         |
+| `update_channel` | string          | Self-update channel: `"stable"` or `"edge"`.                      | `"stable"`     |
 | `symlink_protection` | boolean     | Refuse to serve assets/scripts reached via a symlink resolving outside a site's document root. | `true` |
 | `mcp_enabled` | boolean            | Serve Yerd's tools to local AI agents over MCP (`yerd mcp`).       | `false`        |
+| `lan_enabled` | boolean            | Expose `.test` sites to other devices on the LAN ([`yerd lan`](cli/lan)). | `false`   |
+| `lan_setup_port` | integer (u16)   | Port for the LAN remote-device bootstrap endpoint.                 | `7073`         |
 | `ports`     | table                | HTTP / HTTPS listen ports.                                        | `80` / `443`   |
-| `php`       | table                | PHP defaults and global ini settings.                             | see below      |
+| `php`       | table                | PHP defaults, global ini settings, per-version overrides and pool settings. | see below |
 | `parked`    | table                | Parked directory paths.                                           | empty          |
 | `linked`    | array of tables      | Explicitly linked sites.                                          | empty          |
 | `overrides` | array of tables      | Per-site overrides for **parked** sites.                          | empty          |
 | `services`  | table                | Per-service `[services.<id>]` tables; every installed engine auto-starts on boot. | empty          |
 | `mail`      | table                | Built-in mail-capture SMTP server.                                | on / `2525`    |
 | `dumps`     | table                | Laravel ▸ Dumps telemetry settings.                               | off / `2304`   |
-| `domains`   | table                | Per-site domain sets (primary, aliases, subdomains, wildcards).   | empty          |
+| `tunnel`    | table                | Cloudflare Named Tunnel persistence.                              | empty          |
+| `groups`    | table                | User-defined site groups and per-site membership.                 | empty          |
+| `domains`   | table                | Per-site and per-proxy domain sets (primary, aliases, subdomains, wildcards). | empty |
+| `proxies`   | array of tables      | Whole-host reverse proxies (`reverb.test` → an upstream URL).      | empty          |
+| `proxy_rules` | table              | Per-site path-prefix reverse-proxy rules.                         | empty          |
+| `route_rules` | table              | Per-site path-prefix routing rules (prefix → a file inside the site). | empty       |
 
 ::: warning Unknown keys are rejected
-The parser uses `deny_unknown_fields` at every level. A typo'd or stray key (top-level, or inside `[ports]`, `[php]`, `[parked]`, `[mail]`, `[dumps]`, `[dumps.features]`, `[domains]`, a `[domains.linked.<name>]` / `[domains.parked."<docroot>"]` entry, `[proxy_rules]`, a `[[proxies]]` entry, a `[services.<id>]` table, a `[[linked]]` entry, an `[[overrides]]` entry, or a `[[php.extensions.<version>]]` entry) is a hard parse error - the daemon will refuse to load the file rather than silently ignore it.
+The parser uses `deny_unknown_fields` at every level. A typo'd or stray key (top-level, or inside `[ports]`, `[php]`, `[parked]`, `[mail]`, `[dumps]`, `[dumps.features]`, `[domains]`, a `[domains.linked.<name>]` / `[domains.parked."<docroot>"]` / `[domains.proxy.<name>]` entry, `[proxy_rules]`, `[route_rules]`, a `[[proxies]]` entry, a `[services.<id>]` table, a `[[linked]]` entry, an `[[overrides]]` entry, or a `[[php.extensions.<version>]]` entry) is a hard parse error - the daemon will refuse to load the file rather than silently ignore it.
 
 The free-form maps are the exception, because their keys *are* the data. `[services.<id>.overrides]` (like `[php.directives."<version>"]`) takes arbitrary directive names, so `deny_unknown_fields` does not apply *inside* it - the keys are shape-checked instead, and a bad one is dropped rather than failing the load. It still applies to the enclosing `[services.<id>]` table.
 :::
 
 ### `version`
 
-The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `18`, and Yerd always writes `version = 18`. Older `version = 1` through `version = 17` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
+The schema version. This key is **required** - a missing `version` is a hard error (`MissingVersion`), and a non-integer or negative value is rejected (`NonIntegerVersion`). The current schema version is `23`, and Yerd always writes `version = 23`. Older `version = 1` through `version = 22` files are migrated forward automatically on load. See [Schema versioning](#schema-versioning-and-migration) below.
 
 ### `tld`
 
@@ -538,9 +546,56 @@ pointing at a `.<tld>` host). Collisions with parked sites and the
 loopback-on-own-port loop guard are enforced by the daemon, which alone knows
 the actively bound ports and sees parked sites on disk.
 
+### `[route_rules]`
+
+Per-site path-prefix **routing** rules (schema v21) - URIs under a prefix that
+match no real file are handled by a target *inside the site*. **Empty by
+default** (the whole table is omitted) until you add a rule. Split by site class
+exactly like `[proxy_rules]` and `[domains]`: linked rules key by site name,
+parked rules by byte-exact document-root, so routing survives a directory
+rename.
+
+| Key                    | TOML type                       | Meaning                                       |
+| ---------------------- | ------------------------------- | --------------------------------------------- |
+| `[route_rules.linked]` | table (`name → array of rules`) | Rules for **linked** sites, keyed by name.    |
+| `[route_rules.parked]` | table (`docroot → array`)       | Rules for **parked** sites, keyed by docroot. |
+
+Each rule is a `{ prefix, target }` table, where `target` is a path **relative to
+the site's served root**. Removing a site's last rule drops its key entirely, so
+the file round-trips byte-identically.
+
+```toml
+# A legacy portal with a nested Yii/CodeIgniter API at /api
+[[route_rules.linked.portal]]
+prefix = "/api"
+target = "api/index.php"
+
+# A JavaScript SPA: history-API deep links serve the app shell
+[[route_rules.linked.dashboard]]
+prefix = "/"
+target = "index.html"
+```
+
+A rule applies only when the request matched no real file - exactly nginx's
+`try_files $uri $uri/ <target>`. A `.php` target runs as a nested front
+controller and accepts every HTTP method; anything else is served as a static
+document and answers only `GET`/`HEAD`. The `target` is validated as a **safe
+relative path** at load, so a hand-edited absolute path or one containing `..` is
+a hard parse error rather than a silent security hole.
+
+::: warning Not the same as `[proxy_rules]`
+A proxy rule forwards to a separate running HTTP service; a routing rule resolves
+to a file inside the site's own tree. When a site has both on the same prefix,
+the proxy rule wins - it intercepts before PHP resolution runs at all.
+:::
+
+Manage these with [`yerd route`](cli/routes), or the **Routing** tab of the
+desktop app's site details sidebar. A site whose web root holds an `index.html`
+and no `index.php` gets SPA routing automatically, with no rule stored here.
+
 ## Schema versioning and migration
 
-Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `18`.
+Every config file **must** carry a top-level `version = N` key - it is the single trigger for forward migration. The current schema version is `23`.
 
 When the daemon loads a file, it routes on the version it finds:
 
@@ -571,6 +626,9 @@ A file written by a *newer* Yerd than you are running is refused rather than mis
 - **`v17 → v18`** is a bare version bump: v18 only **added** the optional `[php.directives]` table (free-form per-version ini directives), which defaults to empty when absent.
 - **`v18 → v19`** is a bare version bump: v19 only **added** the top-level `lan_enabled` and `lan_setup_port` scalars (LAN exposure and its remote-setup port), which default to `false` / `7073` when absent.
 - **`v19 → v20`** is a bare version bump: v20 only **added** the optional `[php.pool]` table (per-version FPM pool settings), which defaults to empty when absent.
+- **`v20 → v21`** is a bare version bump: v21 only **added** the optional `[route_rules]` table (per-site path-prefix routing rules), which defaults to empty when absent.
+- **`v21 → v22`** is a bare version bump: v22 only **added** the optional `[services.<id>.overrides]` sub-table (free-form engine config directives), which defaults to empty when absent.
+- **`v22 → v23`** is a bare version bump: v23 only **added** the optional `[domains.proxy]` table (routable-domain deltas for whole-host proxies), which defaults to empty when absent.
 
 The on-disk schema version is deliberately decoupled from the IPC protocol version; the two evolve independently.
 
@@ -594,11 +652,11 @@ Yerd does not `fsync` the file or its parent directory after a save. For a devel
 
 ## A complete annotated example
 
-This is a valid `yerd.toml` covering the core fields (see the sections above for the newer optional tables - `update_channel`, `[tunnel]`, `[groups]`, `[php.extensions]`, `[domains]`, `[[proxies]]`, `[proxy_rules]`, `wp_auto_login` - omitted here for brevity):
+This is a valid `yerd.toml` covering the core fields (see the sections above for the newer optional tables - `update_channel`, `[tunnel]`, `[groups]`, `[php.extensions]`, `[php.pool]`, `[domains]`, `[[proxies]]`, `[proxy_rules]`, `[route_rules]`, `[services.<id>.overrides]`, `wp_auto_login` - omitted here for brevity):
 
 ```toml
-# Schema version - mandatory, always written as 18 by this release.
-version = 18
+# Schema version - mandatory, always written as 23 by this release.
+version = 23
 
 # TLD served by the resolver; sites resolve as <name>.test
 tld = "test"


### PR DESCRIPTION
<!-- Thanks for contributing to Yerd! Please fill in the sections below. -->

## What does this PR do?

Reviews every commit since the v2.0.4 release and updates the developer docs, CLI reference, config reference, and UI guide to match what actually shipped.

- Undocumented features documented — the site details sidebar (#190/#216), the direct-mode trailing-slash 301 (#199), and the macOS certutil resolution fix (#206) had no docs at all.
- Partial coverage completed — routing rules (#202) gained their IPC surface, [route_rules] config table, and crate-level docs; service overrides (#204) gained yerd-core/yerd-services/yerd-doctor coverage and the new ServiceOverrideInvalid finding; proxy domains (#205) gained the user-facing guide; FPM streaming (#214) replaced the stale buffer-until-END_REQUEST description.
- Stale references corrected — config schema version was still documented as 18 (now 23), yerd-config's CURRENT_VERSION as 11, cross-platform.md still called NSS trust "planned", and gui.md referenced a component renamed three commits ago.
- Module maps refreshed — yerd-core, yerd-proxy, yerd-services, yerd-platform, and both binaries were missing modules added over the last three weeks.
- CLI reference completed — added the Routing rules group, php ini/php pool, and the previously undocumented service add/remove/set-autostart/set-site commands.

Docs-only; npm run build passes and every new cross-page anchor was verified against the generated HTML.

## Related issues

n/a

## Type of change

- [x] Documentation

## Platforms tested

n/a

## Checklist

n/a

@coderabbitai ignore
