### PR TITLE
[Fix] Native zoom animation for macOS window maximize

### DIFF
--- a/apps/yerd-gui/src-tauri/Cargo.toml
+++ b/apps/yerd-gui/src-tauri/Cargo.toml
@@ -83,7 +83,7 @@ block2           = "0.6"
 # (`DispatchQueue::main().exec_async`) so the login-launch probe is authoritative
 # — `run_on_main_thread` would run inline on the main thread and lose the race.
 dispatch2        = "0.3"
-objc2-app-kit    = { version = "0.3", features = ["NSApplication", "NSImage", "NSResponder", "NSGraphics", "objc2-core-foundation"] }
+objc2-app-kit    = { version = "0.3", features = ["NSAnimation", "NSApplication", "NSImage", "NSResponder", "NSGraphics", "NSScreen", "NSWindow", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3", features = ["NSData", "NSString", "NSError", "objc2-core-foundation"] }
 # In-process user-domain CA trust (mac_trust.rs). Versions track what
 # yerd-platform already resolves, so no duplicate compiles. `core-foundation`

--- a/apps/yerd-gui/src-tauri/src/mac_zoom.rs
+++ b/apps/yerd-gui/src-tauri/src/mac_zoom.rs
@@ -1,0 +1,303 @@
+//! Window zoom for Yerd's borderless macOS windows.
+//!
+//! Every Yerd window is `decorations: false`, so its `NSWindow` carries no
+//! `Titled` style mask and tao refuses the native `zoom:` path. Its fallback,
+//! `setFrame:display:NO animate:YES`, is wrong twice over: it suppresses redraw,
+//! and it animates *synchronously*, blocking the main thread in a nested run
+//! loop for the whole animation. The webview renders out of process, so it
+//! cannot deliver a repaint until that returns - and because the window is
+//! `transparent: true`, the not-yet-painted area a growing window exposes is
+//! see-through. The result reads as the old-size window sliding into the corner
+//! and snapping to size, while shrinking (which only ever clips) looks fine.
+//!
+//! Animating through the `animator` proxy instead keeps the run loop turning,
+//! so the webview repaints as the frame moves and the window grows and shrinks
+//! like any other.
+//!
+//! State stays consistent with tao: for a borderless window its `is_maximized`
+//! compares the window frame against the screen's visible frame, which is the
+//! frame this module zooms to.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use objc2_app_kit::{NSAnimatablePropertyContainer, NSWindow, NSWindowStyleMask};
+use objc2_foundation::{NSPoint, NSRect, NSSize};
+use tauri::{Manager, WebviewWindow};
+
+/// How long a scheduled frame animation is assumed to still be running. AppKit's
+/// implicit animation duration is 0.25s; the margin only has to outlast that.
+const ANIMATION_SETTLE: Duration = Duration::from_millis(400);
+
+/// Per-window zoom bookkeeping, keyed by window label. `NSRect` is plain `f64`
+/// geometry, so it crosses the mutex freely.
+static ZOOM_STATES: OnceLock<Mutex<HashMap<String, ZoomState>>> = OnceLock::new();
+
+/// What this module has asked of one window.
+#[derive(Clone, Copy, Default)]
+struct ZoomState {
+    /// The frame to un-zoom to, saved on the way into a zoom.
+    restore: Option<NSRect>,
+    /// The frame the last animation was asked to produce, and when. While that
+    /// animation runs, `NSWindow::frame` interpolates towards it, so a toggle
+    /// arriving mid-flight has to reason about the target instead of the live
+    /// frame - otherwise it reads a half-grown window as "not zoomed" and
+    /// overwrites `restore` with that intermediate rect.
+    target: Option<(NSRect, Instant)>,
+}
+
+impl ZoomState {
+    /// The frame the window is settling on, if an animation could still be in
+    /// flight. `None` once it has settled, when the live frame is authoritative
+    /// again (the user may have moved or resized the window since).
+    fn in_flight_target(&self, now: Instant) -> Option<NSRect> {
+        self.target
+            .filter(|(_, since)| now.duration_since(*since) < ANIMATION_SETTLE)
+            .map(|(target, _)| target)
+    }
+}
+
+/// Zoom `window` to its screen's visible frame, or back to the frame it had
+/// before the last zoom. Runs on the main thread, where AppKit requires it, and
+/// returns as soon as the animation is scheduled rather than driving it.
+pub(crate) fn toggle(window: &WebviewWindow) {
+    let owned = window.clone();
+    let _ = window.run_on_main_thread(move || toggle_on_main(&owned));
+}
+
+fn toggle_on_main(window: &WebviewWindow) {
+    let Some(ns_window) = ns_window(window) else {
+        return;
+    };
+    if ns_window
+        .styleMask()
+        .contains(NSWindowStyleMask::FullScreen)
+    {
+        return;
+    }
+    let Some(screen) = ns_window.screen() else {
+        return;
+    };
+
+    let mut state = load_state(window.label());
+    let target = next_target(
+        &mut state,
+        ns_window.frame(),
+        screen.visibleFrame(),
+        configured_size(window),
+        Instant::now(),
+    );
+    store_state(window.label(), state);
+
+    let Some(target) = target else {
+        return;
+    };
+    ns_window.animator().setFrame_display(target, true);
+}
+
+/// Decide the frame a toggle should animate to, advancing `state`. Returns
+/// `None` when there is nothing to un-zoom to.
+///
+/// Pure: the caller supplies the live frame, the screen's visible frame and the
+/// window's configured size, so the whole decision is unit-testable without
+/// AppKit.
+fn next_target(
+    state: &mut ZoomState,
+    frame: NSRect,
+    visible: NSRect,
+    configured: Option<NSSize>,
+    now: Instant,
+) -> Option<NSRect> {
+    let current = state.in_flight_target(now).unwrap_or(frame);
+    let target = if is_zoomed(current, visible) {
+        match state.restore.take() {
+            Some(restored) => restored,
+            None => centered(configured?, visible),
+        }
+    } else {
+        state.restore = Some(current);
+        visible
+    };
+    state.target = Some((target, now));
+    Some(target)
+}
+
+/// Borrow the window's live `NSWindow`.
+fn ns_window(window: &WebviewWindow) -> Option<&NSWindow> {
+    let ptr = window.ns_window().ok()?;
+    if ptr.is_null() {
+        return None;
+    }
+    // SAFETY: ns_window() returns the window's live NSWindow pointer, and every
+    // caller is already on the main thread (toggle() dispatches there), where
+    // AppKit window access must happen.
+    Some(unsafe { &*ptr.cast::<NSWindow>() })
+}
+
+/// Whether the window already fills its screen's visible frame. Mirrors tao's
+/// borderless `is_maximized` check - including its 1pt tolerance - so
+/// `Window::is_maximized` and this module never disagree.
+fn is_zoomed(frame: NSRect, visible: NSRect) -> bool {
+    (frame.size.width - visible.size.width).abs() < 1.0
+        && (frame.size.height - visible.size.height).abs() < 1.0
+}
+
+fn load_state(label: &str) -> ZoomState {
+    ZOOM_STATES
+        .get_or_init(Mutex::default)
+        .lock()
+        .ok()
+        .and_then(|states| states.get(label).copied())
+        .unwrap_or_default()
+}
+
+fn store_state(label: &str, state: ZoomState) {
+    if let Ok(mut states) = ZOOM_STATES.get_or_init(Mutex::default).lock() {
+        states.insert(label.to_owned(), state);
+    }
+}
+
+/// The window's declared size from `tauri.conf.json`, in points (AppKit
+/// geometry and Tauri's logical sizes share a unit). Un-zooming falls back to
+/// it, centred, for a window zoomed by something other than this module - macOS
+/// window tiling fills the visible frame exactly, which `is_zoomed` cannot tell
+/// apart from our own zoom.
+fn configured_size(window: &WebviewWindow) -> Option<NSSize> {
+    window
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|cfg| cfg.label == window.label())
+        .map(|cfg| NSSize::new(cfg.width, cfg.height))
+}
+
+fn centered(size: NSSize, visible: NSRect) -> NSRect {
+    let origin = NSPoint::new(
+        visible.origin.x + (visible.size.width - size.width) / 2.0,
+        visible.origin.y + (visible.size.height - size.height) / 2.0,
+    );
+    NSRect::new(origin, size)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{centered, is_zoomed, next_target, ZoomState, ANIMATION_SETTLE};
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+    use std::time::{Duration, Instant};
+
+    const VISIBLE: NSRect = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 875.0));
+    const CONFIGURED: NSSize = NSSize::new(1040.0, 860.0);
+
+    fn rect(x: f64, y: f64, w: f64, h: f64) -> NSRect {
+        NSRect::new(NSPoint::new(x, y), NSSize::new(w, h))
+    }
+
+    fn same(a: NSRect, b: NSRect) -> bool {
+        a.origin.x == b.origin.x
+            && a.origin.y == b.origin.y
+            && a.size.width == b.size.width
+            && a.size.height == b.size.height
+    }
+
+    /// One toggle at `now`, with `frame` as the window's live frame.
+    fn toggle(state: &mut ZoomState, frame: NSRect, now: Instant) -> Option<NSRect> {
+        next_target(state, frame, VISIBLE, Some(CONFIGURED), now)
+    }
+
+    #[test]
+    fn is_zoomed_matches_the_visible_frame_within_a_point() {
+        let visible = rect(0.0, 0.0, 1440.0, 875.0);
+        for (frame, expected) in [
+            (visible, true),
+            (rect(0.0, 0.0, 1439.5, 874.5), true),
+            (rect(200.0, 100.0, 1440.0, 875.0), true),
+            (rect(0.0, 0.0, 1438.0, 875.0), false),
+            (rect(0.0, 0.0, 1440.0, 800.0), false),
+            (rect(0.0, 0.0, 1040.0, 860.0), false),
+        ] {
+            assert_eq!(is_zoomed(frame, visible), expected);
+        }
+    }
+
+    #[test]
+    fn centered_places_the_window_in_the_middle_of_the_visible_frame() {
+        let visible = rect(100.0, 50.0, 1440.0, 900.0);
+        let frame = centered(NSSize::new(1040.0, 860.0), visible);
+        assert_eq!(frame.origin.x, 300.0);
+        assert_eq!(frame.origin.y, 70.0);
+        assert_eq!(frame.size.width, 1040.0);
+        assert_eq!(frame.size.height, 860.0);
+    }
+
+    #[test]
+    fn a_settled_toggle_round_trips_through_the_original_frame() {
+        let mut state = ZoomState::default();
+        let original = rect(80.0, 60.0, 1040.0, 860.0);
+        let now = Instant::now();
+
+        let zoomed = toggle(&mut state, original, now).expect("zooms");
+        assert!(same(zoomed, VISIBLE));
+
+        let settled = now + ANIMATION_SETTLE;
+        let restored = toggle(&mut state, VISIBLE, settled).expect("restores");
+        assert!(same(restored, original));
+    }
+
+    #[test]
+    fn a_toggle_mid_animation_reverses_it_without_losing_the_original_frame() {
+        let mut state = ZoomState::default();
+        let original = rect(80.0, 60.0, 1040.0, 860.0);
+        let now = Instant::now();
+
+        toggle(&mut state, original, now);
+
+        let mid_zoom = rect(40.0, 30.0, 1240.0, 868.0);
+        let reversed = toggle(&mut state, mid_zoom, now + Duration::from_millis(100))
+            .expect("reverses the zoom");
+        assert!(same(reversed, original));
+
+        let mid_restore = rect(60.0, 45.0, 1140.0, 864.0);
+        let rezoomed =
+            toggle(&mut state, mid_restore, now + Duration::from_millis(200)).expect("re-zooms");
+        assert!(same(rezoomed, VISIBLE));
+
+        let settled = now + Duration::from_millis(200) + ANIMATION_SETTLE;
+        let restored = toggle(&mut state, VISIBLE, settled).expect("restores");
+        assert!(same(restored, original));
+    }
+
+    #[test]
+    fn a_window_zoomed_by_the_system_restores_to_its_configured_size() {
+        let mut state = ZoomState::default();
+
+        let restored = toggle(&mut state, VISIBLE, Instant::now()).expect("restores");
+        assert!(same(restored, centered(CONFIGURED, VISIBLE)));
+    }
+
+    #[test]
+    fn a_manual_resize_after_the_animation_settles_is_taken_at_face_value() {
+        let mut state = ZoomState::default();
+        let original = rect(80.0, 60.0, 1040.0, 860.0);
+        let now = Instant::now();
+
+        toggle(&mut state, original, now);
+
+        let dragged = rect(10.0, 20.0, 700.0, 500.0);
+        let settled = now + ANIMATION_SETTLE;
+        let zoomed = toggle(&mut state, dragged, settled).expect("zooms");
+        assert!(same(zoomed, VISIBLE));
+
+        let restored = toggle(&mut state, VISIBLE, settled + ANIMATION_SETTLE).expect("restores");
+        assert!(same(restored, dragged));
+    }
+
+    #[test]
+    fn an_unconfigured_window_zoomed_by_the_system_is_left_alone() {
+        let mut state = ZoomState::default();
+
+        assert!(next_target(&mut state, VISIBLE, VISIBLE, None, Instant::now()).is_none());
+    }
+}

--- a/apps/yerd-gui/src-tauri/src/main.rs
+++ b/apps/yerd-gui/src-tauri/src/main.rs
@@ -12,6 +12,8 @@ mod launch_probe;
 mod logging;
 #[cfg(target_os = "macos")]
 mod mac_trust;
+#[cfg(target_os = "macos")]
+mod mac_zoom;
 mod mail_window;
 #[cfg(target_os = "macos")]
 mod smappservice;
@@ -185,6 +187,7 @@ fn main() {
             commands::job_cancel,
             commands::save_mail_attachment,
             show_dumps_window,
+            toggle_window_zoom,
             daemon::daemon_installed,
             daemon::daemon_diagnostics,
             daemon::start_daemon,
@@ -593,6 +596,18 @@ pub(crate) fn show_dumps(app: &tauri::AppHandle) -> tauri::Result<()> {
 fn show_dumps_window(app: tauri::AppHandle) -> Result<(), crate::error::GuiError> {
     show_dumps(&app)
         .map_err(|e| crate::error::GuiError::internal(format!("failed to show dumps window: {e}")))
+}
+
+/// Toggle the calling window between zoomed and restored, without the frame
+/// animation tao applies to a decorationless window (see `mac_zoom`). Registered
+/// on every platform so the handler list stays platform-independent; the
+/// frontend only calls it on macOS, where it is the titlebar's zoom path.
+#[tauri::command]
+fn toggle_window_zoom(window: tauri::WebviewWindow) {
+    #[cfg(target_os = "macos")]
+    mac_zoom::toggle(&window);
+    #[cfg(not(target_os = "macos"))]
+    let _ = window;
 }
 
 /// Show or hide the app's Dock presence by flipping the macOS activation policy:

--- a/apps/yerd-gui/src/components/TitleBar.spec.ts
+++ b/apps/yerd-gui/src/components/TitleBar.spec.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   onResized: vi.fn(),
   hostPlatform: vi.fn(),
   setGuiMaximized: vi.fn(),
+  toggleWindowZoom: vi.fn(),
   resized: null as null | (() => void),
 }));
 
@@ -32,6 +33,7 @@ vi.mock("@tauri-apps/api/window", () => ({
 vi.mock("@/ipc/client", () => ({
   hostPlatform: mocks.hostPlatform,
   setGuiMaximized: mocks.setGuiMaximized,
+  toggleWindowZoom: mocks.toggleWindowZoom,
   getTitleBarStyle: vi.fn(async () => "auto"),
   setTitleBarStyle: vi.fn(async () => {}),
 }));
@@ -59,6 +61,14 @@ async function flushMicrotasks(times = 10): Promise<void> {
 
 let wrapper: ReturnType<typeof mount> | null = null;
 
+/** A click's press/release pair. `detail` is read-only on a `UIEvent`, so the
+ *  click count has to come from the constructor rather than `trigger()`. */
+function pressAndRelease(el: Element, detail: number): void {
+  for (const type of ["mousedown", "mouseup"]) {
+    el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, detail }));
+  }
+}
+
 /**
  * Mount the titlebar on a host that reports a reliable maximized state
  * (`linux`), then clear the mounted-time calls so each test counts only its
@@ -68,6 +78,18 @@ async function mountTitleBar() {
   wrapper = mount(TitleBar);
   await flushMicrotasks();
   mocks.isMaximized.mockClear();
+  return wrapper;
+}
+
+/**
+ * Mount the titlebar for a given host, attached to the document so events
+ * bubble as far as the document-level listener Tauri's drag-region script
+ * installs in a real webview.
+ */
+async function mountOn(platform: string) {
+  mocks.hostPlatform.mockResolvedValue(platform);
+  wrapper = mount(TitleBar, { attachTo: document.body });
+  await flushMicrotasks();
   return wrapper;
 }
 
@@ -84,6 +106,7 @@ beforeEach(() => {
   });
   mocks.hostPlatform.mockResolvedValue("linux");
   mocks.setGuiMaximized.mockResolvedValue(undefined);
+  mocks.toggleWindowZoom.mockResolvedValue(undefined);
   vi.useFakeTimers();
 });
 
@@ -140,5 +163,69 @@ describe("TitleBar resize debounce", () => {
 
     await vi.advanceTimersByTimeAsync(DEBOUNCE_MS * 4);
     expect(mocks.isMaximized).not.toHaveBeenCalled();
+  });
+});
+
+describe("TitleBar zoom gesture", () => {
+  it("zooms through the host command on macOS", async () => {
+    const w = await mountOn("macos");
+
+    await w.get('button[aria-label="Zoom"]').trigger("click");
+    await flushMicrotasks();
+
+    expect(mocks.toggleWindowZoom).toHaveBeenCalledOnce();
+    expect(mocks.toggleMaximize).not.toHaveBeenCalled();
+  });
+
+  it("keeps Tauri's own maximize off macOS", async () => {
+    const w = await mountOn("linux");
+
+    await w.get('button[aria-label="Maximize"]').trigger("click");
+    await flushMicrotasks();
+
+    expect(mocks.toggleMaximize).toHaveBeenCalledOnce();
+    expect(mocks.toggleWindowZoom).not.toHaveBeenCalled();
+  });
+
+  it("zooms on a double click on the bar, but not through a control", async () => {
+    const w = await mountOn("macos");
+
+    await w.get("header").trigger("dblclick");
+    await flushMicrotasks();
+    expect(mocks.toggleWindowZoom).toHaveBeenCalledOnce();
+
+    await w.get('button[aria-label="Zoom"]').trigger("dblclick");
+    await flushMicrotasks();
+    expect(mocks.toggleWindowZoom).toHaveBeenCalledOnce();
+  });
+
+  it("zooms on a double click in the gaps around the controls", async () => {
+    const w = await mountOn("macos");
+
+    const controls = w.get('button[aria-label="Close"]').element.parentElement;
+    expect(controls).not.toBeNull();
+    controls?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    await flushMicrotasks();
+
+    expect(mocks.toggleWindowZoom).toHaveBeenCalledOnce();
+  });
+
+  it("hides a double click's press and release from the drag region", async () => {
+    const w = await mountOn("macos");
+    const seen: string[] = [];
+    const record = (e: Event) => seen.push(`${e.type}:${(e as MouseEvent).detail}`);
+    document.addEventListener("mousedown", record);
+    document.addEventListener("mouseup", record);
+
+    try {
+      pressAndRelease(w.get("header").element, 1);
+      expect(seen).toEqual(["mousedown:1", "mouseup:1"]);
+
+      pressAndRelease(w.get("header").element, 2);
+      expect(seen).toEqual(["mousedown:1", "mouseup:1"]);
+    } finally {
+      document.removeEventListener("mousedown", record);
+      document.removeEventListener("mouseup", record);
+    }
   });
 });

--- a/apps/yerd-gui/src/components/TitleBar.vue
+++ b/apps/yerd-gui/src/components/TitleBar.vue
@@ -3,14 +3,15 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import { Copy, Minus, Plus, Square, X } from "lucide-vue-next";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import logoUrl from "@/assets/logo.svg";
-import { hostPlatform, setGuiMaximized } from "@/ipc/client";
+import { hostPlatform, setGuiMaximized, toggleWindowZoom } from "@/ipc/client";
 import { useTitleBarStyle } from "@/lib/titleBarStyle";
 import { supportsReliableMaximizedState } from "@/lib/windowState";
 
 // The window is decorationless (see tauri.conf.json) so we draw our own
 // titlebar. It's a `data-tauri-drag-region`, giving native click-drag-to-move
-// and double-click-to-zoom for free; the controls below opt out by being their
-// own (non-drag) elements.
+// for free; the controls below opt out by being their own (non-drag) elements.
+// Double-click-to-zoom is handled here rather than by the drag region - see
+// `toggleMaximize`.
 //
 // `title` lets a secondary window (the Mails viewer) reuse this bar with its own
 // caption; the optional `actions` slot draws window-scoped buttons on the right
@@ -149,9 +150,54 @@ function scheduleMaximizedRefresh(): void {
   }, 150);
 }
 
+/**
+ * Zoom/restore the window. macOS goes through `toggle_window_zoom`: our windows
+ * are decorationless, and for those Tauri's `toggleMaximize` animates the frame
+ * with redraw suppressed - the window appears to slide to the screen corner at
+ * its old size, then snap to full size when the animation ends. The command
+ * runs the same animation with the window actually drawn.
+ *
+ * That command schedules the animation and returns, so there is no settled
+ * frame to read afterwards - the macOS branch leaves the state refresh to
+ * `onResized`'s debounce rather than sampling a frame mid-flight.
+ */
 async function toggleMaximize(): Promise<void> {
-  await win.toggleMaximize();
+  try {
+    if (platform.value === "macos") {
+      await toggleWindowZoom();
+      return;
+    }
+    await win.toggleMaximize();
+  } catch {
+    return;
+  }
   refreshMaximized();
+}
+
+/**
+ * Keep the titlebar the single owner of double-click-to-zoom. Tauri's
+ * drag-region script listens on `document` and runs its own
+ * `internal_toggle_maximize` for a titlebar double click: on macOS that is the
+ * animated path `toggleMaximize` exists to avoid, and on every host it is a
+ * second toggle racing this one. Stopping the second press and release before
+ * they reach that listener leaves `onTitleBarDoubleClick` in sole control.
+ */
+function stopNativeZoomGesture(event: MouseEvent): void {
+  if (event.detail === 2) event.stopPropagation();
+}
+
+/** The clickable elements a double click must not zoom through. Mirrors the set
+ *  Tauri's drag-region script treats as blocking a drag. */
+const INTERACTIVE_SELECTOR =
+  "a, button, input, select, textarea, label, summary, [contenteditable=true]";
+
+/** Double-clicking the bar zooms, including the gaps around the controls, but a
+ *  double click *on* a control (a traffic light, a slotted action) belongs to
+ *  that control alone. */
+function onTitleBarDoubleClick(event: MouseEvent): void {
+  const target = event.target;
+  if (target instanceof Element && target.closest(INTERACTIVE_SELECTOR)) return;
+  void toggleMaximize();
 }
 
 // macOS-only: real traffic lights drop to a flat gray while the window is
@@ -256,7 +302,9 @@ function controlButtonClass(kind: ControlKind): string {
   <header
     data-tauri-drag-region
     class="relative flex h-8 w-full shrink-0 items-center border-b bg-muted px-3 text-foreground dark:bg-card"
-    @dblclick="toggleMaximize"
+    @mousedown="stopNativeZoomGesture"
+    @mouseup="stopNativeZoomGesture"
+    @dblclick="onTitleBarDoubleClick"
   >
     <!-- macOS: traffic lights (close / minimize / zoom). Colored while the
          window is focused, flat gray otherwise; glyphs revealed on hover. -->

--- a/apps/yerd-gui/src/ipc/client.ts
+++ b/apps/yerd-gui/src/ipc/client.ts
@@ -1136,6 +1136,16 @@ export async function setGuiMaximized(maximized: boolean): Promise<void> {
   await call<void>("set_gui_maximized", { maximized });
 }
 
+/**
+ * macOS: zoom the calling window, or restore it, with the native frame
+ * animation. Tauri's own maximize animates a decorationless window's frame with
+ * redraw suppressed, which reads as the window sliding to the screen corner at
+ * its old size before snapping to full size.
+ */
+export async function toggleWindowZoom(): Promise<void> {
+  await call<void>("toggle_window_zoom");
+}
+
 /** Return supported IDEs detected on the host. */
 export async function getInstalledIdes(): Promise<IdeOption[]> {
   return call<IdeOption[]>("get_installed_ides");


### PR DESCRIPTION
## What does this PR do?

Maximizing a decorationless macOS window no longer appears to slide into the screen corner at its old size before snapping — the GUI now zooms via NSWindow's animator proxy instead of tao's synchronous, redraw-suppressed setFrame:display:NO animate:YES fallback, so the webview repaints while the window grows and shrinks.

## Related issues

n/a

## Type of change

- [x] Bug fix

## Platforms tested

- [x] macOS

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` is clean
- [x] `cargo test` passes
- [x] Pure crates/modules still do no I/O (logic stays out of the OS edges)
- [x] Docs updated if behaviour or CLI changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS window zoom and restore support for borderless application windows.
  * Added zoom controls through the title bar maximize button and title bar double-click gestures.
  * Preserved native maximize behavior on other platforms.

* **Bug Fixes**
  * Prevented accidental zooming when double-clicking interactive title bar controls.
  * Improved zoom behavior during rapid toggles, resizing, and fullscreen use.

* **Tests**
  * Added coverage for macOS and Linux title bar zoom interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->