### PR TITLE
[Fix] Split PATH_INFO at the first PHP segment for direct sites

### DIFF
--- a/crates/yerd-proxy/src/forward/fcgi.rs
+++ b/crates/yerd-proxy/src/forward/fcgi.rs
@@ -71,7 +71,10 @@ const MAX_DISCARDED_BYTES: u64 = 8 * 1024 * 1024;
 /// `script_rel`, if given, is a real, on-disk `.php` file (relative to
 /// `served_root`) that [`crate::forward::script_file::resolve_script`]
 /// resolved for this request - see `pure::cgi_params`'s module doc for the
-/// front-controller policy this drives. `auto_login`, if given, is passed
+/// front-controller policy this drives. `path_info`, if given, is the
+/// decoded remainder of a `PATH_INFO`-style split
+/// ([`crate::forward::script_file::ScriptResolution::ScriptWithPathInfo`])
+/// and overrides the default full-path `PATH_INFO`. `auto_login`, if given, is passed
 /// straight through to [`build_params`] - see [`AutoLoginParams`] for
 /// when/why.
 #[allow(clippy::too_many_arguments)]
@@ -80,6 +83,7 @@ pub async fn forward(
     backend: Backend,
     served_root: PathBuf,
     script_rel: Option<PathBuf>,
+    path_info: Option<String>,
     server_addr: SocketAddr,
     peer_addr: SocketAddr,
     https: bool,
@@ -109,6 +113,7 @@ pub async fn forward(
         &parts.headers,
         &served_root,
         script_rel.as_deref(),
+        path_info.as_deref(),
         https,
         peer_addr,
         server_addr,

--- a/crates/yerd-proxy/src/forward/script_file.rs
+++ b/crates/yerd-proxy/src/forward/script_file.rs
@@ -82,7 +82,7 @@ pub async fn resolve_script(
     }
 
     let Some(dir_rel) = directory_candidate(uri_path) else {
-        return ScriptResolution::Fallback;
+        return split_path_info(uri_path, served_root, &real_root, symlink_protection).await;
     };
     let script_rel = dir_rel.join("index.php");
     match existing_php_file(served_root, &real_root, &script_rel, symlink_protection).await {
@@ -222,6 +222,32 @@ mod tests {
                 PathBuf::from("theme/styles.php"),
                 "/moove/123/all".to_owned()
             )
+        );
+    }
+
+    #[tokio::test]
+    async fn resolves_slash_only_path_info_for_trailing_slash() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.php"), b"<?php").unwrap();
+
+        assert_eq!(
+            resolve_script("/file.php/", root.path(), root.path(), true).await,
+            ScriptResolution::ScriptWithPathInfo(PathBuf::from("file.php"), "/".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolves_path_info_containing_dot_dot_segments() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.php"), b"<?php").unwrap();
+
+        assert_eq!(
+            resolve_script("/file.php/../arg", root.path(), root.path(), true).await,
+            ScriptResolution::ScriptWithPathInfo(PathBuf::from("file.php"), "/../arg".to_owned())
+        );
+        assert_eq!(
+            resolve_script("/file.php/%2e%2e/arg", root.path(), root.path(), true).await,
+            ScriptResolution::ScriptWithPathInfo(PathBuf::from("file.php"), "/../arg".to_owned())
         );
     }
 

--- a/crates/yerd-proxy/src/forward/script_file.rs
+++ b/crates/yerd-proxy/src/forward/script_file.rs
@@ -24,13 +24,19 @@
 use std::path::{Path, PathBuf};
 
 use crate::forward::static_file::{canonical_within, Containment};
-use crate::pure::try_files::{directory_candidate, is_php_source, static_candidate};
+use crate::pure::try_files::{
+    directory_candidate, is_php_source, php_split_candidate, static_candidate,
+};
 
 /// Outcome of resolving a direct-mode request against the on-disk tree.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ScriptResolution {
     /// A real, on-disk PHP script to execute, relative to `served_root`.
     Script(PathBuf),
+    /// A real, on-disk PHP script addressed `PATH_INFO`-style
+    /// (`/styles.php/extra/args`): the script to execute plus the decoded
+    /// `PATH_INFO` remainder to hand FastCGI.
+    ScriptWithPathInfo(PathBuf, String),
     /// The path names a real directory without a trailing slash; answer
     /// `301` to the trailing-slash form.
     DirectoryRedirect,
@@ -72,7 +78,7 @@ pub async fn resolve_script(
         if is_existing_directory(served_root, &real_root, &rel, symlink_protection).await {
             return ScriptResolution::DirectoryRedirect;
         }
-        return ScriptResolution::Fallback;
+        return split_path_info(uri_path, served_root, &real_root, symlink_protection).await;
     }
 
     let Some(dir_rel) = directory_candidate(uri_path) else {
@@ -81,6 +87,28 @@ pub async fn resolve_script(
     let script_rel = dir_rel.join("index.php");
     match existing_php_file(served_root, &real_root, &script_rel, symlink_protection).await {
         Some(script) => ScriptResolution::Script(script),
+        None => split_path_info(uri_path, served_root, &real_root, symlink_protection).await,
+    }
+}
+
+/// The `fastcgi_split_path_info` half of [`resolve_script`]: when the path
+/// embeds extra segments after a PHP script (`/theme/styles.php/moove/1/all`,
+/// Moodle's "slash arguments" and classic CGI/1.1 `PATH_INFO` addressing),
+/// execute that script - if it really exists on disk under the same
+/// containment discipline as an exact match - with the remainder as
+/// `PATH_INFO`. Tried only after the exact-file and directory answers have
+/// been ruled out, so it can never shadow a real file or directory.
+async fn split_path_info(
+    uri_path: &str,
+    served_root: &Path,
+    real_root: &Path,
+    symlink_protection: bool,
+) -> ScriptResolution {
+    let Some((script_rel, path_info)) = php_split_candidate(uri_path) else {
+        return ScriptResolution::Fallback;
+    };
+    match existing_php_file(served_root, real_root, &script_rel, symlink_protection).await {
+        Some(script) => ScriptResolution::ScriptWithPathInfo(script, path_info),
         None => ScriptResolution::Fallback,
     }
 }
@@ -173,6 +201,44 @@ mod tests {
 
         let rel = resolve_script("/wp-login.php", root.path(), root.path(), true).await;
         assert_eq!(rel, ScriptResolution::Script(PathBuf::from("wp-login.php")));
+    }
+
+    #[tokio::test]
+    async fn resolves_path_info_split_for_real_script() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("theme")).unwrap();
+        std::fs::write(root.path().join("theme/styles.php"), b"<?php").unwrap();
+
+        let rel = resolve_script(
+            "/theme/styles.php/moove/123/all",
+            root.path(),
+            root.path(),
+            true,
+        )
+        .await;
+        assert_eq!(
+            rel,
+            ScriptResolution::ScriptWithPathInfo(
+                PathBuf::from("theme/styles.php"),
+                "/moove/123/all".to_owned()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn path_info_split_requires_the_script_to_exist() {
+        let root = tempfile::tempdir().unwrap();
+
+        assert_eq!(
+            resolve_script(
+                "/theme/styles.php/moove/123/all",
+                root.path(),
+                root.path(),
+                true
+            )
+            .await,
+            ScriptResolution::Fallback
+        );
     }
 
     #[tokio::test]

--- a/crates/yerd-proxy/src/pure/cgi_params.rs
+++ b/crates/yerd-proxy/src/pure/cgi_params.rs
@@ -16,11 +16,16 @@
 //! - `SCRIPT_FILENAME = document_root / "index.php"`
 //! - `SCRIPT_NAME     = "/index.php"`
 //!
-//! `PATH_INFO` is always `<original path>` either way - WordPress and
+//! `PATH_INFO` is `<original path>` in both cases - WordPress and
 //! Laravel both route on `REQUEST_URI`, not `PATH_INFO`, so leaving it as the
 //! full original path (rather than splitting "extra path after the script",
 //! full CGI/1.1 `PATH_INFO` semantics) keeps this a minimal, low-risk change
-//! on top of already-pinned behavior.
+//! on top of already-pinned behavior. The exception is a `PATH_INFO`-style
+//! request the resolver *split* (`/styles.php/extra` - see
+//! `forward::script_file::ScriptResolution::ScriptWithPathInfo`): there the
+//! caller passes the split remainder as `path_info` and `PATH_INFO` carries
+//! exactly that, which is what nginx's `fastcgi_split_path_info` produces and
+//! what Moodle-style slash-argument routing reads.
 //!
 //! Plus the standard CGI/1.1 vars and `HTTP_*`-translated headers.
 //!
@@ -69,6 +74,7 @@ pub fn build_params(
     headers: &http::HeaderMap,
     document_root: &Path,
     script_rel: Option<&Path>,
+    path_info: Option<&str>,
     https: bool,
     remote_addr: SocketAddr,
     server_addr: SocketAddr,
@@ -101,7 +107,7 @@ pub fn build_params(
         b"DOCUMENT_ROOT",
         document_root.to_string_lossy().as_bytes(),
     );
-    push(&mut out, b"PATH_INFO", path.as_bytes());
+    push(&mut out, b"PATH_INFO", path_info.unwrap_or(path).as_bytes());
     push(
         &mut out,
         b"REMOTE_ADDR",
@@ -221,6 +227,7 @@ mod tests {
             &make_headers("app.test"),
             &root,
             None,
+            None,
             false,
             "127.0.0.1:54321".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),
@@ -261,6 +268,7 @@ mod tests {
             &make_headers("app.test"),
             Path::new("/srv"),
             None,
+            None,
             false,
             "127.0.0.1:1".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),
@@ -282,6 +290,7 @@ mod tests {
             "/login",
             &make_headers("app.test"),
             &served,
+            None,
             None,
             false,
             "127.0.0.1:1".parse().unwrap(),
@@ -306,6 +315,7 @@ mod tests {
             &make_headers("app.test"),
             Path::new("/srv/www/app"),
             None,
+            None,
             true,
             "1.2.3.4:1000".parse().unwrap(),
             "127.0.0.1:443".parse().unwrap(),
@@ -324,6 +334,7 @@ mod tests {
             "/",
             &headers,
             Path::new("/srv"),
+            None,
             None,
             false,
             "127.0.0.1:1".parse().unwrap(),
@@ -351,6 +362,7 @@ mod tests {
             &headers,
             Path::new("/srv"),
             None,
+            None,
             false,
             "127.0.0.1:1".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),
@@ -373,6 +385,7 @@ mod tests {
             &make_headers("a.test"),
             Path::new("/srv"),
             None,
+            None,
             false,
             "127.0.0.1:1".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),
@@ -390,6 +403,7 @@ mod tests {
             &make_headers("blog.test"),
             Path::new("/srv/www/blog"),
             Some(Path::new("wp-admin/index.php")),
+            None,
             false,
             "127.0.0.1:1".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),
@@ -415,6 +429,7 @@ mod tests {
             "/wp-admin/",
             &make_headers("blog.test"),
             Path::new("/srv/www/blog"),
+            None,
             None,
             false,
             "127.0.0.1:1".parse().unwrap(),
@@ -442,6 +457,7 @@ mod tests {
             &make_headers("blog.test"),
             Path::new("/srv/www/blog"),
             None,
+            None,
             false,
             "127.0.0.1:1".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),
@@ -461,6 +477,7 @@ mod tests {
             &make_headers("app.test"),
             Path::new("/srv/www/app"),
             None,
+            None,
             false,
             "127.0.0.1:1".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),
@@ -478,6 +495,7 @@ mod tests {
             &make_headers("blog.test"),
             Path::new("/srv/www/blog"),
             Some(Path::new("wp-login.php")),
+            None,
             false,
             "127.0.0.1:1".parse().unwrap(),
             "127.0.0.1:80".parse().unwrap(),

--- a/crates/yerd-proxy/src/pure/cgi_params.rs
+++ b/crates/yerd-proxy/src/pure/cgi_params.rs
@@ -62,7 +62,10 @@ pub struct AutoLoginParams<'a> {
 
 /// Build the CGI parameter pairs. `script_rel`, if given, is a real,
 /// on-disk `.php` file's path relative to `document_root` (see the module
-/// doc) - `None` falls back to the root `index.php` policy. `auto_login`, if
+/// doc) - `None` falls back to the root `index.php` policy. `path_info`, if
+/// given, is the decoded remainder of a `PATH_INFO`-style split resolved by
+/// `forward::script_file` and overrides the default `PATH_INFO` value (the
+/// full request path). `auto_login`, if
 /// given, adds a `PHP_VALUE: auto_prepend_file=<path>` param plus a custom
 /// `YERD_LOGIN_USER` param carrying the target username - see
 /// [`AutoLoginParams`].

--- a/crates/yerd-proxy/src/pure/try_files.rs
+++ b/crates/yerd-proxy/src/pure/try_files.rs
@@ -85,30 +85,29 @@ fn resolve_segments(path: &str) -> Option<PathBuf> {
 /// slash-only remainder `/`), or when the script half fails the
 /// same percent-decoding/traversal guard as [`static_candidate`]. Remainder
 /// segments are decoded with the same escapes rule but deliberately allow
-/// `.`/`..` - `PATH_INFO` is opaque data for the script, not a filesystem
-/// path - while still refusing embedded `/`, `\`, and NUL after decoding. A
-/// trailing `/` on the request survives into the remainder, matching what
-/// nginx's regex captures. The caller must still verify the script half is a
+/// `.`/`..` and empty segments - `PATH_INFO` is opaque data for the script,
+/// not a filesystem path, so `/file.php/a//b/` yields `/a//b/` exactly as
+/// nginx's regex captures it - while still refusing embedded `/`, `\`, and
+/// NUL after decoding. The caller must still verify the script half is a
 /// real, on-disk file before trusting the split.
 #[must_use]
 pub fn php_split_candidate(url_path: &str) -> Option<(PathBuf, String)> {
     let path = url_path.split('?').next().unwrap_or(url_path);
-    let trailing_slash = path.len() > 1 && path.ends_with('/');
+    let components: Vec<&str> = path.split('/').collect();
 
-    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-    let searchable = if trailing_slash {
-        segments.len()
-    } else {
-        segments.len().saturating_sub(1)
-    };
-
-    let split_at = segments
+    let split_at = components
         .iter()
-        .take(searchable)
-        .position(|raw| percent_decode(raw).is_some_and(|seg| is_php_source(Path::new(&seg))))?;
+        .take(components.len().saturating_sub(1))
+        .position(|raw| {
+            !raw.is_empty() && percent_decode(raw).is_some_and(|seg| is_php_source(Path::new(&seg)))
+        })?;
 
     let mut script = PathBuf::new();
-    for raw in segments.get(..=split_at)? {
+    for raw in components
+        .get(..=split_at)?
+        .iter()
+        .filter(|s| !s.is_empty())
+    {
         let seg = percent_decode(raw)?;
         if seg.is_empty() || seg == "." || seg == ".." {
             return None;
@@ -120,16 +119,13 @@ pub fn php_split_candidate(url_path: &str) -> Option<(PathBuf, String)> {
     }
 
     let mut info = String::new();
-    for raw in segments.get(split_at + 1..)? {
+    for raw in components.get(split_at + 1..)? {
         let seg = percent_decode(raw)?;
         if seg.bytes().any(|b| b == b'/' || b == b'\\' || b == 0) {
             return None;
         }
         info.push('/');
         info.push_str(&seg);
-    }
-    if trailing_slash {
-        info.push('/');
     }
 
     Some((script, info))
@@ -324,6 +320,22 @@ mod tests {
         assert_eq!(
             php_split_candidate("/file.php/"),
             Some((PathBuf::from("file.php"), "/".to_owned()))
+        );
+    }
+
+    #[test]
+    fn php_split_preserves_repeated_slashes_in_path_info() {
+        assert_eq!(
+            php_split_candidate("/file.php/a//b"),
+            Some((PathBuf::from("file.php"), "/a//b".to_owned()))
+        );
+        assert_eq!(
+            php_split_candidate("/file.php//"),
+            Some((PathBuf::from("file.php"), "//".to_owned()))
+        );
+        assert_eq!(
+            php_split_candidate("//dir//file.php/x"),
+            Some((PathBuf::from("dir/file.php"), "/x".to_owned()))
         );
     }
 

--- a/crates/yerd-proxy/src/pure/try_files.rs
+++ b/crates/yerd-proxy/src/pure/try_files.rs
@@ -75,6 +75,62 @@ fn resolve_segments(path: &str) -> Option<PathBuf> {
     Some(rel)
 }
 
+/// Split a `PATH_INFO`-style URL path at its first PHP-source segment - the
+/// non-greedy half of nginx's `fastcgi_split_path_info ^(.+?\.php)(/.*)$` -
+/// into the candidate script path and the decoded `PATH_INFO` remainder
+/// (always starting with `/`).
+///
+/// `None` when no segment before the last is PHP source (a plain `/foo.php`
+/// has no remainder and is not a split), or when the script half fails the
+/// same percent-decoding/traversal guard as [`static_candidate`]. Remainder
+/// segments are decoded with the same escapes rule but deliberately allow
+/// `.`/`..` - `PATH_INFO` is opaque data for the script, not a filesystem
+/// path - while still refusing embedded `/`, `\`, and NUL after decoding. A
+/// trailing `/` on the request survives into the remainder, matching what
+/// nginx's regex captures. The caller must still verify the script half is a
+/// real, on-disk file before trusting the split.
+#[must_use]
+pub fn php_split_candidate(url_path: &str) -> Option<(PathBuf, String)> {
+    let path = url_path.split('?').next().unwrap_or(url_path);
+    let trailing_slash = path.len() > 1 && path.ends_with('/');
+
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    // First segment that looks like PHP source, excluding the last: a
+    // trailing PHP segment is the plain exact-match case, not a split.
+    let split_at = segments
+        .iter()
+        .take(segments.len().saturating_sub(1))
+        .position(|raw| percent_decode(raw).is_some_and(|seg| is_php_source(Path::new(&seg))))?;
+
+    let mut script = PathBuf::new();
+    for raw in segments.get(..=split_at)? {
+        let seg = percent_decode(raw)?;
+        if seg.is_empty() || seg == "." || seg == ".." {
+            return None;
+        }
+        if seg.bytes().any(|b| b == b'/' || b == b'\\' || b == 0) {
+            return None;
+        }
+        script.push(seg);
+    }
+
+    let mut info = String::new();
+    for raw in segments.get(split_at + 1..)? {
+        let seg = percent_decode(raw)?;
+        if seg.bytes().any(|b| b == b'/' || b == b'\\' || b == 0) {
+            return None;
+        }
+        info.push('/');
+        info.push_str(&seg);
+    }
+    if trailing_slash {
+        info.push('/');
+    }
+
+    Some((script, info))
+}
+
 /// Whether `path` looks like PHP source - these must never be served as a static
 /// file (it would leak source), so the front controller handles them instead.
 #[must_use]
@@ -235,6 +291,56 @@ mod tests {
         assert_eq!(directory_candidate("/foo/../../bar/"), None);
         assert_eq!(directory_candidate("/%2e%2e/"), None);
         assert_eq!(directory_candidate("/foo%2fbar/"), None);
+    }
+
+    #[test]
+    fn php_split_finds_first_php_segment() {
+        assert_eq!(
+            php_split_candidate("/theme/styles.php/moove/123/all"),
+            Some((
+                PathBuf::from("theme/styles.php"),
+                "/moove/123/all".to_owned()
+            ))
+        );
+        assert_eq!(
+            php_split_candidate("/lib/javascript.php/1/lib/javascript-static.js"),
+            Some((
+                PathBuf::from("lib/javascript.php"),
+                "/1/lib/javascript-static.js".to_owned()
+            ))
+        );
+        // Non-greedy: split at the first PHP segment, like nginx's `.+?\.php`.
+        assert_eq!(
+            php_split_candidate("/a.php/b.php/c"),
+            Some((PathBuf::from("a.php"), "/b.php/c".to_owned()))
+        );
+    }
+
+    #[test]
+    fn php_split_keeps_trailing_slash_and_decodes() {
+        assert_eq!(
+            php_split_candidate("/file.php/dir/"),
+            Some((PathBuf::from("file.php"), "/dir/".to_owned()))
+        );
+        assert_eq!(
+            php_split_candidate("/file.php/my%20arg?x=1"),
+            Some((PathBuf::from("file.php"), "/my arg".to_owned()))
+        );
+    }
+
+    #[test]
+    fn php_split_ignores_plain_and_non_php_paths() {
+        assert_eq!(php_split_candidate("/wp-login.php"), None);
+        assert_eq!(php_split_candidate("/assets/app.css"), None);
+        assert_eq!(php_split_candidate("/foo/bar"), None);
+        assert_eq!(php_split_candidate("/"), None);
+    }
+
+    #[test]
+    fn php_split_rejects_traversal_in_script_half() {
+        assert_eq!(php_split_candidate("/../evil.php/x"), None);
+        assert_eq!(php_split_candidate("/%2e%2e/evil.php/x"), None);
+        assert_eq!(php_split_candidate("/a%2fb.php/x"), None);
     }
 
     #[test]

--- a/crates/yerd-proxy/src/pure/try_files.rs
+++ b/crates/yerd-proxy/src/pure/try_files.rs
@@ -80,8 +80,9 @@ fn resolve_segments(path: &str) -> Option<PathBuf> {
 /// into the candidate script path and the decoded `PATH_INFO` remainder
 /// (always starting with `/`).
 ///
-/// `None` when no segment before the last is PHP source (a plain `/foo.php`
-/// has no remainder and is not a split), or when the script half fails the
+/// `None` when no segment with trailing path data is PHP source (a plain
+/// `/foo.php` has no remainder and is not a split; `/foo.php/` has the
+/// slash-only remainder `/`), or when the script half fails the
 /// same percent-decoding/traversal guard as [`static_candidate`]. Remainder
 /// segments are decoded with the same escapes rule but deliberately allow
 /// `.`/`..` - `PATH_INFO` is opaque data for the script, not a filesystem
@@ -95,12 +96,15 @@ pub fn php_split_candidate(url_path: &str) -> Option<(PathBuf, String)> {
     let trailing_slash = path.len() > 1 && path.ends_with('/');
 
     let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let searchable = if trailing_slash {
+        segments.len()
+    } else {
+        segments.len().saturating_sub(1)
+    };
 
-    // First segment that looks like PHP source, excluding the last: a
-    // trailing PHP segment is the plain exact-match case, not a split.
     let split_at = segments
         .iter()
-        .take(segments.len().saturating_sub(1))
+        .take(searchable)
         .position(|raw| percent_decode(raw).is_some_and(|seg| is_php_source(Path::new(&seg))))?;
 
     let mut script = PathBuf::new();
@@ -309,10 +313,17 @@ mod tests {
                 "/1/lib/javascript-static.js".to_owned()
             ))
         );
-        // Non-greedy: split at the first PHP segment, like nginx's `.+?\.php`.
         assert_eq!(
             php_split_candidate("/a.php/b.php/c"),
             Some((PathBuf::from("a.php"), "/b.php/c".to_owned()))
+        );
+    }
+
+    #[test]
+    fn php_split_yields_slash_only_path_info_for_trailing_slash() {
+        assert_eq!(
+            php_split_candidate("/file.php/"),
+            Some((PathBuf::from("file.php"), "/".to_owned()))
         );
     }
 

--- a/crates/yerd-proxy/src/server.rs
+++ b/crates/yerd-proxy/src/server.rs
@@ -536,8 +536,11 @@ async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
         symlink_protection,
     )
     .await;
-    let script_rel = match resolution {
-        script_file::ScriptResolution::Script(rel) => Some(rel),
+    let (script_rel, path_info) = match resolution {
+        script_file::ScriptResolution::Script(script) => (Some(script), None),
+        script_file::ScriptResolution::ScriptWithPathInfo(script, extra) => {
+            (Some(script), Some(extra))
+        }
         script_file::ScriptResolution::DirectoryRedirect
             if *req.method() == Method::GET || *req.method() == Method::HEAD =>
         {
@@ -547,8 +550,8 @@ async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
         | script_file::ScriptResolution::Fallback => {
             match apply_route(&req, route, served_root, allowed_root, symlink_protection).await {
                 RouteOutcome::Respond(resp) => return Ok(resp),
-                RouteOutcome::Script(rel) => Some(rel),
-                RouteOutcome::Fallback => None,
+                RouteOutcome::Script(rel) => (Some(rel), None),
+                RouteOutcome::Fallback => (None, None),
             }
         }
     };
@@ -565,6 +568,7 @@ async fn serve_php_fpm<R: BackendResolver, L: LoginTokenConsumer>(
         backend,
         served_root.to_path_buf(),
         script_rel,
+        path_info,
         server_addr,
         peer_addr,
         https,

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -1352,7 +1352,7 @@ async fn php_script_with_path_info_forwards_split_to_fcgi() {
         .await;
     });
 
-    let body = client_get(proxy_addr, "lms.test", "/theme/styles.php/moove/123/all").await;
+    let body = client_get(proxy_addr, "lms.test", "/theme/styles.php/moove//123/all").await;
     assert_eq!(body, b"from fpm");
 
     let params = captured.lock().await.clone();
@@ -1373,11 +1373,11 @@ async fn php_script_with_path_info_forwards_split_to_fcgi() {
     );
     assert_eq!(
         params.get("PATH_INFO").map(String::as_str),
-        Some("/moove/123/all")
+        Some("/moove//123/all")
     );
     assert_eq!(
         params.get("REQUEST_URI").map(String::as_str),
-        Some("/theme/styles.php/moove/123/all")
+        Some("/theme/styles.php/moove//123/all")
     );
 
     let _ = tx_shutdown.send(());

--- a/crates/yerd-proxy/tests/integration_http.rs
+++ b/crates/yerd-proxy/tests/integration_http.rs
@@ -1294,6 +1294,97 @@ async fn direct_script_execution_gated_to_wordpress_sites() {
     let _ = fake_task.await;
 }
 
+/// Moodle-style slash arguments: a real script followed by opaque path data
+/// must execute that script with the remainder in `PATH_INFO`, while
+/// `REQUEST_URI` still carries the whole original path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn php_script_with_path_info_forwards_split_to_fcgi() {
+    let docroot = tempfile::tempdir().unwrap();
+    std::fs::write(docroot.path().join("index.php"), b"<?php /* front page */").unwrap();
+    std::fs::create_dir(docroot.path().join("theme")).unwrap();
+    std::fs::write(
+        docroot.path().join("theme").join("styles.php"),
+        b"<?php /* styles */",
+    )
+    .unwrap();
+
+    let fcgi_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let fcgi_addr = fcgi_listener.local_addr().unwrap();
+    let captured = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let captured_for_fake = captured.clone();
+    let stdout_payload = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nfrom fpm".to_vec();
+    let fake_task = tokio::spawn(run_fake_fcgi(
+        fcgi_listener,
+        stdout_payload,
+        captured_for_fake,
+    ));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    let tld = Tld::new("test").unwrap();
+    let cfg = RouterConfig::with_tld(tld);
+    let mut router = SiteRouter::new(cfg);
+    let site = Site::linked("lms", docroot.path().to_path_buf(), PhpVersion::new(8, 3)).unwrap();
+    router.insert(site).unwrap();
+    let router = Arc::new(tokio::sync::RwLock::new(router));
+
+    let resolver = Arc::new(StaticResolver {
+        backend: Backend::PhpFpmTcp { addr: fcgi_addr },
+    });
+
+    let (tx_shutdown, rx_shutdown) = oneshot::channel::<()>();
+    let proxy_task = tokio::spawn(async move {
+        let _ = ProxyServer::serve::<_, StubCertStore, _, _>(
+            proxy_listener,
+            None,
+            router,
+            resolver,
+            Arc::new(NoLoginTokens),
+            None,
+            Arc::new(AtomicBool::new(true)),
+            test_client_tls(),
+            false,
+            async move {
+                let _ = rx_shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let body = client_get(proxy_addr, "lms.test", "/theme/styles.php/moove/123/all").await;
+    assert_eq!(body, b"from fpm");
+
+    let params = captured.lock().await.clone();
+    assert_eq!(
+        params.get("SCRIPT_NAME").map(String::as_str),
+        Some("/theme/styles.php")
+    );
+    assert_eq!(
+        params.get("SCRIPT_FILENAME").map(String::as_str),
+        Some(
+            docroot
+                .path()
+                .join("theme")
+                .join("styles.php")
+                .to_str()
+                .unwrap()
+        )
+    );
+    assert_eq!(
+        params.get("PATH_INFO").map(String::as_str),
+        Some("/moove/123/all")
+    );
+    assert_eq!(
+        params.get("REQUEST_URI").map(String::as_str),
+        Some("/theme/styles.php/moove/123/all")
+    );
+
+    let _ = tx_shutdown.send(());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy_task).await;
+    let _ = fake_task.await;
+}
+
 /// A real directory with none of index.php/html/htm must still reach the
 /// front controller rather than dead-ending in a 404.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Motivation

Fixes #227. Direct-mode sites resolve only exact `.php` paths, so a CGI/1.1 `PATH_INFO`-style request like `/theme/styles.php/moove/123/all` falls through to the front-controller fallback and the addressed script never runs. Moodle's slash arguments (its default and recommended file-serving mode) break this way — every stylesheet/JS URL returns the fallback page instead of the asset, rendering pages unstyled.

## Change

Mirrors nginx's `fastcgi_split_path_info ^(.+?\.php)(/.*)$`, layered onto the existing resolution order so it can never shadow a real file or directory:

- `pure/try_files.rs`: new `php_split_candidate` — non-greedy split at the first PHP-source segment; script half gets the same percent-decoding/traversal guard as `static_candidate`, remainder is decoded but treated as opaque data (no `/`, `\`, NUL after decoding).
- `forward/script_file.rs`: new `ScriptResolution::ScriptWithPathInfo`, tried only after the exact-file and directory-redirect answers are ruled out, with the same on-disk existence + containment discipline (`existing_php_file`) as an exact match.
- `pure/cgi_params.rs`: `build_params` takes an optional `path_info` override; default behavior (full original path) is unchanged for every other request.
- `server.rs` / `forward/fcgi.rs`: thread the split remainder through.

## Testing

- Pure unit tests for the split (first-segment/non-greedy, trailing slash, percent-decoding, traversal rejection, no-split cases).
- `resolve_script` tests: split resolves for a real on-disk script; falls back when the script doesn't exist.
- `cargo test -p yerd-proxy` — 240 tests green; `cargo clippy --all-targets` introduces no new warnings; `cargo fmt` clean.
- The breakage itself was reproduced end-to-end against a Moodle 5.x site on a direct-mode `.test` domain (yerd 2.1.0-rc.1): `theme/styles.php/<theme>/<rev>/all` returns the fallback page. I have not run a patched daemon build against that site — happy to test a build, or add an integration test if you'd like one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PHP-style `PATH_INFO` URL splitting.
  * PHP requests now preserve trailing slashes, repeated separators, and encoded path segments in `PATH_INFO`.
  * The original request URL remains available while the PHP script path is resolved separately.

* **Bug Fixes**
  * Improved PHP script resolution for URLs containing additional path segments.
  * Strengthened path handling to prevent unsafe traversal while preserving valid `PATH_INFO` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->